### PR TITLE
feat: implement todo b5.2 — ECPG connection errors are now fatal

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,7 +66,7 @@ AS_IF([test "x$with_systemdsystemunitdir" != "xno"],
       [AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])])
 AM_CONDITIONAL([HAVE_SYSTEMD], [test "x$with_systemdsystemunitdir" != "xno"])
 
-AS_IF([test "x$enable_server" == "xyes"], [
+AS_IF([test "x$enable_server" == "xyes" -o "x$enable_tests" == "xyes"], [
     PKG_CHECK_MODULES([ECPG], [libecpg])
 ])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -53,4 +53,9 @@ fss_server_CXXFLAGS = $(AM_CXXFLAGS) $(JSONCPP_CFLAGS)
 fss_server_CFLAGS = $(AM_CFLAGS) $(ECPG_CFLAGS)
 fss_server_LDADD = libfss.la libfss-transport.la $(JSONCPP_LIBS) $(ECPG_LIBS)
 fss_server_LDADD += libfss-transport-ssl.la
+else
+if ENABLE_TESTS
+BUILT_SOURCES = server-db.c
+CLEANFILES = server-db.c
+endif
 endif

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -11,7 +11,13 @@ extern "C" {
 
 flight_safety_system::server::db_connection::db_connection(const std::string &host, const std::string &user, const std::string &pass, const std::string &db) : db_lock()
 {
-    db_connect(host.c_str(), user.c_str(), pass.c_str(), db.c_str());
+    connected_ = (db_connect(host.c_str(), user.c_str(), pass.c_str(), db.c_str()) == 1);
+}
+
+auto
+flight_safety_system::server::db_connection::isConnected() const -> bool
+{
+    return connected_;
 }
 
 flight_safety_system::server::db_connection::~db_connection()

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -76,11 +76,13 @@ public:
     virtual auto getCommand(uint64_t asset_id) -> std::shared_ptr<asset_command> = 0;
     virtual auto getActiveServers() -> std::vector<fss_server_details> = 0;
     virtual auto getSmmSettings(uint64_t asset_id) -> std::shared_ptr<smm_settings> = 0;
+    virtual auto isConnected() const -> bool = 0;
 };
 
 class db_connection: public IDatabase {
 private:
     std::mutex db_lock;
+    bool connected_{false};
 public:
     db_connection(const std::string &host, const std::string &user, const std::string &pass, const std::string &db);
     db_connection(db_connection&) = delete;
@@ -96,6 +98,7 @@ public:
     auto getCommand(uint64_t asset_id) -> std::shared_ptr<asset_command> override;
     auto getActiveServers() -> std::vector<fss_server_details> override;
     auto getSmmSettings(uint64_t asset_id) -> std::shared_ptr<smm_settings> override;
+    auto isConnected() const -> bool override;
 };
 
 class fss_client_rtt {

--- a/src/server-db.h
+++ b/src/server-db.h
@@ -1,4 +1,4 @@
-void db_connect(const char *host, const char *user, const char *pass, const char *db);
+int db_connect(const char *host, const char *user, const char *pass, const char *db);
 void db_disconnect(void);
 
 unsigned long long db_get_asset_id(const char *asset_name);

--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -7,20 +7,18 @@
 #define SMM_SERVER_LEN 256
 #define SMM_PASSWORD_LEN 256
 
-void db_connect(const char *host, const char *user, const char *pass, const char *db)
+int db_connect(const char *host, const char *user, const char *pass, const char *db)
 {
     char *target = NULL;
     if (asprintf(&target, "%s@%s", db, host) < 0)
     {
-        return;
+        return 0;
     }
     EXEC SQL BEGIN DECLARE SECTION;
     const char *db_target = target;
     const char *db_user = user;
     const char *db_pass = pass;
     EXEC SQL END DECLARE SECTION;
-
-    EXEC SQL WHENEVER SQLERROR SQLPRINT;
 
     if (db_pass != NULL && strlen(db_pass) > 0)
     {
@@ -30,10 +28,25 @@ void db_connect(const char *host, const char *user, const char *pass, const char
     {
         EXEC SQL CONNECT TO :db_target AS conn USER :db_user;
     }
-    
+
+    if (sqlca.sqlcode < 0)
+    {
+        sqlprint();
+        free(target);
+        return 0;
+    }
+
     EXEC SQL SET AUTOCOMMIT TO ON;
-    
+
+    if (sqlca.sqlcode < 0)
+    {
+        sqlprint();
+        free(target);
+        return 0;
+    }
+
     free(target);
+    return 1;
 }
 
 unsigned long long db_get_asset_id(const char *asset_name_arg)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -171,6 +171,12 @@ main(int argc, char *argv[]) -> int
 
     auto dbc = std::make_shared<flight_safety_system::server::db_connection>(config["postgres"]["host"].asString(), config["postgres"]["user"].asString(), config["postgres"]["pass"].asString(), config["postgres"]["db"].asString());
 
+    if (!dbc->isConnected())
+    {
+        FSS_LOG_ERROR("server", "Failed to connect to database; aborting");
+        return 1;
+    }
+
     constexpr std::size_t default_db_queue_depth = 10000;
     std::size_t db_queue_depth = config.isMember("db_queue_depth") ? config["db_queue_depth"].asUInt() : default_db_queue_depth;
     flight_safety_system::server::db_write_sink sink =

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -20,9 +20,13 @@ all_test_SOURCES = main.cpp messages.cpp connection.cpp client.cpp \
 	server_session_test.cpp \
 	async_db_write_test.cpp \
 	timeout_test.cpp \
+	db_connection_test.cpp \
 	../src/client_session.cpp \
-	../src/db-write-queue.cpp
-all_test_LDADD = ../src/libfss-transport.la ../src/libfss-client-ssl.la ../src/libfss.la $(JSONCPP_LIBS)
+	../src/db-write-queue.cpp \
+	../src/db.cpp \
+	../src/server-db.c
+all_test_CFLAGS = $(ECPG_CFLAGS)
+all_test_LDADD = ../src/libfss-transport.la ../src/libfss-client-ssl.la ../src/libfss.la $(JSONCPP_LIBS) $(ECPG_LIBS)
 
 all_test_SOURCES += connection-ssl.cpp certs certs-alt certs/expired
 all_test_LDADD += ../src/libfss-transport-ssl.la $(GNUTLS_LIBS) $(CATCH2_LIBS)
@@ -30,6 +34,7 @@ all_test_LDADD += ../src/libfss-transport-ssl.la $(GNUTLS_LIBS) $(CATCH2_LIBS)
 EXTRA_DIST = test_helpers.hpp mock_database.hpp
 
 BUILT_SOURCES += certs certs-alt certs/expired
+
 certs:
 	mkdir certs
 	(cd certs; ../../certs/generate-ca.sh; ../../certs/generate-server.sh localhost; ../../certs/generate-client.sh client)

--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -1,0 +1,22 @@
+#ifdef HAVE_CATCH2_CATCH_ALL_HPP
+#include <catch2/catch_all.hpp>
+#elif HAVE_CATCH2_CATCH_HPP
+#include <catch2/catch.hpp>
+#elif HAVE_CATCH_CATCH_HPP
+#include <catch/catch.hpp>
+#elif HAVE_CATCH_HPP
+#include <catch.hpp>
+#else
+#error No catch header
+#endif
+
+#include "fss-server.hpp"
+
+TEST_CASE("db_connection: invalid host reports not connected")
+{
+    /* Use a host that is guaranteed to refuse the connection so the test
+     * does not depend on a running PostgreSQL instance. */
+    flight_safety_system::server::db_connection dbc(
+        "db.invalid", "user", "pass", "db");
+    REQUIRE_FALSE(dbc.isConnected());
+}

--- a/tests/mock_database.hpp
+++ b/tests/mock_database.hpp
@@ -90,6 +90,8 @@ public:
         return it == smm.end() ? nullptr : it->second;
     }
 
+    auto isConnected() const -> bool override { return true; }
+
     void pushCommand(uint64_t asset_id, std::shared_ptr<flight_safety_system::server::asset_command> cmd)
     {
         commands[asset_id].push_back(std::move(cmd));


### PR DESCRIPTION
## Description

db_connect returns int (1=success, 0=failure); db_connection stores connected_ and exposes isConnected(); server aborts startup if the database is unreachable rather than running without a persistence layer. Adds configure.ac ECPG check for --enable-tests and a negative test.

## Summary by Sourcery

Make database connections report connectivity status and abort server startup when the database is unreachable.

New Features:
- Expose an isConnected() status method on the IDatabase interface and db_connection implementation to report database connectivity.

Enhancements:
- Change db_connect to return a success/failure code and have db_connection track connection state, causing the server to exit on startup if the database connection cannot be established.

Build:
- Require ECPG when either the server or tests are enabled and compile/link db and server-db sources into the test binary, generating server-db.c when only tests are built.

Tests:
- Add a db_connection test that verifies an invalid host results in a non-connected state.