### PR TITLE
fix: eliminate use-after-free hazard in recv thread (todo c2.3)

### DIFF
--- a/.cppcheck-suppress
+++ b/.cppcheck-suppress
@@ -26,8 +26,8 @@ dangerousTypeCast:src/transport.cpp:38
 dangerousTypeCast:src/transport.cpp:39
 duplicateBreak:src/transport.cpp:35
 duplicateBreak:src/transport.cpp:40
-cstyleCast:src/transport.cpp:225
-constVariablePointer:src/transport.cpp:225
+cstyleCast:src/transport.cpp:229
+constVariablePointer:src/transport.cpp:229
 
 # transport-helpers.cpp — network address utility C-style casts + AF_UNSPEC tautology
 dangerousTypeCast:src/transport-helpers.cpp:23

--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -271,8 +271,13 @@ flight_safety_system::client_ssl::fss_server::sendVersion()
 auto
 flight_safety_system::client_ssl::fss_server::reconnect_to() -> bool
 {
-    this->setConnection(std::make_shared<flight_safety_system::transport_ssl::fss_connection_client>(this->ca_file, this->private_key_file, this->public_key_file));
-    return this->getConnection()->connectTo(this->getAddress(), this->getPort());
+    auto new_conn = flight_safety_system::transport_ssl::fss_connection_client::create(this->ca_file, this->private_key_file, this->public_key_file, this->getAddress(), this->getPort());
+    if (new_conn == nullptr)
+    {
+        return false;
+    }
+    this->setConnection(new_conn);
+    return true;
 }
 
 void

--- a/src/fss-transport-ssl.hpp
+++ b/src/fss-transport-ssl.hpp
@@ -45,21 +45,23 @@ public:
     auto operator=(fss_connection_client &&) -> fss_connection& = delete;
     ~fss_connection_client() override;
     auto connectTo(const std::string &address, uint16_t port) -> bool override;
+    static auto create(std::string t_ca, std::string t_private_key, std::string t_public_key, const std::string &address, uint16_t port) -> std::shared_ptr<fss_connection_client>;
 };
 
 
 class fss_connection_server : public fss_connection {
 private:
     std::list<std::string> possible_names{};
+    fss_connection_server(int t_fd, std::string t_ca, std::string t_private_key, std::string t_public_key, std::string t_crl = {});
 protected:
     auto setupSSL() -> bool;
 public:
-    fss_connection_server(int t_fd, std::string t_ca, std::string t_private_key, std::string t_public_key, std::string t_crl = {});
     fss_connection_server(fss_connection_server&) = delete;
     fss_connection_server(fss_connection_server&&) = delete;
     auto operator=(fss_connection_server&) -> fss_connection_server& = delete;
     auto operator=(fss_connection_server&&) -> fss_connection_server& = delete;
     ~fss_connection_server() override;
+    static auto create(int t_fd, std::string t_ca, std::string t_private_key, std::string t_public_key, std::string t_crl) -> std::shared_ptr<fss_connection_server>;
     auto getClientNames() -> std::list<std::string> override;
 };
 

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -20,12 +20,6 @@ extern const char *
 inet_ntop_stor(struct sockaddr_storage *src, char *dst, size_t dstlen, uint16_t *port);
 #endif
 
-static void
-recv_msg_thread(flight_safety_system::transport_ssl::fss_connection *conn)
-{
-    conn->processMessages();
-}
-
 flight_safety_system::transport_ssl::fss_connection::fss_connection(std::string t_ca, std::string t_private_key, std::string t_public_key, std::string t_crl) : flight_safety_system::transport::fss_connection(), credentials(new gnutls::certificate_credentials()), ca_file(std::move(t_ca)), private_key_file(std::move(t_private_key)), public_key_file(std::move(t_public_key)), crl_file(std::move(t_crl))
 {
 }
@@ -59,10 +53,17 @@ flight_safety_system::transport_ssl::fss_connection_server::fss_connection_serve
 {
     this->setFd(t_fd);
     this->usable = this->setupSSL();
-    if (this->usable)
+}
+
+auto
+flight_safety_system::transport_ssl::fss_connection_server::create(int t_fd, std::string t_ca, std::string t_private_key, std::string t_public_key, std::string t_crl) -> std::shared_ptr<fss_connection_server>
+{
+    auto conn = std::shared_ptr<fss_connection_server>(new fss_connection_server(t_fd, std::move(t_ca), std::move(t_private_key), std::move(t_public_key), std::move(t_crl)));
+    if (conn->usable)
     {
-        this->startRecvThread(std::thread(recv_msg_thread, this));
+        conn->startRecvThread(std::thread([conn]() -> void { conn->processMessages(); }));
     }
+    return conn;
 }
 
 flight_safety_system::transport_ssl::fss_connection_client::fss_connection_client(std::string t_ca, std::string t_private_key, std::string t_public_key) : fss_connection(std::move(t_ca), std::move(t_private_key), std::move(t_public_key))
@@ -108,12 +109,19 @@ flight_safety_system::transport_ssl::fss_connection_client::connectTo(const std:
 
     this->usable = this->setupSSL();
 
-    if (this->usable)
-    {
-        this->startRecvThread(std::thread(recv_msg_thread, this));
-    }
-
     return this->usable;
+}
+
+auto
+flight_safety_system::transport_ssl::fss_connection_client::create(std::string t_ca, std::string t_private_key, std::string t_public_key, const std::string &address, uint16_t port) -> std::shared_ptr<fss_connection_client>
+{
+    auto conn = std::make_shared<fss_connection_client>(std::move(t_ca), std::move(t_private_key), std::move(t_public_key));
+    if (!conn->connectTo(address, port))
+    {
+        return nullptr;
+    }
+    conn->startRecvThread(std::thread([conn]() -> void { conn->processMessages(); }));
+    return conn;
 }
 
 auto
@@ -302,7 +310,7 @@ flight_safety_system::transport_ssl::fss_connection::recvBytes(void *t_bytes, si
 auto
 flight_safety_system::transport_ssl::fss_listen::newConnection(int t_newfd) -> std::shared_ptr<flight_safety_system::transport::fss_connection>
 {
-    return std::make_shared<flight_safety_system::transport_ssl::fss_connection_server>(t_newfd, this->ca_file, this->private_key_file, this->public_key_file, this->crl_file);
+    return flight_safety_system::transport_ssl::fss_connection_server::create(t_newfd, this->ca_file, this->private_key_file, this->public_key_file, this->crl_file);
 }
 
 flight_safety_system::transport_ssl::fss_listen::fss_listen(uint16_t t_port, flight_safety_system::transport::fss_connect_cb t_cb, std::string t_ca, std::string t_private_key, std::string t_public_key, std::string t_crl) : flight_safety_system::transport::fss_listen(t_port, t_cb), ca_file(std::move(t_ca)), private_key_file(std::move(t_private_key)), public_key_file(std::move(t_public_key)), crl_file(std::move(t_crl))

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -45,12 +45,6 @@ inet_ntop_stor(struct sockaddr_storage *src, char *dst, size_t dstlen, uint16_t 
 
 flight_safety_system::transport::fss_connection::fss_connection() = default;
 
-static void
-recv_msg_thread(flight_safety_system::transport::fss_connection *conn)
-{
-    conn->processMessages();
-}
-
 flight_safety_system::transport::fss_connection::fss_connection(int t_fd, size_t t_max_queue_size)
     : fd(t_fd), max_queue_size(t_max_queue_size)
 {
@@ -60,7 +54,7 @@ auto
 flight_safety_system::transport::fss_connection::create(int t_fd, size_t t_max_queue_size) -> std::shared_ptr<fss_connection>
 {
     auto conn = std::shared_ptr<fss_connection>(new fss_connection(t_fd, t_max_queue_size));
-    conn->startRecvThread(std::thread(recv_msg_thread, conn.get()));
+    conn->startRecvThread(std::thread([conn]() -> void { conn->processMessages(); }));
     return conn;
 }
 
@@ -73,6 +67,7 @@ flight_safety_system::transport::fss_connection::getDroppedMessages() -> uint64_
 void
 flight_safety_system::transport::fss_connection::disconnect()
 {
+    this->run.store(false);
     int orig_fd = this->fd.exchange(-1);
     if (orig_fd != -1)
     {
@@ -81,7 +76,18 @@ flight_safety_system::transport::fss_connection::disconnect()
     }
     if (this->recv_thread.joinable())
     {
-        this->recv_thread.join();
+        if (this->recv_thread.get_id() == std::this_thread::get_id())
+        {
+            /* Destructor called from within the recv thread itself (possible
+             * when the lambda is the last shared_ptr owner).  Detach so the
+             * thread can finish normally without trying to join itself. */
+            this->recv_thread.detach();
+            this->recv_thread = std::thread();
+        }
+        else
+        {
+            this->recv_thread.join();
+        }
     }
 }
 
@@ -116,6 +122,18 @@ flight_safety_system::transport::fss_connection::processMessages()
         {
             FSS_LOG_INFO("transport", "Remote closed the connection");
             this->run.store(false);
+            {
+                std::lock_guard<std::mutex> lock_holder(this->msg_lock);
+                if (this->handler != nullptr)
+                {
+                    this->handler->processMessage(msg);
+                }
+                else
+                {
+                    this->messages.push(msg);
+                }
+            }
+            break;
         }
         {
             std::lock_guard<std::mutex> lock_holder(this->msg_lock);
@@ -196,7 +214,7 @@ flight_safety_system::transport::fss_connection::connectTo(const std::string &ad
 
     set_tcp_keepalive(current_fd);
 
-    this->recv_thread = std::thread(recv_msg_thread, this);
+    this->startRecvThread(std::thread([this]() -> void { this->processMessages(); }));
 
     return true;
 }

--- a/tests/connection-ssl.cpp
+++ b/tests/connection-ssl.cpp
@@ -99,7 +99,7 @@ TEST_CASE("SSL - Listen - Callback")
     auto listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(listen_port, test_client_connect_cb, CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
     REQUIRE(listen != nullptr);
 
-    flight_safety_system::transport::fss_connection *conn = new flight_safety_system::transport_ssl::fss_connection_client(CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+    std::shared_ptr<flight_safety_system::transport::fss_connection> conn = std::make_shared<flight_safety_system::transport_ssl::fss_connection_client>(CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
     REQUIRE(conn != nullptr);
     REQUIRE(conn->connectTo("localhost", listen_port));
 
@@ -122,5 +122,4 @@ TEST_CASE("SSL - Listen - Callback")
     REQUIRE(!cb->connected());
 
     client_conn = nullptr;
-    delete conn;
 }

--- a/tests/reconnect_test.cpp
+++ b/tests/reconnect_test.cpp
@@ -88,7 +88,11 @@ TEST_CASE("reconnect: client reconnects after listener bounce")
     accepted_conn = nullptr;
 
     /* Drop the listener and the accepted connection — from the client's
-     * perspective, the server side has gone away. */
+     * perspective, the server side has gone away.  With the shared_ptr-capture
+     * thread design the recv thread keeps the connection alive until it exits,
+     * so we must explicitly disconnect before dropping the reference to ensure
+     * the TCP connection closes immediately. */
+    original->disconnect();
     original = nullptr;
     listen = nullptr;
 


### PR DESCRIPTION
## Description

Replace raw-pointer recv thread launches with shared_ptr-capturing lambdas so the connection object is guaranteed live for the thread's full lifetime.

Phases implemented:
- Phase 1: fss_connection::create captures shared_ptr in thread lambda
- Phase 2: fss_connection_server gains a static create() factory that starts the recv thread after the shared_ptr is formed, removing the raw-this hazard in the constructor
- Phase 3: connectTo() in plain transport and SSL client use lambda form for consistency (safe via join-before-destructor, but no raw function ptr)

Added self-join guard in disconnect(): when the lambda is the last shared_ptr owner the destructor runs from the recv thread itself; detach instead of join to avoid EDEADLK.

Updated reconnect test to call disconnect() explicitly before dropping the server connection reference — required because the lambda now extends object lifetime past the last external shared_ptr drop (production server code already uses this explicit-disconnect pattern).

## Summary by Sourcery

Guard connection recv threads against use-after-free by ensuring they capture shared_ptr-owned connection objects and by making disconnect and construction patterns thread-safe.

Bug Fixes:
- Prevent potential use-after-free in recv threads by having thread lambdas capture shared_ptr-managed connection instances instead of raw this pointers.
- Avoid deadlock when disconnect is invoked from within the recv thread by conditionally detaching instead of joining the thread on self-join.

Enhancements:
- Introduce factory create() methods for SSL connection server and client types to start recv threads only after shared_ptr ownership is established.
- Refine fss_connection::disconnect and processMessages behavior to stop the run loop deterministically and ensure final messages are delivered before shutdown.
- Update SSL client reconnect logic to use the new factory and connection establishment pattern for safer resource management.

Tests:
- Adjust reconnect and SSL connection tests to account for the new shared_ptr-based lifetime of connections and explicit disconnect requirements.