### PR TITLE
Add atomic wrappers

### DIFF
--- a/examples/fake_client.cpp
+++ b/examples/fake_client.cpp
@@ -4,11 +4,11 @@
 
 #include <unistd.h>
 
-bool running = true;
+volatile sig_atomic_t running = 1;
 
 void sigIntHandler(int signum __attribute__((unused)))
 {
-    running = false;
+    running = 0;
 }
 
 auto
@@ -42,7 +42,7 @@ main(int argc, char *argv[]) -> int
     
     constexpr int send_interval = 5;
     int counter = 0;
-    while (running)
+    while (running == 1)
     {
         sleep (1);
         client->attemptReconnect();

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -1,5 +1,6 @@
 #include "fss-transport.hpp"
 
+#include <atomic>
 #include <string>
 #include <list>
 #include <mutex>
@@ -79,9 +80,10 @@ public:
 
 class fss_client: public transport::fss_message_cb {
 private:
-    bool identified{false};
-    bool aircraft{false};
+    std::atomic<bool> identified{false};
+    std::atomic<bool> aircraft{false};
     std::string name{};
+    std::mutex client_lock{};
     std::list<std::shared_ptr<fss_client_rtt>> outstanding_rtt_requests{};
     auto getName() -> std::string;
     uint64_t last_command_send_ts{0};

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -105,7 +105,7 @@ public:
 };
 
 class fss_connection {
-    bool run{false};
+    std::atomic<bool> run{false};
     std::atomic<int> fd{-1};
     uint64_t last_msg_id{0};
     fss_message_cb *handler{nullptr};

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <sys/types.h>
 #include <thread>
@@ -105,7 +106,7 @@ public:
 
 class fss_connection {
     bool run{false};
-    int fd{-1};
+    std::atomic<int> fd{-1};
     uint64_t last_msg_id{0};
     fss_message_cb *handler{nullptr};
     std::queue<std::shared_ptr<fss_message>> messages{};

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -227,6 +227,7 @@ flight_safety_system::server::fss_client::~fss_client() = default;
 void
 flight_safety_system::server::fss_client::sendCommand()
 {
+    std::lock_guard<std::mutex> guard(this->client_lock);
     uint64_t ts = fss_current_timestamp();
     auto ac = dbc->asset_get_command(this->name);
     constexpr int timeout_time = 10 * sec_to_msec;
@@ -262,6 +263,7 @@ flight_safety_system::server::fss_client::isAircraft() -> bool
 auto
 flight_safety_system::server::fss_client::getName() -> std::string
 {
+    std::lock_guard<std::mutex> guard(this->client_lock);
     return this->name;
 }
 
@@ -271,13 +273,21 @@ flight_safety_system::server::fss_client::sendRTTRequest(const std::shared_ptr<f
 {
     uint64_t ts = fss_current_timestamp();
     this->getConnection()->sendMsg(rtt_req);
-    this->outstanding_rtt_requests.push_back(std::make_shared<fss_client_rtt>(ts, rtt_req->getId()));
+    {
+        std::lock_guard<std::mutex> guard(this->client_lock);
+        this->outstanding_rtt_requests.push_back(std::make_shared<fss_client_rtt>(ts, rtt_req->getId()));
+    }
 }
 
 void
 flight_safety_system::server::fss_client::sendSMMSettings()
 {
-    auto smm = dbc->asset_get_smm_settings(this->name);
+    std::string client_name;
+    {
+        std::lock_guard<std::mutex> guard(this->client_lock);
+        client_name = this->name;
+    }
+    auto smm = dbc->asset_get_smm_settings(client_name);
     if (smm != nullptr)
     {
         auto settings_msg = std::make_shared<flight_safety_system::transport::fss_message_smm_settings>(smm->getAddress(), smm->getUsername(), smm->getPassword());
@@ -320,8 +330,9 @@ flight_safety_system::server::fss_client::processMessage(std::shared_ptr<flight_
             auto identity_msg = std::dynamic_pointer_cast<flight_safety_system::transport::fss_message_identity>(msg);
             if (identity_msg != nullptr)
             {
-                this->name = identity_msg->getName();
+                auto client_name = identity_msg->getName();
                 auto possible_names = this->getConnection()->getClientNames();
+                bool name_valid = false;
                 if (possible_names.empty())
                 {
                     /* No client names, so accept anything */
@@ -331,19 +342,24 @@ flight_safety_system::server::fss_client::processMessage(std::shared_ptr<flight_
                 {
                     for (const auto &possible_name: possible_names)
                     {
-                        if (possible_name == this->name)
+                        if (possible_name == client_name)
                         {
-                            this->identified = true;
+                            name_valid = true;
                             break;
                         }
                     }
                 }
-                if (!this->identified)
+                if (!name_valid)
                 {
                     clients->clientDisconnected(this);
                     return;
                 }
+                {
+                    std::lock_guard<std::mutex> guard(this->client_lock);
+                    this->name = std::move(client_name);
+                }
                 this->aircraft = true;
+                this->identified = true;
                 /* send the current command */
                 this->sendCommand();
                 /* send SMM config and servers list */
@@ -387,6 +403,7 @@ flight_safety_system::server::fss_client::processMessage(std::shared_ptr<flight_
                 auto rtt_resp_msg = std::dynamic_pointer_cast<flight_safety_system::transport::fss_message_rtt_response>(msg);
                 if (rtt_resp_msg != nullptr)
                 {
+                    std::lock_guard<std::mutex> guard(this->client_lock);
                     for(const auto &req : this->outstanding_rtt_requests)
                     {
                         if(req->getRequestId() == rtt_resp_msg->getRequestId())
@@ -394,10 +411,13 @@ flight_safety_system::server::fss_client::processMessage(std::shared_ptr<flight_
                             rtt_req = req;
                         }
                     }
+                    if (rtt_req != nullptr)
+                    {
+                        this->outstanding_rtt_requests.remove(rtt_req);
+                    }
                 }
                 if (rtt_req != nullptr)
                 {
-                    this->outstanding_rtt_requests.remove(rtt_req);
 #ifdef DEBUG
                     std::cout << "RTT for " << this->getName() << " is " << (current_ts - rtt_req->getTimeStamp()) << std::endl;
 #endif

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -10,6 +10,7 @@
 #include <list>
 #include <memory>
 #include <mutex>
+#include <atomic>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Weffc++"
@@ -130,7 +131,7 @@ private:
     std::list<std::shared_ptr<flight_safety_system::server::fss_client>> clients{};
     std::queue<std::shared_ptr<flight_safety_system::server::fss_client>> disconnected{};
     uint32_t total_clients{0};
-    bool shutting_down{false};
+    std::atomic<bool> shutting_down{false};
 public:
     server_clients() = default;
     ~server_clients() {
@@ -444,11 +445,11 @@ flight_safety_system::server::fss_client::processMessage(std::shared_ptr<flight_
     }
 }
 
-bool running = true;
+volatile sig_atomic_t running = 1;
 
 void sigIntHandler(int signum __attribute__((unused)))
 {
-    running = false;
+    running = 0;
 }
 
 auto
@@ -521,7 +522,7 @@ main(int argc, char *argv[]) -> int
 
     int counter = 0;
     constexpr int send_config_period = 15;
-    while (running)
+    while (running == 1)
     {
         sleep (1);
         clients->cleanupRemovableClients();

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -56,11 +56,10 @@ flight_safety_system::transport::fss_connection::fss_connection(int t_fd) : fd(t
 void
 flight_safety_system::transport::fss_connection::disconnect()
 {
-    if (this->fd != -1)
+    int orig_fd = this->fd.exchange(-1);
+    if (orig_fd != -1)
     {
-        int orig_fd = this->fd;
-        this->fd = -1;
-        shutdown(orig_fd, 2);
+        shutdown(orig_fd, SHUT_RDWR);
         close(orig_fd);
     }
     if (this->recv_thread.joinable())
@@ -146,16 +145,17 @@ flight_safety_system::transport::fss_connection::connectTo(const std::string &ad
         std::cout << "Trying to connect to " << address << " (" << addr_str << "):" << port << std::endl;
 #endif
 
-    if (this->fd == -1)
+    if (this->fd.load() == -1)
     {
-        this->fd = socket(remote.ss_family == AF_INET ? PF_INET : PF_INET6, SOCK_STREAM, IPPROTO_TCP);
+        this->fd.store(socket(remote.ss_family == AF_INET ? PF_INET : PF_INET6, SOCK_STREAM, IPPROTO_TCP));
     }
 
+    int current_fd = this->fd.load();
     // Limit the total number of SYN's that are sent
     int synRetries = 2;
-    setsockopt(this->fd, IPPROTO_TCP, TCP_SYNCNT, &synRetries, sizeof(synRetries));
+    setsockopt(current_fd, IPPROTO_TCP, TCP_SYNCNT, &synRetries, sizeof(synRetries));
 
-    if (connect(this->fd, reinterpret_cast<struct sockaddr *>(&remote), remote.ss_family == AF_INET ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6)) < 0)
+    if (connect(current_fd, reinterpret_cast<struct sockaddr *>(&remote), remote.ss_family == AF_INET ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6)) < 0)
     {
         perror(("Failed to connect to " + address).c_str());
         return false;
@@ -200,6 +200,11 @@ print_bl(std::shared_ptr<flight_safety_system::transport::buf_len> bl)
 auto
 flight_safety_system::transport::fss_connection::sendMsg(const std::shared_ptr<buf_len> &bl) -> bool
 {
+    int current_fd = this->fd.load();
+    if (current_fd == -1)
+    {
+        return false;
+    }
     size_t sent = 0;
     size_t to_send = bl->getLength();
     const char *data = bl->getData();
@@ -208,7 +213,7 @@ flight_safety_system::transport::fss_connection::sendMsg(const std::shared_ptr<b
 #endif
     while (sent < to_send)
     {
-        ssize_t transfered = send(this->fd, &data[sent], to_send - sent, 0);
+        ssize_t transfered = send(current_fd, &data[sent], to_send - sent, 0);
         if (transfered < 0)
         {
             return false;
@@ -236,19 +241,24 @@ flight_safety_system::transport::fss_connection::setHandler(fss_message_cb *cb)
 auto
 flight_safety_system::transport::fss_connection::recvBytes(void *t_bytes, size_t t_max_bytes) -> ssize_t
 {
-    return recv(this->fd, t_bytes, t_max_bytes, 0);
+    int current_fd = this->fd.load();
+    if (current_fd == -1)
+    {
+        return -1;
+    }
+    return recv(current_fd, t_bytes, t_max_bytes, 0);
 }
 
 auto
 flight_safety_system::transport::fss_connection::getFd() -> int
 {
-    return this->fd;
+    return this->fd.load();
 }
 
 void
 flight_safety_system::transport::fss_connection::setFd(int new_fd)
 {
-    this->fd = new_fd;
+    this->fd.store(new_fd);
 }
 
 void

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -86,8 +86,8 @@ auto flight_safety_system::transport::fss_connection::getMessageId() -> uint64_t
 void
 flight_safety_system::transport::fss_connection::processMessages()
 {
-    this->run = true;
-    while (this->run)
+    this->run.store(true);
+    while (this->run.load())
     {
         auto msg = this->recvMsg();
         if (msg == nullptr)
@@ -97,7 +97,7 @@ flight_safety_system::transport::fss_connection::processMessages()
         if (msg && msg->getType() == message_type_closed)
         {
             std::cerr << "Remote closed the connection" << std::endl;
-            this->run = false;
+            this->run.store(false);
         }
         if (this->handler != nullptr)
         {


### PR DESCRIPTION
## Description

Use atomic wrappers to avoid concurrent access

## Summary by Sourcery

Strengthen thread-safety and signal-safety in the server and transport layers by introducing atomic state variables and proper locking.

Bug Fixes:
- Guard client name and RTT request list accesses with a mutex to avoid concurrent data races.
- Use an atomic file descriptor and run flag in the transport connection to prevent races between sender, receiver, and disconnect logic.
- Replace plain global running flags with sig_atomic_t for signal-safe shutdown handling.