### PR TITLE
Set REUSEADDR on the server socket to allow faster restarting

### DIFF
--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -425,7 +425,14 @@ flight_safety_system::transport::fss_listen::startListening() -> bool
     if (this->getFd() < 0)
     {
         this->setFd(socket(PF_INET6, SOCK_STREAM, IPPROTO_TCP));
+        if (this->getFd() < 0)
+        {
+            perror("Failed to open socket: ");
+            return false;
+        }
     }
+    int reuse = 1;
+    setsockopt(this->getFd(), SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
     struct sockaddr_in6 bind_addr = {};
     bind_addr.sin6_family = AF_INET6;
     bind_addr.sin6_port = htons(this->port);


### PR DESCRIPTION
## Summary by Sourcery

Set the server's IPv6 listening socket to be reusable and improve error handling when socket creation fails.

Enhancements:
- Enable SO_REUSEADDR on the server listening socket to allow faster restarts and port reuse.
- Add explicit error handling and early return when the server socket cannot be created.