### PR TITLE
fix: bump GnuTLS minimum version from 3.3.0 to 3.6.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ PKG_INSTALLDIR
 
 # Check for required pkg-config
 PKG_CHECK_MODULES([JSONCPP], [jsoncpp])
-PKG_CHECK_MODULES([GNUTLS], [gnutls >= 3.3.0])
+PKG_CHECK_MODULES([GNUTLS], [gnutls >= 3.6.0])
 
 AC_ARG_ENABLE([server],AS_HELP_STRING([--enable-server], [Build the server (fss-server)]))
 AC_ARG_ENABLE([tests],AS_HELP_STRING([--enable-tests], [Build the tests (Requires catch2)]))


### PR DESCRIPTION
## Description

3.3.x reached end-of-life in 2016 and lacks TLS 1.3, CHACHA20-POLY1305, and AES-GCM support. 3.6.0 is the safe floor for all required cipher suites and is a prerequisite for the hardened TLS priority string (S3.3).

## Summary by Sourcery

Build:
- Increase the pkg-config requirement for GnuTLS from version 3.3.0 to 3.6.0 in configure.ac.