### PR TITLE
feat: reduce command delivery latency to ~100ms

### DIFF
--- a/e2e/test_command_latency.py
+++ b/e2e/test_command_latency.py
@@ -1,0 +1,71 @@
+"""todo09: the server polls for new commands every 100ms, so an injected row
+must reach the aircraft session in well under a second. This test inserts a
+TERM row and asserts the server's "dispatched command" log line appears in
+under 1 second — the pre-todo09 loop would have taken up to 1000ms plus the
+per-iteration body before sending."""
+from __future__ import annotations
+
+import re
+import time
+
+import pytest
+
+
+_DISPATCH_RE = re.compile(r"dispatched command dbid=(\d+)")
+
+# Should match flight_safety_system::server::command_poll_ms in src/fss-server.hpp
+COMMAND_POLL_MS = 100
+
+
+def _wait_for_dispatch(log_path, dbid: int, timeout: float) -> float | None:
+    """Poll the server log file for a dispatch line referencing `dbid`.
+    Returns seconds waited, or None on timeout."""
+    deadline = time.monotonic() + timeout
+    start = time.monotonic()
+    while time.monotonic() < deadline:
+        try:
+            text = log_path.read_text(errors="replace")
+        except FileNotFoundError:
+            text = ""
+        for match in _DISPATCH_RE.finditer(text):
+            if int(match.group(1)) == dbid:
+                return time.monotonic() - start
+        time.sleep(0.02)
+    return None
+
+
+@pytest.mark.requires_docker
+def test_command_dispatched_under_one_second(db_conn, fake_client, server_proc):
+    """Insert a command after the client has identified, then assert the
+    server dispatches it in <1s (should be well under — ~100ms)."""
+    with db_conn.cursor() as cur:
+        cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
+        asset_id = cur.fetchone()[0]
+
+    fake_client("test1")
+
+    # Let the client connect and identify. The server dispatches any existing
+    # command on identify, so we wait until identify is done before inserting.
+    time.sleep(5)
+
+    # Note how many dispatch lines exist pre-insert; we only care about
+    # the dbid returned by the INSERT below.
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO assets_assetcommand (asset_id, command, position, altitude) "
+            "VALUES (%s, 'TERM', "
+            "        ST_SetSRID(ST_MakePoint(0, 0), 4326)::geography, 0) "
+            "RETURNING id",
+            (asset_id,),
+        )
+        new_dbid = cur.fetchone()[0]
+
+    elapsed = _wait_for_dispatch(server_proc["log"], new_dbid, timeout=3.0)
+    assert elapsed is not None, (
+        f"server never dispatched command dbid={new_dbid}; log:\n"
+        + server_proc["log"].read_text(errors="replace")
+    )
+    # The poll loop runs every 100ms; allow 1s (or 10x poll) to cover DB
+    # round-trip jitter and e2e noise.
+    latency_bound = max(1.0, 10 * COMMAND_POLL_MS / 1000.0)
+    assert elapsed < latency_bound, f"command dispatch took {elapsed:.3f}s, expected <{latency_bound}s"

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -112,6 +112,7 @@ fss::server::fss_client::sendCommand()
                 break;
         }
         this->getConnection()->sendMsg(msg);
+        FSS_LOG_INFO("server", "dispatched command dbid=" << ac->getDBId() << " to " << this->name);
     }
 }
 

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -13,6 +13,9 @@
 
 namespace  flight_safety_system {
 namespace server {
+
+constexpr int command_poll_ms = 100;
+
 class smm_settings {
 private:
     std::string address;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -218,24 +218,35 @@ main(int argc, char *argv[]) -> int
         },
         config["ssl"]["ca_public_key"].asString(), config["ssl"]["server_private_key"].asString(), config["ssl"]["server_public_key"].asString());
 
-    uint64_t counter = 0;
-    constexpr int send_config_period = 15;
+    /* Split tick: sendCommand runs every command_poll_ms so safety-critical
+     * commands (TERM, DISARM) reach aircraft in <=100ms instead of <=1s.
+     * Per-second tasks (RTT, timeout sweep) and per-15s tasks (server list,
+     * SMM settings) retain their original cadence via the tick counter. */
+    constexpr int command_poll_ms = flight_safety_system::server::command_poll_ms;
+    static_assert(1000 % command_poll_ms == 0, "command_poll_ms must evenly divide 1000 to avoid tick skew");
+    static_assert(1000 / command_poll_ms > 0, "command_poll_ms must be <= 1000ms");
+
+    constexpr int usec_per_msec = 1000;
+    constexpr int ticks_per_sec = 1000 / command_poll_ms;
+    constexpr int send_config_period_ticks = 15 * ticks_per_sec;
+    uint64_t tick_counter = 0;
     while (running == 1)
     {
-        sleep (1);
-        clients->cleanupRemovableClients();
-        clients->checkTimeouts();
+        usleep(command_poll_ms * usec_per_msec);
+        clients->sendCommand();
+        if ((tick_counter % ticks_per_sec) == 0)
         {
+            clients->cleanupRemovableClients();
+            clients->checkTimeouts();
             auto rtt_req = std::make_shared<flight_safety_system::transport::fss_message_rtt_request>();
             clients->sendRTTRequest(rtt_req);
-            clients->sendCommand();
         }
-        if ((counter % send_config_period) == 0)
+        if ((tick_counter % send_config_period_ticks) == 0)
         {
             clients->broadcastMsg(flight_safety_system::server::build_server_list_msg(dbc.get()));
             clients->sendSMMSettings();
         }
-        counter++;
+        tick_counter++;
     }
 
     /* Explicit shutdown ordering: stop accepting before disconnecting

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -172,6 +172,69 @@ TEST_CASE("session: server list sent on identify contains seeded servers")
     CHECK(servers[1].second == 9090);
 }
 
+TEST_CASE("session: rapid sendCommand does not duplicate a single pending command")
+{
+    /* todo09: the main loop now calls sendCommand every 100ms to drop
+     * command delivery latency. That is only safe if repeated calls with
+     * the same pending row do not resend the message. Verify idempotency
+     * by driving sendCommand for 2s worth of ticks against one
+     * queued command and counting command messages on the wire. */
+    fss_test::MockDatabase mock;
+    constexpr uint64_t asset_id = 7;
+    mock.asset_ids["craft"] = asset_id;
+    mock.pushCommand(asset_id, std::make_shared<fss::server::asset_command>(
+        /*dbid*/ 1, /*ts*/ 100, "TERM", 0.0, 0.0, 0));
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    constexpr int ticks_per_sec = 1000 / fss::server::command_poll_ms;
+    for (int i = 0; i < 2 * ticks_per_sec; ++i) { session->sendCommand(); }
+
+    int command_count = 0;
+    for (const auto &msg : conn->sent)
+    {
+        if (msg->getType() == fss::transport::message_type_command) { ++command_count; }
+    }
+    REQUIRE(command_count == 1);
+}
+
+TEST_CASE("session: a freshly queued command is delivered on the very next sendCommand")
+{
+    /* todo09: the latency claim is "next 100ms tick picks it up". Model
+     * that by pushing a command AFTER identify, then issuing a single
+     * sendCommand and asserting the message appears immediately. */
+    fss_test::MockDatabase mock;
+    constexpr uint64_t asset_id = 9;
+    mock.asset_ids["craft"] = asset_id;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    const std::size_t sent_before = conn->sent.size();
+
+    mock.pushCommand(asset_id, std::make_shared<fss::server::asset_command>(
+        /*dbid*/ 42, /*ts*/ 500, "DISARM", 0.0, 0.0, 0));
+    session->sendCommand();
+
+    bool delivered = false;
+    for (std::size_t i = sent_before; i < conn->sent.size(); ++i)
+    {
+        if (conn->sent[i]->getType() == fss::transport::message_type_command) { delivered = true; }
+    }
+    REQUIRE(delivered);
+}
+
 TEST_CASE("session: RTT timeout disconnects client")
 {
     fss_test::MockDatabase mock;


### PR DESCRIPTION
## Description

Server main loop now ticks every 100ms and dispatches sendCommand every tick, so safety-critical commands (TERM, DISARM) reach aircraft in ≤100ms instead of ≤1s. RTT/timeout sweep stay at 1s and server list/SMM at 15s via a tick counter. Added a dispatch log line for audit + e2e observability, plus unit tests covering rapid-call idempotency and a new e2e test asserting <1s end-to-end latency.

## Summary by Sourcery

Reduce command delivery latency by polling and dispatching commands every 100ms while preserving existing RTT, timeout, and configuration broadcast cadences.

New Features:
- Add configurable 100ms command polling interval for server command dispatch.
- Log each dispatched command with its database ID for operational observability and auditability.

Enhancements:
- Refine the server main loop to separate high-frequency command dispatch from lower-frequency maintenance and configuration tasks.

Tests:
- Add unit tests to ensure repeated sendCommand calls are idempotent and that newly queued commands are dispatched on the next poll.
- Add an end-to-end test that verifies commands are dispatched and observed in logs within a sub-second latency bound.