### PR TITLE
feat: implement reject unknown asset and RTT timeout

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -13,6 +13,7 @@ namespace fss = flight_safety_system;
 
 constexpr int sec_to_msec = 1000;
 constexpr uint64_t rtt_retry_interval = 10 * sec_to_msec;
+constexpr uint64_t rtt_timeout = 30 * sec_to_msec;
 
 fss::server::smm_settings::smm_settings(std::string t_address, std::string t_username, std::string t_password) : address(std::move(t_address)), username(std::move(t_username)), password(std::move(t_password))
 {
@@ -116,20 +117,43 @@ fss::server::fss_client::sendCommand()
 }
 
 void
+fss::server::fss_client::setClock(std::shared_ptr<fss::IClock> t_clock)
+{
+    if (t_clock == nullptr)
+    {
+        return;
+    }
+    this->clock = std::move(t_clock);
+}
+
+void
 fss::server::fss_client::sendRTTRequest(const std::shared_ptr<fss::transport::fss_message_rtt_request> &rtt_req)
 {
-    std::lock_guard<std::mutex> guard(this->client_lock);
-    uint64_t ts = fss_current_timestamp();
-    if (!this->outstanding_rtt_requests.empty())
+    bool timed_out = false;
     {
-        auto &last = this->outstanding_rtt_requests.back();
-        if (ts - last->getTimeStamp() < rtt_retry_interval)
+        std::lock_guard<std::mutex> guard(this->client_lock);
+        uint64_t now = this->clock->now_ms();
+        if (!this->outstanding_rtt_requests.empty())
         {
-            return;
+            if (now - this->outstanding_rtt_requests.front()->getTimeStamp() > rtt_timeout)
+            {
+                timed_out = true;
+            }
+            else if (now - this->outstanding_rtt_requests.back()->getTimeStamp() < rtt_retry_interval)
+            {
+                return;
+            }
+        }
+        if (!timed_out)
+        {
+            this->getConnection()->sendMsg(rtt_req);
+            this->outstanding_rtt_requests.push_back(std::make_shared<fss_client_rtt>(now, rtt_req->getId()));
         }
     }
-    this->getConnection()->sendMsg(rtt_req);
-    this->outstanding_rtt_requests.push_back(std::make_shared<fss_client_rtt>(ts, rtt_req->getId()));
+    if (timed_out)
+    {
+        this->client_handler->clientDisconnected(this);
+    }
 }
 
 void
@@ -198,6 +222,11 @@ fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss_mess
                     });
                 }
                 if (!name_valid)
+                {
+                    this->client_handler->clientDisconnected(this);
+                    return;
+                }
+                if (this->dbc->getAssetId(client_name) == 0)
                 {
                     this->client_handler->clientDisconnected(this);
                     return;

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "fss.hpp"
 #include "fss-transport.hpp"
 
 #include <atomic>
@@ -124,6 +125,7 @@ private:
     uint64_t last_command_dbid{0};
     IDatabase *dbc;
     fss_client_handler *client_handler;
+    std::shared_ptr<IClock> clock{std::make_shared<WallClock>()};
 public:
     fss_client(std::shared_ptr<transport::fss_connection> conn, IDatabase *t_dbc, fss_client_handler *t_handler);
     fss_client(fss_client&) = delete;
@@ -136,6 +138,7 @@ public:
     void sendSMMSettings();
     void sendCommand();
     auto isAircraft() -> bool;
+    void setClock(std::shared_ptr<IClock> t_clock);
 };
 } // namespace server
 } // namespace flight_safety_system

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -53,6 +53,12 @@ protected:
     }
 };
 
+struct FakeClock : public fss::IClock {
+    uint64_t t{0};
+    auto now_ms() const -> uint64_t override { return t; }
+    void advance(uint64_t ms) { t += ms; }
+};
+
 class NullClientHandler : public fss::server::fss_client_handler {
 public:
     int disconnects{0};
@@ -68,15 +74,8 @@ public:
 
 } // namespace
 
-TEST_CASE("session: rejects identify when asset unknown to database",
-          "[!shouldfail][todo16]")
+TEST_CASE("session: rejects identify when asset unknown to database")
 {
-    /* Desired behaviour: if IDatabase::getAssetId returns 0 at identify,
-     * the session must not send SMM settings, server list, or commands
-     * to the peer. Currently server.cpp accepts the identity and only
-     * the silent-drop happens inside DB methods, so the peer still sees
-     * application traffic — [!shouldfail] captures the target contract
-     * while we refactor. */
     fss_test::MockDatabase mock;
 
     auto conn = std::make_shared<FakeConnection>();
@@ -123,13 +122,8 @@ TEST_CASE("session: getCommand returns newest-timestamp entry")
     REQUIRE(saw_command);
 }
 
-TEST_CASE("session: RTT timeout disconnects client",
-          "[!shouldfail][todo17]")
+TEST_CASE("session: RTT timeout disconnects client")
 {
-    /* Pending todo/17: once ClientSession accepts an IClock seam, the
-     * test will advance time past the RTT timeout and assert that
-     * clientDisconnected fires. The production code has no timeout
-     * logic today, so this fails by design. */
     fss_test::MockDatabase mock;
     mock.asset_ids["craft"] = 1;
 
@@ -137,13 +131,18 @@ TEST_CASE("session: RTT timeout disconnects client",
     conn->cert_names.push_back("craft");
     NullClientHandler handler;
 
+    auto clock = std::make_shared<FakeClock>();
     auto session = std::make_shared<fss::server::fss_client>(conn, &mock, &handler);
+    session->setClock(clock);
     session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
 
-    auto rtt_req = std::make_shared<fss::transport::fss_message_rtt_request>();
-    session->sendRTTRequest(rtt_req);
+    auto rtt_req1 = std::make_shared<fss::transport::fss_message_rtt_request>();
+    session->sendRTTRequest(rtt_req1);      // queued at t=0
 
-    /* No clock seam yet: simulate "time past RTT timeout" by asserting
-     * the disconnect callback has fired. It has not. */
+    clock->advance(30001);                  // past rtt_timeout (30 s)
+
+    auto rtt_req2 = std::make_shared<fss::transport::fss_message_rtt_request>();
+    session->sendRTTRequest(rtt_req2);      // triggers timeout → disconnect
+
     REQUIRE(handler.disconnects > 0);
 }


### PR DESCRIPTION
## Description

reject identify when getAssetId returns 0, calling clientDisconnected instead of sending SMM settings, server list, and commands to an unknown peer.

add IClock seam to fss_client and disconnect when an outstanding RTT request exceeds the 30 s timeout, detected on the next sendRTTRequest call.

## Summary by Sourcery

Reject unknown assets during client identification and enforce RTT request timeouts using a pluggable clock.

Bug Fixes:
- Prevent sending SMM settings, server list, or commands to clients whose asset ID cannot be resolved.
- Disconnect clients when an outstanding RTT request exceeds the configured timeout.

Enhancements:
- Introduce an IClock seam for fss_client with a default WallClock implementation to enable time-based behaviours and testing.

Tests:
- Convert previously expected-failing tests for unknown-asset rejection and RTT timeout disconnection into passing tests using the new clock seam and behaviour.