### PR TITLE
feat: implement todo12 — certificate revocation support

### DIFF
--- a/.cppcheck-suppress
+++ b/.cppcheck-suppress
@@ -11,8 +11,8 @@ constVariablePointer:src/fss-log.hpp:66
 useStlAlgorithm:src/client-ssl.cpp:130
 
 # fss-transport-ssl.hpp — deleted-operator= re-declared in derived class
-duplInheritedMember:src/fss-transport-ssl.hpp:29
 duplInheritedMember:src/fss-transport-ssl.hpp:30
+duplInheritedMember:src/fss-transport-ssl.hpp:31
 
 # server.cpp
 missingOverride:src/server.cpp:136

--- a/certs/revoke-client.sh
+++ b/certs/revoke-client.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -e
+
+# Usage: revoke-client.sh <client-name>
+# Revokes the named client certificate and regenerates the CRL.
+# The updated CRL is written to crl.pem in the current directory.
+# New connections will use the updated CRL automatically.
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <client-name>" >&2
+    exit 1
+fi
+
+CA_PUBLIC_PEM=ca.public.pem
+CA_PRIVATE_PEM=ca.private.pem
+CLIENT_PUBLIC_PEM=${1}.public.pem
+CRL_FILE=crl.pem
+REVOKED_DIR=revoked
+
+if [ ! -f "${CA_PUBLIC_PEM}" ]; then
+    echo "Error: CA certificate not found: ${CA_PUBLIC_PEM}" >&2
+    exit 1
+fi
+
+if [ ! -f "${CA_PRIVATE_PEM}" ]; then
+    echo "Error: CA private key not found: ${CA_PRIVATE_PEM}" >&2
+    exit 1
+fi
+
+if [ ! -f "${CLIENT_PUBLIC_PEM}" ]; then
+    echo "Error: Certificate not found: ${CLIENT_PUBLIC_PEM}" >&2
+    exit 1
+fi
+
+mkdir -p "${REVOKED_DIR}"
+cp "${CLIENT_PUBLIC_PEM}" "${REVOKED_DIR}/${1}.public.pem"
+
+LOAD_CERT_ARGS=()
+for cert in "${REVOKED_DIR}"/*.public.pem; do
+    LOAD_CERT_ARGS+=("--load-certificate" "${cert}")
+done
+
+certtool --generate-crl \
+    --load-ca-privkey "${CA_PRIVATE_PEM}" \
+    --load-ca-certificate "${CA_PUBLIC_PEM}" \
+    "${LOAD_CERT_ARGS[@]}" \
+    --outfile "${CRL_FILE}"
+
+echo "CRL updated: ${CRL_FILE}"
+echo "New connections will use the updated CRL automatically."

--- a/src/fss-transport-ssl.hpp
+++ b/src/fss-transport-ssl.hpp
@@ -15,15 +15,16 @@ private:
     std::string ca_file;
     std::string private_key_file;
     std::string public_key_file;
+    std::string crl_file;
 protected:
     std::unique_ptr<gnutls::session> session{nullptr};
     bool usable{false};
     auto sendMsg(const std::shared_ptr<flight_safety_system::transport::buf_len> &bl) -> bool override;
     auto recvBytes(void *bytes, size_t max_bytes) -> ssize_t override;
-    void setupSession();
+    auto setupSession() -> bool;
 public:
-    fss_connection(std::string t_ca, std::string t_private_key, std::string t_public_key);
-    fss_connection(int t_fd, std::string t_ca, std::string t_private_key, std::string t_public_key);
+    fss_connection(std::string t_ca, std::string t_private_key, std::string t_public_key, std::string t_crl = {});
+    fss_connection(int t_fd, std::string t_ca, std::string t_private_key, std::string t_public_key, std::string t_crl = {});
     fss_connection(fss_connection&) = delete;
     fss_connection(fss_connection&&) = delete;
     auto operator=(fss_connection&) -> fss_connection& = delete;
@@ -53,7 +54,7 @@ private:
 protected:
     auto setupSSL() -> bool;
 public:
-    fss_connection_server(int t_fd, std::string t_ca, std::string t_private_key, std::string t_public_key);
+    fss_connection_server(int t_fd, std::string t_ca, std::string t_private_key, std::string t_public_key, std::string t_crl = {});
     fss_connection_server(fss_connection_server&) = delete;
     fss_connection_server(fss_connection_server&&) = delete;
     auto operator=(fss_connection_server&) -> fss_connection_server& = delete;
@@ -67,10 +68,11 @@ private:
     std::string ca_file;
     std::string private_key_file;
     std::string public_key_file;
+    std::string crl_file;
 protected:
     auto newConnection(int fd) -> std::shared_ptr<flight_safety_system::transport::fss_connection> override;
 public:
-    fss_listen(uint16_t t_port, flight_safety_system::transport::fss_connect_cb t_cb, std::string t_ca, std::string t_private_key, std::string t_public_key);
+    fss_listen(uint16_t t_port, flight_safety_system::transport::fss_connect_cb t_cb, std::string t_ca, std::string t_private_key, std::string t_public_key, std::string t_crl = {});
 };
 } // namespace transport_ssl
 } // namespace flight_safety_system

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -208,6 +208,11 @@ main(int argc, char *argv[]) -> int
         FSS_LOG_ERROR("server", "Missing ssl parameter, all of these are required: 'ca_public_key', 'server_private_key', 'server_public_key'");
         exit(-1);
     }
+    std::string crl_file = config["ssl"].isMember("crl_file") ? config["ssl"]["crl_file"].asString() : std::string{};
+    if (!crl_file.empty())
+    {
+        FSS_LOG_INFO("server", "CRL file configured: " << crl_file);
+    }
     listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(config["port"].asInt(),
         [dbc, writer, &clients](std::shared_ptr<flight_safety_system::transport::fss_connection> conn) -> bool {
 #ifdef DEBUG
@@ -216,7 +221,7 @@ main(int argc, char *argv[]) -> int
             clients->clientConnected(std::make_shared<flight_safety_system::server::fss_client>(std::move(conn), dbc.get(), writer, clients.get()));
             return true;
         },
-        config["ssl"]["ca_public_key"].asString(), config["ssl"]["server_private_key"].asString(), config["ssl"]["server_public_key"].asString());
+        config["ssl"]["ca_public_key"].asString(), config["ssl"]["server_private_key"].asString(), config["ssl"]["server_public_key"].asString(), crl_file);
 
     /* Split tick: sendCommand runs every command_poll_ms so safety-critical
      * commands (TERM, DISARM) reach aircraft in <=100ms instead of <=1s.

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -26,11 +26,11 @@ recv_msg_thread(flight_safety_system::transport_ssl::fss_connection *conn)
     conn->processMessages();
 }
 
-flight_safety_system::transport_ssl::fss_connection::fss_connection(std::string t_ca, std::string t_private_key, std::string t_public_key) : flight_safety_system::transport::fss_connection(), credentials(new gnutls::certificate_credentials()), ca_file(std::move(t_ca)), private_key_file(std::move(t_private_key)), public_key_file(std::move(t_public_key))
+flight_safety_system::transport_ssl::fss_connection::fss_connection(std::string t_ca, std::string t_private_key, std::string t_public_key, std::string t_crl) : flight_safety_system::transport::fss_connection(), credentials(new gnutls::certificate_credentials()), ca_file(std::move(t_ca)), private_key_file(std::move(t_private_key)), public_key_file(std::move(t_public_key)), crl_file(std::move(t_crl))
 {
 }
 
-flight_safety_system::transport_ssl::fss_connection::fss_connection(int t_fd, std::string t_ca, std::string t_private_key, std::string t_public_key) : flight_safety_system::transport::fss_connection(t_fd), credentials(new gnutls::certificate_credentials()), ca_file(std::move(t_ca)), private_key_file(std::move(t_private_key)), public_key_file(std::move(t_public_key))
+flight_safety_system::transport_ssl::fss_connection::fss_connection(int t_fd, std::string t_ca, std::string t_private_key, std::string t_public_key, std::string t_crl) : flight_safety_system::transport::fss_connection(t_fd), credentials(new gnutls::certificate_credentials()), ca_file(std::move(t_ca)), private_key_file(std::move(t_private_key)), public_key_file(std::move(t_public_key)), crl_file(std::move(t_crl))
 {
 }
 
@@ -55,7 +55,7 @@ flight_safety_system::transport_ssl::fss_connection_client::~fss_connection_clie
 
 flight_safety_system::transport_ssl::fss_connection_server::~fss_connection_server() = default;
 
-flight_safety_system::transport_ssl::fss_connection_server::fss_connection_server(int t_fd, std::string t_ca, std::string t_private_key, std::string t_public_key) : flight_safety_system::transport_ssl::fss_connection(std::move(t_ca), std::move(t_private_key), std::move(t_public_key))
+flight_safety_system::transport_ssl::fss_connection_server::fss_connection_server(int t_fd, std::string t_ca, std::string t_private_key, std::string t_public_key, std::string t_crl) : flight_safety_system::transport_ssl::fss_connection(std::move(t_ca), std::move(t_private_key), std::move(t_public_key), std::move(t_crl))
 {
     this->setFd(t_fd);
     this->usable = this->setupSSL();
@@ -116,16 +116,29 @@ flight_safety_system::transport_ssl::fss_connection_client::connectTo(const std:
     return this->usable;
 }
 
-void
-flight_safety_system::transport_ssl::fss_connection::setupSession()
+auto
+flight_safety_system::transport_ssl::fss_connection::setupSession() -> bool
 {
     this->session->set_priority (nullptr, nullptr);
 
     this->credentials->set_x509_trust_file(this->ca_file.c_str(), GNUTLS_X509_FMT_PEM);
     this->credentials->set_x509_key_file(this->public_key_file.c_str(), this->private_key_file.c_str(), GNUTLS_X509_FMT_PEM);
+    if (!this->crl_file.empty())
+    {
+        try
+        {
+            this->credentials->set_x509_crl_file(this->crl_file.c_str(), GNUTLS_X509_FMT_PEM);
+        }
+        catch (gnutls::exception &e)
+        {
+            FSS_LOG_ERROR("ssl", "Failed to load CRL file '" << this->crl_file << "': " << e.what());
+            return false;
+        }
+    }
     this->session->set_credentials(*this->credentials);
 
     this->session->set_transport_ptr((gnutls_transport_ptr_t)(intptr_t)this->getFd());
+    return true;
 }
 
 auto
@@ -135,7 +148,10 @@ flight_safety_system::transport_ssl::fss_connection_client::setupSSL() -> bool
 
     this->session = std::unique_ptr<gnutls::session>(clientSession);
 
-    this->setupSession();
+    if (!this->setupSession())
+    {
+        return false;
+    }
 
     clientSession->set_verify_cert(this->hostname.c_str(), 0);
 
@@ -164,7 +180,10 @@ flight_safety_system::transport_ssl::fss_connection_server::setupSSL() -> bool
 
     this->session = std::unique_ptr<gnutls::session>(serverSession);
 
-    this->setupSession();
+    if (!this->setupSession())
+    {
+        return false;
+    }
 
     serverSession->set_certificate_request(GNUTLS_CERT_REQUIRE);
 
@@ -283,10 +302,10 @@ flight_safety_system::transport_ssl::fss_connection::recvBytes(void *t_bytes, si
 auto
 flight_safety_system::transport_ssl::fss_listen::newConnection(int t_newfd) -> std::shared_ptr<flight_safety_system::transport::fss_connection>
 {
-    return std::make_shared<flight_safety_system::transport_ssl::fss_connection_server>(t_newfd, this->ca_file, this->private_key_file, this->public_key_file);
+    return std::make_shared<flight_safety_system::transport_ssl::fss_connection_server>(t_newfd, this->ca_file, this->private_key_file, this->public_key_file, this->crl_file);
 }
 
-flight_safety_system::transport_ssl::fss_listen::fss_listen(uint16_t t_port, flight_safety_system::transport::fss_connect_cb t_cb, std::string t_ca, std::string t_private_key, std::string t_public_key) : flight_safety_system::transport::fss_listen(t_port, t_cb), ca_file(std::move(t_ca)), private_key_file(std::move(t_private_key)), public_key_file(std::move(t_public_key))
+flight_safety_system::transport_ssl::fss_listen::fss_listen(uint16_t t_port, flight_safety_system::transport::fss_connect_cb t_cb, std::string t_ca, std::string t_private_key, std::string t_public_key, std::string t_crl) : flight_safety_system::transport::fss_listen(t_port, t_cb), ca_file(std::move(t_ca)), private_key_file(std::move(t_private_key)), public_key_file(std::move(t_public_key)), crl_file(std::move(t_crl))
 {
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Add certificate revocation list (CRL) support to the SSL transport layer and integrate it into the server configuration.

New Features:
- Allow SSL connections to be configured with an optional certificate revocation list file that is loaded into the GnuTLS credentials.
- Provide a helper script to revoke client certificates and regenerate the CRL used by new connections.

Enhancements:
- Propagate CRL configuration through SSL connection, server connection, and listener classes, failing SSL setup if the CRL cannot be loaded.
- Log configured CRL usage and errors when loading the CRL file to aid operational debugging.