### PR TITLE
feat: implement todo16 — validate non-aircraft identity against cert CN

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -291,8 +291,24 @@ fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss_mess
         }
         else if(msg->getType() == fss::transport::message_type_identity_non_aircraft)
         {
-            this->identified = true;
+            /* todo16: identify the non-aircraft client by its leaf cert CN.
+             * Without this check any holder of any cert valid against the
+             * CA could become a non-aircraft session anonymously, bypassing
+             * the per-asset identity contract aircraft connections enforce
+             * (todo15). */
+            auto possible_names = this->getConnection()->getClientNames();
+            if (possible_names.empty())
+            {
+                FSS_LOG_ERROR("server", "Rejecting non-aircraft client: no CN found in certificate");
+                this->client_handler->clientDisconnected(this);
+                return;
+            }
+            {
+                std::lock_guard<std::mutex> guard(this->client_lock);
+                this->name = possible_names.front();
+            }
             this->aircraft = false;
+            this->identified = true;
         }
         else
         {

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -137,6 +137,44 @@ TEST_CASE("session: rejects identify when no cert CN present")
     REQUIRE(handler.disconnects > 0);
 }
 
+TEST_CASE("session: rejects non-aircraft identify when no cert CN present")
+{
+    /* todo16: a non-aircraft client with no cert CN must be rejected.
+     * Previously the non-aircraft branch accepted any cert valid against
+     * the CA without naming itself, bypassing the per-asset identity
+     * contract aircraft connections enforce (todo15). */
+    fss_test::MockDatabase mock;
+
+    auto conn = std::make_shared<FakeConnection>();
+    /* cert_names intentionally empty */
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity_non_aircraft>());
+
+    REQUIRE(handler.disconnects > 0);
+    REQUIRE_FALSE(session->isAircraft());
+}
+
+TEST_CASE("session: accepts non-aircraft identify when cert CN present")
+{
+    /* todo16: with a leaf CN present, a non-aircraft identity is accepted
+     * and the connection is not torn down. */
+    fss_test::MockDatabase mock;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("ground-station-1");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity_non_aircraft>());
+
+    REQUIRE(handler.disconnects == 0);
+    REQUIRE_FALSE(session->isAircraft());
+}
+
 TEST_CASE("session: rejects identify when asset unknown to database")
 {
     fss_test::MockDatabase mock;


### PR DESCRIPTION
## Summary by Sourcery

Validate non-aircraft client sessions against their certificate common name and tighten identification behavior.

New Features:
- Enforce that non-aircraft client sessions derive their identity from the leaf certificate common name before being marked as identified.

Bug Fixes:
- Reject non-aircraft client connections that present no certificate common name instead of accepting them anonymously.

Tests:
- Add tests covering non-aircraft identification success when a certificate CN is present and rejection when it is missing.