### PR TITLE
Update dependencies for ubuntu noble

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install Deps
-      run: sudo apt update && sudo apt install -y libjsoncpp-dev libecpg-dev catch libgnutlsxx28 libgnutls28-dev gnutls-bin
+      run: sudo apt update && sudo apt install -y libjsoncpp-dev libecpg-dev catch libgnutls28-dev gnutls-bin
     - name: autogen
       run: ./autogen.sh
     - name: configure


### PR DESCRIPTION
## Description

libgnutlsxx doesn't exist separately in ubuntu noble.