### PR TITLE
Send all bytes ssl

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -166,8 +166,8 @@ public:
     void clientDisconnected(flight_safety_system::server::fss_client *client)
     {
         /* If we are shutting down, don't worry */
-        if (this->shutting_down) return;
         std::lock_guard<std::mutex> guard(this->lock);
+        if (this->shutting_down) return;
         for (const auto &c : this->clients)
         {
             if (c.get() == client)

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -218,13 +218,26 @@ flight_safety_system::transport_ssl::fss_connection::sendMsg(const std::shared_p
     }
     size_t to_send = bl->getLength();
     const char *data = bl->getData();
-    try
+    size_t sent = 0;
+    while (sent < to_send)
     {
-        this->session->send(data, to_send);
-    }
-    catch (gnutls::exception &ex)
-    {
-        std::cerr << "send: caught gnutls exception: " << ex.get_code() << ", " << ex.what() << std::endl;        
+        ssize_t transferred = 0;
+        try
+        {
+            transferred = this->session->send(&data[sent], to_send - sent);
+        }
+        catch (gnutls::exception &ex)
+        {
+            std::cerr << "send: caught gnutls exception: " << ex.get_code() << ", " << ex.what() << std::endl;
+            this->usable = false;
+            return false;
+        }
+        if (transferred <= 0)
+        {
+            this->usable = false;
+            return false;
+        }
+        sent += transferred;
     }
     return true;
 }


### PR DESCRIPTION
## Summary by Sourcery

Ensure SSL transport sends entire message buffers and tighten client disconnection handling during server shutdown.

Bug Fixes:
- Loop SSL send operations until all bytes are transmitted or a failure occurs, marking the connection unusable on errors.
- Guard client disconnection handling with the server mutex before checking shutdown state to avoid race conditions.