### PR TITLE
tests: inject IClock seam for deterministic reconnect backoff

### DIFF
--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -246,10 +246,19 @@ flight_safety_system::client_ssl::fss_server::reconnect_to() -> bool
     return this->getConnection()->connectTo(this->getAddress(), this->getPort());
 }
 
+void
+flight_safety_system::client_ssl::fss_server::setClock(std::shared_ptr<flight_safety_system::IClock> t_clock)
+{
+    if (t_clock == nullptr) {
+        return;
+    }
+    this->clock = std::move(t_clock);
+}
+
 auto
 flight_safety_system::client_ssl::fss_server::reconnect() -> bool
 {
-    uint64_t ts = fss_current_timestamp();
+    uint64_t ts = this->clock->now_ms();
     uint64_t elapsed_time = ts - this->last_tried;
 
     if (this->getConnection() != nullptr)

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -1,4 +1,5 @@
 #include <fss-transport-ssl.hpp>
+#include <fss.hpp>
 
 #include <list>
 #include <memory>
@@ -63,8 +64,9 @@ private:
     static constexpr uint64_t retry_delay_start = 1000;
     static constexpr uint64_t retry_delay_cap = 30000;
     uint64_t retry_delay{retry_delay_start};
+    std::shared_ptr<flight_safety_system::IClock> clock{std::make_shared<flight_safety_system::WallClock>()};
 protected:
-    auto reconnect_to() -> bool;
+    virtual auto reconnect_to() -> bool;
 public:
     fss_server(fss_client *t_client, std::string t_address, uint16_t t_port, std::string t_ca, std::string t_private_key, std::string t_public_key);
     fss_server(fss_server &other) = delete;
@@ -78,6 +80,7 @@ public:
     virtual auto reconnect() -> bool;
     virtual auto getClient() -> fss_client *;
     virtual void sendIdentify();
+    void setClock(std::shared_ptr<flight_safety_system::IClock> t_clock);
 };
 
 

--- a/src/fss-main.cpp
+++ b/src/fss-main.cpp
@@ -11,3 +11,9 @@ flight_safety_system::fss_current_timestamp() -> uint64_t
     constexpr int usec_to_msec = 1000;
     return tv.tv_sec * sec_to_msec + (tv.tv_usec / usec_to_msec);
 }
+
+auto
+flight_safety_system::WallClock::now_ms() const -> uint64_t
+{
+    return flight_safety_system::fss_current_timestamp();
+}

--- a/src/fss.hpp
+++ b/src/fss.hpp
@@ -16,5 +16,21 @@
 namespace flight_safety_system {
 
 auto fss_current_timestamp() -> uint64_t;
+
+class IClock {
+public:
+    IClock() = default;
+    IClock(const IClock&) = delete;
+    IClock(IClock&&) = delete;
+    auto operator=(const IClock&) -> IClock& = delete;
+    auto operator=(IClock&&) -> IClock& = delete;
+    virtual ~IClock() = default;
+    virtual auto now_ms() const -> uint64_t = 0;
+};
+
+class WallClock : public IClock {
+public:
+    auto now_ms() const -> uint64_t override;
+};
 } // namespace flight_safety_system
 

--- a/tests/reconnect_test.cpp
+++ b/tests/reconnect_test.cpp
@@ -45,6 +45,29 @@ auto make_listener(uint16_t port)
         port, accept_cb, CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
 }
 
+struct FakeClock : public flight_safety_system::IClock {
+    uint64_t t{0};
+    auto now_ms() const -> uint64_t override { return t; }
+    void advance(uint64_t ms) { t += ms; }
+};
+
+class CountingServer : public flight_safety_system::client_ssl::fss_server {
+public:
+    using fss_server::fss_server;
+    CountingServer(const CountingServer&) = delete;
+    CountingServer(CountingServer&&) = delete;
+    auto operator=(const CountingServer&) -> CountingServer& = delete;
+    auto operator=(CountingServer&&) -> CountingServer& = delete;
+    ~CountingServer() override = default;
+    int attempts{0};
+protected:
+    auto reconnect_to() -> bool override
+    {
+        ++attempts;
+        return false;
+    }
+};
+
 } // namespace
 
 TEST_CASE("reconnect: client reconnects after listener bounce")
@@ -116,6 +139,64 @@ TEST_CASE("reconnect: attemptReconnect is throttled within the retry window")
     for (int i = 0; i < 100; ++i) { client->attemptReconnect(); }
     auto elapsed = std::chrono::steady_clock::now() - start;
     REQUIRE(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count() < 500);
+}
+
+TEST_CASE("reconnect: fake clock throttles attempts within retry window")
+{
+    auto client = std::make_shared<flight_safety_system::client_ssl::fss_client>(
+        CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+    auto server = std::make_shared<CountingServer>(
+        client.get(), "127.0.0.1", static_cast<uint16_t>(20599),
+        CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+    auto fake = std::make_shared<FakeClock>();
+    server->setClock(fake);
+
+    /* last_tried starts at 0 and retry_delay at 1000ms. The throttle is
+     * strict >: elapsed of exactly 1000 is still a no-op. */
+    server->reconnect();
+    REQUIRE(server->attempts == 0);
+
+    fake->advance(1000);
+    server->reconnect();
+    REQUIRE(server->attempts == 0);
+
+    fake->advance(1);
+    server->reconnect();
+    REQUIRE(server->attempts == 1);
+}
+
+TEST_CASE("reconnect: fake clock exposes exponential backoff growth")
+{
+    auto client = std::make_shared<flight_safety_system::client_ssl::fss_client>(
+        CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+    auto server = std::make_shared<CountingServer>(
+        client.get(), "127.0.0.1", static_cast<uint16_t>(20600),
+        CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+    auto fake = std::make_shared<FakeClock>();
+    server->setClock(fake);
+
+    /* First attempt: clock must exceed the initial 1000ms retry delay. */
+    fake->advance(1001);
+    server->reconnect();
+    REQUIRE(server->attempts == 1);
+
+    /* Retry delay has doubled to 2000ms. A 1001ms gap must not fire. */
+    fake->advance(1001);
+    server->reconnect();
+    REQUIRE(server->attempts == 1);
+
+    /* 2001ms since last_tried → attempt 2, delay doubles to 4000. */
+    fake->advance(1001);
+    server->reconnect();
+    REQUIRE(server->attempts == 2);
+
+    fake->advance(4000);
+    server->reconnect();
+    REQUIRE(server->attempts == 2);
+
+    fake->advance(1);
+    server->reconnect();
+    REQUIRE(server->attempts == 3);
 }
 
 TEST_CASE("reconnect: multi-server failover keeps secondary reachable")


### PR DESCRIPTION
## Description

Replace the direct fss_current_timestamp() call in client_ssl::fss_server reconnect() with an injectable IClock, so tests can exercise throttle boundaries and exponential backoff growth without wall-clock sleeps.

## Summary by Sourcery

Inject a pluggable clock abstraction into the SSL client reconnect logic to allow deterministic testing of reconnect throttling and exponential backoff.

New Features:
- Introduce an IClock interface and WallClock implementation to provide timestamp access via an injectable clock instance.
- Allow fss_server to accept a custom clock for controlling reconnect timing behavior.

Tests:
- Add FakeClock and CountingServer test helpers to simulate time and count reconnect attempts deterministically.
- Add tests that verify reconnect throttling boundaries and exponential backoff progression using the fake clock.