### PR TITLE
feat: implement todo s3.3 — harden TLS cipher priority

### DIFF
--- a/.cppcheck-suppress
+++ b/.cppcheck-suppress
@@ -11,8 +11,8 @@ constVariablePointer:src/fss-log.hpp:66
 useStlAlgorithm:src/client-ssl.cpp:130
 
 # fss-transport-ssl.hpp — deleted-operator= re-declared in derived class
-duplInheritedMember:src/fss-transport-ssl.hpp:30
 duplInheritedMember:src/fss-transport-ssl.hpp:31
+duplInheritedMember:src/fss-transport-ssl.hpp:32
 
 # server.cpp
 missingOverride:src/server.cpp:136

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -70,6 +70,7 @@ jobs:
         valgrind \
           --leak-check=full \
           --error-exitcode=1 \
+          --suppressions=../valgrind.supp \
           .libs/all_test
 
   # ─── 3. Coverage collection and upload ───────────────────────────────────

--- a/src/fss-transport-ssl.hpp
+++ b/src/fss-transport-ssl.hpp
@@ -1,6 +1,7 @@
 #include <fss-transport.hpp>
 
 #include <list>
+#include <string>
 
 namespace gnutls {
     class certificate_credentials;
@@ -30,6 +31,7 @@ public:
     auto operator=(fss_connection&) -> fss_connection& = delete;
     auto operator=(fss_connection&&) -> fss_connection& = delete;
     ~fss_connection() override;
+    auto getSessionDesc() -> std::string;
 };
 
 class fss_connection_client : public fss_connection {

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -127,7 +127,20 @@ flight_safety_system::transport_ssl::fss_connection_client::create(std::string t
 auto
 flight_safety_system::transport_ssl::fss_connection::setupSession() -> bool
 {
-    this->session->set_priority (nullptr, nullptr);
+    const char *err_pos = nullptr;
+    try
+    {
+        this->session->set_priority(
+            "SECURE256:+SECURE128:-VERS-TLS1.0:-VERS-TLS1.1:%SERVER_PRECEDENCE",
+            &err_pos);
+    }
+    catch (gnutls::exception &ex)
+    {
+        FSS_LOG_ERROR("ssl", "Failed to set TLS priority: " << ex.what()
+                      << (err_pos ? std::string(" near: ") + err_pos : ""));
+        this->usable = false;
+        return false;
+    }
 
     this->credentials->set_x509_trust_file(this->ca_file.c_str(), GNUTLS_X509_FMT_PEM);
     this->credentials->set_x509_key_file(this->public_key_file.c_str(), this->private_key_file.c_str(), GNUTLS_X509_FMT_PEM);
@@ -320,4 +333,14 @@ flight_safety_system::transport_ssl::fss_listen::fss_listen(uint16_t t_port, fli
 auto flight_safety_system::transport_ssl::fss_connection_server::getClientNames() -> std::list<std::string>
 {
     return this->possible_names;
+}
+
+auto flight_safety_system::transport_ssl::fss_connection::getSessionDesc() -> std::string
+{
+    if (!this->session) { return {}; }
+    char *desc = gnutls_session_get_desc(this->session->ptr());
+    if (desc == nullptr) { return {}; }
+    std::string result(desc);
+    gnutls_free(desc);
+    return result;
 }

--- a/tests/connection-ssl.cpp
+++ b/tests/connection-ssl.cpp
@@ -1,5 +1,6 @@
 #include <cstddef>
 #include <memory>
+#include <string>
 #ifdef HAVE_CATCH2_CATCH_ALL_HPP
 #include <catch2/catch_all.hpp>
 #elif HAVE_CATCH2_CATCH_HPP
@@ -120,6 +121,37 @@ TEST_CASE("SSL - Listen - Callback")
 
     cb->disconnect();
     REQUIRE(!cb->connected());
+
+    client_conn = nullptr;
+}
+
+TEST_CASE("SSL - Negotiated cipher suite is AEAD (TLS 1.2+)")
+{
+    const uint16_t listen_port = fss_test::pick_port();
+    REQUIRE(listen_port != 0);
+    client_conn = nullptr;
+
+    auto listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(
+        listen_port, test_client_connect_cb, CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
+    REQUIRE(listen != nullptr);
+
+    auto conn = std::make_shared<flight_safety_system::transport_ssl::fss_connection_client>(
+        CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+    REQUIRE(conn->connectTo("localhost", listen_port));
+
+    std::string desc = conn->getSessionDesc();
+    REQUIRE_FALSE(desc.empty());
+
+    // Protocol must be TLS 1.2 or TLS 1.3 — TLS 1.0/1.1 are excluded by the priority string
+    bool modern_tls = desc.find("TLS1.2") != std::string::npos ||
+                      desc.find("TLS1.3") != std::string::npos;
+    REQUIRE(modern_tls);
+
+    // Cipher must be AEAD (AES-GCM, AES-CCM, or ChaCha20-Poly1305)
+    bool aead = desc.find("GCM") != std::string::npos ||
+                desc.find("POLY1305") != std::string::npos ||
+                desc.find("-CCM") != std::string::npos;
+    REQUIRE(aead);
 
     client_conn = nullptr;
 }

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -1,0 +1,16 @@
+# Suppress false positive: glibc allocates the TLS Dynamic Thread Vector (DTV)
+# for each new thread via _dl_allocate_tls.  The pointer is stored in the
+# thread's %fs register, not in a regular heap slot, so Valgrind cannot find it
+# and reports it as "possibly lost".  This is harmless — glibc frees the DTV
+# in _dl_deallocate_tls when the thread exits.
+{
+   glibc_pthread_tls_dtv_false_positive
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   fun:calloc
+   fun:allocate_dtv
+   fun:_dl_allocate_tls
+   fun:allocate_stack
+   fun:pthread_create*
+}


### PR DESCRIPTION
## Description

Replace set_priority(nullptr) with an explicit priority string that restricts negotiation to SECURE256/SECURE128 ciphers and disables TLS 1.0/1.1, ensuring only strong AEAD cipher suites are accepted.

Add getSessionDesc() to fss_connection and a Catch2 test that establishes a real TLS connection and asserts the negotiated protocol is TLS 1.2+ and the cipher suite is from the AEAD family.

## Summary by Sourcery

Harden TLS session configuration by enforcing modern cipher and protocol priorities and expose session description for verification.

New Features:
- Expose a getSessionDesc() API on TLS connections to retrieve a human-readable description of the negotiated session.

Enhancements:
- Restrict TLS priorities to SECURE256/SECURE128 ciphers, disable TLS 1.0/1.1, and enforce server cipher precedence with error logging on configuration failure.

Tests:
- Add an integration test that performs a real TLS handshake and asserts the negotiated protocol is TLS 1.2+ and uses an AEAD cipher suite.