### PR TITLE
Make last_msg_id atomic

### DIFF
--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -108,7 +108,7 @@ public:
 class fss_connection {
     std::atomic<bool> run{false};
     std::atomic<int> fd{-1};
-    uint64_t last_msg_id{0};
+    std::atomic<uint64_t> last_msg_id{0};
     fss_message_cb *handler{nullptr};
     std::queue<std::shared_ptr<fss_message>> messages{};
     std::thread recv_thread{};


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Improve concurrency safety of the connection state by making the last message ID field atomic.