### PR TITLE
fix: drain server lists in ~fss_client() to prevent recv-thread use-a…

### DIFF
--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -43,7 +43,19 @@ flight_safety_system::client_ssl::fss_client::fss_client(std::string t_ca, std::
 {
 }
 
-flight_safety_system::client_ssl::fss_client::~fss_client() = default;
+flight_safety_system::client_ssl::fss_client::~fss_client()
+{
+    // Drain both lists before disconnecting so that any concurrent
+    // serverRequiresReconnect call sees empty lists and cannot push_back
+    // into a list that is already being destroyed.
+    std::list<std::shared_ptr<fss_server>> all;
+    all.splice(all.end(), this->servers);
+    all.splice(all.end(), this->reconnect_servers);
+    for (const auto &server : all)
+    {
+        server->disconnect();
+    }
+}
 
 void
 flight_safety_system::client_ssl::fss_client::disconnect()


### PR DESCRIPTION
## Description

The default destructor destroyed reconnect_servers (declared second, therefore destroyed first) while a background recv thread could still call serverRequiresReconnect() and push_back into it, producing a definitely-lost Valgrind leak.  Splice both lists into a local before disconnecting so any concurrent serverRequiresReconnect() sees empty lists and skips the push.

## Summary by Sourcery

Bug Fixes:
- Prevent a race where the background recv thread could push servers into reconnect lists while they were being destroyed, causing leaks and undefined behavior.