### PR TITLE
feat: implement todo15 — restrict identity validation to leaf cert CN

### DIFF
--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -185,27 +185,38 @@ flight_safety_system::transport_ssl::fss_connection_server::setupSSL() -> bool
 
     std::vector<gnutls_datum_t> cert_list;
 
-    if (this->session->get_peers_certificate(cert_list))
+    /* Only the leaf cert (index 0) carries the peer's identity; CNs of
+     * intermediate CAs in the chain are issuer names, not identities, and
+     * must not be accepted as a valid client name. */
+    if (this->session->get_peers_certificate(cert_list) && !cert_list.empty())
     {
-        for (auto cert : cert_list)
+        gnutls_x509_crt_t cert_data = {};
+
+        int rc = gnutls_x509_crt_init(&cert_data);
+        if (rc < 0)
         {
-            gnutls_x509_crt_t cert_data = {};
-
-            gnutls_x509_crt_init(&cert_data);
-
-            gnutls_x509_crt_import(cert_data, &cert, GNUTLS_X509_FMT_DER);
-
-            const size_t dn_max_len = 512;
-            char name_buf[dn_max_len];
-            size_t name_len = dn_max_len;
-            int rc = gnutls_x509_crt_get_dn_by_oid(cert_data, GNUTLS_OID_X520_COMMON_NAME,
-                                                     0, 0, name_buf, &name_len);
-            if (rc == GNUTLS_E_SUCCESS && name_len > 0)
-            {
-                this->possible_names.push_back(std::string(name_buf, name_len));
-            }
-            gnutls_x509_crt_deinit(cert_data);
+            FSS_LOG_ERROR("ssl", "Failed to initialize X.509 certificate: " << gnutls_strerror(rc));
+            return false;
         }
+
+        rc = gnutls_x509_crt_import(cert_data, &cert_list[0], GNUTLS_X509_FMT_DER);
+        if (rc < 0)
+        {
+            FSS_LOG_ERROR("ssl", "Failed to import X.509 certificate: " << gnutls_strerror(rc));
+            gnutls_x509_crt_deinit(cert_data);
+            return false;
+        }
+
+        const size_t dn_max_len = 512;
+        char name_buf[dn_max_len];
+        size_t name_len = dn_max_len;
+        rc = gnutls_x509_crt_get_dn_by_oid(cert_data, GNUTLS_OID_X520_COMMON_NAME,
+                                                 0, 0, name_buf, &name_len);
+        if (rc == GNUTLS_E_SUCCESS && name_len > 0)
+        {
+            this->possible_names.push_back(std::string(name_buf, name_len));
+        }
+        gnutls_x509_crt_deinit(cert_data);
     }
 
     return true;

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -90,6 +90,53 @@ public:
 
 } // namespace
 
+TEST_CASE("session: rejects identify when claimed name does not match cert CN")
+{
+    /* todo15: identity name must match a CN from the peer certificate.
+     * A client presenting cert CN=craft must not be allowed to claim
+     * identity "imposter" — that would let any holder of any valid
+     * client cert masquerade as any aircraft. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["imposter"] = 1;
+    mock.asset_ids["craft"] = 2;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("imposter"));
+
+    REQUIRE(handler.disconnects > 0);
+    /* No server-list / command messages should leak out before disconnect. */
+    for (const auto &m : conn->sent)
+    {
+        REQUIRE(m->getType() != fss::transport::message_type_server_list);
+        REQUIRE(m->getType() != fss::transport::message_type_command);
+    }
+}
+
+TEST_CASE("session: rejects identify when no cert CN present")
+{
+    /* todo15: getClientNames() returns empty when the peer presented no
+     * cert (or the leaf had no CN). The server must refuse to identify
+     * such a connection rather than treating absence of a CN as
+     * permission to claim any name. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    /* cert_names intentionally empty */
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    REQUIRE(handler.disconnects > 0);
+}
+
 TEST_CASE("session: rejects identify when asset unknown to database")
 {
     fss_test::MockDatabase mock;


### PR DESCRIPTION
## Description

CN extraction iterated the full peer cert chain, so an intermediate CA's CN could satisfy the identity check. Use only cert_list[0] (the leaf) — only the leaf carries the peer's identity. Adds session-level tests for CN mismatch and missing-CN rejection paths.

## Summary by Sourcery

Restrict SSL client identity extraction to the leaf certificate’s common name and add coverage for rejecting invalid or missing certificate identities.

Bug Fixes:
- Ensure client identity validation uses only the leaf certificate CN instead of any CN in the certificate chain.

Enhancements:
- Improve robustness of SSL certificate handling by validating X.509 init/import results and aborting setup on failure.

Tests:
- Add session-level tests verifying rejection when the claimed identity does not match the certificate CN and when no certificate CN is present.