### PR TITLE
github: Update the apt database before install packages

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install Deps
-      run: sudo apt install -y libjsoncpp-dev libecpg-dev catch libgnutlsxx28 libgnutls28-dev gnutls-bin
+      run: sudo apt update && sudo apt install -y libjsoncpp-dev libecpg-dev catch libgnutlsxx28 libgnutls28-dev gnutls-bin
     - name: autogen
       run: ./autogen.sh
     - name: configure

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install dependencies
-      run: sudo apt install libjsoncpp-dev gnutls-dev libecpg-dev gnutls-bin
+      run: sudo apt update && sudo apt install libjsoncpp-dev gnutls-dev libecpg-dev gnutls-bin
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
## Description

This is required sometimes to avoid trying to download files that don't exist.

## Checklist
- [x] I/we wrote this code my/ourself