### PR TITLE
Mock database

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -48,7 +48,7 @@ pkgconfig_DATA += fss-client-ssl.pc
 if SERVER
 sbin_PROGRAMS += fss-server
 
-fss_server_SOURCES = server.cpp fss-server.hpp db.cpp server-db.pgc server-db.h
+fss_server_SOURCES = server.cpp client_session.cpp fss-server.hpp db.cpp server-db.pgc server-db.h
 fss_server_CXXFLAGS = $(AM_CXXFLAGS) $(JSONCPP_CFLAGS)
 fss_server_CFLAGS = $(AM_CFLAGS) $(ECPG_CFLAGS)
 fss_server_LDADD = libfss.la libfss-transport.la $(JSONCPP_LIBS) $(ECPG_LIBS)

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -1,0 +1,317 @@
+#include "fss-transport.hpp"
+#include "fss.hpp"
+#include "fss-log.hpp"
+#include "fss-server.hpp"
+
+#include <algorithm>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <utility>
+
+namespace fss = flight_safety_system;
+
+constexpr int sec_to_msec = 1000;
+constexpr uint64_t rtt_retry_interval = 10 * sec_to_msec;
+
+fss::server::smm_settings::smm_settings(std::string t_address, std::string t_username, std::string t_password) : address(std::move(t_address)), username(std::move(t_username)), password(std::move(t_password))
+{
+}
+
+auto fss::server::smm_settings::getAddress() -> std::string { return this->address; }
+auto fss::server::smm_settings::getUsername() -> std::string { return this->username; }
+auto fss::server::smm_settings::getPassword() -> std::string { return this->password; }
+
+fss::server::fss_server_details::fss_server_details(std::string t_address, uint16_t t_port) : address(std::move(t_address)), port(t_port)
+{
+}
+
+auto fss::server::fss_server_details::getAddress() -> std::string { return this->address; }
+auto fss::server::fss_server_details::getPort() -> uint16_t { return this->port; }
+
+fss::server::asset_command::asset_command(uint64_t t_dbid, uint64_t t_timestamp, const std::string &t_cmd, double t_latitude, double t_longitude, uint16_t t_altitude) : dbid(t_dbid), timestamp(t_timestamp), latitude(t_latitude), longitude(t_longitude), altitude(t_altitude)
+{
+    if (t_cmd == "RTL") {
+        this->command = transport::asset_command_rtl;
+    } else if (t_cmd == "HOLD") {
+        this->command = transport::asset_command_hold;
+    } else if (t_cmd == "GOTO") {
+        this->command = transport::asset_command_goto;
+    } else if (t_cmd == "RON") {
+        this->command = transport::asset_command_resume;
+    } else if (t_cmd == "DISARM") {
+        this->command = transport::asset_command_disarm;
+    } else if (t_cmd == "ALT") {
+        this->command = transport::asset_command_altitude;
+    } else if (t_cmd == "TERM") {
+        this->command = transport::asset_command_terminate;
+    } else if (t_cmd == "MAN") {
+        this->command = transport::asset_command_manual;
+    }
+}
+
+auto fss::server::asset_command::getDBId() -> uint64_t { return this->dbid; }
+auto fss::server::asset_command::getTimeStamp() -> uint64_t { return this->timestamp; }
+auto fss::server::asset_command::getCommand() -> fss::transport::fss_asset_command { return this->command; }
+auto fss::server::asset_command::getLatitude() -> double { return this->latitude; }
+auto fss::server::asset_command::getLongitude() -> double { return this->longitude; }
+auto fss::server::asset_command::getAltitude() -> uint16_t { return this->altitude; }
+
+fss::server::fss_client_rtt::fss_client_rtt(uint64_t t_timestamp, uint64_t t_reqid) : timestamp(t_timestamp), reqid(t_reqid)
+{
+}
+
+auto fss::server::fss_client_rtt::getTimeStamp() -> uint64_t { return this->timestamp; }
+auto fss::server::fss_client_rtt::getRequestId() -> uint64_t { return this->reqid; }
+
+fss::server::fss_client::fss_client(std::shared_ptr<fss::transport::fss_connection> t_conn, IDatabase *t_dbc, fss_client_handler *t_handler) : fss_message_cb(std::move(t_conn)), dbc(t_dbc), client_handler(t_handler)
+{
+    this->getConnection()->setHandler(this);
+}
+
+fss::server::fss_client::~fss_client() = default;
+
+auto
+fss::server::fss_client::isAircraft() -> bool
+{
+    return this->aircraft;
+}
+
+auto
+fss::server::fss_client::getName() -> std::string
+{
+    std::lock_guard<std::mutex> guard(this->client_lock);
+    return this->name;
+}
+
+void
+fss::server::fss_client::sendCommand()
+{
+    std::lock_guard<std::mutex> guard(this->client_lock);
+    uint64_t ts = fss_current_timestamp();
+    uint64_t asset_id = this->dbc->getAssetId(this->name);
+    if (asset_id == 0) { return; }
+    auto ac = this->dbc->getCommand(asset_id);
+    constexpr int timeout_time = 10 * sec_to_msec;
+    if (ac != nullptr && (ac->getDBId() != this->last_command_dbid || ts > (this->last_command_send_ts + timeout_time)))
+    {
+        this->last_command_send_ts = ts;
+        this->last_command_dbid = ac->getDBId();
+        std::shared_ptr<fss::transport::fss_message_asset_command> msg = nullptr;
+        auto command = ac->getCommand();
+        switch (command)
+        {
+            case fss::transport::asset_command_goto:
+                msg = std::make_shared<fss::transport::fss_message_asset_command>(command, ac->getTimeStamp(), ac->getLatitude(), ac->getLongitude());
+                break;
+            case fss::transport::asset_command_altitude:
+                msg = std::make_shared<fss::transport::fss_message_asset_command>(command, ac->getTimeStamp(), ac->getAltitude());
+                break;
+            default:
+                msg = std::make_shared<fss::transport::fss_message_asset_command>(command, ac->getTimeStamp());
+                break;
+        }
+        this->getConnection()->sendMsg(msg);
+    }
+}
+
+void
+fss::server::fss_client::sendRTTRequest(const std::shared_ptr<fss::transport::fss_message_rtt_request> &rtt_req)
+{
+    std::lock_guard<std::mutex> guard(this->client_lock);
+    uint64_t ts = fss_current_timestamp();
+    if (!this->outstanding_rtt_requests.empty())
+    {
+        auto &last = this->outstanding_rtt_requests.back();
+        if (ts - last->getTimeStamp() < rtt_retry_interval)
+        {
+            return;
+        }
+    }
+    this->getConnection()->sendMsg(rtt_req);
+    this->outstanding_rtt_requests.push_back(std::make_shared<fss_client_rtt>(ts, rtt_req->getId()));
+}
+
+void
+fss::server::fss_client::sendSMMSettings()
+{
+    std::string client_name;
+    {
+        std::lock_guard<std::mutex> guard(this->client_lock);
+        client_name = this->name;
+    }
+    uint64_t asset_id = this->dbc->getAssetId(client_name);
+    if (asset_id == 0) { return; }
+    auto smm = this->dbc->getSmmSettings(asset_id);
+    if (smm != nullptr)
+    {
+        auto settings_msg = std::make_shared<fss::transport::fss_message_smm_settings>(smm->getAddress(), smm->getUsername(), smm->getPassword());
+        this->getConnection()->sendMsg(settings_msg);
+    }
+}
+
+namespace {
+auto getServersListMsg(fss::server::IDatabase *dbc) -> std::shared_ptr<fss::transport::fss_message_server_list>
+{
+    auto server_list = std::make_shared<fss::transport::fss_message_server_list>();
+    for (auto &server_details : dbc->getActiveServers())
+    {
+        server_list->addServer(server_details.getAddress(), server_details.getPort());
+    }
+    return server_list;
+}
+} // namespace
+
+void
+fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss_message> msg)
+{
+    if (msg == nullptr)
+    {
+        return;
+    }
+#ifdef DEBUG
+    std::cout << "Got message " << msg->getType() << std::endl;
+#endif
+    if (msg->getType() == fss::transport::message_type_closed)
+    {
+        this->client_handler->clientDisconnected(this);
+        return;
+    }
+    if (!this->identified)
+    {
+        if (msg->getType() == fss::transport::message_type_identity)
+        {
+            auto identity_msg = std::dynamic_pointer_cast<fss::transport::fss_message_identity>(msg);
+            if (identity_msg != nullptr)
+            {
+                auto client_name = identity_msg->getName();
+                auto possible_names = this->getConnection()->getClientNames();
+                bool name_valid = false;
+                if (possible_names.empty())
+                {
+                    FSS_LOG_ERROR("server", "Rejecting client: no CN found in certificate");
+                }
+                else
+                {
+                    name_valid = std::any_of(possible_names.begin(), possible_names.end(), [&client_name](const auto &n) {
+                        return n == client_name;
+                    });
+                }
+                if (!name_valid)
+                {
+                    this->client_handler->clientDisconnected(this);
+                    return;
+                }
+                {
+                    std::lock_guard<std::mutex> guard(this->client_lock);
+                    this->name = std::move(client_name);
+                }
+                this->aircraft = true;
+                this->identified = true;
+                this->sendCommand();
+                this->sendSMMSettings();
+                this->getConnection()->sendMsg(getServersListMsg(this->dbc));
+            }
+        }
+        else if(msg->getType() == fss::transport::message_type_identity_non_aircraft)
+        {
+            this->identified = true;
+            this->aircraft = false;
+        }
+        else
+        {
+            this->sendMsg(std::make_shared<fss::transport::fss_message_identity_required>());
+        }
+    }
+    else
+    {
+        std::string client_name = this->getName();
+        uint64_t asset_id = this->dbc->getAssetId(client_name);
+        switch (msg->getType())
+        {
+            case fss::transport::message_type_unknown:
+            case fss::transport::message_type_closed:
+            case fss::transport::message_type_identity:
+            case fss::transport::message_type_identity_non_aircraft:
+            case fss::transport::message_type_identity_required:
+                break;
+            case fss::transport::message_type_rtt_request:
+            {
+                auto reply_msg = std::make_shared<fss::transport::fss_message_rtt_response>(msg->getId());
+                this->getConnection()->sendMsg(reply_msg);
+            }
+                break;
+            case fss::transport::message_type_rtt_response:
+            {
+                std::shared_ptr<fss_client_rtt> rtt_req = nullptr;
+                uint64_t current_ts = fss_current_timestamp();
+                auto rtt_resp_msg = std::dynamic_pointer_cast<fss::transport::fss_message_rtt_response>(msg);
+                if (rtt_resp_msg != nullptr)
+                {
+                    std::lock_guard<std::mutex> guard(this->client_lock);
+                    for(const auto &req : this->outstanding_rtt_requests)
+                    {
+                        if(req->getRequestId() == rtt_resp_msg->getRequestId())
+                        {
+                            rtt_req = req;
+                        }
+                    }
+                    if (rtt_req != nullptr)
+                    {
+                        this->outstanding_rtt_requests.remove(rtt_req);
+                    }
+                }
+                if (rtt_req != nullptr && asset_id != 0)
+                {
+#ifdef DEBUG
+                    std::cout << "RTT for " << client_name << " is " << (current_ts - rtt_req->getTimeStamp()) << std::endl;
+#endif
+                    this->dbc->recordRtt(asset_id, current_ts - rtt_req->getTimeStamp());
+                }
+            }
+                break;
+            case fss::transport::message_type_position_report:
+            {
+                if (this->aircraft && asset_id != 0)
+                {
+                    this->dbc->recordPosition(asset_id, msg->getLatitude(), msg->getLongitude(), msg->getAltitude());
+                }
+                this->client_handler->broadcastMsg(msg, this);
+            }
+                break;
+            case fss::transport::message_type_system_status:
+            {
+                auto status_msg = std::dynamic_pointer_cast<fss::transport::fss_message_system_status>(msg);
+                if (status_msg != nullptr && asset_id != 0)
+                {
+                    this->dbc->recordStatus(asset_id, status_msg->getBatRemaining(), status_msg->getBatMAHUsed(), status_msg->getBatVoltage());
+                }
+            }
+                break;
+            case fss::transport::message_type_search_status:
+            {
+                auto status_msg = std::dynamic_pointer_cast<fss::transport::fss_message_search_status>(msg);
+                if (status_msg != nullptr && asset_id != 0)
+                {
+                    this->dbc->recordSearchStatus(asset_id, status_msg->getSearchId(), status_msg->getSearchCompleted(), status_msg->getSearchTotal());
+                }
+            }
+                break;
+            case fss::transport::message_type_command:
+            case fss::transport::message_type_server_list:
+            case fss::transport::message_type_smm_settings:
+                break;
+        }
+    }
+}
+
+namespace flight_safety_system {
+namespace server {
+/* Exposed so server.cpp can broadcast the server list without duplicating
+ * the helper. Not in the public header — only the server binary uses it. */
+auto build_server_list_msg(IDatabase *dbc) -> std::shared_ptr<transport::fss_message_server_list>
+{
+    return getServersListMsg(dbc);
+}
+} // namespace server
+} // namespace flight_safety_system

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -7,6 +7,7 @@ extern "C" {
 
 #include <mutex>
 #include <string>
+#include <vector>
 
 flight_safety_system::server::db_connection::db_connection(const std::string &host, const std::string &user, const std::string &pass, const std::string &db) : db_lock()
 {
@@ -19,105 +20,80 @@ flight_safety_system::server::db_connection::~db_connection()
 }
 
 auto
-flight_safety_system::server::db_connection::check_asset(const std::string &asset_name) -> bool
+flight_safety_system::server::db_connection::getAssetId(const std::string &name) -> uint64_t
 {
     std::lock_guard<std::mutex> guard(this->db_lock);
-    uint64_t asset_id = db_get_asset_id(asset_name.c_str());
-    return asset_id != 0;
+    return db_get_asset_id(name.c_str());
 }
 
 void
-flight_safety_system::server::db_connection::asset_add_rtt(const std::string &asset_name, uint64_t delta)
+flight_safety_system::server::db_connection::recordRtt(uint64_t asset_id, uint64_t rtt_ms)
 {
     std::lock_guard<std::mutex> guard(this->db_lock);
-    uint64_t asset_id = db_get_asset_id(asset_name.c_str());
-    if (asset_id != 0)
-    {
-        db_rtt_create_entry(asset_id, delta);
-    }
+    db_rtt_create_entry(asset_id, rtt_ms);
 }
 
 void
-flight_safety_system::server::db_connection::asset_add_status(const std::string &asset_name, uint8_t bat_percent, uint32_t bat_mah_used, double bat_voltage)
+flight_safety_system::server::db_connection::recordStatus(uint64_t asset_id, uint8_t bat_percent, uint32_t bat_mah_used, double bat_voltage)
 {
     std::lock_guard<std::mutex> guard(this->db_lock);
-    uint64_t asset_id = db_get_asset_id(asset_name.c_str());
-    if (asset_id != 0)
-    {
-        db_status_create_entry(asset_id, bat_percent, bat_mah_used, bat_voltage);
-    }
+    db_status_create_entry(asset_id, bat_percent, bat_mah_used, bat_voltage);
 }
 
 void
-flight_safety_system::server::db_connection::asset_add_search_status(const std::string &asset_name, uint64_t search_id, uint64_t search_completed, uint64_t search_total)
+flight_safety_system::server::db_connection::recordSearchStatus(uint64_t asset_id, uint64_t search_id, uint64_t completed, uint64_t total)
 {
     std::lock_guard<std::mutex> guard(this->db_lock);
-    uint64_t asset_id = db_get_asset_id(asset_name.c_str());
-    if (asset_id != 0)
-    {
-        db_search_status_create_entry(asset_id, search_id, search_completed, search_total);
-    }
+    db_search_status_create_entry(asset_id, search_id, completed, total);
 }
 
 void
-flight_safety_system::server::db_connection::asset_add_position(const std::string &asset_name, double latitude, double longitude, uint16_t altitude)
+flight_safety_system::server::db_connection::recordPosition(uint64_t asset_id, double latitude, double longitude, uint16_t altitude)
 {
     std::lock_guard<std::mutex> guard(this->db_lock);
-    uint64_t asset_id = db_get_asset_id(asset_name.c_str());
-    if (asset_id != 0)
-    {
-        db_position_create_entry(asset_id, latitude, longitude, altitude);
-    }
+    db_position_create_entry(asset_id, latitude, longitude, altitude);
 }
 
 auto
-flight_safety_system::server::db_connection::asset_get_command(const std::string &asset_name) -> std::shared_ptr<asset_command>
+flight_safety_system::server::db_connection::getCommand(uint64_t asset_id) -> std::shared_ptr<asset_command>
 {
     std::shared_ptr<asset_command> res = nullptr;
     {
         std::lock_guard<std::mutex> guard(this->db_lock);
-        uint64_t asset_id = db_get_asset_id(asset_name.c_str());
-        if (asset_id != 0)
+        struct asset_command_s *command = db_asset_command_get(asset_id);
+        if (command)
         {
-            struct asset_command_s *command = db_asset_command_get(asset_id);
-            if (command)
-            {
-                res = std::make_shared<asset_command>(command->dbid, command->timestamp, std::string(command->command), command->latitude, command->longitude, command->altitude);
-                free (command->command);
-                free (command);
-            }
+            res = std::make_shared<asset_command>(command->dbid, command->timestamp, std::string(command->command), command->latitude, command->longitude, command->altitude);
+            free (command->command);
+            free (command);
         }
     }
     return res;
 }
 
 auto
-flight_safety_system::server::db_connection::asset_get_smm_settings(const std::string &asset_name) -> std::shared_ptr<smm_settings>
+flight_safety_system::server::db_connection::getSmmSettings(uint64_t asset_id) -> std::shared_ptr<smm_settings>
 {
     std::shared_ptr<smm_settings> res = nullptr;
     {
         std::lock_guard<std::mutex> guard(this->db_lock);
-        uint64_t asset_id = db_get_asset_id(asset_name.c_str());
-        if (asset_id != 0)
+        struct smm_settings_s *settings = db_asset_smm_settings_get(asset_id);
+        if (settings)
         {
-            struct smm_settings_s *settings = db_asset_smm_settings_get(asset_id);
-            if (settings)
-            {
-                res = std::make_shared<smm_settings>(std::string(settings->address), std::string(settings->username), std::string(settings->password));
-                free (settings->address);
-                free (settings->username);
-                free (settings->password);
-                free (settings);
-            }
+            res = std::make_shared<smm_settings>(std::string(settings->address), std::string(settings->username), std::string(settings->password));
+            free (settings->address);
+            free (settings->username);
+            free (settings->password);
+            free (settings);
         }
     }
     return res;
 }
 
 auto
-flight_safety_system::server::db_connection::get_active_fss_servers() -> std::list<std::shared_ptr<fss_server_details>>
+flight_safety_system::server::db_connection::getActiveServers() -> std::vector<fss_server_details>
 {
-    std::list<std::shared_ptr<fss_server_details>> res;
+    std::vector<fss_server_details> res;
     struct fss_server_s **servers = nullptr;
     {
         std::lock_guard<std::mutex> guard(this->db_lock);
@@ -127,7 +103,7 @@ flight_safety_system::server::db_connection::get_active_fss_servers() -> std::li
     {
         for(size_t i = 0; servers[i] != nullptr; i++)
         {
-            res.push_back(std::make_shared<fss_server_details>(servers[i]->address, servers[i]->port));
+            res.emplace_back(servers[i]->address, servers[i]->port);
             free (servers[i]->address);
             free (servers[i]);
         }

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -1,9 +1,13 @@
+#pragma once
+
 #include "fss-transport.hpp"
 
 #include <atomic>
+#include <memory>
 #include <string>
 #include <list>
 #include <mutex>
+#include <vector>
 
 namespace  flight_safety_system {
 namespace server {
@@ -48,7 +52,28 @@ public:
     auto getAltitude() -> uint16_t;
 };
 
-class db_connection {
+/* Pure-virtual database seam: lets ClientSession be unit-tested against
+ * an in-memory mock without a live PostgreSQL. db_connection implements
+ * it in production; tests/mock_database.hpp implements it in Catch2. */
+class IDatabase {
+public:
+    IDatabase() = default;
+    IDatabase(const IDatabase &) = delete;
+    IDatabase(IDatabase &&) = delete;
+    auto operator=(const IDatabase &) -> IDatabase & = delete;
+    auto operator=(IDatabase &&) -> IDatabase & = delete;
+    virtual ~IDatabase() = default;
+    virtual auto getAssetId(const std::string &name) -> uint64_t = 0;
+    virtual void recordPosition(uint64_t asset_id, double latitude, double longitude, uint16_t altitude) = 0;
+    virtual void recordRtt(uint64_t asset_id, uint64_t rtt_ms) = 0;
+    virtual void recordStatus(uint64_t asset_id, uint8_t bat_percent, uint32_t bat_mah_used, double bat_voltage) = 0;
+    virtual void recordSearchStatus(uint64_t asset_id, uint64_t search_id, uint64_t completed, uint64_t total) = 0;
+    virtual auto getCommand(uint64_t asset_id) -> std::shared_ptr<asset_command> = 0;
+    virtual auto getActiveServers() -> std::vector<fss_server_details> = 0;
+    virtual auto getSmmSettings(uint64_t asset_id) -> std::shared_ptr<smm_settings> = 0;
+};
+
+class db_connection: public IDatabase {
 private:
     std::mutex db_lock;
 public:
@@ -57,15 +82,15 @@ public:
     db_connection(db_connection&&) = delete;
     auto operator=(db_connection&) -> db_connection& = delete;
     auto operator=(db_connection&&) -> db_connection& = delete;
-    ~db_connection();
-    auto check_asset(const std::string &asset_name) -> bool;
-    void asset_add_rtt(const std::string &asset_name, uint64_t rtt);
-    void asset_add_status(const std::string &asset_name, uint8_t bat_percent, uint32_t bat_mah_used, double bat_voltage);
-    void asset_add_search_status(const std::string &asset_name, uint64_t search_id, uint64_t search_completed, uint64_t search_total);
-    void asset_add_position(const std::string &asset_name, double latitude, double longitude, uint16_t altitude);
-    auto asset_get_command(const std::string &asset_name) -> std::shared_ptr<asset_command>;
-    auto asset_get_smm_settings(const std::string &asset_name) -> std::shared_ptr<smm_settings>;
-    auto get_active_fss_servers() -> std::list<std::shared_ptr<fss_server_details>>;
+    ~db_connection() override;
+    auto getAssetId(const std::string &name) -> uint64_t override;
+    void recordPosition(uint64_t asset_id, double latitude, double longitude, uint16_t altitude) override;
+    void recordRtt(uint64_t asset_id, uint64_t rtt_ms) override;
+    void recordStatus(uint64_t asset_id, uint8_t bat_percent, uint32_t bat_mah_used, double bat_voltage) override;
+    void recordSearchStatus(uint64_t asset_id, uint64_t search_id, uint64_t completed, uint64_t total) override;
+    auto getCommand(uint64_t asset_id) -> std::shared_ptr<asset_command> override;
+    auto getActiveServers() -> std::vector<fss_server_details> override;
+    auto getSmmSettings(uint64_t asset_id) -> std::shared_ptr<smm_settings> override;
 };
 
 class fss_client_rtt {
@@ -97,10 +122,10 @@ private:
     auto getName() -> std::string;
     uint64_t last_command_send_ts{0};
     uint64_t last_command_dbid{0};
-    std::shared_ptr<db_connection> dbc;
+    IDatabase *dbc;
     fss_client_handler *client_handler;
 public:
-    fss_client(std::shared_ptr<transport::fss_connection> conn, std::shared_ptr<db_connection> t_dbc, fss_client_handler *t_handler);
+    fss_client(std::shared_ptr<transport::fss_connection> conn, IDatabase *t_dbc, fss_client_handler *t_handler);
     fss_client(fss_client&) = delete;
     fss_client(fss_client&&) = delete;
     auto operator=(fss_client&) -> fss_client& = delete;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -4,6 +4,7 @@
 #include "fss.hpp"
 #include "fss-server.hpp"
 
+#include <algorithm>
 #include <iostream>
 #include <fstream>
 #include <csignal>
@@ -19,110 +20,13 @@
 
 #include <unistd.h>
 
-constexpr int sec_to_msec = 1000;
-constexpr uint64_t rtt_retry_interval = 10 * sec_to_msec;
-
-flight_safety_system::server::smm_settings::smm_settings(std::string t_address, std::string t_username, std::string t_password) : address(std::move(t_address)), username(std::move(t_username)), password(std::move(t_password))
-{
-}
-
-auto
-flight_safety_system::server::smm_settings::getAddress() -> std::string
-{
-    return this->address;
-}
-auto
-flight_safety_system::server::smm_settings::getUsername() -> std::string
-{
-    return this->username;
-}
-auto
-flight_safety_system::server::smm_settings::getPassword() -> std::string
-{
-    return this->password;
-}
-
-flight_safety_system::server::fss_server_details::fss_server_details(std::string t_address, uint16_t t_port) : address(std::move(t_address)), port(t_port)
-{
-}
-
-auto
-flight_safety_system::server::fss_server_details::getAddress() -> std::string
-{
-    return this->address;
-}
-auto
-flight_safety_system::server::fss_server_details::getPort() -> uint16_t
-{
-    return this->port;
-}
-
-flight_safety_system::server::asset_command::asset_command(uint64_t t_dbid, uint64_t t_timestamp, const std::string &t_cmd, double t_latitude, double t_longitude, uint16_t t_altitude) : dbid(t_dbid), timestamp(t_timestamp), latitude(t_latitude), longitude(t_longitude), altitude(t_altitude)
-{
-    if (t_cmd == "RTL") {
-        this->command = transport::asset_command_rtl;
-    } else if (t_cmd == "HOLD") {
-        this->command = transport::asset_command_hold;
-    } else if (t_cmd == "GOTO") {
-        this->command = transport::asset_command_goto;
-    } else if (t_cmd == "RON") {
-        this->command = transport::asset_command_resume;
-    } else if (t_cmd == "DISARM") {
-        this->command = transport::asset_command_disarm;
-    } else if (t_cmd == "ALT") {
-        this->command = transport::asset_command_altitude;
-    } else if (t_cmd == "TERM") {
-        this->command = transport::asset_command_terminate;
-    } else if (t_cmd == "MAN") {
-        this->command = transport::asset_command_manual;
-    }
-}
-
-auto
-flight_safety_system::server::asset_command::getDBId() -> uint64_t
-{
-    return this->dbid;
-}
-auto
-flight_safety_system::server::asset_command::getTimeStamp() -> uint64_t
-{
-    return this->timestamp;
-}
-auto
-flight_safety_system::server::asset_command::getCommand() -> transport::fss_asset_command
-{
-    return this->command;
-}
-auto
-flight_safety_system::server::asset_command::getLatitude() -> double
-{
-    return this->latitude;
-}
-auto
-flight_safety_system::server::asset_command::getLongitude() -> double
-{
-    return this->longitude;
-}
-auto
-flight_safety_system::server::asset_command::getAltitude() -> uint16_t
-{
-    return this->altitude;
-}
-
-flight_safety_system::server::fss_client_rtt::fss_client_rtt(uint64_t t_timestamp, uint64_t t_reqid) : timestamp(t_timestamp), reqid(t_reqid)
-{
-}
-
-auto
-flight_safety_system::server::fss_client_rtt::getTimeStamp() -> uint64_t
-{
-    return this->timestamp;
-}
-auto
-flight_safety_system::server::fss_client_rtt::getRequestId() -> uint64_t
-{
-    return this->reqid;
-}
+namespace flight_safety_system {
+namespace server {
+/* Defined in client_session.cpp. Exposed here so the periodic broadcast
+ * of the active server list can reuse the helper. */
+auto build_server_list_msg(IDatabase *dbc) -> std::shared_ptr<transport::fss_message_server_list>;
+} // namespace server
+} // namespace flight_safety_system
 
 class server_clients : public flight_safety_system::server::fss_client_handler {
 private:
@@ -134,7 +38,6 @@ private:
 public:
     server_clients() = default;
     ~server_clients() {
-        /* Prevent changes while we empty the client list */
         this->shutting_down = true;
         std::lock_guard<std::mutex> guard(this->lock);
         for (const auto &c: this->clients)
@@ -164,17 +67,15 @@ public:
     };
     void clientDisconnected(flight_safety_system::server::fss_client *client) override
     {
-        /* If we are shutting down, don't worry */
         std::lock_guard<std::mutex> guard(this->lock);
         if (this->shutting_down) return;
-        for (const auto &c : this->clients)
+        auto it = std::find_if(this->clients.begin(), this->clients.end(), [client](const auto &c) {
+            return c.get() == client;
+        });
+        if (it != this->clients.end())
         {
-            if (c.get() == client)
-            {
-                this->disconnected.push(c);
-                this->clients.remove(c);
-                break;
-            }
+            this->disconnected.push(*it);
+            this->clients.erase(it);
         }
     };
     void broadcastMsg(const std::shared_ptr<flight_safety_system::transport::fss_message> &msg, flight_safety_system::server::fss_client *except = nullptr) override
@@ -214,261 +115,6 @@ public:
     };
 };
 
-flight_safety_system::server::fss_client::fss_client(std::shared_ptr<flight_safety_system::transport::fss_connection> t_conn, std::shared_ptr<flight_safety_system::server::db_connection> t_dbc, flight_safety_system::server::fss_client_handler *t_handler) : fss_message_cb(std::move(t_conn)), dbc(std::move(t_dbc)), client_handler(t_handler)
-{
-    this->getConnection()->setHandler(this);
-}
-
-flight_safety_system::server::fss_client::~fss_client() = default;
-
-void
-flight_safety_system::server::fss_client::sendCommand()
-{
-    std::lock_guard<std::mutex> guard(this->client_lock);
-    uint64_t ts = fss_current_timestamp();
-    auto ac = this->dbc->asset_get_command(this->name);
-    constexpr int timeout_time = 10 * sec_to_msec;
-    if (ac != nullptr && (ac->getDBId() != this->last_command_dbid || ts > (this->last_command_send_ts + timeout_time)))
-    {
-        /* New command or time to re-send */
-        this->last_command_send_ts = ts;
-        this->last_command_dbid = ac->getDBId();
-        std::shared_ptr<flight_safety_system::transport::fss_message_asset_command> msg = nullptr;
-        auto command = ac->getCommand();
-        switch (command)
-        {
-            case flight_safety_system::transport::asset_command_goto:
-                msg = std::make_shared<flight_safety_system::transport::fss_message_asset_command>(command, ac->getTimeStamp(), ac->getLatitude(), ac->getLongitude());
-                break;
-            case flight_safety_system::transport::asset_command_altitude:
-                msg = std::make_shared<flight_safety_system::transport::fss_message_asset_command>(command, ac->getTimeStamp(), ac->getAltitude());
-                break;
-            default:
-                msg = std::make_shared<flight_safety_system::transport::fss_message_asset_command>(command, ac->getTimeStamp());
-                break;
-        }
-        this->getConnection()->sendMsg(msg);
-    }
-}
-
-auto
-flight_safety_system::server::fss_client::isAircraft() -> bool
-{
-    return this->aircraft;
-}
-
-auto
-flight_safety_system::server::fss_client::getName() -> std::string
-{
-    std::lock_guard<std::mutex> guard(this->client_lock);
-    return this->name;
-}
-
-
-void
-flight_safety_system::server::fss_client::sendRTTRequest(const std::shared_ptr<flight_safety_system::transport::fss_message_rtt_request> &rtt_req)
-{
-    std::lock_guard<std::mutex> guard(this->client_lock);
-    uint64_t ts = fss_current_timestamp();
-    /* Back off if there are unanswered RTT requests, but retry periodically */
-    if (!this->outstanding_rtt_requests.empty())
-    {
-        auto &last = this->outstanding_rtt_requests.back();
-        if (ts - last->getTimeStamp() < rtt_retry_interval)
-        {
-            return;
-        }
-    }
-    this->getConnection()->sendMsg(rtt_req);
-    this->outstanding_rtt_requests.push_back(std::make_shared<fss_client_rtt>(ts, rtt_req->getId()));
-}
-
-void
-flight_safety_system::server::fss_client::sendSMMSettings()
-{
-    std::string client_name;
-    {
-        std::lock_guard<std::mutex> guard(this->client_lock);
-        client_name = this->name;
-    }
-    auto smm = this->dbc->asset_get_smm_settings(client_name);
-    if (smm != nullptr)
-    {
-        auto settings_msg = std::make_shared<flight_safety_system::transport::fss_message_smm_settings>(smm->getAddress(), smm->getUsername(), smm->getPassword());
-        this->getConnection()->sendMsg(settings_msg);
-    }
-}
-
-auto getServersListMsg(const std::shared_ptr<flight_safety_system::server::db_connection> &dbc) -> std::shared_ptr<flight_safety_system::transport::fss_message_server_list>
-{
-    auto known_servers = dbc->get_active_fss_servers();
-    auto server_list = std::make_shared<flight_safety_system::transport::fss_message_server_list>();
-    for (const auto &server_details : known_servers)
-    {
-        server_list->addServer(server_details->getAddress(),server_details->getPort());
-    }
-    return server_list;
-}
-
-void
-flight_safety_system::server::fss_client::processMessage(std::shared_ptr<flight_safety_system::transport::fss_message> msg)
-{
-    if (msg == nullptr)
-    {
-        return;
-    }
-#ifdef DEBUG
-    std::cout << "Got message " << msg->getType() << std::endl;
-#endif
-    if (msg->getType() == flight_safety_system::transport::message_type_closed)
-    {
-        /* Connection has been closed, cleanup */
-        this->client_handler->clientDisconnected(this);
-        return;
-    }
-    if (!this->identified)
-    {
-        /* Only accept identify messages */
-        if (msg->getType() == flight_safety_system::transport::message_type_identity)
-        {
-            auto identity_msg = std::dynamic_pointer_cast<flight_safety_system::transport::fss_message_identity>(msg);
-            if (identity_msg != nullptr)
-            {
-                auto client_name = identity_msg->getName();
-                auto possible_names = this->getConnection()->getClientNames();
-                bool name_valid = false;
-                if (possible_names.empty())
-                {
-                    FSS_LOG_ERROR("server", "Rejecting client: no CN found in certificate");
-                }
-                else
-                {
-                    for (const auto &possible_name: possible_names)
-                    {
-                        if (possible_name == client_name)
-                        {
-                            name_valid = true;
-                            break;
-                        }
-                    }
-                }
-                if (!name_valid)
-                {
-                    this->client_handler->clientDisconnected(this);
-                    return;
-                }
-                {
-                    std::lock_guard<std::mutex> guard(this->client_lock);
-                    this->name = std::move(client_name);
-                }
-                this->aircraft = true;
-                this->identified = true;
-                /* send the current command */
-                this->sendCommand();
-                /* send SMM config and servers list */
-                this->sendSMMSettings();
-                /* Send all the known fss servers */
-                this->getConnection()->sendMsg(getServersListMsg(this->dbc));
-            }
-        }
-        else if(msg->getType() == flight_safety_system::transport::message_type_identity_non_aircraft)
-        {
-            this->identified = true;
-            this->aircraft = false;
-        }
-        else
-        {
-            this->sendMsg(std::make_shared<flight_safety_system::transport::fss_message_identity_required>());
-        }
-    }
-    else
-    {
-        std::string client_name = this->getName();
-        switch (msg->getType())
-        {
-            case flight_safety_system::transport::message_type_unknown:
-            case flight_safety_system::transport::message_type_closed:
-            case flight_safety_system::transport::message_type_identity:
-            case flight_safety_system::transport::message_type_identity_non_aircraft:
-            case flight_safety_system::transport::message_type_identity_required:
-                break;
-            case flight_safety_system::transport::message_type_rtt_request:
-            {
-                /* Send a response */
-                auto reply_msg = std::make_shared<flight_safety_system::transport::fss_message_rtt_response>(msg->getId());
-                this->getConnection()->sendMsg(reply_msg);
-            }
-                break;
-            case flight_safety_system::transport::message_type_rtt_response:
-            {
-                /* Find the original message and calculate the response time */
-                std::shared_ptr<fss_client_rtt> rtt_req = nullptr;
-                uint64_t current_ts = fss_current_timestamp();
-                auto rtt_resp_msg = std::dynamic_pointer_cast<flight_safety_system::transport::fss_message_rtt_response>(msg);
-                if (rtt_resp_msg != nullptr)
-                {
-                    std::lock_guard<std::mutex> guard(this->client_lock);
-                    for(const auto &req : this->outstanding_rtt_requests)
-                    {
-                        if(req->getRequestId() == rtt_resp_msg->getRequestId())
-                        {
-                            rtt_req = req;
-                        }
-                    }
-                    if (rtt_req != nullptr)
-                    {
-                        this->outstanding_rtt_requests.remove(rtt_req);
-                    }
-                }
-                if (rtt_req != nullptr)
-                {
-#ifdef DEBUG
-                    std::cout << "RTT for " << client_name << " is " << (current_ts - rtt_req->getTimeStamp()) << std::endl;
-#endif
-                    this->dbc->asset_add_rtt(client_name, current_ts - rtt_req->getTimeStamp());
-                }
-            }
-                break;
-            case flight_safety_system::transport::message_type_position_report:
-            {
-                if (this->aircraft)
-                {
-                    /* Capture and store in the database */
-                    this->dbc->asset_add_position(client_name, msg->getLatitude(), msg->getLongitude(), msg->getAltitude());
-                }
-                /* Reflect this message to all aircraft clients */
-                this->client_handler->broadcastMsg(msg, this);
-            }
-                break;
-            case flight_safety_system::transport::message_type_system_status:
-            {
-                /* Capture and store in the database */
-                auto status_msg = std::dynamic_pointer_cast<flight_safety_system::transport::fss_message_system_status>(msg);
-                if (status_msg != nullptr)
-                {
-                    this->dbc->asset_add_status(client_name, status_msg->getBatRemaining(), status_msg->getBatMAHUsed(), status_msg->getBatVoltage());
-                }
-            }
-                break;
-            case flight_safety_system::transport::message_type_search_status:
-            {
-                /* Capture and store in the database */
-                auto status_msg = std::dynamic_pointer_cast<flight_safety_system::transport::fss_message_search_status>(msg);
-                if (status_msg != nullptr)
-                {
-                    this->dbc->asset_add_search_status(client_name, status_msg->getSearchId(), status_msg->getSearchCompleted(), status_msg->getSearchTotal());
-                }
-            }
-                break;
-            /* These are server->client only */
-            case flight_safety_system::transport::message_type_command:
-            case flight_safety_system::transport::message_type_server_list:
-            case flight_safety_system::transport::message_type_smm_settings:
-                break;
-        }
-    }
-}
-
 volatile sig_atomic_t running = 1;
 
 void sigIntHandler(int signum __attribute__((unused)))
@@ -479,19 +125,16 @@ void sigIntHandler(int signum __attribute__((unused)))
 auto
 main(int argc, char *argv[]) -> int
 {
-    /* Watch out for sigint */
     struct sigaction sa_int = {};
     sa_int.sa_handler = sigIntHandler;
     sigemptyset(&sa_int.sa_mask);
     sa_int.sa_flags = 0;
     sigaction(SIGINT, &sa_int, nullptr);
-    /* Ignore sig pipe */
     struct sigaction sa_pipe = {};
     sa_pipe.sa_handler = SIG_IGN;
     sigemptyset(&sa_pipe.sa_mask);
     sa_pipe.sa_flags = 0;
     sigaction(SIGPIPE, &sa_pipe, nullptr);
-    /* Read config */
     std::string conf_file = (argc > 1 ? std::string(argv[1]) : "/etc/fss/server.json");
     std::ifstream configfile(conf_file);
     if (!configfile.is_open())
@@ -507,13 +150,10 @@ main(int argc, char *argv[]) -> int
         flight_safety_system::log::set_level(config["log_level"].asString());
     }
 
-    /* Connect to database */
     auto dbc = std::make_shared<flight_safety_system::server::db_connection>(config["postgres"]["host"].asString(), config["postgres"]["user"].asString(), config["postgres"]["pass"].asString(), config["postgres"]["db"].asString());
 
-    /* Create the clients tracking */
     auto clients = std::make_shared<server_clients>();
 
-    /* Open listen socket */
     std::shared_ptr<flight_safety_system::transport::fss_listen> listen;
     FSS_LOG_INFO("server", "Starting fss server in TLS mode");
     std::string ca_public_key = config["ssl"]["ca_public_key"].asString();
@@ -529,23 +169,10 @@ main(int argc, char *argv[]) -> int
 #ifdef DEBUG
             std::cout << "New client connected" << std::endl;
 #endif
-            clients->clientConnected(std::make_shared<flight_safety_system::server::fss_client>(std::move(conn), dbc, clients.get()));
+            clients->clientConnected(std::make_shared<flight_safety_system::server::fss_client>(std::move(conn), dbc.get(), clients.get()));
             return true;
         },
         config["ssl"]["ca_public_key"].asString(), config["ssl"]["server_private_key"].asString(), config["ssl"]["server_public_key"].asString());
-
-    /* Process client messages:
-       - Battery status
-       - Position (reflect to other clients)
-       - Search information
-     */
-    /* Events:
-       - Client Connect
-       - Client Disconnect
-     */
-    /* Periodic activity
-       - Per client, send RTT message
-     */
 
     uint64_t counter = 0;
     constexpr int send_config_period = 15;
@@ -553,17 +180,14 @@ main(int argc, char *argv[]) -> int
     {
         sleep (1);
         clients->cleanupRemovableClients();
-        /* Send RTT messages to all clients */
         {
             auto rtt_req = std::make_shared<flight_safety_system::transport::fss_message_rtt_request>();
             clients->sendRTTRequest(rtt_req);
             clients->sendCommand();
         }
-        /* Send Config settings to all clients */
         if ((counter % send_config_period) == 0)
         {
-            /* Send all the known fss servers */
-            clients->broadcastMsg(getServersListMsg(dbc));
+            clients->broadcastMsg(flight_safety_system::server::build_server_list_msg(dbc.get()));
             clients->sendSMMSettings();
         }
         counter++;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -16,13 +16,15 @@ all_test_SOURCES = main.cpp messages.cpp connection.cpp client.cpp \
 	queue_test.cpp \
 	reconnect_test.cpp \
 	connection_negative_test.cpp \
-	ssl_failure_test.cpp
+	ssl_failure_test.cpp \
+	server_session_test.cpp \
+	../src/client_session.cpp
 all_test_LDADD = ../src/libfss-transport.la ../src/libfss-client-ssl.la ../src/libfss.la $(JSONCPP_LIBS)
 
 all_test_SOURCES += connection-ssl.cpp certs certs-alt certs/expired
 all_test_LDADD += ../src/libfss-transport-ssl.la $(GNUTLS_LIBS) $(CATCH2_LIBS)
 
-EXTRA_DIST = test_helpers.hpp
+EXTRA_DIST = test_helpers.hpp mock_database.hpp
 
 BUILT_SOURCES += certs certs-alt certs/expired
 certs:

--- a/tests/mock_database.hpp
+++ b/tests/mock_database.hpp
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "fss-server.hpp"
+
+namespace fss_test {
+
+/* In-memory IDatabase for unit tests. No thread-safety: tests drive the
+ * session synchronously. Commands are held newest-first so getCommand
+ * returns the most recently pushed entry, matching the production
+ * "ORDER BY timestamp DESC LIMIT 1" semantics. */
+class MockDatabase : public flight_safety_system::server::IDatabase {
+public:
+    std::map<std::string, uint64_t> asset_ids{};
+    std::map<uint64_t, std::shared_ptr<flight_safety_system::server::smm_settings>> smm{};
+    std::map<uint64_t, std::vector<std::shared_ptr<flight_safety_system::server::asset_command>>> commands{};
+    std::vector<flight_safety_system::server::fss_server_details> active_servers{};
+
+    struct recorded_rtt { uint64_t asset_id; uint64_t rtt_ms; };
+    struct recorded_pos { uint64_t asset_id; double latitude; double longitude; uint16_t altitude; };
+    struct recorded_status { uint64_t asset_id; uint8_t bat_percent; uint32_t bat_mah_used; double bat_voltage; };
+    struct recorded_search { uint64_t asset_id; uint64_t search_id; uint64_t completed; uint64_t total; };
+
+    std::vector<recorded_rtt> rtts{};
+    std::vector<recorded_pos> positions{};
+    std::vector<recorded_status> statuses{};
+    std::vector<recorded_search> searches{};
+
+    MockDatabase() = default;
+    MockDatabase(const MockDatabase &) = delete;
+    MockDatabase(MockDatabase &&) = delete;
+    auto operator=(const MockDatabase &) -> MockDatabase & = delete;
+    auto operator=(MockDatabase &&) -> MockDatabase & = delete;
+    ~MockDatabase() override = default;
+
+    auto getAssetId(const std::string &name) -> uint64_t override
+    {
+        auto it = asset_ids.find(name);
+        return it == asset_ids.end() ? 0 : it->second;
+    }
+
+    void recordPosition(uint64_t asset_id, double latitude, double longitude, uint16_t altitude) override
+    {
+        positions.push_back({asset_id, latitude, longitude, altitude});
+    }
+
+    void recordRtt(uint64_t asset_id, uint64_t rtt_ms) override
+    {
+        rtts.push_back({asset_id, rtt_ms});
+    }
+
+    void recordStatus(uint64_t asset_id, uint8_t bat_percent, uint32_t bat_mah_used, double bat_voltage) override
+    {
+        statuses.push_back({asset_id, bat_percent, bat_mah_used, bat_voltage});
+    }
+
+    void recordSearchStatus(uint64_t asset_id, uint64_t search_id, uint64_t completed, uint64_t total) override
+    {
+        searches.push_back({asset_id, search_id, completed, total});
+    }
+
+    auto getCommand(uint64_t asset_id) -> std::shared_ptr<flight_safety_system::server::asset_command> override
+    {
+        auto it = commands.find(asset_id);
+        if (it == commands.end() || it->second.empty()) { return nullptr; }
+        std::shared_ptr<flight_safety_system::server::asset_command> newest = nullptr;
+        for (const auto &cmd : it->second)
+        {
+            if (newest == nullptr || cmd->getTimeStamp() > newest->getTimeStamp())
+            {
+                newest = cmd;
+            }
+        }
+        return newest;
+    }
+
+    auto getActiveServers() -> std::vector<flight_safety_system::server::fss_server_details> override
+    {
+        return active_servers;
+    }
+
+    auto getSmmSettings(uint64_t asset_id) -> std::shared_ptr<flight_safety_system::server::smm_settings> override
+    {
+        auto it = smm.find(asset_id);
+        return it == smm.end() ? nullptr : it->second;
+    }
+
+    void pushCommand(uint64_t asset_id, std::shared_ptr<flight_safety_system::server::asset_command> cmd)
+    {
+        commands[asset_id].push_back(std::move(cmd));
+    }
+};
+
+} // namespace fss_test

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -1,0 +1,149 @@
+#ifdef HAVE_CATCH2_CATCH_ALL_HPP
+#include <catch2/catch_all.hpp>
+#elif HAVE_CATCH2_CATCH_HPP
+#include <catch2/catch.hpp>
+#elif HAVE_CATCH_CATCH_HPP
+#include <catch/catch.hpp>
+#elif HAVE_CATCH_HPP
+#include <catch.hpp>
+#else
+#error No catch header
+#endif
+
+#include <list>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "fss-transport.hpp"
+#include "fss-server.hpp"
+#include "mock_database.hpp"
+
+namespace fss = flight_safety_system;
+
+namespace {
+
+/* Stand-in for the real fss_connection used by fss_client. The default
+ * fss_connection ctor leaves fd = -1 and does NOT spawn a recv thread,
+ * so we can drive processMessage from the test synchronously.
+ *
+ * Interception point: sendMsg(fss_message) internally calls the virtual
+ * sendMsg(buf_len). We override that one and decode the framed buffer
+ * back into an fss_message so tests can assert on outbound traffic. */
+class FakeConnection : public fss::transport::fss_connection {
+public:
+    std::vector<std::shared_ptr<fss::transport::fss_message>> sent{};
+    std::list<std::string> cert_names{};
+
+    FakeConnection() = default;
+    FakeConnection(const FakeConnection &) = delete;
+    FakeConnection(FakeConnection &&) = delete;
+    auto operator=(const FakeConnection &) -> FakeConnection & = delete;
+    auto operator=(FakeConnection &&) -> FakeConnection & = delete;
+    ~FakeConnection() override = default;
+
+    auto getClientNames() -> std::list<std::string> override { return cert_names; }
+
+protected:
+    auto sendMsg(const std::shared_ptr<fss::transport::buf_len> &bl) -> bool override
+    {
+        auto msg = fss::transport::fss_message::decode(bl);
+        if (msg != nullptr) { sent.push_back(msg); }
+        return true;
+    }
+};
+
+class NullClientHandler : public fss::server::fss_client_handler {
+public:
+    int disconnects{0};
+    std::vector<std::shared_ptr<fss::transport::fss_message>> broadcasts{};
+    ~NullClientHandler() override = default;
+    void clientDisconnected(fss::server::fss_client * /*client*/) override { ++disconnects; }
+    void broadcastMsg(const std::shared_ptr<fss::transport::fss_message> &msg,
+                      fss::server::fss_client * /*except*/ = nullptr) override
+    {
+        broadcasts.push_back(msg);
+    }
+};
+
+} // namespace
+
+TEST_CASE("session: rejects identify when asset unknown to database",
+          "[!shouldfail][todo16]")
+{
+    /* Desired behaviour: if IDatabase::getAssetId returns 0 at identify,
+     * the session must not send SMM settings, server list, or commands
+     * to the peer. Currently server.cpp accepts the identity and only
+     * the silent-drop happens inside DB methods, so the peer still sees
+     * application traffic — [!shouldfail] captures the target contract
+     * while we refactor. */
+    fss_test::MockDatabase mock;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("unknownAsset");
+    NullClientHandler handler;
+
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, &handler);
+    auto identify = std::make_shared<fss::transport::fss_message_identity>("unknownAsset");
+    session->processMessage(identify);
+
+    REQUIRE(conn->sent.empty());
+}
+
+TEST_CASE("session: getCommand returns newest-timestamp entry")
+{
+    /* The production ECPG query is ORDER BY timestamp DESC LIMIT 1; the
+     * mock replicates that. Injecting two commands, the session's
+     * sendCommand must dispatch the one with the higher timestamp. */
+    fss_test::MockDatabase mock;
+    constexpr uint64_t asset_id = 42;
+    mock.asset_ids["craft"] = asset_id;
+    mock.pushCommand(asset_id, std::make_shared<fss::server::asset_command>(
+        /*dbid*/ 1, /*ts*/ 100, "HOLD", 0.0, 0.0, 0));
+    mock.pushCommand(asset_id, std::make_shared<fss::server::asset_command>(
+        /*dbid*/ 2, /*ts*/ 500, "RTL", 0.0, 0.0, 0));
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, &handler);
+    /* Drive the session to identify + send initial command. */
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    bool saw_command = false;
+    for (const auto &msg : conn->sent)
+    {
+        if (msg->getType() == fss::transport::message_type_command)
+        {
+            saw_command = true;
+            REQUIRE(msg->getTimeStamp() == 500);
+        }
+    }
+    REQUIRE(saw_command);
+}
+
+TEST_CASE("session: RTT timeout disconnects client",
+          "[!shouldfail][todo17]")
+{
+    /* Pending todo/17: once ClientSession accepts an IClock seam, the
+     * test will advance time past the RTT timeout and assert that
+     * clientDisconnected fires. The production code has no timeout
+     * logic today, so this fails by design. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    auto rtt_req = std::make_shared<fss::transport::fss_message_rtt_request>();
+    session->sendRTTRequest(rtt_req);
+
+    /* No clock seam yet: simulate "time past RTT timeout" by asserting
+     * the disconnect callback has fired. It has not. */
+    REQUIRE(handler.disconnects > 0);
+}


### PR DESCRIPTION
## Description

Create a virtual implementation of the database so the unit tests can mock the database.
Use the mock database to check how client sessions are handled.

## Summary by Sourcery

Introduce a database abstraction and refactor client session handling to enable unit testing of server–client interactions without a live PostgreSQL instance.

New Features:
- Add an IDatabase interface to abstract database access for server client sessions.
- Provide an in-memory MockDatabase implementation for tests, capturing asset IDs, commands, status, RTT, and server list data.
- Split client session logic into a dedicated client_session module that can be exercised independently of the server main loop.

Enhancements:
- Refactor db_connection to implement the new IDatabase interface and operate primarily on asset IDs instead of asset names.
- Adjust server startup and client wiring to use the new client_session module and shared database abstraction.
- Streamline server list construction to reuse a shared helper function for both client identification and periodic broadcasts.

Tests:
- Add server_session_test exercising client session behavior against the MockDatabase and a fake fss_connection, including expected-failing tests for future timeouts and asset validation.
- Extend test build configuration to compile the new client_session module and distribute the mock database helper.