### PR TITLE
Avoid the possibility of integer overflow

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -539,7 +539,7 @@ main(int argc, char *argv[]) -> int
        - Per client, send RTT message
      */
 
-    int counter = 0;
+    uint64_t counter = 0;
     constexpr int send_config_period = 15;
     while (running == 1)
     {


### PR DESCRIPTION
This would take many years, but if it was later changed to more frequent updating it may be an issue.

## Summary by Sourcery

Bug Fixes:
- Use a 64-bit unsigned counter type for the main loop counter to avoid integer overflow over long runtimes.