### PR TITLE
Use create factory to avoid passing this to recv_thread from constructor

### DIFF
--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -120,9 +120,10 @@ protected:
     auto getFd() -> int;
     void setFd(int new_fd);
     void startRecvThread(std::thread t_recv_thread);
+    explicit fss_connection(int fd);
 public:
     fss_connection();
-    explicit fss_connection(int fd);
+    static auto create(int fd) -> std::shared_ptr<fss_connection>;
     fss_connection(fss_connection&) = delete;
     fss_connection(fss_connection&&) = delete;
     auto operator=(fss_connection &) -> fss_connection& = delete;

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -47,8 +47,16 @@ recv_msg_thread(flight_safety_system::transport::fss_connection *conn)
     conn->processMessages();
 }
 
-flight_safety_system::transport::fss_connection::fss_connection(int t_fd) : fd(t_fd), recv_thread(std::thread(recv_msg_thread, this))
+flight_safety_system::transport::fss_connection::fss_connection(int t_fd) : fd(t_fd)
 {
+}
+
+auto
+flight_safety_system::transport::fss_connection::create(int t_fd) -> std::shared_ptr<fss_connection>
+{
+    auto conn = std::shared_ptr<fss_connection>(new fss_connection(t_fd));
+    conn->startRecvThread(std::thread(recv_msg_thread, conn.get()));
+    return conn;
 }
 
 void
@@ -383,7 +391,7 @@ flight_safety_system::transport::fss_listen::processMessages()
 auto
 flight_safety_system::transport::fss_listen::newConnection(int t_newfd) -> std::shared_ptr<flight_safety_system::transport::fss_connection>
 {
-    return std::make_shared<flight_safety_system::transport::fss_connection>(t_newfd);
+    return flight_safety_system::transport::fss_connection::create(t_newfd);
 }
 
 auto


### PR DESCRIPTION
## Summary by Sourcery

Introduce a factory method for fss_connection to manage recv thread startup without passing this from the constructor.

Enhancements:
- Add a static create factory method on fss_connection that constructs the connection and starts its receive thread.
- Update fss_listen::newConnection to create connections via the new factory instead of direct construction.