### PR TITLE
feat: implement todo07 — bounded message queues with drop-oldest policy

### DIFF
--- a/.cppcheck-suppress
+++ b/.cppcheck-suppress
@@ -26,8 +26,8 @@ dangerousTypeCast:src/transport.cpp:38
 dangerousTypeCast:src/transport.cpp:39
 duplicateBreak:src/transport.cpp:35
 duplicateBreak:src/transport.cpp:40
-cstyleCast:src/transport.cpp:209
-constVariablePointer:src/transport.cpp:209
+cstyleCast:src/transport.cpp:225
+constVariablePointer:src/transport.cpp:225
 
 # transport-helpers.cpp — network address utility C-style casts + AF_UNSPEC tautology
 dangerousTypeCast:src/transport-helpers.cpp:23

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <queue>
 #include <sys/types.h>
 #include <thread>
 #include <list>
@@ -106,6 +107,7 @@ public:
 };
 
 class fss_connection {
+    static constexpr size_t default_max_queue_size = 1000;
     std::atomic<bool> run{false};
     std::atomic<int> fd{-1};
     std::atomic<uint64_t> last_msg_id{0};
@@ -114,6 +116,8 @@ class fss_connection {
     std::thread recv_thread{};
     std::mutex send_lock{};
     std::mutex msg_lock{};
+    size_t max_queue_size{default_max_queue_size};
+    std::atomic<uint64_t> dropped_messages{0};
 protected:
     auto recvMsg() -> std::shared_ptr<fss_message>;
     auto getMessageId() -> uint64_t;
@@ -122,10 +126,11 @@ protected:
     auto getFd() -> int;
     void setFd(int new_fd);
     void startRecvThread(std::thread t_recv_thread);
-    explicit fss_connection(int fd);
+    explicit fss_connection(int fd, size_t t_max_queue_size = default_max_queue_size);
 public:
     fss_connection();
-    static auto create(int fd) -> std::shared_ptr<fss_connection>;
+    static auto create(int fd, size_t t_max_queue_size = default_max_queue_size) -> std::shared_ptr<fss_connection>;
+    auto getDroppedMessages() -> uint64_t;
     fss_connection(fss_connection&) = delete;
     fss_connection(fss_connection&&) = delete;
     auto operator=(fss_connection &) -> fss_connection& = delete;

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -51,16 +51,23 @@ recv_msg_thread(flight_safety_system::transport::fss_connection *conn)
     conn->processMessages();
 }
 
-flight_safety_system::transport::fss_connection::fss_connection(int t_fd) : fd(t_fd)
+flight_safety_system::transport::fss_connection::fss_connection(int t_fd, size_t t_max_queue_size)
+    : fd(t_fd), max_queue_size(t_max_queue_size)
 {
 }
 
 auto
-flight_safety_system::transport::fss_connection::create(int t_fd) -> std::shared_ptr<fss_connection>
+flight_safety_system::transport::fss_connection::create(int t_fd, size_t t_max_queue_size) -> std::shared_ptr<fss_connection>
 {
-    auto conn = std::shared_ptr<fss_connection>(new fss_connection(t_fd));
+    auto conn = std::shared_ptr<fss_connection>(new fss_connection(t_fd, t_max_queue_size));
     conn->startRecvThread(std::thread(recv_msg_thread, conn.get()));
     return conn;
+}
+
+auto
+flight_safety_system::transport::fss_connection::getDroppedMessages() -> uint64_t
+{
+    return this->dropped_messages.load();
 }
 
 void
@@ -118,6 +125,15 @@ flight_safety_system::transport::fss_connection::processMessages()
             }
             else
             {
+                if (this->max_queue_size != 0 && this->messages.size() >= this->max_queue_size)
+                {
+                    this->messages.pop();
+                    uint64_t dropped = ++this->dropped_messages;
+                    if (dropped == 1 || dropped % 100 == 0)
+                    {
+                        FSS_LOG_WARN("transport", "Message queue full, dropping oldest message. Total dropped: " << dropped);
+                    }
+                }
                 this->messages.push(msg);
             }
         }

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -85,6 +85,47 @@ class test_message_cb: public flight_safety_system::transport::fss_message_cb
 };
 
 
+class small_queue_listen : public flight_safety_system::transport::fss_listen {
+public:
+    static constexpr size_t queue_limit = 5;
+    small_queue_listen(uint16_t t_port, flight_safety_system::transport::fss_connect_cb t_cb)
+        : fss_listen(t_port, std::move(t_cb)) {}
+protected:
+    auto newConnection(int t_fd) -> std::shared_ptr<flight_safety_system::transport::fss_connection> override {
+        return flight_safety_system::transport::fss_connection::create(t_fd, queue_limit);
+    }
+};
+
+TEST_CASE("Queue overflow drops oldest messages")
+{
+    constexpr size_t extra = 3;
+    const auto port = fss_test::pick_port();
+    REQUIRE(port != 0);
+
+    auto listen = std::make_shared<small_queue_listen>(port, test_client_connect_cb);
+    REQUIRE(listen != nullptr);
+
+    auto conn = std::make_shared<flight_safety_system::transport::fss_connection>();
+    REQUIRE(conn != nullptr);
+    REQUIRE(conn->connectTo("localhost", port));
+
+    REQUIRE(fss_test::wait_for([]() { return client_conn != nullptr; }));
+
+    for (size_t i = 0; i < small_queue_listen::queue_limit + extra; ++i) {
+        conn->sendMsg(std::make_shared<flight_safety_system::transport::fss_message_rtt_request>());
+    }
+
+    REQUIRE(fss_test::wait_for([&]() { return client_conn->getDroppedMessages() >= extra; }));
+    REQUIRE(client_conn->getDroppedMessages() == extra);
+
+    size_t count = 0;
+    while (client_conn->getMsg() != nullptr) { ++count; }
+    REQUIRE(count == small_queue_listen::queue_limit);
+
+    conn = nullptr;
+    client_conn = nullptr;
+}
+
 TEST_CASE("Listen - Callback")
 {
     constexpr int listen_port = 20203;

--- a/tests/queue_test.cpp
+++ b/tests/queue_test.cpp
@@ -37,6 +37,16 @@ auto accept_cb(std::shared_ptr<fss_connection> new_conn) -> bool
     return true;
 }
 
+class large_queue_listen : public fss_listen {
+public:
+    large_queue_listen(uint16_t t_port, flight_safety_system::transport::fss_connect_cb t_cb)
+        : fss_listen(t_port, std::move(t_cb)) {}
+protected:
+    auto newConnection(int t_fd) -> std::shared_ptr<fss_connection> override {
+        return fss_connection::create(t_fd, 20000);
+    }
+};
+
 } // namespace
 
 TEST_CASE("queue: FIFO ordering is preserved across many messages")
@@ -118,7 +128,7 @@ TEST_CASE("queue: 10k messages over loopback with no drops")
 {
     server_side_conn = nullptr;
     constexpr uint16_t port = 20504;
-    auto listen = std::make_shared<fss_listen>(port, accept_cb);
+    auto listen = std::make_shared<large_queue_listen>(port, accept_cb);
     REQUIRE(listen != nullptr);
 
     auto client = std::make_shared<fss_connection>();


### PR DESCRIPTION
## Description

Add a configurable max queue depth (default 1000) to fss_connection. When the queue is full, the oldest message is dropped and a counter incremented; a WARN is logged on the first drop and every 100th thereafter. fss_connection::create() accepts an optional queue size so tests and subclasses can override the limit. The existing 10k-message throughput test now uses a 20k-limit listener to preserve its no-drop guarantee; a new overflow test verifies drop count and queue contents.

## Summary by Sourcery

Introduce bounded message queues for fss_connection with a drop-oldest policy and expose drop metrics.

New Features:
- Allow fss_connection instances to be created with a configurable maximum inbound message queue size, defaulting to 1000 messages.
- Expose a counter on fss_connection to report the total number of dropped messages when the queue overflows.

Enhancements:
- Apply a drop-oldest policy when the inbound message queue reaches its configured limit, with periodic WARN logging on drops.
- Extend test listeners to support custom queue size limits, including a high-capacity listener for throughput tests and a small-queue listener for targeted overflow behavior.

Tests:
- Add a queue overflow test to verify dropped message counting and that the queue retains only the most recent messages up to the configured limit.
- Update the existing 10k loopback queue test to use a larger-capacity listener to maintain its no-drop guarantee under the new queue limits.