### PR TITLE
Improve message locking

### DIFF
--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -112,6 +112,7 @@ class fss_connection {
     std::queue<std::shared_ptr<fss_message>> messages{};
     std::thread recv_thread{};
     std::mutex send_lock{};
+    std::mutex msg_lock{};
 protected:
     auto recvMsg() -> std::shared_ptr<fss_message>;
     auto getMessageId() -> uint64_t;

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -106,14 +106,16 @@ flight_safety_system::transport::fss_connection::processMessages()
             std::cerr << "Remote closed the connection" << std::endl;
             this->run.store(false);
         }
-        if (this->handler != nullptr)
-        {
-            this->handler->processMessage(msg);
-        }
-        else
         {
             std::lock_guard<std::mutex> lock_holder(this->msg_lock);
-            this->messages.push(msg);
+            if (this->handler != nullptr)
+            {
+                this->handler->processMessage(msg);
+            }
+            else
+            {
+                this->messages.push(msg);
+            }
         }
     }
 }
@@ -121,9 +123,9 @@ flight_safety_system::transport::fss_connection::processMessages()
 auto
 flight_safety_system::transport::fss_connection::getMsg() -> std::shared_ptr<flight_safety_system::transport::fss_message>
 {
+    std::lock_guard<std::mutex> lock_holder(this->msg_lock);
     if (this->handler == nullptr)
     {
-        std::lock_guard<std::mutex> lock_holder(this->msg_lock);
         if (!this->messages.empty())
         {
             auto msg = this->messages.front();

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -282,7 +282,12 @@ flight_safety_system::transport::fss_connection::recvMsg() -> std::shared_ptr<fl
     std::string data;
     data.resize(sizeof (uint16_t));
     ssize_t received = this->recvBytes(&data[0], data.size());
-    if (received == static_cast<ssize_t>(data.size()))
+    if(received <= 0 || errno == EBADF)
+    {
+        /* Connection was closed */
+        msg = std::make_shared<flight_safety_system::transport::fss_message_closed>();
+    }
+    else if (received == static_cast<ssize_t>(data.size()))
     {
         uint16_t data_length_n;
         memcpy(&data_length_n, data.data(), sizeof(uint16_t));
@@ -302,6 +307,11 @@ flight_safety_system::transport::fss_connection::recvMsg() -> std::shared_ptr<fl
                 perror("Error receiving data");
                 break;
             }
+            else if (this_time == 0)
+            {
+                /* Connection was closed */
+                break;
+            }
             received += this_time;
         }
         if (received == total_length)
@@ -317,11 +327,6 @@ flight_safety_system::transport::fss_connection::recvMsg() -> std::shared_ptr<fl
         {
             perror ("Failed to get all the data: ");
         }
-    }
-    else if(received == 0 || (received < 0 || errno == EBADF))
-    {
-        /* Connection was closed */
-        msg = std::make_shared<flight_safety_system::transport::fss_message_closed>();
     }
     else
     {

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -99,8 +99,9 @@ flight_safety_system::transport::fss_connection::processMessages()
         if (msg == nullptr)
         {
             std::cerr << "Got a null msg" << std::endl;
+            continue;
         }
-        if (msg && msg->getType() == message_type_closed)
+        if (msg->getType() == message_type_closed)
         {
             std::cerr << "Remote closed the connection" << std::endl;
             this->run.store(false);

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -112,6 +112,7 @@ flight_safety_system::transport::fss_connection::processMessages()
         }
         else
         {
+            std::lock_guard<std::mutex> lock_holder(this->msg_lock);
             this->messages.push(msg);
         }
     }
@@ -122,6 +123,7 @@ flight_safety_system::transport::fss_connection::getMsg() -> std::shared_ptr<fli
 {
     if (this->handler == nullptr)
     {
+        std::lock_guard<std::mutex> lock_holder(this->msg_lock);
         if (!this->messages.empty())
         {
             auto msg = this->messages.front();
@@ -233,6 +235,7 @@ flight_safety_system::transport::fss_connection::sendMsg(const std::shared_ptr<b
 void
 flight_safety_system::transport::fss_connection::setHandler(fss_message_cb *cb)
 {
+    std::lock_guard<std::mutex> lock_holder(this->msg_lock);
     this->handler = cb;
     if (this->handler != nullptr)
     {


### PR DESCRIPTION
## Summary by Sourcery

Improve message processing robustness and thread safety in the transport connection.

Bug Fixes:
- Avoid dereferencing null messages and correctly skip them during processing.
- Treat zero or negative reads and bad file descriptors as closed connections when receiving messages, including during partial data reads.

Enhancements:
- Synchronize access to the message handler and message queue with a dedicated mutex to prevent concurrent access issues.