### PR TITLE
Return a different code from recvBytes when the connect is invalid

### DIFF
--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -235,7 +235,7 @@ flight_safety_system::transport_ssl::fss_connection::recvBytes(void *t_bytes, si
     if (!this->usable)
     {
         std::cerr << "Attempt to recv on unusable transport_ssl::fss_connection" << std::endl;
-        return -1;
+        return -2;
     }
     ssize_t bytes_recved = -1;
     try
@@ -245,6 +245,10 @@ flight_safety_system::transport_ssl::fss_connection::recvBytes(void *t_bytes, si
     catch (gnutls::exception &ex)
     {
         std::cerr << "recv: caught gnutls exception: " << ex.get_code() << ", " << ex.what() << std::endl;
+        if (ex.get_code() != GNUTLS_E_AGAIN)
+        {
+            this->usable = false;
+        }
     }
     return bytes_recved;
 }

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -256,9 +256,9 @@ auto
 flight_safety_system::transport::fss_connection::recvBytes(void *t_bytes, size_t t_max_bytes) -> ssize_t
 {
     int current_fd = this->fd.load();
-    if (current_fd == -1)
+    if (current_fd < 0)
     {
-        return -1;
+        return -2;
     }
     return recv(current_fd, t_bytes, t_max_bytes, 0);
 }
@@ -289,7 +289,7 @@ flight_safety_system::transport::fss_connection::recvMsg() -> std::shared_ptr<fl
     std::string data;
     data.resize(sizeof (uint16_t));
     ssize_t received = this->recvBytes(&data[0], data.size());
-    if(received <= 0 || errno == EBADF)
+    if((received == -2) || (received < 0 && errno == EBADF) || received == 0)
     {
         /* Connection was closed */
         msg = std::make_shared<flight_safety_system::transport::fss_message_closed>();
@@ -337,6 +337,7 @@ flight_safety_system::transport::fss_connection::recvMsg() -> std::shared_ptr<fl
     }
     else
     {
+        std::cerr << "Failed to get the message length, got " << received << " bytes instead of " << sizeof(uint16_t) << std::endl;
         perror("Failed to get header: ");
     }
     return msg;


### PR DESCRIPTION
The current code always returned -1, but didn't set errno, so the recvMsg function couldn't tell whether the connection was lost or some other error occurred.

## Summary by Sourcery

Differentiate between invalid connections and other receive errors in transport connection handling.

Bug Fixes:
- Return a distinct error code from recvBytes when the connection/file descriptor is invalid so recvMsg can correctly detect closed connections.
- Adjust recvMsg logic to treat explicit invalid-connection results, EBADF errors, and zero-length reads as connection closures.
- Update SSL transport to return the new invalid-connection error code and mark the connection unusable on non-retryable GnuTLS exceptions.
- Log detailed errors when failing to read the message length header to aid diagnosis of receive failures.