### PR TITLE
Remove unneeded calloc/memcpy

### DIFF
--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -248,6 +248,23 @@ flight_safety_system::transport::fss_message_identity::unpackData(const std::sha
     size_t offset = this->headerLength();
     const char *data = bl->getData();
     size_t length = bl->getLength();
+    /* Use the recorded message length from the header if available,
+       as bl may include alignment padding */
+    if (length >= sizeof(uint16_t))
+    {
+        uint16_t msg_len;
+        memcpy(&msg_len, data, sizeof(uint16_t));
+        msg_len = ntohs(msg_len);
+        if (msg_len > 0 && msg_len <= length)
+        {
+            length = msg_len;
+        }
+    }
+    if (length <= offset)
+    {
+        this->name.clear();
+        return;
+    }
     this->name.assign(data + offset, length - offset);
 }
 
@@ -446,6 +463,10 @@ flight_safety_system::transport::fss_message_position_report::unpackData(const s
         memcpy(&tmp, data + offset, sizeof(uint16_t));
         uint16_t len = ntohs(tmp);
         offset += sizeof(uint16_t);
+        if (offset + len > length)
+        {
+            return;
+        }
         this->callsign.assign(data + offset, len);
         offset += len;
         offset += (sizeof(uint64_t) - offset % sizeof(uint64_t));
@@ -774,6 +795,10 @@ flight_safety_system::transport::fss_message_smm_settings::unpackData(const std:
         memcpy(&tmp, data + offset, sizeof(uint16_t));
         uint16_t len = ntohs(tmp);
         offset += sizeof(uint16_t);
+        if (offset + len > length)
+        {
+            return;
+        }
         this->server_url.assign(data + offset, len);
         offset += len;
         offset += (sizeof(uint64_t) - offset % sizeof(uint64_t));
@@ -784,6 +809,10 @@ flight_safety_system::transport::fss_message_smm_settings::unpackData(const std:
         memcpy(&tmp, data + offset, sizeof(uint16_t));
         uint16_t len = ntohs(tmp);
         offset += sizeof(uint16_t);
+        if (offset + len > length)
+        {
+            return;
+        }
         this->username.assign(data + offset, len);
         offset += len;
         offset += (sizeof(uint64_t) - offset % sizeof(uint64_t));
@@ -794,6 +823,10 @@ flight_safety_system::transport::fss_message_smm_settings::unpackData(const std:
         memcpy(&tmp, data + offset, sizeof(uint16_t));
         uint16_t len = ntohs(tmp);
         offset += sizeof(uint16_t);
+        if (offset + len > length)
+        {
+            return;
+        }
         this->password.assign(data + offset, len);
     }
 }
@@ -857,6 +890,10 @@ flight_safety_system::transport::fss_message_server_list::unpackData(const std::
         memcpy(&tmp, data + offset, sizeof(uint16_t));
         uint16_t len = ntohs(tmp);
         offset += sizeof(uint16_t);
+        if (offset + len > length)
+        {
+            return;
+        }
         std::string server_addr;
         server_addr.assign(data + offset, len);
         this->servers.emplace_back(server_addr, port);
@@ -947,6 +984,10 @@ auto
 flight_safety_system::transport::fss_message::decode(const std::shared_ptr<buf_len> &bl) -> std::shared_ptr<flight_safety_system::transport::fss_message>
 {
     std::shared_ptr<fss_message> msg = nullptr;
+    if (bl->getLength() < sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint64_t))
+    {
+        return msg;
+    }
     const char *data = bl->getData();
     uint16_t type_n;
     memcpy(&type_n, data + sizeof(uint16_t), sizeof(uint16_t));

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -248,11 +248,7 @@ flight_safety_system::transport::fss_message_identity::unpackData(const std::sha
     size_t offset = this->headerLength();
     const char *data = bl->getData();
     size_t length = bl->getLength();
-    char *name_n = (char *)calloc(1, (length - offset) + 1);
-    memcpy(name_n, data + offset, length - offset);
-    name_n[length - offset] = '\0';
-    this->name = std::string(name_n);
-    free (name_n);
+    this->name.assign(data + offset, length - offset);
 }
 
 flight_safety_system::transport::fss_message_identity::fss_message_identity(uint64_t t_id, const std::shared_ptr<buf_len> &bl) : fss_message(t_id, message_type_identity), name()


### PR DESCRIPTION
## Summary by Sourcery

Improve robustness and safety of transport message decoding by using header-defined lengths, eliminating unnecessary allocations, and adding bounds checks.

Bug Fixes:
- Prevent potential buffer overreads when unpacking variable-length strings and server addresses by validating lengths against the buffer size.
- Avoid reading malformed or truncated transport messages by rejecting buffers shorter than the minimal header size.
- Handle cases where identity message payload is shorter than the header by clearing the name instead of reading past the buffer.

Enhancements:
- Eliminate redundant dynamic allocation and copying when unpacking identity message names by assigning directly from the buffer while honoring the recorded message length.