### PR TITLE
feat: implement todo c2.5 — track and surface DB write failures

### DIFF
--- a/src/db-write-queue.cpp
+++ b/src/db-write-queue.cpp
@@ -71,6 +71,12 @@ db_write_queue::dropped_count() const -> uint64_t
 }
 
 auto
+db_write_queue::write_failure_count() const -> uint64_t
+{
+    return this->write_failures.load();
+}
+
+auto
 db_write_queue::pending_count() const -> std::size_t
 {
     std::lock_guard<std::mutex> guard(this->mtx);
@@ -96,11 +102,21 @@ db_write_queue::run()
         }
         catch (const std::exception &e)
         {
-            FSS_LOG_ERROR("db-writer", "sink threw exception: " << e.what());
+            uint64_t failures = ++this->write_failures;
+            constexpr uint64_t log_every = 100;
+            if (failures == 1 || (failures % log_every) == 0)
+            {
+                FSS_LOG_ERROR("db-writer", "sink failed (total=" << failures << "): " << e.what());
+            }
         }
         catch (...)
         {
-            FSS_LOG_ERROR("db-writer", "sink threw unknown exception");
+            uint64_t failures = ++this->write_failures;
+            constexpr uint64_t log_every = 100;
+            if (failures == 1 || (failures % log_every) == 0)
+            {
+                FSS_LOG_ERROR("db-writer", "sink failed (total=" << failures << "): unknown exception");
+            }
         }
     }
 }

--- a/src/db-write-queue.hpp
+++ b/src/db-write-queue.hpp
@@ -34,6 +34,7 @@ private:
     std::deque<db_write_task> q{};
     bool stopping{false};
     std::atomic<uint64_t> dropped{0};
+    std::atomic<uint64_t> write_failures{0};
     std::thread worker{};
 
     void run();
@@ -49,6 +50,7 @@ public:
     void enqueue(db_write_task task);
     void stop();
     auto dropped_count() const -> uint64_t;
+    auto write_failure_count() const -> uint64_t;
     auto pending_count() const -> std::size_t;
 };
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -251,6 +251,13 @@ main(int argc, char *argv[]) -> int
             clients->checkTimeouts();
             auto rtt_req = std::make_shared<flight_safety_system::transport::fss_message_rtt_request>();
             clients->sendRTTRequest(rtt_req);
+            static uint64_t last_failure_count = 0;
+            uint64_t current_failures = writer->write_failure_count();
+            if (current_failures != last_failure_count)
+            {
+                FSS_LOG_ERROR("server", "DB write failures since start: " << current_failures);
+                last_failure_count = current_failures;
+            }
         }
         if ((tick_counter % send_config_period_ticks) == 0)
         {

--- a/tests/async_db_write_test.cpp
+++ b/tests/async_db_write_test.cpp
@@ -214,6 +214,25 @@ TEST_CASE("db_write_queue: drop log message appears on stderr when queue fills")
     flight_safety_system::log::set_level("info");
 }
 
+TEST_CASE("db_write_queue: write_failure_count tracks sink exceptions")
+{
+    constexpr uint64_t task_count = 5;
+    auto throwing_sink = [](const fss::server::db_write_task &) -> void {
+        throw std::runtime_error("injected sink failure");
+    };
+
+    fss::server::db_write_queue q(100, throwing_sink);
+    for (uint64_t i = 1; i <= task_count; ++i)
+    {
+        q.enqueue(fss::server::rtt_write{i, 0});
+    }
+
+    REQUIRE(fss_test::wait_for([&]() -> bool { return q.write_failure_count() == task_count; }));
+    q.stop();
+
+    REQUIRE(q.write_failure_count() == task_count);
+}
+
 TEST_CASE("db_write_queue: destructor without explicit stop drains pending work")
 {
     auto cap = std::make_shared<CapturingSink>();


### PR DESCRIPTION
## Description

Add write_failures atomic counter to db_write_queue with rate-limited logging (first failure and every 100th); expose via write_failure_count() accessor; surface in server main loop at ERROR level once per second when the count changes; add test verifying the counter against an always-throwing sink.

## Summary by Sourcery

Track and report database write failures from the async db write queue through to the server main loop, with rate-limited logging and test coverage.

New Features:
- Add a write_failure_count accessor on db_write_queue to expose the number of failed sink writes.
- Log DB sink failures with a running total, rate-limited to the first and every 100th failure.
- Surface the cumulative DB write failure count in the server loop whenever it changes.

Tests:
- Add a test verifying that write_failure_count matches the number of exceptions thrown by an always-failing sink.