### PR TITLE
Add structured logging via fss-log.hpp

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,7 +12,7 @@ AM_CPPFLAGS += $(CODE_COVERAGE_CPPFLAGS)
 bin_PROGRAMS =
 sbin_PROGRAMS =
 lib_LTLIBRARIES = libfss.la libfss-transport.la
-include_HEADERS = fss.hpp
+include_HEADERS = fss.hpp fss-log.hpp
 pkgconfig_DATA = fss.pc
 
 libfss_la_LDFLAGS = -version-info 0:0:0

--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -1,8 +1,8 @@
 #include <fss-client-ssl.hpp>
+#include "fss-log.hpp"
 
 #include <iostream>
 #include <fstream>
-#include <ostream>
 #include <string>
 #include <utility>
 
@@ -17,7 +17,7 @@ flight_safety_system::client_ssl::fss_client::fss_client(const std::string &t_fi
     std::ifstream configfile(t_fileName);
     if (!configfile.is_open())
     {
-        std::cerr << "Failed to load configuration" << std::endl;
+        FSS_LOG_ERROR("client", "Failed to load configuration");
         return;
     }
     Json::Value config;

--- a/src/fss-log.hpp
+++ b/src/fss-log.hpp
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <iostream>
+#include <mutex>
+#include <sstream>
+#include <string>
+
+namespace flight_safety_system {
+namespace log {
+
+enum class level : int {
+    ERROR = 0,
+    WARN  = 1,
+    INFO  = 2,
+    DEBUG = 3,
+};
+
+namespace detail {
+
+inline std::atomic<level> & current_level()
+{
+    static std::atomic<level> lvl{[]() -> level {
+        level l = level::INFO;
+        const char *env = std::getenv("FSS_LOG_LEVEL");
+        if (env == nullptr) { return l; }
+        std::string s{env};
+        if (s == "error" || s == "ERROR")      { l = level::ERROR; }
+        else if (s == "warn"  || s == "WARN")  { l = level::WARN;  }
+        else if (s == "info"  || s == "INFO")  { l = level::INFO;  }
+        else if (s == "debug" || s == "DEBUG") { l = level::DEBUG; }
+        return l;
+    }()};
+    return lvl;
+}
+
+inline std::mutex & log_mutex()
+{
+    static std::mutex m;
+    return m;
+}
+
+inline const char * level_str(level lvl)
+{
+    switch (lvl)
+    {
+        case level::ERROR: return "ERROR";
+        case level::WARN:  return "WARN ";
+        case level::INFO:  return "INFO ";
+        case level::DEBUG: return "DEBUG";
+    }
+    return "?????";
+}
+
+} // namespace detail
+
+inline void set_level(const std::string &lvl_str)
+{
+    if (lvl_str == "error" || lvl_str == "ERROR")      { detail::current_level() = level::ERROR; }
+    else if (lvl_str == "warn"  || lvl_str == "WARN")  { detail::current_level() = level::WARN;  }
+    else if (lvl_str == "info"  || lvl_str == "INFO")  { detail::current_level() = level::INFO;  }
+    else if (lvl_str == "debug" || lvl_str == "DEBUG") { detail::current_level() = level::DEBUG; }
+}
+
+inline void write(level lvl, const char *component, const std::string &msg)
+{
+    std::lock_guard<std::mutex> guard(detail::log_mutex());
+    auto now = std::chrono::system_clock::now();
+    std::time_t t = std::chrono::system_clock::to_time_t(now);
+    char buf[21]{};
+    struct tm gm_tm{};
+    gmtime_r(&t, &gm_tm);
+    std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &gm_tm);
+    std::cerr << buf
+              << " [" << detail::level_str(lvl) << "]"
+              << " [" << component << "] "
+              << msg << "\n";
+}
+
+} // namespace log
+} // namespace flight_safety_system
+
+/* Stream-expression logging: FSS_LOG_ERROR("comp", "val=" << val) */
+#define FSS_LOG(lvl, comp, ...) \
+    do { \
+        auto _fss_log_lvl = (lvl); \
+        if (_fss_log_lvl <= flight_safety_system::log::detail::current_level()) { \
+            std::ostringstream _fss_log_oss; \
+            _fss_log_oss << __VA_ARGS__; \
+            flight_safety_system::log::write(_fss_log_lvl, (comp), _fss_log_oss.str()); \
+        } \
+    } while (false)
+
+#define FSS_LOG_ERROR(comp, ...) FSS_LOG(flight_safety_system::log::level::ERROR, (comp), __VA_ARGS__)
+#define FSS_LOG_WARN(comp, ...)  FSS_LOG(flight_safety_system::log::level::WARN,  (comp), __VA_ARGS__)
+#define FSS_LOG_INFO(comp, ...)  FSS_LOG(flight_safety_system::log::level::INFO,  (comp), __VA_ARGS__)
+#define FSS_LOG_DEBUG(comp, ...) FSS_LOG(flight_safety_system::log::level::DEBUG, (comp), __VA_ARGS__)
+
+/* perror() replacement: appends ": strerror(errno)" to msg (msg must be a string expression) */
+#define FSS_PERROR(comp, msg) \
+    do { \
+        int _fss_saved_errno = errno; \
+        std::string _fss_perror_msg = (msg); \
+        FSS_LOG_ERROR((comp), _fss_perror_msg << ": " << std::strerror(_fss_saved_errno)); \
+    } while (false)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1,6 +1,6 @@
 #include "fss-transport.hpp"
-#include <ostream>
 #include "fss-transport-ssl.hpp"
+#include "fss-log.hpp"
 #include "fss.hpp"
 #include "fss-server.hpp"
 
@@ -339,7 +339,7 @@ flight_safety_system::server::fss_client::processMessage(std::shared_ptr<flight_
                 bool name_valid = false;
                 if (possible_names.empty())
                 {
-                    std::cerr << "Rejecting client: no CN found in certificate" << std::endl;
+                    FSS_LOG_ERROR("server", "Rejecting client: no CN found in certificate");
                 }
                 else
                 {
@@ -496,11 +496,16 @@ main(int argc, char *argv[]) -> int
     std::ifstream configfile(conf_file);
     if (!configfile.is_open())
     {
-        std::cerr << "Failed to load configuration: " << conf_file << std::endl;
+        FSS_LOG_ERROR("server", "Failed to load configuration: " << conf_file);
         exit(-1);
     }
     Json::Value config;
     configfile >> config;
+
+    if (config.isMember("log_level"))
+    {
+        flight_safety_system::log::set_level(config["log_level"].asString());
+    }
 
     /* Connect to database */
     auto dbc = std::make_shared<flight_safety_system::server::db_connection>(config["postgres"]["host"].asString(), config["postgres"]["user"].asString(), config["postgres"]["pass"].asString(), config["postgres"]["db"].asString());
@@ -510,13 +515,13 @@ main(int argc, char *argv[]) -> int
 
     /* Open listen socket */
     std::shared_ptr<flight_safety_system::transport::fss_listen> listen;
-    std::cerr << "Starting fss server in TLS mode" << std::endl;
+    FSS_LOG_INFO("server", "Starting fss server in TLS mode");
     std::string ca_public_key = config["ssl"]["ca_public_key"].asString();
     std::string server_private_key = config["ssl"]["server_private_key"].asString();
     std::string server_public_key = config["ssl"]["server_public_key"].asString();
     if (ca_public_key == "" || server_private_key == "" || server_public_key == "")
     {
-        std::cerr << "Missing ssl parameter, all of these are required: 'ca_public_key', 'server_private_key', 'server_public_key'" << std::endl;
+        FSS_LOG_ERROR("server", "Missing ssl parameter, all of these are required: 'ca_public_key', 'server_private_key', 'server_public_key'");
         exit(-1);
     }
     listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(config["port"].asInt(),

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -1,5 +1,6 @@
 #include "fss-transport-ssl.hpp"
 #include "fss-transport.hpp"
+#include "fss-log.hpp"
 #include "transport.hpp"
 
 #include <cstdint>
@@ -43,7 +44,7 @@ flight_safety_system::transport_ssl::fss_connection::~fss_connection()
         }
         catch (gnutls::exception &ex)
         {
-            std::cerr << "fss_connection shutdown, gnutls exception during bye" << std::endl;
+            FSS_LOG_WARN("ssl", "fss_connection shutdown, gnutls exception during bye");
         }
         this->usable = false;
     }
@@ -75,7 +76,7 @@ flight_safety_system::transport_ssl::fss_connection_client::connectTo(const std:
     struct sockaddr_storage remote = {};
     if (!convert_str_to_sa (address, port, &remote))
     {
-        std::cerr << "Failed to convert '" << address << "' to a usable address\n";
+        FSS_LOG_ERROR("ssl", "Failed to convert '" << address << "' to a usable address");
         return false;
     }
 
@@ -97,7 +98,7 @@ flight_safety_system::transport_ssl::fss_connection_client::connectTo(const std:
 
     if (connect(this->getFd(), reinterpret_cast<struct sockaddr *>(&remote), remote.ss_family == AF_INET ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6)) < 0)
     {
-        perror(("Failed to connect to " + address).c_str());
+        FSS_PERROR("ssl", "Failed to connect to " + address);
         close(this->getFd());
         this->setFd(-1);
         return false;
@@ -143,11 +144,11 @@ flight_safety_system::transport_ssl::fss_connection_client::setupSSL() -> bool
     }
     catch (gnutls::exception &e)
     {
-        std::cerr << "TLS error: " << e.what() << std::endl;
+        FSS_LOG_ERROR("ssl", "TLS error: " << e.what());
     }
     if (ret < 0)
     {
-        std::cerr << "Failed to hand shake: " << ret << std::endl;
+        FSS_LOG_ERROR("ssl", "Failed to hand shake: " << ret);
         return false;
     }
 
@@ -172,11 +173,11 @@ flight_safety_system::transport_ssl::fss_connection_server::setupSSL() -> bool
     }
     catch(gnutls::exception &e)
     {
-        std::cerr << "TLS error: " << e.what() << std::endl;
+        FSS_LOG_ERROR("ssl", "TLS error: " << e.what());
     }
     if (ret < 0)
     {
-        std::cerr << "Failed to hand shake: " << ret << std::endl;
+        FSS_LOG_ERROR("ssl", "Failed to hand shake: " << ret);
         return false;
     }
 
@@ -213,7 +214,7 @@ flight_safety_system::transport_ssl::fss_connection::sendMsg(const std::shared_p
 {
     if (!this->usable)
     {
-        std::cerr << "Attempt to send on unusable transport_ssl::fss_connection" << std::endl;
+        FSS_LOG_ERROR("ssl", "Attempt to send on unusable transport_ssl::fss_connection");
         return false;
     }
     size_t to_send = bl->getLength();
@@ -228,7 +229,7 @@ flight_safety_system::transport_ssl::fss_connection::sendMsg(const std::shared_p
         }
         catch (gnutls::exception &ex)
         {
-            std::cerr << "send: caught gnutls exception: " << ex.get_code() << ", " << ex.what() << std::endl;
+            FSS_LOG_ERROR("ssl", "send: caught gnutls exception: " << ex.get_code() << ", " << ex.what());
             this->usable = false;
             return false;
         }
@@ -247,7 +248,7 @@ flight_safety_system::transport_ssl::fss_connection::recvBytes(void *t_bytes, si
 {
     if (!this->usable)
     {
-        std::cerr << "Attempt to recv on unusable transport_ssl::fss_connection" << std::endl;
+        FSS_LOG_ERROR("ssl", "Attempt to recv on unusable transport_ssl::fss_connection");
         return -2;
     }
     ssize_t bytes_recved = -1;
@@ -257,7 +258,7 @@ flight_safety_system::transport_ssl::fss_connection::recvBytes(void *t_bytes, si
     }
     catch (gnutls::exception &ex)
     {
-        std::cerr << "recv: caught gnutls exception: " << ex.get_code() << ", " << ex.what() << std::endl;
+        FSS_LOG_ERROR("ssl", "recv: caught gnutls exception: " << ex.get_code() << ", " << ex.what());
         if (ex.get_code() != GNUTLS_E_AGAIN)
         {
             this->usable = false;

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <vector>
 #include "fss-transport.hpp"
+#include "fss-log.hpp"
 
 #include <iostream>
 
@@ -101,12 +102,12 @@ flight_safety_system::transport::fss_connection::processMessages()
         auto msg = this->recvMsg();
         if (msg == nullptr)
         {
-            std::cerr << "Got a null msg" << std::endl;
+            FSS_LOG_WARN("transport", "Got a null msg");
             continue;
         }
         if (msg->getType() == message_type_closed)
         {
-            std::cerr << "Remote closed the connection" << std::endl;
+            FSS_LOG_INFO("transport", "Remote closed the connection");
             this->run.store(false);
         }
         {
@@ -148,7 +149,7 @@ flight_safety_system::transport::fss_connection::connectTo(const std::string &ad
     struct sockaddr_storage remote = {};
     if (!convert_str_to_sa (address, port, &remote))
     {
-        std::cerr << "Failed to convert '" << address << "' to a usable address\n";
+        FSS_LOG_ERROR("transport", "Failed to convert '" << address << "' to a usable address");
         return false;
     }
 
@@ -171,7 +172,7 @@ flight_safety_system::transport::fss_connection::connectTo(const std::string &ad
 
     if (connect(current_fd, reinterpret_cast<struct sockaddr *>(&remote), remote.ss_family == AF_INET ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6)) < 0)
     {
-        perror(("Failed to connect to " + address).c_str());
+        FSS_PERROR("transport", "Failed to connect to " + address);
         close(current_fd);
         this->fd.store(-1);
         return false;
@@ -301,7 +302,7 @@ flight_safety_system::transport::fss_connection::recvMsg() -> std::shared_ptr<fl
         }
         if (this_time < 0)
         {
-            perror("Failed to get header");
+            FSS_PERROR("transport", "Failed to get header");
             return std::make_shared<flight_safety_system::transport::fss_message_closed>();
         }
         received += this_time;
@@ -327,7 +328,7 @@ flight_safety_system::transport::fss_connection::recvMsg() -> std::shared_ptr<fl
         ssize_t this_time = this->recvBytes(&data[received], total_length - received);
         if (this_time < 0)
         {
-            perror("Error receiving data");
+            FSS_PERROR("transport", "Error receiving data");
             break;
         }
         else if (this_time == 0)
@@ -348,7 +349,7 @@ flight_safety_system::transport::fss_connection::recvMsg() -> std::shared_ptr<fl
     }
     else
     {
-        perror ("Failed to get all the data: ");
+        FSS_PERROR("transport", "Failed to get all the data");
     }
     return msg;
 }
@@ -390,7 +391,7 @@ flight_safety_system::transport::fss_listen::processMessages()
             {
                 return;
             }
-            perror("Failed to accept: ");
+            FSS_PERROR("transport", "Failed to accept");
             continue;
         }
 #ifdef DEBUG
@@ -427,7 +428,7 @@ flight_safety_system::transport::fss_listen::startListening() -> bool
         this->setFd(socket(PF_INET6, SOCK_STREAM, IPPROTO_TCP));
         if (this->getFd() < 0)
         {
-            perror("Failed to open socket: ");
+            FSS_PERROR("transport", "Failed to open socket");
             return false;
         }
     }
@@ -438,14 +439,14 @@ flight_safety_system::transport::fss_listen::startListening() -> bool
     bind_addr.sin6_port = htons(this->port);
     if (bind(this->getFd(), reinterpret_cast<struct sockaddr *>(&bind_addr), sizeof(bind_addr)) < 0)
     {
-        perror("Failed to bind socket: ");
+        FSS_PERROR("transport", "Failed to bind socket");
         close(this->getFd());
         this->setFd(-1);
         return false;
     }
     if(listen(this->getFd(), this->max_pending_connections) < 0)
     {
-        perror("Failed to listen on socket: ");
+        FSS_PERROR("transport", "Failed to listen on socket");
         close(this->getFd());
         this->setFd(-1);
         return false;


### PR DESCRIPTION
## Description

Replaces all perror/std::cerr calls with a header-only logger that emits ISO-8601 timestamped lines in the format:
  2026-04-16T12:00:00Z [ERROR] [component] message

Log level defaults to INFO and is configurable via the FSS_LOG_LEVEL environment variable or "log_level" key in server.json.

## Summary by Sourcery

Introduce a structured, level-based logging facility and migrate existing transport, SSL, server, and client components to use it instead of direct stderr/perror output.

New Features:
- Add a header-only logging utility that emits timestamped, component-tagged log lines with configurable log levels via environment variable or configuration.
- Provide convenience macros for level-specific logging and a perror-style helper that logs errno-based errors consistently.

Enhancements:
- Replace raw std::cerr and perror calls in transport, SSL transport, server, and SSL client code with structured log calls, including clearer component tagging and log levels.
- Expose the logging header as a public include in the library build configuration.
- Allow server log level to be configured via a log_level field in server JSON configuration.