### PR TITLE
feat: implement todo02 — wire-protocol version handshake

### DIFF
--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -261,6 +261,13 @@ flight_safety_system::client_ssl::fss_server::sendIdentify()
     this->getConnection()->sendMsg(ident_msg);
 }
 
+void
+flight_safety_system::client_ssl::fss_server::sendVersion()
+{
+    auto version_msg = std::make_shared<flight_safety_system::transport::fss_message_version>();
+    this->getConnection()->sendMsg(version_msg);
+}
+
 auto
 flight_safety_system::client_ssl::fss_server::reconnect_to() -> bool
 {
@@ -306,6 +313,9 @@ flight_safety_system::client_ssl::fss_server::reconnect() -> bool
         else
         {
             this->getConnection()->setHandler(this);
+            /* todo02: protocol version handshake must be the first message
+             * exchanged after TLS connect, before identity. */
+            this->sendVersion();
             this->sendIdentify();
             this->retry_count = 0;
             this->last_tried = 0;
@@ -354,6 +364,24 @@ flight_safety_system::client_ssl::fss_server::processMessage(std::shared_ptr<fli
             case flight_safety_system::transport::message_type_identity_non_aircraft:
             case flight_safety_system::transport::message_type_identity_required:
                 break;
+            case flight_safety_system::transport::message_type_version:
+            {
+                auto version_msg = std::dynamic_pointer_cast<flight_safety_system::transport::fss_message_version>(msg);
+                if (version_msg != nullptr)
+                {
+                    uint16_t peer_version = version_msg->getProtocolVersion();
+                    uint16_t peer_min = version_msg->getMinSupportedVersion();
+                    if (peer_version < flight_safety_system::transport::FSS_PROTOCOL_MIN_VERSION
+                        || peer_min > flight_safety_system::transport::FSS_PROTOCOL_VERSION)
+                    {
+                        FSS_LOG_ERROR("client", "Server protocol version incompatible: peer=" << peer_version << " peer_min=" << peer_min << " us=" << flight_safety_system::transport::FSS_PROTOCOL_VERSION << " us_min=" << flight_safety_system::transport::FSS_PROTOCOL_MIN_VERSION);
+                        this->getClient()->serverRequiresReconnect(this);
+                        return;
+                    }
+                    uint16_t negotiated = std::min(peer_version, flight_safety_system::transport::FSS_PROTOCOL_VERSION);
+                    this->getConnection()->setNegotiatedVersion(negotiated);
+                }
+            } break;
             case flight_safety_system::transport::message_type_rtt_request:
             {
                 /* Send a response */

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -216,8 +216,38 @@ fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss_mess
         this->client_handler->clientDisconnected(this);
         return;
     }
+    if (msg->getType() == fss::transport::message_type_version)
+    {
+        auto version_msg = std::dynamic_pointer_cast<fss::transport::fss_message_version>(msg);
+        if (version_msg != nullptr)
+        {
+            uint16_t peer_version = version_msg->getProtocolVersion();
+            uint16_t peer_min = version_msg->getMinSupportedVersion();
+            if (peer_version < fss::transport::FSS_PROTOCOL_MIN_VERSION
+                || peer_min > fss::transport::FSS_PROTOCOL_VERSION)
+            {
+                FSS_LOG_ERROR("server", "Client protocol version incompatible: peer=" << peer_version << " peer_min=" << peer_min << " us=" << fss::transport::FSS_PROTOCOL_VERSION << " us_min=" << fss::transport::FSS_PROTOCOL_MIN_VERSION);
+                this->client_handler->clientDisconnected(this);
+                return;
+            }
+            uint16_t negotiated = std::min(peer_version, fss::transport::FSS_PROTOCOL_VERSION);
+            this->getConnection()->setNegotiatedVersion(negotiated);
+            this->version_received = true;
+            auto resp = std::make_shared<fss::transport::fss_message_version>();
+            this->getConnection()->sendMsg(resp);
+        }
+        return;
+    }
     if (!this->identified)
     {
+        /* todo02: legacy clients (pre-version-handshake) send identity
+         * directly. Log once so the legacy connection is visible, then
+         * fall through with negotiated_version = LEGACY (0). */
+        if (!this->version_received)
+        {
+            FSS_LOG_WARN("server", "Legacy client: no protocol version handshake (assuming version 0)");
+            this->version_received = true;
+        }
         if (msg->getType() == fss::transport::message_type_identity)
         {
             auto identity_msg = std::dynamic_pointer_cast<fss::transport::fss_message_identity>(msg);
@@ -280,6 +310,7 @@ fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss_mess
             case fss::transport::message_type_identity:
             case fss::transport::message_type_identity_non_aircraft:
             case fss::transport::message_type_identity_required:
+            case fss::transport::message_type_version:
                 break;
             case fss::transport::message_type_rtt_request:
             {

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -88,6 +88,7 @@ public:
     virtual auto reconnect() -> bool;
     virtual auto getClient() -> fss_client *;
     virtual void sendIdentify();
+    virtual void sendVersion();
     void setClock(std::shared_ptr<flight_safety_system::IClock> t_clock);
     void setServerTimeoutMs(uint64_t ms) { this->server_timeout_ms = ms; }
     auto isServerTimedOut() -> bool;

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -121,6 +121,7 @@ class fss_client: public transport::fss_message_cb {
 private:
     std::atomic<bool> identified{false};
     std::atomic<bool> aircraft{false};
+    std::atomic<bool> version_received{false};
     std::string name{};
     std::mutex client_lock{};
     std::list<std::shared_ptr<fss_client_rtt>> outstanding_rtt_requests{};

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -15,6 +15,18 @@ namespace flight_safety_system {
 namespace transport {
 
 static constexpr double FSS_COORD_SCALE = 0.0000001;
+
+/* Wire-protocol version handshake (todo02).
+ * - FSS_PROTOCOL_VERSION_LEGACY (0): unversioned protocol that pre-dates the
+ *   handshake. Used as the negotiated value when the peer never sends a
+ *   version message (e.g. an old client still in the field).
+ * - FSS_PROTOCOL_VERSION: the highest version this build speaks.
+ * - FSS_PROTOCOL_MIN_VERSION: the lowest version this build still accepts.
+ *   If the peer's max < our min (or vice-versa), we disconnect. */
+static constexpr uint16_t FSS_PROTOCOL_VERSION_LEGACY = 0;
+static constexpr uint16_t FSS_PROTOCOL_VERSION = 1;
+static constexpr uint16_t FSS_PROTOCOL_MIN_VERSION = 1;
+
 class fss_connection;
 class fss_listen;
 class fss_message;
@@ -47,6 +59,10 @@ using fss_message_type = enum fss_message_type_e {
 
     /* Please send identity */
     message_type_identity_required,
+
+    /* Protocol version handshake (todo02). Sent first by both peers after
+     * TLS handshake; the negotiated version is min(peer max, our max). */
+    message_type_version,
 };
 
 using fss_asset_command = enum fss_asset_command_e {
@@ -120,6 +136,7 @@ class fss_connection {
     std::mutex msg_lock{};
     size_t max_queue_size{default_max_queue_size};
     std::atomic<uint64_t> dropped_messages{0};
+    std::atomic<uint16_t> negotiated_version{FSS_PROTOCOL_VERSION_LEGACY};
 protected:
     auto recvMsg() -> std::shared_ptr<fss_message>;
     auto getMessageId() -> uint64_t;
@@ -140,6 +157,8 @@ public:
     virtual ~fss_connection();
     void setHandler(fss_message_cb *cb);
     virtual auto connectTo(const std::string &address, uint16_t port) -> bool;
+    auto getNegotiatedVersion() -> uint16_t { return this->negotiated_version.load(); }
+    void setNegotiatedVersion(uint16_t v) { this->negotiated_version.store(v); }
     auto sendMsg(const std::shared_ptr<fss_message> &msg) -> bool;
     auto getMsg() -> std::shared_ptr<fss_message>;
     virtual void processMessages();
@@ -378,6 +397,23 @@ protected:
 public:
     fss_message_identity_required();
     fss_message_identity_required(uint64_t t_id, const std::shared_ptr<buf_len> &bl);
+};
+
+class fss_message_version : public fss_message {
+private:
+    uint16_t protocol_version{FSS_PROTOCOL_VERSION};
+    uint16_t min_supported_version{FSS_PROTOCOL_MIN_VERSION};
+    uint32_t feature_flags{0};
+protected:
+    void unpackData(const std::shared_ptr<buf_len> &bl);
+    void packData(std::shared_ptr<buf_len> bl) override;
+public:
+    fss_message_version();
+    fss_message_version(uint16_t t_version, uint16_t t_min_version, uint32_t t_flags);
+    fss_message_version(uint64_t t_id, const std::shared_ptr<buf_len> &bl);
+    auto getProtocolVersion() const -> uint16_t { return this->protocol_version; }
+    auto getMinSupportedVersion() const -> uint16_t { return this->min_supported_version; }
+    auto getFeatureFlags() const -> uint32_t { return this->feature_flags; }
 };
 } // namespace transport
 } // namespace flight_safety_system

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -962,6 +962,51 @@ flight_safety_system::transport::fss_message_identity_required::fss_message_iden
 {
 }
 
+flight_safety_system::transport::fss_message_version::fss_message_version() : fss_message(message_type_version)
+{
+}
+
+flight_safety_system::transport::fss_message_version::fss_message_version(uint16_t t_version, uint16_t t_min_version, uint32_t t_flags) : fss_message(message_type_version), protocol_version(t_version), min_supported_version(t_min_version), feature_flags(t_flags)
+{
+}
+
+flight_safety_system::transport::fss_message_version::fss_message_version(uint64_t t_id, const std::shared_ptr<buf_len> &bl) : fss_message(t_id, message_type_version)
+{
+    this->unpackData(bl);
+}
+
+void
+flight_safety_system::transport::fss_message_version::packData(std::shared_ptr<buf_len> bl)
+{
+    uint16_t version_n = fss_htobe16(this->protocol_version);
+    uint16_t min_version_n = fss_htobe16(this->min_supported_version);
+    uint32_t flags_n = fss_htobe32(this->feature_flags);
+    bl->addData(reinterpret_cast<const char *>(&version_n), sizeof(uint16_t));
+    bl->addData(reinterpret_cast<const char *>(&min_version_n), sizeof(uint16_t));
+    bl->addData(reinterpret_cast<const char *>(&flags_n), sizeof(uint32_t));
+}
+
+void
+flight_safety_system::transport::fss_message_version::unpackData(const std::shared_ptr<buf_len> &bl)
+{
+    size_t offset = this->headerLength();
+    const char *data = bl->getData();
+    size_t length = bl->getLength();
+    if (length - offset >= sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint32_t))
+    {
+        uint16_t tmp16;
+        memcpy(&tmp16, data + offset, sizeof(uint16_t));
+        this->protocol_version = fss_be16toh(tmp16);
+        offset += sizeof(uint16_t);
+        memcpy(&tmp16, data + offset, sizeof(uint16_t));
+        this->min_supported_version = fss_be16toh(tmp16);
+        offset += sizeof(uint16_t);
+        uint32_t tmp32;
+        memcpy(&tmp32, data + offset, sizeof(uint32_t));
+        this->feature_flags = fss_be32toh(tmp32);
+    }
+}
+
 
 auto
 flight_safety_system::transport::fss_message::decode(const std::shared_ptr<buf_len> &bl) -> std::shared_ptr<flight_safety_system::transport::fss_message>
@@ -1016,6 +1061,9 @@ flight_safety_system::transport::fss_message::decode(const std::shared_ptr<buf_l
             break;
         case message_type_identity_required:
             msg = std::make_shared<fss_message_identity_required>(msg_id, bl);
+            break;
+        case message_type_version:
+            msg = std::make_shared<fss_message_version>(msg_id, bl);
             break;
     }
 

--- a/tests/messages.cpp
+++ b/tests/messages.cpp
@@ -502,3 +502,45 @@ TEST_CASE("Identity (Non-Aircraft) Message Check") {
     REQUIRE(decoded_generic->getType() == flight_safety_system::transport::message_type_identity_non_aircraft);
     REQUIRE(decoded_generic->getId() == msg_id);
 }
+
+TEST_CASE("Version Message Round-trip") {
+    auto msg_id = static_cast<uint64_t>(random());
+    constexpr uint16_t version = 3;
+    constexpr uint16_t min_version = 2;
+    constexpr uint32_t flags = 0xDEADBEEFU;
+
+    auto msg = std::make_shared<flight_safety_system::transport::fss_message_version>(version, min_version, flags);
+    REQUIRE(msg->getType() == flight_safety_system::transport::message_type_version);
+    REQUIRE(msg->getProtocolVersion() == version);
+    REQUIRE(msg->getMinSupportedVersion() == min_version);
+    REQUIRE(msg->getFeatureFlags() == flags);
+
+    msg->setId(msg_id);
+    auto bl = msg->getPacked();
+    REQUIRE(bl != nullptr);
+
+    auto decoded = std::make_shared<flight_safety_system::transport::fss_message_version>(msg_id, bl);
+    REQUIRE(decoded->getType() == flight_safety_system::transport::message_type_version);
+    REQUIRE(decoded->getId() == msg_id);
+    REQUIRE(decoded->getProtocolVersion() == version);
+    REQUIRE(decoded->getMinSupportedVersion() == min_version);
+    REQUIRE(decoded->getFeatureFlags() == flags);
+
+    auto decoded_generic = flight_safety_system::transport::fss_message::decode(bl);
+    REQUIRE(decoded_generic != nullptr);
+    REQUIRE(decoded_generic->getType() == flight_safety_system::transport::message_type_version);
+    REQUIRE(decoded_generic->getId() == msg_id);
+    auto decoded_generic_version = std::dynamic_pointer_cast<flight_safety_system::transport::fss_message_version>(decoded_generic);
+    REQUIRE(decoded_generic_version != nullptr);
+    REQUIRE(decoded_generic_version->getProtocolVersion() == version);
+    REQUIRE(decoded_generic_version->getMinSupportedVersion() == min_version);
+    REQUIRE(decoded_generic_version->getFeatureFlags() == flags);
+}
+
+TEST_CASE("Version Message Defaults") {
+    auto msg = std::make_shared<flight_safety_system::transport::fss_message_version>();
+    REQUIRE(msg->getType() == flight_safety_system::transport::message_type_version);
+    REQUIRE(msg->getProtocolVersion() == flight_safety_system::transport::FSS_PROTOCOL_VERSION);
+    REQUIRE(msg->getMinSupportedVersion() == flight_safety_system::transport::FSS_PROTOCOL_MIN_VERSION);
+    REQUIRE(msg->getFeatureFlags() == 0);
+}

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -260,3 +260,89 @@ TEST_CASE("session: RTT timeout disconnects client")
 
     REQUIRE(handler.disconnects > 0);
 }
+
+TEST_CASE("session: version handshake stores negotiated version and replies")
+{
+    /* todo02: version exchange — when the client opens with a version
+     * message, the server records the negotiated version on the
+     * connection and replies with its own version. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+
+    REQUIRE(conn->getNegotiatedVersion() == fss::transport::FSS_PROTOCOL_VERSION_LEGACY);
+
+    auto version = std::make_shared<fss::transport::fss_message_version>(
+        fss::transport::FSS_PROTOCOL_VERSION,
+        fss::transport::FSS_PROTOCOL_MIN_VERSION,
+        0U);
+    session->processMessage(version);
+
+    REQUIRE(conn->getNegotiatedVersion() == fss::transport::FSS_PROTOCOL_VERSION);
+    REQUIRE(handler.disconnects == 0);
+
+    bool saw_version_response = false;
+    for (const auto &m : conn->sent)
+    {
+        if (m->getType() == fss::transport::message_type_version) { saw_version_response = true; }
+    }
+    REQUIRE(saw_version_response);
+}
+
+TEST_CASE("session: version handshake rejects incompatible peer")
+{
+    /* todo02: when the client's max version is below our minimum, the
+     * server disconnects rather than continuing in an unsupported
+     * dialect. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+
+    /* Peer claims to only support version 0 (max = 0). Our min is 1, so
+     * this is a hard reject. */
+    auto version = std::make_shared<fss::transport::fss_message_version>(
+        /*version*/ 0U, /*min_version*/ 0U, /*flags*/ 0U);
+    session->processMessage(version);
+
+    REQUIRE(handler.disconnects > 0);
+}
+
+TEST_CASE("session: legacy client (no version handshake) is accepted")
+{
+    /* todo02: pre-versioning clients send identity directly. The server
+     * must accept this and treat the connection as legacy (version 0). */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+
+    /* No version message — go straight to identity, like an old client. */
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    REQUIRE(handler.disconnects == 0);
+    REQUIRE(conn->getNegotiatedVersion() == fss::transport::FSS_PROTOCOL_VERSION_LEGACY);
+
+    bool saw_server_list = false;
+    for (const auto &m : conn->sent)
+    {
+        if (m->getType() == fss::transport::message_type_server_list) { saw_server_list = true; }
+    }
+    REQUIRE(saw_server_list);
+}


### PR DESCRIPTION
## Description

Add a version negotiation message exchanged after TLS handshake so future protocol changes can branch on the negotiated version instead of being silent breaking changes. Pre-versioning clients still work: sending identity directly is treated as legacy version 0 and logged once per connection.

## Summary by Sourcery

Introduce a wire-protocol version handshake between clients and server to negotiate compatible protocol versions while preserving support for legacy, unversioned clients.

New Features:
- Add a version handshake message type to the transport protocol, including serialization, decoding, and associated metadata for protocol and feature versions.
- Implement client and server logic to exchange version messages immediately after TLS setup, negotiate a common protocol version, and record it on the connection.

Enhancements:
- Reject connections when the peer's supported protocol range is incompatible, triggering disconnect or client reconnect as appropriate.
- Treat clients that skip the version handshake as legacy connections pinned to version 0, while still allowing normal identity and server list flow.

Tests:
- Add unit tests for version message encoding/decoding and for server session behavior across successful negotiation, incompatible versions, and legacy (no-handshake) clients.