### PR TITLE
feat: implement todo06 — add jitter to reconnect backoff

### DIFF
--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -288,13 +288,16 @@ flight_safety_system::client_ssl::fss_server::reconnect() -> bool
         this->clearConnection();
     }
 
-    if (elapsed_time > this->retry_delay)
+    if (elapsed_time > this->effective_delay)
     {
         this->retry_count++;
         if (this->retry_delay < retry_delay_cap)
         {
             this->retry_delay += this->retry_delay;
         }
+        int64_t jitter_range = static_cast<int64_t>(this->retry_delay) / 4;
+        std::uniform_int_distribution<int64_t> dist(-jitter_range, jitter_range);
+        this->effective_delay = static_cast<uint64_t>(static_cast<int64_t>(this->retry_delay) + dist(this->rng));
         this->last_tried = ts;
         if (!this->reconnect_to())
         {
@@ -307,6 +310,7 @@ flight_safety_system::client_ssl::fss_server::reconnect() -> bool
             this->retry_count = 0;
             this->last_tried = 0;
             this->retry_delay = retry_delay_start;
+            this->effective_delay = retry_delay_start;
             return true;
         }
     }

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <list>
 #include <memory>
+#include <random>
 
 namespace flight_safety_system {
 namespace client_ssl {
@@ -66,6 +67,8 @@ private:
     static constexpr uint64_t retry_delay_start = 1000;
     static constexpr uint64_t retry_delay_cap = 30000;
     uint64_t retry_delay{retry_delay_start};
+    uint64_t effective_delay{retry_delay_start};
+    std::mt19937 rng{std::random_device{}()};
     std::shared_ptr<flight_safety_system::IClock> clock{std::make_shared<flight_safety_system::WallClock>()};
     std::atomic<bool> liveness_active{false};
     std::atomic<uint64_t> last_message_received_time{0};
@@ -88,6 +91,7 @@ public:
     void setClock(std::shared_ptr<flight_safety_system::IClock> t_clock);
     void setServerTimeoutMs(uint64_t ms) { this->server_timeout_ms = ms; }
     auto isServerTimedOut() -> bool;
+    auto getEffectiveDelay() const -> uint64_t { return this->effective_delay; }
 };
 
 

--- a/tests/reconnect_test.cpp
+++ b/tests/reconnect_test.cpp
@@ -10,11 +10,12 @@
 #error No catch header
 #endif
 
-#include <atomic>
+#include <algorithm>
 #include <chrono>
 #include <memory>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include "fss-transport.hpp"
 #include "fss-client-ssl.hpp"
@@ -175,28 +176,64 @@ TEST_CASE("reconnect: fake clock exposes exponential backoff growth")
     auto fake = std::make_shared<FakeClock>();
     server->setClock(fake);
 
-    /* First attempt: clock must exceed the initial 1000ms retry delay. */
+    /* First attempt: clock must exceed the initial 1000ms retry delay (no jitter yet). */
     fake->advance(1001);
     server->reconnect();
     REQUIRE(server->attempts == 1);
 
-    /* Retry delay has doubled to 2000ms. A 1001ms gap must not fire. */
-    fake->advance(1001);
+    /* Base doubles to 2000ms; with ±25% jitter effective_delay ∈ [1500, 2500].
+     * 1499ms < 1500ms (min) so this is always below the window. */
+    fake->advance(1499);
     server->reconnect();
     REQUIRE(server->attempts == 1);
 
-    /* 2001ms since last_tried → attempt 2, delay doubles to 4000. */
-    fake->advance(1001);
+    /* 2501ms > 2500ms (max) so this always fires regardless of jitter. */
+    fake->advance(1002);
     server->reconnect();
     REQUIRE(server->attempts == 2);
 
-    fake->advance(4000);
+    /* Base doubles to 4000ms; effective_delay ∈ [3000, 5000].
+     * 2999ms < 3000ms (min) so still below window. */
+    fake->advance(2999);
     server->reconnect();
     REQUIRE(server->attempts == 2);
 
-    fake->advance(1);
+    /* 5001ms > 5000ms (max) so always fires. */
+    fake->advance(2002);
     server->reconnect();
     REQUIRE(server->attempts == 3);
+}
+
+TEST_CASE("reconnect: jitter keeps effective delay within 25% of base")
+{
+    auto client = std::make_shared<flight_safety_system::client_ssl::fss_client>(
+        CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+
+    /* Run enough instances to verify bounds and variation. */
+    std::vector<uint64_t> delays;
+    for (int i = 0; i < 20; ++i)
+    {
+        auto server = std::make_shared<CountingServer>(
+            client.get(), "127.0.0.1", static_cast<uint16_t>(20601),
+            CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+        auto fake = std::make_shared<FakeClock>();
+        server->setClock(fake);
+
+        fake->advance(1001);
+        server->reconnect();
+        REQUIRE(server->attempts == 1);
+
+        /* Base doubled to 2000ms; effective_delay must be within [1500, 2500]. */
+        uint64_t eff = server->getEffectiveDelay();
+        REQUIRE(eff >= 1500);
+        REQUIRE(eff <= 2500);
+        delays.push_back(eff);
+    }
+
+    /* Delays must not all be identical — jitter should introduce variation. */
+    bool any_differ = std::any_of(delays.begin() + 1, delays.end(),
+                                  [&](uint64_t d) { return d != delays[0]; });
+    REQUIRE(any_differ);
 }
 
 TEST_CASE("reconnect: multi-server failover keeps secondary reachable")


### PR DESCRIPTION
## Description

Adds ±25% random jitter to the exponential backoff delay so that multiple clients reconnecting after an outage spread their attempts instead of thundering-herding the server.

## Summary by Sourcery

Add randomized jitter to reconnect backoff delays to avoid synchronized client retries and extend tests to cover jitter behavior and bounds.

New Features:
- Introduce an effective reconnect delay with ±25% random jitter around the exponential backoff base value.

Enhancements:
- Expose the computed effective reconnect delay for testing and initialize it alongside backoff state transitions.

Tests:
- Update reconnect backoff tests to account for jitter-adjusted timing windows and add coverage to ensure jitter stays within bounds and produces variation.