### PR TITLE
Resolve gnutls duplicate definitions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([flight-safety-system], [0.11.0], [sjp@canterburyairpatrol.org])
+AC_INIT([flight-safety-system], [0.12.0], [sjp@canterburyairpatrol.org])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign -Wno-portability])
 
 m4_include([m4/ax_cxx_compile_stdcxx.m4])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
-flight-safety-system (0.11.0) unstable; urgency=medium
+flight-safety-system (0.12.0) unstable; urgency=medium
 
   * Updated
 
- -- unknown <sjp@canterburyairpatrol.org>  Fri, 6 Oct 2023 00:00:00 +0000
+ -- unknown <sjp@canterburyairpatrol.org>  Sat, 26 Oct 2024 00:00:00 +0000
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,8 +1,8 @@
 AUTOMAKE_OPTIONS = subdir-objects
 ACLOCAL_AMFLAGS = $(ACLOCAL_FLAGS)
 
-AM_CXXFLAGS = -pthread -fPIC -std=c++11 -I. -Werror -Wall -Wshadow -Wunused -Wnull-dereference -Wformat=2 -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wpedantic -Weffc++ -include config.h
-AM_CFLAGS = -pthread -fPIC -std=c99 -I. -Werror -Wall -Wshadow -Wunused -Wnull-dereference -Wformat=2 -pedantic -D_GNU_SOURCE
+AM_CXXFLAGS = -pthread -fPIC -std=c++11 -I. -Werror -Wall -Wshadow -Wunused -Wnull-dereference -Wformat=2 -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wpedantic -Weffc++ -include config.h -ggdb
+AM_CFLAGS = -pthread -fPIC -std=c99 -I. -Werror -Wall -Wshadow -Wunused -Wnull-dereference -Wformat=2 -pedantic -D_GNU_SOURCE -ggdb
 AM_CPPFLAGS =
 
 AM_CFLAGS += $(CODE_COVERAGE_CFLAGS)

--- a/src/fss-transport-ssl.hpp
+++ b/src/fss-transport-ssl.hpp
@@ -14,10 +14,11 @@ private:
     std::string private_key_file;
     std::string public_key_file;
 protected:
+    std::unique_ptr<gnutls::session> session{nullptr};
     bool usable{false};
-    auto sendSessionMsg(gnutls::session &session, const std::shared_ptr<flight_safety_system::transport::buf_len> &bl) -> bool;
-    auto recvSessionBytes(gnutls::session &session, void *bytes, size_t max_bytes) -> ssize_t;
-    void setupSession(gnutls::session &session);
+    auto sendMsg(const std::shared_ptr<flight_safety_system::transport::buf_len> &bl) -> bool override;
+    auto recvBytes(void *bytes, size_t max_bytes) -> ssize_t override;
+    void setupSession();
 public:
     fss_connection(std::string t_ca, std::string t_private_key, std::string t_public_key);
     fss_connection(int t_fd, std::string t_ca, std::string t_private_key, std::string t_public_key);
@@ -30,12 +31,9 @@ public:
 
 class fss_connection_client : public fss_connection {
 private:
-    gnutls::client_session session;
     std::string hostname{};
 protected:
     auto setupSSL() -> bool;
-    auto sendMsg(const std::shared_ptr<flight_safety_system::transport::buf_len> &bl) -> bool override;
-    auto recvBytes(void *bytes, size_t max_bytes) -> ssize_t override;
 public:
     fss_connection_client(std::string t_ca, std::string t_private_key, std::string t_public_key);
     fss_connection_client(fss_connection_client &) = delete;
@@ -50,11 +48,8 @@ public:
 class fss_connection_server : public fss_connection {
 private:
     std::list<std::string> possible_names{};
-    gnutls::server_session session{};
 protected:
     auto setupSSL() -> bool;
-    auto sendMsg(const std::shared_ptr<flight_safety_system::transport::buf_len> &bl) -> bool override;
-    auto recvBytes(void *bytes, size_t max_bytes) -> ssize_t override;
 public:
     fss_connection_server(int t_fd, std::string t_ca, std::string t_private_key, std::string t_public_key);
     fss_connection_server(fss_connection_server&) = delete;

--- a/src/fss-transport-ssl.hpp
+++ b/src/fss-transport-ssl.hpp
@@ -2,8 +2,10 @@
 
 #include <list>
 
-#include <gnutls/gnutls.h>
-#include <gnutls/gnutlsxx.h>
+namespace gnutls {
+    class certificate_credentials;
+    class session;
+};
 
 namespace flight_safety_system {
 namespace transport_ssl {

--- a/src/fss-transport-ssl.hpp
+++ b/src/fss-transport-ssl.hpp
@@ -9,7 +9,7 @@ namespace flight_safety_system {
 namespace transport_ssl {
 class fss_connection : public flight_safety_system::transport::fss_connection {
 private:
-    gnutls::certificate_credentials credentials{};
+    std::unique_ptr<gnutls::certificate_credentials> credentials;
     std::string ca_file;
     std::string private_key_file;
     std::string public_key_file;

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -24,11 +24,11 @@ recv_msg_thread(flight_safety_system::transport_ssl::fss_connection *conn)
     conn->processMessages();
 }
 
-flight_safety_system::transport_ssl::fss_connection::fss_connection(std::string t_ca, std::string t_private_key, std::string t_public_key) : flight_safety_system::transport::fss_connection(), ca_file(std::move(t_ca)), private_key_file(std::move(t_private_key)), public_key_file(std::move(t_public_key))
+flight_safety_system::transport_ssl::fss_connection::fss_connection(std::string t_ca, std::string t_private_key, std::string t_public_key) : flight_safety_system::transport::fss_connection(), credentials(new gnutls::certificate_credentials()), ca_file(std::move(t_ca)), private_key_file(std::move(t_private_key)), public_key_file(std::move(t_public_key))
 {
 }
 
-flight_safety_system::transport_ssl::fss_connection::fss_connection(int t_fd, std::string t_ca, std::string t_private_key, std::string t_public_key) : flight_safety_system::transport::fss_connection(t_fd), ca_file(std::move(t_ca)), private_key_file(std::move(t_private_key)), public_key_file(std::move(t_public_key))
+flight_safety_system::transport_ssl::fss_connection::fss_connection(int t_fd, std::string t_ca, std::string t_private_key, std::string t_public_key) : flight_safety_system::transport::fss_connection(t_fd), credentials(new gnutls::certificate_credentials()), ca_file(std::move(t_ca)), private_key_file(std::move(t_private_key)), public_key_file(std::move(t_public_key))
 {
 }
 
@@ -130,9 +130,9 @@ flight_safety_system::transport_ssl::fss_connection::setupSession(gnutls::sessio
 {
     session.set_priority (nullptr, nullptr);
 
-    this->credentials.set_x509_trust_file(this->ca_file.c_str(), GNUTLS_X509_FMT_PEM);
-    this->credentials.set_x509_key_file(this->public_key_file.c_str(), this->private_key_file.c_str(), GNUTLS_X509_FMT_PEM);
-    session.set_credentials(this->credentials);
+    this->credentials->set_x509_trust_file(this->ca_file.c_str(), GNUTLS_X509_FMT_PEM);
+    this->credentials->set_x509_key_file(this->public_key_file.c_str(), this->private_key_file.c_str(), GNUTLS_X509_FMT_PEM);
+    session.set_credentials(*this->credentials);
 
     session.set_transport_ptr((gnutls_transport_ptr_t)(intptr_t)this->getFd());
 }

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -12,6 +12,12 @@
 #include <thread>
 #include <netinet/tcp.h>
 
+#ifdef DEBUG
+// This is defined in transport.cpp
+extern const char *
+inet_ntop_stor(struct sockaddr_storage *src, char *dst, size_t dstlen, uint16_t *port);
+#endif
+
 static void
 recv_msg_thread(flight_safety_system::transport_ssl::fss_connection *conn)
 {

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -32,15 +32,13 @@ flight_safety_system::transport_ssl::fss_connection::fss_connection(int t_fd, st
 {
 }
 
-flight_safety_system::transport_ssl::fss_connection::~fss_connection() = default;
-
-flight_safety_system::transport_ssl::fss_connection_client::~fss_connection_client()
+flight_safety_system::transport_ssl::fss_connection::~fss_connection()
 {
     if (this->usable)
     {
         try
         {
-            this->session.bye(GNUTLS_SHUT_WR);
+            this->session->bye(GNUTLS_SHUT_WR);
         }
         catch (gnutls::exception &ex)
         {
@@ -51,22 +49,9 @@ flight_safety_system::transport_ssl::fss_connection_client::~fss_connection_clie
     this->disconnect();
 }
 
-flight_safety_system::transport_ssl::fss_connection_server::~fss_connection_server()
-{
-    if (this->usable)
-    {
-        try
-        {
-            this->session.bye(GNUTLS_SHUT_WR);
-        }
-        catch (gnutls::exception &ex)
-        {
-            std::cerr << "fss_connection shutdown, gnutls exception during bye" << std::endl;
-        }
-        this->usable = false;
-    }
-    this->disconnect();
-}
+flight_safety_system::transport_ssl::fss_connection_client::~fss_connection_client() = default;
+
+flight_safety_system::transport_ssl::fss_connection_server::~fss_connection_server() = default;
 
 flight_safety_system::transport_ssl::fss_connection_server::fss_connection_server(int t_fd, std::string t_ca, std::string t_private_key, std::string t_public_key) : flight_safety_system::transport_ssl::fss_connection(std::move(t_ca), std::move(t_private_key), std::move(t_public_key))
 {
@@ -78,7 +63,7 @@ flight_safety_system::transport_ssl::fss_connection_server::fss_connection_serve
     }
 }
 
-flight_safety_system::transport_ssl::fss_connection_client::fss_connection_client(std::string t_ca, std::string t_private_key, std::string t_public_key) : fss_connection(std::move(t_ca), std::move(t_private_key), std::move(t_public_key)), session{}
+flight_safety_system::transport_ssl::fss_connection_client::fss_connection_client(std::string t_ca, std::string t_private_key, std::string t_public_key) : fss_connection(std::move(t_ca), std::move(t_private_key), std::move(t_public_key))
 {
 }
 
@@ -126,28 +111,32 @@ flight_safety_system::transport_ssl::fss_connection_client::connectTo(const std:
 }
 
 void
-flight_safety_system::transport_ssl::fss_connection::setupSession(gnutls::session &session)
+flight_safety_system::transport_ssl::fss_connection::setupSession()
 {
-    session.set_priority (nullptr, nullptr);
+    this->session->set_priority (nullptr, nullptr);
 
     this->credentials->set_x509_trust_file(this->ca_file.c_str(), GNUTLS_X509_FMT_PEM);
     this->credentials->set_x509_key_file(this->public_key_file.c_str(), this->private_key_file.c_str(), GNUTLS_X509_FMT_PEM);
-    session.set_credentials(*this->credentials);
+    this->session->set_credentials(*this->credentials);
 
-    session.set_transport_ptr((gnutls_transport_ptr_t)(intptr_t)this->getFd());
+    this->session->set_transport_ptr((gnutls_transport_ptr_t)(intptr_t)this->getFd());
 }
 
 auto
 flight_safety_system::transport_ssl::fss_connection_client::setupSSL() -> bool
 {
-    this->setupSession(this->session);
+    auto clientSession = new gnutls::client_session();
 
-    this->session.set_verify_cert(this->hostname.c_str(), 0);
+    this->session = std::unique_ptr<gnutls::session>(clientSession);
+
+    this->setupSession();
+
+    clientSession->set_verify_cert(this->hostname.c_str(), 0);
 
     int ret = -2;
     try
     {
-        ret = this->session.handshake();
+        ret = this->session->handshake();
     }
     catch (gnutls::exception &e)
     {
@@ -165,14 +154,18 @@ flight_safety_system::transport_ssl::fss_connection_client::setupSSL() -> bool
 auto
 flight_safety_system::transport_ssl::fss_connection_server::setupSSL() -> bool
 {
-    this->setupSession(this->session);
+    auto serverSession = new gnutls::server_session();
 
-    this->session.set_certificate_request(GNUTLS_CERT_REQUIRE);
+    this->session = std::unique_ptr<gnutls::session>(serverSession);
+
+    this->setupSession();
+
+    serverSession->set_certificate_request(GNUTLS_CERT_REQUIRE);
 
     int ret = -1;
     try
     {
-        ret = this->session.handshake();
+        ret = this->session->handshake();
     }
     catch(gnutls::exception &e)
     {
@@ -186,7 +179,7 @@ flight_safety_system::transport_ssl::fss_connection_server::setupSSL() -> bool
 
     std::vector<gnutls_datum_t> cert_list;
 
-    if (this->session.get_peers_certificate(cert_list))
+    if (this->session->get_peers_certificate(cert_list))
     {
         for (auto cert : cert_list)
         {
@@ -222,7 +215,7 @@ flight_safety_system::transport_ssl::fss_connection_server::setupSSL() -> bool
 }
 
 auto
-flight_safety_system::transport_ssl::fss_connection::sendSessionMsg(gnutls::session &session, const std::shared_ptr<flight_safety_system::transport::buf_len> &bl) -> bool
+flight_safety_system::transport_ssl::fss_connection::sendMsg(const std::shared_ptr<flight_safety_system::transport::buf_len> &bl) -> bool
 {
     if (!this->usable)
     {
@@ -233,7 +226,7 @@ flight_safety_system::transport_ssl::fss_connection::sendSessionMsg(gnutls::sess
     const char *data = bl->getData();
     try
     {
-        session.send(data, to_send);
+        this->session->send(data, to_send);
     }
     catch (gnutls::exception &ex)
     {
@@ -243,19 +236,7 @@ flight_safety_system::transport_ssl::fss_connection::sendSessionMsg(gnutls::sess
 }
 
 auto
-flight_safety_system::transport_ssl::fss_connection_client::sendMsg(const std::shared_ptr<flight_safety_system::transport::buf_len> &bl) -> bool
-{
-    return this->sendSessionMsg(this->session, bl);
-}
-
-auto
-flight_safety_system::transport_ssl::fss_connection_server::sendMsg(const std::shared_ptr<flight_safety_system::transport::buf_len> &bl) -> bool
-{
-    return this->sendSessionMsg(this->session, bl);
-}
-
-auto
-flight_safety_system::transport_ssl::fss_connection::recvSessionBytes(gnutls::session &session, void *t_bytes, size_t t_max_bytes) -> ssize_t
+flight_safety_system::transport_ssl::fss_connection::recvBytes(void *t_bytes, size_t t_max_bytes) -> ssize_t
 {
     if (!this->usable)
     {
@@ -265,7 +246,7 @@ flight_safety_system::transport_ssl::fss_connection::recvSessionBytes(gnutls::se
     ssize_t bytes_recved = -1;
     try
     {
-        bytes_recved = session.recv(t_bytes, t_max_bytes);
+        bytes_recved = this->session->recv(t_bytes, t_max_bytes);
     }
     catch (gnutls::exception &ex)
     {
@@ -274,17 +255,6 @@ flight_safety_system::transport_ssl::fss_connection::recvSessionBytes(gnutls::se
     return bytes_recved;
 }
 
-auto
-flight_safety_system::transport_ssl::fss_connection_client::recvBytes(void *t_bytes, size_t t_max_bytes) -> ssize_t
-{
-    return this->recvSessionBytes(this->session, t_bytes, t_max_bytes);
-}
-
-auto
-flight_safety_system::transport_ssl::fss_connection_server::recvBytes(void *t_bytes, size_t t_max_bytes) -> ssize_t
-{
-    return this->recvSessionBytes(this->session, t_bytes, t_max_bytes);
-}
 auto
 flight_safety_system::transport_ssl::fss_listen::newConnection(int t_newfd) -> std::shared_ptr<flight_safety_system::transport::fss_connection>
 {

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -21,7 +21,7 @@
 
 #ifdef DEBUG
 /* Run inet_ntop on a sockaddr_storage object */
-static const char *
+const char *
 inet_ntop_stor(struct sockaddr_storage *src, char *dst, size_t dstlen, uint16_t *port)
 {
     switch (src->ss_family)
@@ -355,7 +355,7 @@ flight_safety_system::transport::fss_listen::processMessages()
         char addr_str[INET6_ADDRSTRLEN];
         uint16_t client_port;
         inet_ntop_stor(&sa, addr_str, INET6_ADDRSTRLEN, &client_port);
-        std::cout << "New client from " << addr_str << ":" << client_port << " as " << fd << std::endl;
+        std::cout << "New client from " << addr_str << ":" << client_port << " as " << newfd << std::endl;
 #endif
         if (this->cb != nullptr)
         {

--- a/tests/connection-ssl.cpp
+++ b/tests/connection-ssl.cpp
@@ -122,4 +122,5 @@ TEST_CASE("SSL - Listen - Callback")
     REQUIRE(!cb->connected());
 
     client_conn = nullptr;
+    delete conn;
 }


### PR DESCRIPTION
## Description

The include of gnutls.h and gnutlsxx.h cause duplicate definitions of the inline functions in gnutlsxx.h for any user of the fss-transport library that includes the fss-transport-ssl.hpp header.

The cleanup of session handling also reduces duplicate code.

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change