### PR TITLE
Use lock_guard in db.cpp instead of manual lock/unlock

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -5,6 +5,7 @@ extern "C" {
 #include "server-db.h"
 }
 
+#include <mutex>
 #include <string>
 
 flight_safety_system::server::db_connection::db_connection(const std::string &host, const std::string &user, const std::string &pass, const std::string &db) : db_lock()
@@ -20,111 +21,108 @@ flight_safety_system::server::db_connection::~db_connection()
 auto
 flight_safety_system::server::db_connection::check_asset(const std::string &asset_name) -> bool
 {
-    this->db_lock.lock();
+    std::lock_guard<std::mutex> guard(this->db_lock);
     uint64_t asset_id = db_get_asset_id(asset_name.c_str());
-    this->db_lock.unlock();
     return asset_id != 0;
 }
 
 void
 flight_safety_system::server::db_connection::asset_add_rtt(const std::string &asset_name, uint64_t delta)
 {
-    this->db_lock.lock();
+    std::lock_guard<std::mutex> guard(this->db_lock);
     uint64_t asset_id = db_get_asset_id(asset_name.c_str());
     if (asset_id != 0)
     {
         db_rtt_create_entry(asset_id, delta);
     }
-    this->db_lock.unlock();
 }
 
 void
 flight_safety_system::server::db_connection::asset_add_status(const std::string &asset_name, uint8_t bat_percent, uint32_t bat_mah_used, double bat_voltage)
 {
-    this->db_lock.lock();
+    std::lock_guard<std::mutex> guard(this->db_lock);
     uint64_t asset_id = db_get_asset_id(asset_name.c_str());
     if (asset_id != 0)
     {
         db_status_create_entry(asset_id, bat_percent, bat_mah_used, bat_voltage);
     }
-    this->db_lock.unlock();
 }
 
 void
 flight_safety_system::server::db_connection::asset_add_search_status(const std::string &asset_name, uint64_t search_id, uint64_t search_completed, uint64_t search_total)
 {
-    this->db_lock.lock();
+    std::lock_guard<std::mutex> guard(this->db_lock);
     uint64_t asset_id = db_get_asset_id(asset_name.c_str());
     if (asset_id != 0)
     {
         db_search_status_create_entry(asset_id, search_id, search_completed, search_total);
     }
-    this->db_lock.unlock();
 }
 
 void
 flight_safety_system::server::db_connection::asset_add_position(const std::string &asset_name, double latitude, double longitude, uint16_t altitude)
 {
-    this->db_lock.lock();
+    std::lock_guard<std::mutex> guard(this->db_lock);
     uint64_t asset_id = db_get_asset_id(asset_name.c_str());
     if (asset_id != 0)
     {
         db_position_create_entry(asset_id, latitude, longitude, altitude);
     }
-    this->db_lock.unlock();
 }
 
 auto
 flight_safety_system::server::db_connection::asset_get_command(const std::string &asset_name) -> std::shared_ptr<asset_command>
 {
-    this->db_lock.lock();
-    uint64_t asset_id = db_get_asset_id(asset_name.c_str());
-    if (asset_id != 0)
+    std::shared_ptr<asset_command> res = nullptr;
     {
-        struct asset_command_s *command = db_asset_command_get(asset_id);
-        if (command)
+        std::lock_guard<std::mutex> guard(this->db_lock);
+        uint64_t asset_id = db_get_asset_id(asset_name.c_str());
+        if (asset_id != 0)
         {
-            this->db_lock.unlock();
-            auto res = std::make_shared<asset_command>(command->dbid, command->timestamp, std::string(command->command), command->latitude, command->longitude, command->altitude);
-            free (command->command);
-            free (command);
-            return res;
+            struct asset_command_s *command = db_asset_command_get(asset_id);
+            if (command)
+            {
+                res = std::make_shared<asset_command>(command->dbid, command->timestamp, std::string(command->command), command->latitude, command->longitude, command->altitude);
+                free (command->command);
+                free (command);
+            }
         }
     }
-    this->db_lock.unlock();
-    return nullptr;
+    return res;
 }
 
 auto
 flight_safety_system::server::db_connection::asset_get_smm_settings(const std::string &asset_name) -> std::shared_ptr<smm_settings>
 {
-    this->db_lock.lock();
-    uint64_t asset_id = db_get_asset_id(asset_name.c_str());
-    if (asset_id != 0)
+    std::shared_ptr<smm_settings> res = nullptr;
     {
-        struct smm_settings_s *settings = db_asset_smm_settings_get(asset_id);
-        if (settings)
+        std::lock_guard<std::mutex> guard(this->db_lock);
+        uint64_t asset_id = db_get_asset_id(asset_name.c_str());
+        if (asset_id != 0)
         {
-            this->db_lock.unlock();
-            auto res = std::make_shared<smm_settings>(std::string(settings->address), std::string(settings->username), std::string(settings->password));
-            free (settings->address);
-            free (settings->username);
-            free (settings->password);
-            free (settings);
-            return res;
+            struct smm_settings_s *settings = db_asset_smm_settings_get(asset_id);
+            if (settings)
+            {
+                res = std::make_shared<smm_settings>(std::string(settings->address), std::string(settings->username), std::string(settings->password));
+                free (settings->address);
+                free (settings->username);
+                free (settings->password);
+                free (settings);
+            }
         }
     }
-    this->db_lock.unlock();
-    return nullptr;
+    return res;
 }
 
 auto
 flight_safety_system::server::db_connection::get_active_fss_servers() -> std::list<std::shared_ptr<fss_server_details>>
 {
     std::list<std::shared_ptr<fss_server_details>> res;
-    this->db_lock.lock();
-    struct fss_server_s **servers = db_active_fss_servers_get();
-    this->db_lock.unlock();
+    struct fss_server_s **servers = nullptr;
+    {
+        std::lock_guard<std::mutex> guard(this->db_lock);
+        servers = db_active_fss_servers_get();
+    }
     if (servers)
     {
         for(size_t i = 0; servers[i] != nullptr; i++)


### PR DESCRIPTION
## Summary by Sourcery

Replace manual mutex lock/unlock operations in the database connection with RAII-based locking to improve thread-safety and exception safety.

Enhancements:
- Use std::lock_guard with the existing mutex in db_connection methods instead of explicit lock()/unlock() calls.
- Simplify asset_get_command and asset_get_smm_settings to return shared_ptr results created within a scoped lock while ensuring proper cleanup of C-style resources.
- Restrict the scope of database mutex locking in get_active_fss_servers to only the server retrieval call.