### PR TITLE
feat: implement todo01 — async database writes

### DIFF
--- a/e2e/test_slow_db_does_not_stall.py
+++ b/e2e/test_slow_db_does_not_stall.py
@@ -1,0 +1,113 @@
+"""End-to-end: a stalled DB must not stop the server from processing messages.
+
+Strategy: hold an EXCLUSIVE lock on assets_assetposition from an independent
+psycopg2 connection. While held, the server's async writer thread blocks on
+its position INSERT, but the per-client recv thread must continue to drain
+the socket (enqueue is non-blocking). After releasing the lock the queue
+must drain and new rows must land.
+"""
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from typing import Dict, Iterator
+
+import psycopg2
+import pytest
+
+from conftest import wait_for_row
+
+
+_LOCKABLE_TABLES = frozenset({"assets_assetposition"})
+
+
+@contextmanager
+def hold_table_lock(db_info: Dict[str, object], table: str) -> Iterator[None]:
+    """Hold an EXCLUSIVE lock on `table` via a fresh connection.
+
+    EXCLUSIVE blocks INSERT/UPDATE/DELETE from other transactions while
+    still permitting SELECT, so the test can continue to observe state.
+    """
+    if table not in _LOCKABLE_TABLES:
+        raise ValueError(f"table {table!r} is not in the allowed list")
+    conn = psycopg2.connect(
+        host=db_info["host"], port=db_info["port"],
+        user=db_info["user"], password=db_info["password"],
+        dbname=db_info["dbname"],
+    )
+    conn.autocommit = False
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f"LOCK TABLE {table} IN EXCLUSIVE MODE")  # noqa: S608 — table validated above
+        yield
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+@pytest.mark.requires_docker
+@pytest.mark.slow
+def test_slow_db_does_not_stall(db_conn, fake_client, migrated_db, server_proc):
+    """With assets_assetposition locked, the server must stay responsive and
+    new position rows must land once the lock releases."""
+    with db_conn.cursor() as cur:
+        cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
+        asset_id = cur.fetchone()[0]
+
+    client = fake_client("test1")
+
+    # Baseline: at least one position row lands before we interfere.
+    first_row = wait_for_row(
+        db_conn,
+        "SELECT id FROM assets_assetposition WHERE asset_id = %s LIMIT 1",
+        params=(asset_id,),
+        timeout=15.0,
+    )
+    assert first_row is not None, "no baseline position row before lock"
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM assets_assetposition WHERE asset_id = %s",
+            (asset_id,),
+        )
+        count_before_lock = cur.fetchone()[0]
+
+    # Hold the lock long enough for the server to buffer several position
+    # reports in its write queue.
+    lock_hold_s = 12
+    with hold_table_lock(migrated_db, "assets_assetposition"):
+        time.sleep(lock_hold_s)
+
+        # During the lock, the writer is blocked — no new rows should have
+        # landed. The recv thread, however, is not blocked; it must keep
+        # enqueuing (verified below by the post-release row count jump).
+        with db_conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM assets_assetposition WHERE asset_id = %s",
+                (asset_id,),
+            )
+            count_during_lock = cur.fetchone()[0]
+        assert count_during_lock == count_before_lock, (
+            f"rows landed despite EXCLUSIVE lock: before={count_before_lock} "
+            f"during={count_during_lock}"
+        )
+
+        # Server must still be alive (recv thread was not blocked on DB).
+        assert server_proc["proc"].poll() is None, "server died during DB stall"
+        assert client["proc"].poll() is None, "client died during DB stall"
+
+    # Lock released. Poll for the queue to drain — the invariant is that
+    # buffered writes make it to the DB (some drops are acceptable under a
+    # smaller queue depth, but here depth is the default 10000).
+    row = wait_for_row(
+        db_conn,
+        "SELECT COUNT(*) FROM assets_assetposition WHERE asset_id = %s HAVING COUNT(*) > %s",
+        params=(asset_id, count_before_lock),
+        timeout=20.0,
+    )
+    assert row is not None, (
+        "no new position rows after lock release — writer did not drain"
+    )
+
+    # Server still responsive — still accepting, no hung worker join.
+    assert server_proc["proc"].poll() is None, "server exited after DB stall"

--- a/examples/server.json
+++ b/examples/server.json
@@ -1,5 +1,6 @@
 {
     "port": 20202,
+    "db_queue_depth": 10000,
     "postgres": {
        "host": "localhost",
        "user": "scott",

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -48,7 +48,7 @@ pkgconfig_DATA += fss-client-ssl.pc
 if SERVER
 sbin_PROGRAMS += fss-server
 
-fss_server_SOURCES = server.cpp client_session.cpp fss-server.hpp db.cpp server-db.pgc server-db.h
+fss_server_SOURCES = server.cpp client_session.cpp fss-server.hpp db.cpp server-db.pgc server-db.h db-write-queue.cpp db-write-queue.hpp
 fss_server_CXXFLAGS = $(AM_CXXFLAGS) $(JSONCPP_CFLAGS)
 fss_server_CFLAGS = $(AM_CFLAGS) $(ECPG_CFLAGS)
 fss_server_LDADD = libfss.la libfss-transport.la $(JSONCPP_LIBS) $(ECPG_LIBS)

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -64,7 +64,7 @@ fss::server::fss_client_rtt::fss_client_rtt(uint64_t t_timestamp, uint64_t t_req
 auto fss::server::fss_client_rtt::getTimeStamp() -> uint64_t { return this->timestamp; }
 auto fss::server::fss_client_rtt::getRequestId() -> uint64_t { return this->reqid; }
 
-fss::server::fss_client::fss_client(std::shared_ptr<fss::transport::fss_connection> t_conn, IDatabase *t_dbc, fss_client_handler *t_handler) : fss_message_cb(std::move(t_conn)), dbc(t_dbc), client_handler(t_handler)
+fss::server::fss_client::fss_client(std::shared_ptr<fss::transport::fss_connection> t_conn, IDatabase *t_dbc, std::shared_ptr<db_write_queue> t_writer, fss_client_handler *t_handler) : fss_message_cb(std::move(t_conn)), dbc(t_dbc), writer(std::move(t_writer)), client_handler(t_handler)
 {
     this->getConnection()->setHandler(this);
 }
@@ -312,7 +312,7 @@ fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss_mess
 #ifdef DEBUG
                     std::cout << "RTT for " << client_name << " is " << (current_ts - rtt_req->getTimeStamp()) << std::endl;
 #endif
-                    this->dbc->recordRtt(asset_id, current_ts - rtt_req->getTimeStamp());
+                    this->writer->enqueue(rtt_write{asset_id, current_ts - rtt_req->getTimeStamp()});
                 }
             }
                 break;
@@ -320,7 +320,7 @@ fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss_mess
             {
                 if (this->aircraft && asset_id != 0)
                 {
-                    this->dbc->recordPosition(asset_id, msg->getLatitude(), msg->getLongitude(), msg->getAltitude());
+                    this->writer->enqueue(position_write{asset_id, msg->getLatitude(), msg->getLongitude(), msg->getAltitude()});
                 }
                 this->client_handler->broadcastMsg(msg, this);
             }
@@ -330,7 +330,7 @@ fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss_mess
                 auto status_msg = std::dynamic_pointer_cast<fss::transport::fss_message_system_status>(msg);
                 if (status_msg != nullptr && asset_id != 0)
                 {
-                    this->dbc->recordStatus(asset_id, status_msg->getBatRemaining(), status_msg->getBatMAHUsed(), status_msg->getBatVoltage());
+                    this->writer->enqueue(status_write{asset_id, status_msg->getBatRemaining(), status_msg->getBatMAHUsed(), status_msg->getBatVoltage()});
                 }
             }
                 break;
@@ -339,7 +339,7 @@ fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss_mess
                 auto status_msg = std::dynamic_pointer_cast<fss::transport::fss_message_search_status>(msg);
                 if (status_msg != nullptr && asset_id != 0)
                 {
-                    this->dbc->recordSearchStatus(asset_id, status_msg->getSearchId(), status_msg->getSearchCompleted(), status_msg->getSearchTotal());
+                    this->writer->enqueue(search_status_write{asset_id, status_msg->getSearchId(), status_msg->getSearchCompleted(), status_msg->getSearchTotal()});
                 }
             }
                 break;

--- a/src/db-write-queue.cpp
+++ b/src/db-write-queue.cpp
@@ -1,0 +1,109 @@
+#include "db-write-queue.hpp"
+#include "fss-log.hpp"
+
+#include <algorithm>
+#include <exception>
+#include <utility>
+
+namespace flight_safety_system {
+namespace server {
+
+db_write_queue::db_write_queue(std::size_t t_max_depth, db_write_sink t_sink)
+    : max_depth(std::max<std::size_t>(1, t_max_depth)), sink(std::move(t_sink))
+{
+    this->worker = std::thread(&db_write_queue::run, this);
+}
+
+db_write_queue::~db_write_queue()
+{
+    this->stop();
+}
+
+void
+db_write_queue::enqueue(db_write_task task)
+{
+    bool did_drop = false;
+    uint64_t total_dropped = 0;
+    {
+        std::lock_guard<std::mutex> guard(this->mtx);
+        if (this->stopping) { return; }
+        if (this->q.size() >= this->max_depth)
+        {
+            this->q.pop_front();
+            total_dropped = this->dropped.fetch_add(1) + 1;
+            did_drop = true;
+        }
+        this->q.push_back(task);
+    }
+    this->cv.notify_one();
+    if (did_drop)
+    {
+        /* Rate-limited: first drop and every 1000th after that. All current
+         * tasks are telemetry; if command writes are added later they should
+         * bypass this policy. */
+        constexpr uint64_t log_every = 1000;
+        if (total_dropped == 1 || (total_dropped % log_every) == 0)
+        {
+            FSS_LOG_WARN("db-writer", "dropped oldest DB write (total dropped=" << total_dropped << ")");
+        }
+    }
+}
+
+void
+db_write_queue::stop()
+{
+    {
+        std::lock_guard<std::mutex> guard(this->mtx);
+        if (this->stopping) { return; }
+        this->stopping = true;
+    }
+    this->cv.notify_all();
+    if (this->worker.joinable())
+    {
+        this->worker.join();
+    }
+}
+
+auto
+db_write_queue::dropped_count() const -> uint64_t
+{
+    return this->dropped.load();
+}
+
+auto
+db_write_queue::pending_count() const -> std::size_t
+{
+    std::lock_guard<std::mutex> guard(this->mtx);
+    return this->q.size();
+}
+
+void
+db_write_queue::run()
+{
+    for (;;)
+    {
+        db_write_task task;
+        {
+            std::unique_lock<std::mutex> lock(this->mtx);
+            this->cv.wait(lock, [this]() -> bool { return this->stopping || !this->q.empty(); });
+            if (this->stopping && this->q.empty()) { return; }
+            task = this->q.front();
+            this->q.pop_front();
+        }
+        try
+        {
+            this->sink(task);
+        }
+        catch (const std::exception &e)
+        {
+            FSS_LOG_ERROR("db-writer", "sink threw exception: " << e.what());
+        }
+        catch (...)
+        {
+            FSS_LOG_ERROR("db-writer", "sink threw unknown exception");
+        }
+    }
+}
+
+} // namespace server
+} // namespace flight_safety_system

--- a/src/db-write-queue.hpp
+++ b/src/db-write-queue.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <variant>
+
+namespace flight_safety_system {
+namespace server {
+
+struct rtt_write            { uint64_t asset_id; uint64_t rtt_ms; };
+struct position_write       { uint64_t asset_id; double latitude; double longitude; uint32_t altitude; };
+struct status_write         { uint64_t asset_id; uint8_t bat_percent; uint32_t bat_mah_used; double bat_voltage; };
+struct search_status_write  { uint64_t asset_id; uint64_t search_id; uint64_t completed; uint64_t total; };
+
+using db_write_task = std::variant<rtt_write, position_write, status_write, search_status_write>;
+using db_write_sink = std::function<void(const db_write_task &)>;
+
+/* C++17 overload helper for std::visit. */
+template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+
+class db_write_queue {
+private:
+    std::size_t max_depth;
+    db_write_sink sink;
+    mutable std::mutex mtx{};
+    std::condition_variable cv{};
+    std::deque<db_write_task> q{};
+    bool stopping{false};
+    std::atomic<uint64_t> dropped{0};
+    std::thread worker{};
+
+    void run();
+
+public:
+    db_write_queue(std::size_t t_max_depth, db_write_sink t_sink);
+    ~db_write_queue();
+    db_write_queue(const db_write_queue &) = delete;
+    db_write_queue(db_write_queue &&) = delete;
+    auto operator=(const db_write_queue &) -> db_write_queue & = delete;
+    auto operator=(db_write_queue &&) -> db_write_queue & = delete;
+
+    void enqueue(db_write_task task);
+    void stop();
+    auto dropped_count() const -> uint64_t;
+    auto pending_count() const -> std::size_t;
+};
+
+} // namespace server
+} // namespace flight_safety_system

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -48,7 +48,7 @@ flight_safety_system::server::db_connection::recordSearchStatus(uint64_t asset_i
 }
 
 void
-flight_safety_system::server::db_connection::recordPosition(uint64_t asset_id, double latitude, double longitude, uint16_t altitude)
+flight_safety_system::server::db_connection::recordPosition(uint64_t asset_id, double latitude, double longitude, uint32_t altitude)
 {
     std::lock_guard<std::mutex> guard(this->db_lock);
     db_position_create_entry(asset_id, latitude, longitude, altitude);

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -2,6 +2,7 @@
 
 #include "fss.hpp"
 #include "fss-transport.hpp"
+#include "db-write-queue.hpp"
 
 #include <atomic>
 #include <memory>
@@ -65,7 +66,7 @@ public:
     auto operator=(IDatabase &&) -> IDatabase & = delete;
     virtual ~IDatabase() = default;
     virtual auto getAssetId(const std::string &name) -> uint64_t = 0;
-    virtual void recordPosition(uint64_t asset_id, double latitude, double longitude, uint16_t altitude) = 0;
+    virtual void recordPosition(uint64_t asset_id, double latitude, double longitude, uint32_t altitude) = 0;
     virtual void recordRtt(uint64_t asset_id, uint64_t rtt_ms) = 0;
     virtual void recordStatus(uint64_t asset_id, uint8_t bat_percent, uint32_t bat_mah_used, double bat_voltage) = 0;
     virtual void recordSearchStatus(uint64_t asset_id, uint64_t search_id, uint64_t completed, uint64_t total) = 0;
@@ -85,7 +86,7 @@ public:
     auto operator=(db_connection&&) -> db_connection& = delete;
     ~db_connection() override;
     auto getAssetId(const std::string &name) -> uint64_t override;
-    void recordPosition(uint64_t asset_id, double latitude, double longitude, uint16_t altitude) override;
+    void recordPosition(uint64_t asset_id, double latitude, double longitude, uint32_t altitude) override;
     void recordRtt(uint64_t asset_id, uint64_t rtt_ms) override;
     void recordStatus(uint64_t asset_id, uint8_t bat_percent, uint32_t bat_mah_used, double bat_voltage) override;
     void recordSearchStatus(uint64_t asset_id, uint64_t search_id, uint64_t completed, uint64_t total) override;
@@ -127,10 +128,11 @@ private:
     uint64_t last_rtt_response_time{0};
     uint64_t client_timeout_ms{30000};
     IDatabase *dbc;
+    std::shared_ptr<db_write_queue> writer;
     fss_client_handler *client_handler;
     std::shared_ptr<IClock> clock{std::make_shared<WallClock>()};
 public:
-    fss_client(std::shared_ptr<transport::fss_connection> conn, IDatabase *t_dbc, fss_client_handler *t_handler);
+    fss_client(std::shared_ptr<transport::fss_connection> conn, IDatabase *t_dbc, std::shared_ptr<db_write_queue> t_writer, fss_client_handler *t_handler);
     fss_client(fss_client&) = delete;
     fss_client(fss_client&&) = delete;
     auto operator=(fss_client&) -> fss_client& = delete;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -171,6 +171,27 @@ main(int argc, char *argv[]) -> int
 
     auto dbc = std::make_shared<flight_safety_system::server::db_connection>(config["postgres"]["host"].asString(), config["postgres"]["user"].asString(), config["postgres"]["pass"].asString(), config["postgres"]["db"].asString());
 
+    constexpr std::size_t default_db_queue_depth = 10000;
+    std::size_t db_queue_depth = config.isMember("db_queue_depth") ? config["db_queue_depth"].asUInt() : default_db_queue_depth;
+    flight_safety_system::server::db_write_sink sink =
+        [dbc](const flight_safety_system::server::db_write_task &task) -> void {
+            std::visit(flight_safety_system::server::overloaded{
+                [&](const flight_safety_system::server::rtt_write &w) -> void {
+                    dbc->recordRtt(w.asset_id, w.rtt_ms);
+                },
+                [&](const flight_safety_system::server::position_write &w) -> void {
+                    dbc->recordPosition(w.asset_id, w.latitude, w.longitude, w.altitude);
+                },
+                [&](const flight_safety_system::server::status_write &w) -> void {
+                    dbc->recordStatus(w.asset_id, w.bat_percent, w.bat_mah_used, w.bat_voltage);
+                },
+                [&](const flight_safety_system::server::search_status_write &w) -> void {
+                    dbc->recordSearchStatus(w.asset_id, w.search_id, w.completed, w.total);
+                },
+            }, task);
+        };
+    auto writer = std::make_shared<flight_safety_system::server::db_write_queue>(db_queue_depth, sink);
+
     auto clients = std::make_shared<server_clients>();
     constexpr int default_client_timeout_sec = 30;
     constexpr int msec_per_sec = 1000;
@@ -188,11 +209,11 @@ main(int argc, char *argv[]) -> int
         exit(-1);
     }
     listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(config["port"].asInt(),
-        [dbc, &clients](std::shared_ptr<flight_safety_system::transport::fss_connection> conn) -> bool {
+        [dbc, writer, &clients](std::shared_ptr<flight_safety_system::transport::fss_connection> conn) -> bool {
 #ifdef DEBUG
             std::cout << "New client connected" << std::endl;
 #endif
-            clients->clientConnected(std::make_shared<flight_safety_system::server::fss_client>(std::move(conn), dbc.get(), clients.get()));
+            clients->clientConnected(std::make_shared<flight_safety_system::server::fss_client>(std::move(conn), dbc.get(), writer, clients.get()));
             return true;
         },
         config["ssl"]["ca_public_key"].asString(), config["ssl"]["server_private_key"].asString(), config["ssl"]["server_public_key"].asString());
@@ -216,4 +237,14 @@ main(int argc, char *argv[]) -> int
         }
         counter++;
     }
+
+    /* Explicit shutdown ordering: stop accepting before disconnecting
+     * clients; join all recv threads (via clients destructor) before
+     * draining the write queue; release the DB connection last since the
+     * sink captures it. */
+    listen.reset();
+    clients.reset();
+    writer->stop();
+    writer.reset();
+    dbc.reset();
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -18,8 +18,10 @@ all_test_SOURCES = main.cpp messages.cpp connection.cpp client.cpp \
 	connection_negative_test.cpp \
 	ssl_failure_test.cpp \
 	server_session_test.cpp \
+	async_db_write_test.cpp \
 	timeout_test.cpp \
-	../src/client_session.cpp
+	../src/client_session.cpp \
+	../src/db-write-queue.cpp
 all_test_LDADD = ../src/libfss-transport.la ../src/libfss-client-ssl.la ../src/libfss.la $(JSONCPP_LIBS)
 
 all_test_SOURCES += connection-ssl.cpp certs certs-alt certs/expired

--- a/tests/async_db_write_test.cpp
+++ b/tests/async_db_write_test.cpp
@@ -1,0 +1,232 @@
+#ifdef HAVE_CATCH2_CATCH_ALL_HPP
+#include <catch2/catch_all.hpp>
+#elif HAVE_CATCH2_CATCH_HPP
+#include <catch2/catch.hpp>
+#elif HAVE_CATCH_CATCH_HPP
+#include <catch/catch.hpp>
+#elif HAVE_CATCH_HPP
+#include <catch.hpp>
+#else
+#error No catch header
+#endif
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "db-write-queue.hpp"
+#include "fss-log.hpp"
+#include "test_helpers.hpp"
+
+namespace fss = flight_safety_system;
+
+namespace {
+
+/* Thread-safe capture of writes. Stores asset_id + rtt_ms (for rtt_write)
+ * or just asset_id for other variants, since these tests only care about
+ * ordering and counts. */
+struct CapturingSink {
+    mutable std::mutex mtx{};
+    std::vector<uint64_t> asset_ids{};
+    std::atomic<uint64_t> count{0};
+    std::chrono::milliseconds delay{0};
+
+    void operator()(const fss::server::db_write_task &task)
+    {
+        if (delay.count() > 0) { std::this_thread::sleep_for(delay); }
+        std::lock_guard<std::mutex> guard(mtx);
+        std::visit(fss::server::overloaded{
+            [&](const fss::server::rtt_write &w) -> void { asset_ids.push_back(w.asset_id); },
+            [&](const fss::server::position_write &w) -> void { asset_ids.push_back(w.asset_id); },
+            [&](const fss::server::status_write &w) -> void { asset_ids.push_back(w.asset_id); },
+            [&](const fss::server::search_status_write &w) -> void { asset_ids.push_back(w.asset_id); },
+        }, task);
+        count.fetch_add(1);
+    }
+
+    auto snapshot() const -> std::vector<uint64_t>
+    {
+        std::lock_guard<std::mutex> guard(mtx);
+        return asset_ids;
+    }
+};
+
+} // namespace
+
+TEST_CASE("db_write_queue: enqueue-then-drain preserves order")
+{
+    auto cap = std::make_shared<CapturingSink>();
+    fss::server::db_write_queue q(100, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+
+    for (uint64_t i = 1; i <= 20; ++i)
+    {
+        q.enqueue(fss::server::rtt_write{i, i * 10});
+    }
+
+    REQUIRE(fss_test::wait_for([&]() -> bool { return cap->count.load() == 20; }));
+    q.stop();
+
+    auto seen = cap->snapshot();
+    REQUIRE(seen.size() == 20);
+    for (size_t i = 0; i < seen.size(); ++i)
+    {
+        REQUIRE(seen[i] == i + 1);
+    }
+    REQUIRE(q.dropped_count() == 0);
+}
+
+TEST_CASE("db_write_queue: bounded queue drops oldest when full")
+{
+    /* Slow sink so we can overflow the queue deterministically. */
+    auto cap = std::make_shared<CapturingSink>();
+    cap->delay = std::chrono::milliseconds(50);
+
+    constexpr std::size_t depth = 5;
+    fss::server::db_write_queue q(depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+
+    /* Worker will pick up task 1 and sleep. Fill 5 slots, then push 10 more;
+     * older entries beyond depth must be dropped. */
+    for (uint64_t i = 1; i <= 20; ++i)
+    {
+        q.enqueue(fss::server::rtt_write{i, 0});
+    }
+
+    REQUIRE(q.dropped_count() > 0);
+
+    /* Stop waits for the worker to drain whatever's left. */
+    q.stop();
+
+    auto seen = cap->snapshot();
+    /* Surviving entries must be monotonically increasing (drop-oldest). */
+    for (size_t i = 1; i < seen.size(); ++i)
+    {
+        REQUIRE(seen[i] > seen[i - 1]);
+    }
+    /* Last entry surviving must be the most recent producer pushed (20). */
+    REQUIRE(seen.back() == 20);
+}
+
+TEST_CASE("db_write_queue: stop drains pending work")
+{
+    auto cap = std::make_shared<CapturingSink>();
+    cap->delay = std::chrono::milliseconds(5);
+
+    fss::server::db_write_queue q(1000, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+    for (uint64_t i = 1; i <= 50; ++i)
+    {
+        q.enqueue(fss::server::position_write{i, 0.0, 0.0, 0});
+    }
+
+    q.stop();
+
+    REQUIRE(cap->count.load() == 50);
+    REQUIRE(q.pending_count() == 0);
+}
+
+TEST_CASE("db_write_queue: stop is idempotent")
+{
+    auto cap = std::make_shared<CapturingSink>();
+    fss::server::db_write_queue q(100, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+    q.enqueue(fss::server::rtt_write{1, 1});
+    REQUIRE(fss_test::wait_for([&]() -> bool { return cap->count.load() == 1; }));
+    q.stop();
+    q.stop();
+    /* Destructor also calls stop — must not deadlock / double-join. */
+}
+
+TEST_CASE("db_write_queue: enqueue after stop is a no-op")
+{
+    auto cap = std::make_shared<CapturingSink>();
+    fss::server::db_write_queue q(100, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+
+    q.enqueue(fss::server::rtt_write{1, 10});
+    q.enqueue(fss::server::rtt_write{2, 20});
+    REQUIRE(fss_test::wait_for([&]() -> bool { return cap->count.load() == 2; }));
+
+    q.stop();
+    const auto dropped_after_stop = q.dropped_count();
+    const auto pending_after_stop = q.pending_count();
+
+    for (uint64_t i = 3; i <= 10; ++i)
+    {
+        q.enqueue(fss::server::rtt_write{i, 0});
+    }
+
+    REQUIRE(q.pending_count() == pending_after_stop);
+    REQUIRE(q.dropped_count() == dropped_after_stop);
+    REQUIRE(cap->count.load() == 2);
+}
+
+TEST_CASE("db_write_queue: slow sink does not block producers")
+{
+    auto cap = std::make_shared<CapturingSink>();
+    cap->delay = std::chrono::milliseconds(200);
+
+    fss::server::db_write_queue q(10000, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+
+    auto start = std::chrono::steady_clock::now();
+    for (uint64_t i = 1; i <= 20; ++i)
+    {
+        q.enqueue(fss::server::rtt_write{i, 0});
+    }
+    auto elapsed = std::chrono::steady_clock::now() - start;
+
+    /* Enqueues must not block waiting on the sink. Use a generous bound so
+     * the test doesn't flake on loaded CI while still catching obviously
+     * blocking behavior. */
+    REQUIRE(elapsed < std::chrono::seconds(1));
+
+    /* The slow sink should not have processed many items yet. */
+    REQUIRE(cap->count.load() < 5);
+
+    REQUIRE(fss_test::wait_for([&]() -> bool { return cap->count.load() == 20; },
+                               std::chrono::milliseconds(6000)));
+    q.stop();
+}
+
+TEST_CASE("db_write_queue: drop log message appears on stderr when queue fills")
+{
+    auto cap = std::make_shared<CapturingSink>();
+    cap->delay = std::chrono::milliseconds(50);
+
+    /* Earlier tests may have left level at ERROR; ensure WARN is visible. */
+    flight_safety_system::log::set_level("warn");
+    fss_test::capture_cerr cerr_capture;
+
+    {
+        fss::server::db_write_queue q(3, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+        for (uint64_t i = 1; i <= 20; ++i)
+        {
+            q.enqueue(fss::server::rtt_write{i, 0});
+        }
+        /* Let the drop happen; worker is slow so all overflow drops occur
+         * during the enqueue loop. */
+        q.stop();
+    }
+
+    auto out = cerr_capture.str();
+    REQUIRE(out.find("db-writer") != std::string::npos);
+    REQUIRE(out.find("dropped") != std::string::npos);
+    flight_safety_system::log::set_level("info");
+}
+
+TEST_CASE("db_write_queue: destructor without explicit stop drains pending work")
+{
+    auto cap = std::make_shared<CapturingSink>();
+    cap->delay = std::chrono::milliseconds(5);
+
+    {
+        fss::server::db_write_queue q(1000, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+        for (uint64_t i = 1; i <= 30; ++i)
+        {
+            q.enqueue(fss::server::search_status_write{i, 0, 0, 0});
+        }
+        /* q goes out of scope; destructor must drain + join. */
+    }
+
+    REQUIRE(cap->count.load() == 30);
+}

--- a/tests/mock_database.hpp
+++ b/tests/mock_database.hpp
@@ -22,7 +22,7 @@ public:
     std::vector<flight_safety_system::server::fss_server_details> active_servers{};
 
     struct recorded_rtt { uint64_t asset_id; uint64_t rtt_ms; };
-    struct recorded_pos { uint64_t asset_id; double latitude; double longitude; uint16_t altitude; };
+    struct recorded_pos { uint64_t asset_id; double latitude; double longitude; uint32_t altitude; };
     struct recorded_status { uint64_t asset_id; uint8_t bat_percent; uint32_t bat_mah_used; double bat_voltage; };
     struct recorded_search { uint64_t asset_id; uint64_t search_id; uint64_t completed; uint64_t total; };
 
@@ -44,7 +44,7 @@ public:
         return it == asset_ids.end() ? 0 : it->second;
     }
 
-    void recordPosition(uint64_t asset_id, double latitude, double longitude, uint16_t altitude) override
+    void recordPosition(uint64_t asset_id, double latitude, double longitude, uint32_t altitude) override
     {
         positions.push_back({asset_id, latitude, longitude, altitude});
     }

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -18,6 +18,7 @@
 #include "fss-transport.hpp"
 #include "fss-server.hpp"
 #include "mock_database.hpp"
+#include "db-write-queue.hpp"
 
 namespace fss = flight_safety_system;
 
@@ -59,6 +60,21 @@ struct FakeClock : public fss::IClock {
     void advance(uint64_t ms) { t += ms; }
 };
 
+/* Builds a db_write_queue that forwards to the mock — tests that don't care
+ * about telemetry still need a non-null writer for the fss_client ctor. */
+auto make_mock_writer(fss_test::MockDatabase &mock) -> std::shared_ptr<fss::server::db_write_queue>
+{
+    auto sink = [&mock](const fss::server::db_write_task &task) -> void {
+        std::visit(fss::server::overloaded{
+            [&](const fss::server::rtt_write &w) -> void { mock.recordRtt(w.asset_id, w.rtt_ms); },
+            [&](const fss::server::position_write &w) -> void { mock.recordPosition(w.asset_id, w.latitude, w.longitude, w.altitude); },
+            [&](const fss::server::status_write &w) -> void { mock.recordStatus(w.asset_id, w.bat_percent, w.bat_mah_used, w.bat_voltage); },
+            [&](const fss::server::search_status_write &w) -> void { mock.recordSearchStatus(w.asset_id, w.search_id, w.completed, w.total); },
+        }, task);
+    };
+    return std::make_shared<fss::server::db_write_queue>(std::size_t{1024}, sink);
+}
+
 class NullClientHandler : public fss::server::fss_client_handler {
 public:
     int disconnects{0};
@@ -82,7 +98,8 @@ TEST_CASE("session: rejects identify when asset unknown to database")
     conn->cert_names.push_back("unknownAsset");
     NullClientHandler handler;
 
-    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, &handler);
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
     auto identify = std::make_shared<fss::transport::fss_message_identity>("unknownAsset");
     session->processMessage(identify);
 
@@ -106,7 +123,8 @@ TEST_CASE("session: getCommand returns newest-timestamp entry")
     conn->cert_names.push_back("craft");
     NullClientHandler handler;
 
-    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, &handler);
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
     /* Drive the session to identify + send initial command. */
     session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
 
@@ -133,7 +151,8 @@ TEST_CASE("session: server list sent on identify contains seeded servers")
     conn->cert_names.push_back("craft");
     NullClientHandler handler;
 
-    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, &handler);
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
     session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
 
     std::shared_ptr<fss::transport::fss_message_server_list> server_list_msg;
@@ -163,7 +182,8 @@ TEST_CASE("session: RTT timeout disconnects client")
     NullClientHandler handler;
 
     auto clock = std::make_shared<FakeClock>();
-    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, &handler);
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
     session->setClock(clock);
     session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
 

--- a/tests/timeout_test.cpp
+++ b/tests/timeout_test.cpp
@@ -16,6 +16,7 @@
 #include "fss-server.hpp"
 #include "fss-client-ssl.hpp"
 #include "mock_database.hpp"
+#include "db-write-queue.hpp"
 
 namespace fss = flight_safety_system;
 
@@ -43,6 +44,15 @@ protected:
     auto sendMsg(const std::shared_ptr<fss::transport::buf_len> &) -> bool override { return true; }
 };
 
+/* These tests never send message types that invoke the writer (rtt_response,
+ * position_report, system_status, search_status), so a no-op sink suffices. */
+auto make_null_writer() -> std::shared_ptr<fss::server::db_write_queue>
+{
+    return std::make_shared<fss::server::db_write_queue>(
+        std::size_t{64},
+        [](const fss::server::db_write_task &) -> void {});
+}
+
 class NullClientHandler : public fss::server::fss_client_handler {
 public:
     int disconnects{0};
@@ -61,7 +71,8 @@ TEST_CASE("timeout: isTimedOut false before identification")
     fss_test::MockDatabase mock;
     auto conn = std::make_shared<FakeConnection>();
     NullClientHandler handler;
-    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, &handler);
+    auto writer = make_null_writer();
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
     auto clock = std::make_shared<FakeClock>();
     session->setClock(clock);
 
@@ -76,7 +87,8 @@ TEST_CASE("timeout: isTimedOut false right after identification")
     auto conn = std::make_shared<FakeConnection>();
     conn->cert_names.push_back("craft");
     NullClientHandler handler;
-    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, &handler);
+    auto writer = make_null_writer();
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
     auto clock = std::make_shared<FakeClock>();
     session->setClock(clock);
 
@@ -92,7 +104,8 @@ TEST_CASE("timeout: isTimedOut true after timeout without RTT response")
     auto conn = std::make_shared<FakeConnection>();
     conn->cert_names.push_back("craft");
     NullClientHandler handler;
-    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, &handler);
+    auto writer = make_null_writer();
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
     auto clock = std::make_shared<FakeClock>();
     session->setClock(clock);
 
@@ -109,7 +122,8 @@ TEST_CASE("timeout: isTimedOut reset by RTT response")
     auto conn = std::make_shared<FakeConnection>();
     conn->cert_names.push_back("craft");
     NullClientHandler handler;
-    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, &handler);
+    auto writer = make_null_writer();
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
     auto clock = std::make_shared<FakeClock>();
     session->setClock(clock);
 
@@ -142,7 +156,8 @@ TEST_CASE("timeout: setTimeoutMs overrides default threshold")
     auto conn = std::make_shared<FakeConnection>();
     conn->cert_names.push_back("craft");
     NullClientHandler handler;
-    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, &handler);
+    auto writer = make_null_writer();
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
     auto clock = std::make_shared<FakeClock>();
     session->setClock(clock);
     session->setTimeoutMs(5000);


### PR DESCRIPTION
## Description

Move telemetry DB writes off the per-client recv thread onto a dedicated worker via a bounded write queue with drop-oldest backpressure. The recv thread now returns immediately from enqueue(), so a slow or stalled DB cannot delay safety-critical command delivery.

## Summary by Sourcery

Introduce an asynchronous, bounded database write queue for telemetry to decouple per-client receive threads from database performance and ensure orderly server shutdown.

New Features:
- Add a db_write_queue component that processes telemetry database writes asynchronously on a dedicated worker thread with a bounded queue and drop-oldest backpressure.
- Route client telemetry (RTT, position, system status, search status) through the asynchronous write queue instead of writing directly to the database, with configurable queue depth via server configuration.

Enhancements:
- Adjust server shutdown ordering to cleanly stop accepting connections, disconnect clients, drain the database write queue, and finally release the database connection.
- Widen the altitude field in database position recording from 16-bit to 32-bit to accommodate a larger range of altitude values.

Build:
- Include db-write-queue sources and headers in the server and test build configurations.

Tests:
- Add unit tests for db_write_queue covering ordering, bounded-queue dropping behavior, draining on stop and destruction, non-blocking producers, and logging on drops.
- Update existing session and timeout tests to construct fss_client instances with a db_write_queue, using real or no-op sinks as appropriate.
- Add an end-to-end test that verifies a stalled database does not block the server from processing client messages and that queued writes are flushed after the stall.