### PR TITLE
feat: implement todo05 — connection timeout and TCP keepalive

### DIFF
--- a/.cppcheck-suppress
+++ b/.cppcheck-suppress
@@ -26,19 +26,19 @@ dangerousTypeCast:src/transport.cpp:38
 dangerousTypeCast:src/transport.cpp:39
 duplicateBreak:src/transport.cpp:35
 duplicateBreak:src/transport.cpp:40
-cstyleCast:src/transport.cpp:207
-constVariablePointer:src/transport.cpp:207
+cstyleCast:src/transport.cpp:209
+constVariablePointer:src/transport.cpp:209
 
 # transport-helpers.cpp — network address utility C-style casts + AF_UNSPEC tautology
-dangerousTypeCast:src/transport-helpers.cpp:22
-cstyleCast:src/transport-helpers.cpp:22
-dangerousTypeCast:src/transport-helpers.cpp:35
-cstyleCast:src/transport-helpers.cpp:35
-dangerousTypeCast:src/transport-helpers.cpp:59
-cstyleCast:src/transport-helpers.cpp:59
-dangerousTypeCast:src/transport-helpers.cpp:64
-cstyleCast:src/transport-helpers.cpp:64
-knownConditionTrueFalse:src/transport-helpers.cpp:16
+dangerousTypeCast:src/transport-helpers.cpp:23
+cstyleCast:src/transport-helpers.cpp:23
+dangerousTypeCast:src/transport-helpers.cpp:36
+cstyleCast:src/transport-helpers.cpp:36
+dangerousTypeCast:src/transport-helpers.cpp:60
+cstyleCast:src/transport-helpers.cpp:60
+dangerousTypeCast:src/transport-helpers.cpp:65
+cstyleCast:src/transport-helpers.cpp:65
+knownConditionTrueFalse:src/transport-helpers.cpp:17
 
 # transport-messages.cpp — wire-protocol packing; C-style casts are intentional
 functionStatic:src/transport-messages.cpp:172

--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -86,6 +86,20 @@ flight_safety_system::client_ssl::fss_client::connectTo(const std::string &t_add
 void
 flight_safety_system::client_ssl::fss_client::attemptReconnect()
 {
+    std::list<fss_server *> timed_out;
+    for (const auto &server : this->servers)
+    {
+        if (server->isServerTimedOut())
+        {
+            timed_out.push_back(server.get());
+        }
+    }
+    for (auto *server : timed_out)
+    {
+        FSS_LOG_WARN("client", "Server connection timed out, scheduling reconnect");
+        this->serverRequiresReconnect(server);
+    }
+
     std::list<std::shared_ptr<fss_server>> reconnected;
     bool any_connected = false;
     for (auto const &server : this->reconnect_servers)
@@ -299,6 +313,13 @@ flight_safety_system::client_ssl::fss_server::reconnect() -> bool
     return false;
 }
 
+auto
+flight_safety_system::client_ssl::fss_server::isServerTimedOut() -> bool
+{
+    if (!this->liveness_active.load(std::memory_order_relaxed)) { return false; }
+    return (this->clock->now_ms() - this->last_message_received_time.load(std::memory_order_relaxed)) > this->server_timeout_ms;
+}
+
 void
 flight_safety_system::client_ssl::fss_server::processMessage(std::shared_ptr<flight_safety_system::transport::fss_message> msg)
 {
@@ -319,6 +340,8 @@ flight_safety_system::client_ssl::fss_server::processMessage(std::shared_ptr<fli
     }
     else
     {
+        this->liveness_active.store(true, std::memory_order_relaxed);
+        this->last_message_received_time.store(this->clock->now_ms(), std::memory_order_relaxed);
         switch (msg->getType())
         {
             case flight_safety_system::transport::message_type_unknown:

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -13,7 +13,6 @@ namespace fss = flight_safety_system;
 
 constexpr int sec_to_msec = 1000;
 constexpr uint64_t rtt_retry_interval = 10 * sec_to_msec;
-constexpr uint64_t rtt_timeout = 30 * sec_to_msec;
 
 fss::server::smm_settings::smm_settings(std::string t_address, std::string t_username, std::string t_password) : address(std::move(t_address)), username(std::move(t_username)), password(std::move(t_password))
 {
@@ -127,6 +126,21 @@ fss::server::fss_client::setClock(std::shared_ptr<fss::IClock> t_clock)
 }
 
 void
+fss::server::fss_client::setTimeoutMs(uint64_t ms)
+{
+    std::lock_guard<std::mutex> guard(this->client_lock);
+    this->client_timeout_ms = ms;
+}
+
+auto
+fss::server::fss_client::isTimedOut() -> bool
+{
+    std::lock_guard<std::mutex> guard(this->client_lock);
+    if (!this->liveness_active) { return false; }
+    return (this->clock->now_ms() - this->last_rtt_response_time) > this->client_timeout_ms;
+}
+
+void
 fss::server::fss_client::sendRTTRequest(const std::shared_ptr<fss::transport::fss_message_rtt_request> &rtt_req)
 {
     bool timed_out = false;
@@ -135,7 +149,7 @@ fss::server::fss_client::sendRTTRequest(const std::shared_ptr<fss::transport::fs
         uint64_t now = this->clock->now_ms();
         if (!this->outstanding_rtt_requests.empty())
         {
-            if (now - this->outstanding_rtt_requests.front()->getTimeStamp() > rtt_timeout)
+            if (now - this->outstanding_rtt_requests.front()->getTimeStamp() > this->client_timeout_ms)
             {
                 timed_out = true;
             }
@@ -234,6 +248,8 @@ fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss_mess
                 {
                     std::lock_guard<std::mutex> guard(this->client_lock);
                     this->name = std::move(client_name);
+                    this->liveness_active = true;
+                    this->last_rtt_response_time = this->clock->now_ms();
                 }
                 this->aircraft = true;
                 this->identified = true;
@@ -288,6 +304,7 @@ fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss_mess
                     if (rtt_req != nullptr)
                     {
                         this->outstanding_rtt_requests.remove(rtt_req);
+                        this->last_rtt_response_time = this->clock->now_ms();
                     }
                 }
                 if (rtt_req != nullptr && asset_id != 0)

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -1,6 +1,8 @@
 #include <fss-transport-ssl.hpp>
 #include <fss.hpp>
 
+#include <atomic>
+#include <cstdint>
 #include <list>
 #include <memory>
 
@@ -65,6 +67,9 @@ private:
     static constexpr uint64_t retry_delay_cap = 30000;
     uint64_t retry_delay{retry_delay_start};
     std::shared_ptr<flight_safety_system::IClock> clock{std::make_shared<flight_safety_system::WallClock>()};
+    std::atomic<bool> liveness_active{false};
+    std::atomic<uint64_t> last_message_received_time{0};
+    uint64_t server_timeout_ms{30000};
 protected:
     virtual auto reconnect_to() -> bool;
 public:
@@ -81,6 +86,8 @@ public:
     virtual auto getClient() -> fss_client *;
     virtual void sendIdentify();
     void setClock(std::shared_ptr<flight_safety_system::IClock> t_clock);
+    void setServerTimeoutMs(uint64_t ms) { this->server_timeout_ms = ms; }
+    auto isServerTimedOut() -> bool;
 };
 
 

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -123,6 +123,9 @@ private:
     auto getName() -> std::string;
     uint64_t last_command_send_ts{0};
     uint64_t last_command_dbid{0};
+    bool liveness_active{false};
+    uint64_t last_rtt_response_time{0};
+    uint64_t client_timeout_ms{30000};
     IDatabase *dbc;
     fss_client_handler *client_handler;
     std::shared_ptr<IClock> clock{std::make_shared<WallClock>()};
@@ -139,6 +142,8 @@ public:
     void sendCommand();
     auto isAircraft() -> bool;
     void setClock(std::shared_ptr<IClock> t_clock);
+    void setTimeoutMs(uint64_t ms);
+    auto isTimedOut() -> bool;
 };
 } // namespace server
 } // namespace flight_safety_system

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -35,6 +35,7 @@ private:
     std::queue<std::shared_ptr<flight_safety_system::server::fss_client>> disconnected{};
     uint32_t total_clients{0};
     std::atomic<bool> shutting_down{false};
+    uint64_t client_timeout_ms{30000};
 public:
     server_clients() = default;
     ~server_clients() override {
@@ -59,8 +60,10 @@ public:
             total_clients--;
         }
     };
+    void setClientTimeoutMs(uint64_t ms) { this->client_timeout_ms = ms; }
     void clientConnected(std::shared_ptr<flight_safety_system::server::fss_client> client)
     {
+        client->setTimeoutMs(this->client_timeout_ms);
         std::lock_guard<std::mutex> guard(this->lock);
         this->total_clients++;
         this->clients.push_back(std::move(client));
@@ -89,6 +92,22 @@ public:
             }
         }
     }
+    void checkTimeouts()
+    {
+        std::vector<std::shared_ptr<flight_safety_system::server::fss_client>> snapshot;
+        {
+            std::lock_guard<std::mutex> guard(this->lock);
+            std::copy(this->clients.begin(), this->clients.end(), std::back_inserter(snapshot));
+        }
+        for (const auto &client : snapshot)
+        {
+            if (client->isTimedOut())
+            {
+                FSS_LOG_WARN("server", "Client timed out, disconnecting");
+                this->clientDisconnected(client.get());
+            }
+        }
+    };
     void sendSMMSettings()
     {
         std::lock_guard<std::mutex> guard(this->lock);
@@ -153,6 +172,10 @@ main(int argc, char *argv[]) -> int
     auto dbc = std::make_shared<flight_safety_system::server::db_connection>(config["postgres"]["host"].asString(), config["postgres"]["user"].asString(), config["postgres"]["pass"].asString(), config["postgres"]["db"].asString());
 
     auto clients = std::make_shared<server_clients>();
+    constexpr int default_client_timeout_sec = 30;
+    constexpr int msec_per_sec = 1000;
+    uint64_t client_timeout_sec = config.isMember("client_timeout") ? config["client_timeout"].asUInt64() : default_client_timeout_sec;
+    clients->setClientTimeoutMs(client_timeout_sec * msec_per_sec);
 
     std::shared_ptr<flight_safety_system::transport::fss_listen> listen;
     FSS_LOG_INFO("server", "Starting fss server in TLS mode");
@@ -180,6 +203,7 @@ main(int argc, char *argv[]) -> int
     {
         sleep (1);
         clients->cleanupRemovableClients();
+        clients->checkTimeouts();
         {
             auto rtt_req = std::make_shared<flight_safety_system::transport::fss_message_rtt_request>();
             clients->sendRTTRequest(rtt_req);

--- a/src/transport-helpers.cpp
+++ b/src/transport-helpers.cpp
@@ -5,6 +5,7 @@
 
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <arpa/inet.h>
 #include <netdb.h>
 
@@ -67,4 +68,17 @@ convert_str_to_sa(const std::string &addr, uint16_t port, struct sockaddr_storag
     }
     
     return family != AF_UNSPEC;
+}
+
+void
+set_tcp_keepalive(int fd)
+{
+    int val = 1;
+    setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &val, sizeof(val));
+    val = 15;
+    setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &val, sizeof(val));
+    val = 5;
+    setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &val, sizeof(val));
+    val = 3;
+    setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &val, sizeof(val));
 }

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -104,6 +104,8 @@ flight_safety_system::transport_ssl::fss_connection_client::connectTo(const std:
         return false;
     }
 
+    set_tcp_keepalive(this->getFd());
+
     this->usable = this->setupSSL();
 
     if (this->usable)

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -178,6 +178,8 @@ flight_safety_system::transport::fss_connection::connectTo(const std::string &ad
         return false;
     }
 
+    set_tcp_keepalive(current_fd);
+
     this->recv_thread = std::thread(recv_msg_thread, this);
 
     return true;
@@ -400,6 +402,7 @@ flight_safety_system::transport::fss_listen::processMessages()
         inet_ntop_stor(&sa, addr_str, INET6_ADDRSTRLEN, &client_port);
         std::cout << "New client from " << addr_str << ":" << client_port << " as " << newfd << std::endl;
 #endif
+        set_tcp_keepalive(newfd);
         if (this->cb != nullptr)
         {
             auto conn = this->newConnection(newfd);

--- a/src/transport.hpp
+++ b/src/transport.hpp
@@ -2,3 +2,4 @@
 #include <cstdint>
 
 auto convert_str_to_sa(const std::string &addr, uint16_t port, struct sockaddr_storage *sa) -> bool;
+void set_tcp_keepalive(int fd);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -18,6 +18,7 @@ all_test_SOURCES = main.cpp messages.cpp connection.cpp client.cpp \
 	connection_negative_test.cpp \
 	ssl_failure_test.cpp \
 	server_session_test.cpp \
+	timeout_test.cpp \
 	../src/client_session.cpp
 all_test_LDADD = ../src/libfss-transport.la ../src/libfss-client-ssl.la ../src/libfss.la $(JSONCPP_LIBS)
 

--- a/tests/timeout_test.cpp
+++ b/tests/timeout_test.cpp
@@ -1,0 +1,263 @@
+#ifdef HAVE_CATCH2_CATCH_ALL_HPP
+#include <catch2/catch_all.hpp>
+#elif HAVE_CATCH2_CATCH_HPP
+#include <catch2/catch.hpp>
+#elif HAVE_CATCH_CATCH_HPP
+#include <catch/catch.hpp>
+#elif HAVE_CATCH_HPP
+#include <catch.hpp>
+#else
+#error No catch header
+#endif
+
+#include <memory>
+
+#include "fss-transport.hpp"
+#include "fss-server.hpp"
+#include "fss-client-ssl.hpp"
+#include "mock_database.hpp"
+
+namespace fss = flight_safety_system;
+
+namespace {
+
+/* ── shared test doubles ─────────────────────────────────── */
+
+struct FakeClock : public fss::IClock {
+    uint64_t t{0};
+    auto now_ms() const -> uint64_t override { return t; }
+    void advance(uint64_t ms) { t += ms; }
+};
+
+class FakeConnection : public fss::transport::fss_connection {
+public:
+    std::list<std::string> cert_names{};
+    FakeConnection() = default;
+    FakeConnection(const FakeConnection &) = delete;
+    FakeConnection(FakeConnection &&) = delete;
+    auto operator=(const FakeConnection &) -> FakeConnection & = delete;
+    auto operator=(FakeConnection &&) -> FakeConnection & = delete;
+    ~FakeConnection() override = default;
+    auto getClientNames() -> std::list<std::string> override { return cert_names; }
+protected:
+    auto sendMsg(const std::shared_ptr<fss::transport::buf_len> &) -> bool override { return true; }
+};
+
+class NullClientHandler : public fss::server::fss_client_handler {
+public:
+    int disconnects{0};
+    ~NullClientHandler() override = default;
+    void clientDisconnected(fss::server::fss_client *) override { ++disconnects; }
+    void broadcastMsg(const std::shared_ptr<fss::transport::fss_message> &,
+                      fss::server::fss_client * = nullptr) override {}
+};
+
+/* ── server-side (fss_client) timeout tests ─────────────── */
+
+} // namespace
+
+TEST_CASE("timeout: isTimedOut false before identification")
+{
+    fss_test::MockDatabase mock;
+    auto conn = std::make_shared<FakeConnection>();
+    NullClientHandler handler;
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, &handler);
+    auto clock = std::make_shared<FakeClock>();
+    session->setClock(clock);
+
+    clock->advance(100000);
+    REQUIRE_FALSE(session->isTimedOut());
+}
+
+TEST_CASE("timeout: isTimedOut false right after identification")
+{
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, &handler);
+    auto clock = std::make_shared<FakeClock>();
+    session->setClock(clock);
+
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    REQUIRE_FALSE(session->isTimedOut());
+}
+
+TEST_CASE("timeout: isTimedOut true after timeout without RTT response")
+{
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, &handler);
+    auto clock = std::make_shared<FakeClock>();
+    session->setClock(clock);
+
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    clock->advance(30001);
+    REQUIRE(session->isTimedOut());
+}
+
+TEST_CASE("timeout: isTimedOut reset by RTT response")
+{
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, &handler);
+    auto clock = std::make_shared<FakeClock>();
+    session->setClock(clock);
+
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    /* Send an RTT request so the session tracks a pending request id.
+     * fss_connection::sendMsg overwrites the message id — capture it after. */
+    auto rtt_req = std::make_shared<fss::transport::fss_message_rtt_request>();
+    session->sendRTTRequest(rtt_req);
+    uint64_t assigned_id = rtt_req->getId();
+
+    clock->advance(20000);
+
+    /* RTT response arrives at t=20000, resetting the liveness clock. */
+    session->processMessage(std::make_shared<fss::transport::fss_message_rtt_response>(assigned_id));
+
+    /* 25 s after the response, still within the 30 s window. */
+    clock->advance(25000);
+    REQUIRE_FALSE(session->isTimedOut());
+
+    /* Another 6 s takes us past the window. */
+    clock->advance(6000);
+    REQUIRE(session->isTimedOut());
+}
+
+TEST_CASE("timeout: setTimeoutMs overrides default threshold")
+{
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, &handler);
+    auto clock = std::make_shared<FakeClock>();
+    session->setClock(clock);
+    session->setTimeoutMs(5000);
+
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    clock->advance(5000);
+    REQUIRE_FALSE(session->isTimedOut());
+
+    clock->advance(1);
+    REQUIRE(session->isTimedOut());
+}
+
+/* ── client-side (fss_server) timeout tests ─────────────── */
+
+namespace {
+
+/* A server that pretends to be connected so it can be placed in
+ * fss_client's connected-servers list without a real TLS handshake. */
+class AlwaysConnectedServer : public fss::client_ssl::fss_server {
+public:
+    using fss_server::fss_server;
+    AlwaysConnectedServer(const AlwaysConnectedServer &) = delete;
+    AlwaysConnectedServer(AlwaysConnectedServer &&) = delete;
+    auto operator=(const AlwaysConnectedServer &) -> AlwaysConnectedServer & = delete;
+    auto operator=(AlwaysConnectedServer &&) -> AlwaysConnectedServer & = delete;
+    ~AlwaysConnectedServer() override = default;
+    auto connected() -> bool override { return true; }
+protected:
+    auto reconnect_to() -> bool override { return false; }
+};
+
+/* A client that exposes addServer and captures status changes. */
+class TestClient : public fss::client_ssl::fss_client {
+public:
+    using fss_client::fss_client;
+    int status_changes{0};
+    fss::client_ssl::connection_status last_status{fss::client_ssl::CLIENT_CONNECTION_STATUS_UNKNOWN};
+
+    void add(const std::shared_ptr<fss::client_ssl::fss_server> &server)
+    {
+        this->addServer(server);
+    }
+protected:
+    void connectionStatusChange(fss::client_ssl::connection_status status) override
+    {
+        ++status_changes;
+        last_status = status;
+    }
+};
+
+} // namespace
+
+TEST_CASE("timeout: isServerTimedOut false before any message")
+{
+    auto client = std::make_shared<TestClient>();
+    auto server = std::make_shared<AlwaysConnectedServer>(
+        client.get(), "127.0.0.1", uint16_t{9999}, "", "", "");
+    auto clock = std::make_shared<FakeClock>();
+    server->setClock(clock);
+
+    clock->advance(100000);
+    REQUIRE_FALSE(server->isServerTimedOut());
+}
+
+TEST_CASE("timeout: isServerTimedOut false right after message")
+{
+    auto client = std::make_shared<TestClient>();
+    auto server = std::make_shared<AlwaysConnectedServer>(
+        client.get(), "127.0.0.1", uint16_t{9999}, "", "", "");
+    auto clock = std::make_shared<FakeClock>();
+    server->setClock(clock);
+
+    /* An RTT request from the server starts the liveness clock. */
+    server->processMessage(std::make_shared<fss::transport::fss_message_rtt_request>());
+
+    clock->advance(29999);
+    REQUIRE_FALSE(server->isServerTimedOut());
+}
+
+TEST_CASE("timeout: isServerTimedOut true after timeout without messages")
+{
+    auto client = std::make_shared<TestClient>();
+    auto server = std::make_shared<AlwaysConnectedServer>(
+        client.get(), "127.0.0.1", uint16_t{9999}, "", "", "");
+    auto clock = std::make_shared<FakeClock>();
+    server->setClock(clock);
+
+    server->processMessage(std::make_shared<fss::transport::fss_message_rtt_request>());
+
+    clock->advance(30001);
+    REQUIRE(server->isServerTimedOut());
+}
+
+TEST_CASE("timeout: attemptReconnect moves timed-out server to reconnect queue")
+{
+    auto client = std::make_shared<TestClient>();
+    auto server = std::make_shared<AlwaysConnectedServer>(
+        client.get(), "127.0.0.1", uint16_t{9999}, "", "", "");
+    auto clock = std::make_shared<FakeClock>();
+    server->setClock(clock);
+
+    /* Register the server as "connected" with the client. */
+    client->add(server);
+
+    /* Start liveness, then let it expire. */
+    server->processMessage(std::make_shared<fss::transport::fss_message_rtt_request>());
+    clock->advance(30001);
+
+    REQUIRE(server->isServerTimedOut());
+
+    client->attemptReconnect();
+
+    /* connectionStatusChange should have fired with DISCONNECTED since the
+     * server moved from servers to reconnect_servers. */
+    REQUIRE(client->status_changes > 0);
+    REQUIRE(client->last_status == fss::client_ssl::CLIENT_CONNECTION_STATUS_DISCONNECTED);
+}


### PR DESCRIPTION
Server-side: fss_client tracks last_rtt_response_time (set on identity, updated on each RTT response). isTimedOut() uses the configurable client_timeout_ms (default 30 s) rather than a hardcoded constant. server_clients::checkTimeouts() calls clientDisconnected for each expired client every second from the main loop. Timeout is readable from server.json as "client_timeout" (seconds).

Client-side: fss_server tracks liveness_active and last_message_received_time (updated on every non-closed incoming message). isServerTimedOut() detects server silence beyond server_timeout_ms. fss_client::attemptReconnect() calls serverRequiresReconnect for any timed-out server before the normal reconnect loop.

TCP keepalive (OS fallback): set_tcp_keepalive() helper applies SO_KEEPALIVE / TCP_KEEPIDLE=15 / TCP_KEEPINTVL=5 / TCP_KEEPCNT=3 on every accepted fd (transport.cpp) and after every outbound connect (transport.cpp, transport-ssl.cpp).

Tests (timeout_test.cpp): 9 Catch2 cases covering isTimedOut false before identification, false/true relative to the threshold, reset by RTT response, configurable threshold, and client-side isServerTimedOut + attemptReconnect integration.

## Summary by Sourcery

Add configurable client/server connection timeouts and TCP keepalive, and integrate timeout-driven disconnect/reconnect handling on both server and client sides.

New Features:
- Introduce configurable server-side client timeout with periodic checks that disconnect inactive clients based on RTT liveness.
- Introduce client-side server timeout detection that triggers moving stale connections into the reconnect flow.
- Enable TCP keepalive on all accepted and outbound connections as an OS-level fallback for detecting dead peers.

Tests:
- Add timeout_test suite covering server-side client timeout behaviour, client-side server timeout behaviour, and their interaction with RTT messages.