### PR TITLE
Don't leak fd on failed connect/bind/listen

### DIFF
--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -11,6 +11,7 @@
 #include <sys/types.h>
 #include <thread>
 #include <netinet/tcp.h>
+#include <unistd.h>
 
 #ifdef DEBUG
 // This is defined in transport.cpp
@@ -97,6 +98,8 @@ flight_safety_system::transport_ssl::fss_connection_client::connectTo(const std:
     if (connect(this->getFd(), reinterpret_cast<struct sockaddr *>(&remote), remote.ss_family == AF_INET ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6)) < 0)
     {
         perror(("Failed to connect to " + address).c_str());
+        close(this->getFd());
+        this->setFd(-1);
         return false;
     }
 

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -169,6 +169,8 @@ flight_safety_system::transport::fss_connection::connectTo(const std::string &ad
     if (connect(current_fd, reinterpret_cast<struct sockaddr *>(&remote), remote.ss_family == AF_INET ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6)) < 0)
     {
         perror(("Failed to connect to " + address).c_str());
+        close(current_fd);
+        this->fd.store(-1);
         return false;
     }
 
@@ -419,11 +421,15 @@ flight_safety_system::transport::fss_listen::startListening() -> bool
     if (bind(this->getFd(), reinterpret_cast<struct sockaddr *>(&bind_addr), sizeof(bind_addr)) < 0)
     {
         perror("Failed to bind socket: ");
+        close(this->getFd());
+        this->setFd(-1);
         return false;
     }
     if(listen(this->getFd(), this->max_pending_connections) < 0)
     {
         perror("Failed to listen on socket: ");
+        close(this->getFd());
+        this->setFd(-1);
         return false;
     }
     this->startRecvThread(std::thread(listen_thread, this));


### PR DESCRIPTION
## Summary by Sourcery

Prevent file descriptor leaks when socket operations fail in transport components.

Bug Fixes:
- Close and invalidate the connection socket descriptor when connect fails in non-SSL transport.
- Close and invalidate the listening socket descriptor when bind or listen fail.
- Close and invalidate the connection socket descriptor when connect fails in SSL transport client.

Enhancements:
- Include unistd header in SSL transport implementation to support socket closure.