### PR TITLE
feat: implement todo11 — named FSS_COORD_SCALE constant at 1e-7 precision

### DIFF
--- a/.cppcheck-suppress
+++ b/.cppcheck-suppress
@@ -41,18 +41,18 @@ cstyleCast:src/transport-helpers.cpp:65
 knownConditionTrueFalse:src/transport-helpers.cpp:17
 
 # transport-messages.cpp — wire-protocol packing; C-style casts are intentional
-functionStatic:src/transport-messages.cpp:172
-functionStatic:src/transport-messages.cpp:226
+functionStatic:src/transport-messages.cpp:173
+functionStatic:src/transport-messages.cpp:227
 cstyleCast:src/transport-messages.cpp:411
 cstyleCast:src/transport-messages.cpp:412
 cstyleCast:src/transport-messages.cpp:600
 cstyleCast:src/transport-messages.cpp:736
-dangerousTypeCast:src/transport-messages.cpp:18
-cstyleCast:src/transport-messages.cpp:18
-dangerousTypeCast:src/transport-messages.cpp:25
-cstyleCast:src/transport-messages.cpp:25
-dangerousTypeCast:src/transport-messages.cpp:339
-cstyleCast:src/transport-messages.cpp:339
+dangerousTypeCast:src/transport-messages.cpp:19
+cstyleCast:src/transport-messages.cpp:19
+dangerousTypeCast:src/transport-messages.cpp:26
+cstyleCast:src/transport-messages.cpp:26
+dangerousTypeCast:src/transport-messages.cpp:340
+cstyleCast:src/transport-messages.cpp:340
 dangerousTypeCast:src/transport-messages.cpp:400
 cstyleCast:src/transport-messages.cpp:400
 dangerousTypeCast:src/transport-messages.cpp:401

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -13,6 +13,8 @@
 namespace flight_safety_system {
 
 namespace transport {
+
+static constexpr double FSS_COORD_SCALE = 0.0000001;
 class fss_connection;
 class fss_listen;
 class fss_message;

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -9,6 +9,7 @@ using flight_safety_system::fss_htobe32;
 using flight_safety_system::fss_be32toh;
 using flight_safety_system::fss_htobe64;
 using flight_safety_system::fss_be64toh;
+using flight_safety_system::transport::FSS_COORD_SCALE;
 
 void
 packString(const std::shared_ptr<flight_safety_system::transport::buf_len> &bl, const std::string &val)
@@ -381,14 +382,13 @@ flight_safety_system::transport::fss_message_position_report::fss_message_positi
     this->unpackData(bl);
 }
 
-constexpr float flt_to_int = 0.000001;
 void
 flight_safety_system::transport::fss_message_position_report::packData(std::shared_ptr<buf_len> bl)
 {
     uint64_t ts = fss_htobe64(this->getTimeStamp());
     /* Convert the lat/long to fixed decimal for transport */
-    int32_t lat = fss_htobe32((int32_t) (this->getLatitude() / flt_to_int));
-    int32_t lng = fss_htobe32((int32_t) (this->getLongitude() / flt_to_int));
+    int32_t lat = fss_htobe32((int32_t) (this->getLatitude() / FSS_COORD_SCALE));
+    int32_t lng = fss_htobe32((int32_t) (this->getLongitude() / FSS_COORD_SCALE));
     uint32_t alt = fss_htobe32(this->getAltitude());
     uint32_t icao_id = fss_htobe32(this->getICAOAddress());
     uint16_t head = fss_htobe16(this->getHeading());
@@ -435,7 +435,7 @@ flight_safety_system::transport::fss_message_position_report::unpackData(const s
         memcpy(&tmp, data + offset, sizeof(int32_t));
         lat = fss_be32toh(tmp);
         offset += sizeof(int32_t);
-        this->latitude = ((double)lat) * flt_to_int;
+        this->latitude = ((double)lat) * FSS_COORD_SCALE;
     }
     if (length - offset >= sizeof(int32_t))
     {
@@ -443,7 +443,7 @@ flight_safety_system::transport::fss_message_position_report::unpackData(const s
         memcpy(&tmp, data + offset, sizeof(int32_t));
         lng = fss_be32toh(tmp);
         offset += sizeof(int32_t);
-        this->longitude = ((double)lng) * flt_to_int;
+        this->longitude = ((double)lng) * FSS_COORD_SCALE;
     }
     if (length - offset >= sizeof(uint32_t))
     {
@@ -595,7 +595,7 @@ flight_safety_system::transport::fss_message_system_status::packData(std::shared
 {
     uint8_t bat_percent_n = this->getBatRemaining();
     uint32_t mah_used_n = fss_htobe32(this->getBatMAHUsed());
-    uint32_t voltage_n = fss_htobe32((int32_t) (this->getBatVoltage() / flt_to_int));
+    uint32_t voltage_n = fss_htobe32((int32_t) (this->getBatVoltage() / FSS_COORD_SCALE));
 
     bl->addData((char *)&bat_percent_n, sizeof(uint8_t));
     bl->addData((char *)&mah_used_n, sizeof(uint32_t));
@@ -625,7 +625,7 @@ flight_safety_system::transport::fss_message_system_status::unpackData(const std
         memcpy(&tmp, data + offset, sizeof(int32_t));
         uint32_t voltage_n = fss_be32toh(tmp);
         offset += sizeof(int32_t);
-        this->voltage = ((double)voltage_n) * flt_to_int;
+        this->voltage = ((double)voltage_n) * FSS_COORD_SCALE;
     }
 }
 
@@ -725,8 +725,8 @@ flight_safety_system::transport::fss_message_asset_command::packData(std::shared
 {
     uint64_t ts = fss_htobe64(this->getTimeStamp());
     /* Convert the lat/long to fixed decimal for transport */
-    int32_t lat = fss_htobe32((int32_t) (this->getLatitude() / flt_to_int));
-    int32_t lng = fss_htobe32((int32_t) (this->getLongitude() / flt_to_int));
+    int32_t lat = fss_htobe32((int32_t) (this->getLatitude() / FSS_COORD_SCALE));
+    int32_t lng = fss_htobe32((int32_t) (this->getLongitude() / FSS_COORD_SCALE));
     uint32_t alt = fss_htobe32(this->getAltitude());
     auto cmd = (uint8_t) this->getCommand();
     bl->addData((char *)&ts, sizeof(uint64_t));
@@ -765,8 +765,8 @@ flight_safety_system::transport::fss_message_asset_command::unpackData(const std
         offset += sizeof(uint32_t);
         this->command = static_cast<fss_asset_command>(static_cast<uint8_t>(data[offset]));
     }
-    this->latitude = lat * flt_to_int;
-    this->longitude = lng * flt_to_int;
+    this->latitude = lat * FSS_COORD_SCALE;
+    this->longitude = lng * FSS_COORD_SCALE;
 }
 
 auto

--- a/tests/coordinate_precision_test.cpp
+++ b/tests/coordinate_precision_test.cpp
@@ -24,19 +24,12 @@ using flight_safety_system::transport::fss_message_position_report;
 /* Regression for todo/11-coordinate-constant.md
  *
  * Coordinates are transported as int32_t fixed-point with scale factor
- * `flt_to_int` (currently 0.000001f in src/transport-messages.cpp). This
- * scale controls the precision of lat/long on the wire. The tests below
- * round-trip representative coordinates through pack+decode and assert
- * accuracy within the documented tolerance. A regression that changes
- * the scale, narrows the integer width, or introduces additional
+ * FSS_COORD_SCALE (0.0000001 / 1e-7, defined in src/fss-transport.hpp).
+ * This scale controls the precision of lat/long on the wire. The tests
+ * below round-trip representative coordinates through pack+decode and
+ * assert accuracy within the documented tolerance. A regression that
+ * changes the scale, narrows the integer width, or introduces additional
  * precision loss will surface here.
- *
- * The current code casts flt_to_int (float) up to double for division
- * and multiplication, so the *effective* scale is ~9.999999974752e-07
- * rather than exactly 1e-6. The tests target 1e-6 worst-case tolerance;
- * a tighter 1e-7 test is tagged [!shouldfail][bug11] and will start
- * passing once the todo lands and the scale becomes an exact double
- * (or the coord representation widens).
  */
 
 namespace {
@@ -119,14 +112,10 @@ TEST_CASE("coord: northernmost latitudes round-trip")
     }
 }
 
-TEST_CASE("coord: 7-decimal-place precision preserved",
-          "[!shouldfail][bug11]")
+TEST_CASE("coord: 7-decimal-place precision preserved")
 {
-    /* With the current float scale constant, the effective multiplier
-     * drifts from exact 1e-6 by ~2.5e-15 per unit count, so values that
-     * should be representable to 7dp actually lose a digit. This test
-     * documents the target precision once the scale becomes an exact
-     * double (per todo/11). */
+    /* FSS_COORD_SCALE = 1e-7 gives int32 resolution of 0.1 µdegree, so
+     * 7-decimal-place coordinates round-trip without loss. */
     double lat = 0.0, lng = 0.0;
     std::tie(lat, lng) = round_trip(-43.5000001, 172.5000001);
     REQUIRE(std::fabs(lat - (-43.5000001)) < 1e-7);


### PR DESCRIPTION
## Description

Replaces the file-local `constexpr float flt_to_int = 0.000001` with `static constexpr double FSS_COORD_SCALE = 0.0000001` in fss-transport.hpp, improving coordinate round-trip precision from ~1e-6 (float) to 1e-7 (double). Updates cppcheck suppression line numbers and promotes the previously-[!shouldfail] 7-decimal-place precision test to a normal pass.

## Summary by Sourcery

Increase coordinate fixed-point precision and centralize the scale factor as a shared constant.

Enhancements:
- Replace the local float coordinate scale with a shared double FSS_COORD_SCALE constant to improve precision of transported coordinates and related voltage fields.

Tests:
- Update coordinate precision tests to target 1e-7 resolution and promote the previous should-fail 7-decimal-place test to a normal passing test.