### PR TITLE
feat: implement todo m7.2 — per-client token-bucket rate limiting

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -133,6 +133,12 @@ fss::server::fss_client::setTimeoutMs(uint64_t ms)
     this->client_timeout_ms = ms;
 }
 
+void
+fss::server::fss_client::setRateLimits(uint64_t capacity, uint64_t refill_per_s)
+{
+    this->msg_rate = rate_limiter(capacity, refill_per_s);
+}
+
 auto
 fss::server::fss_client::isTimedOut() -> bool
 {
@@ -317,6 +323,27 @@ fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss_mess
     }
     else
     {
+        if (!this->msg_rate.consume(this->clock->now_ms()))
+        {
+            auto now_ms = this->clock->now_ms();
+            ++this->rate_limit_rejects;
+            FSS_LOG_DEBUG("server", "Rate-limiting client " << this->name
+                                                            << " (rejects=" << this->rate_limit_rejects << ")");
+            if (this->last_rate_limit_log_ms == 0)
+            {
+                this->last_rate_limit_log_ms = now_ms;
+            }
+            else if (now_ms - this->last_rate_limit_log_ms >= 1000)
+            {
+                FSS_LOG_WARN("server", "Rate-limiting client " << this->name
+                                                               << " - dropped " << this->rate_limit_rejects
+                                                               << " messages in the last "
+                                                               << (now_ms - this->last_rate_limit_log_ms) << "ms");
+                this->rate_limit_rejects = 0;
+                this->last_rate_limit_log_ms = now_ms;
+            }
+            return;
+        }
         std::string client_name = this->getName();
         uint64_t asset_id = this->dbc->getAssetId(client_name);
         switch (msg->getType())

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -3,6 +3,7 @@
 #include "fss.hpp"
 #include "fss-transport.hpp"
 #include "db-write-queue.hpp"
+#include "rate-limiter.hpp"
 
 #include <atomic>
 #include <memory>
@@ -138,6 +139,9 @@ private:
     std::shared_ptr<db_write_queue> writer;
     fss_client_handler *client_handler;
     std::shared_ptr<IClock> clock{std::make_shared<WallClock>()};
+    rate_limiter msg_rate{100, 20};
+    uint64_t rate_limit_rejects{0};
+    uint64_t last_rate_limit_log_ms{0};
 public:
     fss_client(std::shared_ptr<transport::fss_connection> conn, IDatabase *t_dbc, std::shared_ptr<db_write_queue> t_writer, fss_client_handler *t_handler);
     fss_client(fss_client&) = delete;
@@ -152,6 +156,7 @@ public:
     auto isAircraft() -> bool;
     void setClock(std::shared_ptr<IClock> t_clock);
     void setTimeoutMs(uint64_t ms);
+    void setRateLimits(uint64_t capacity, uint64_t refill_per_s); // must be called before any messages are processed
     auto isTimedOut() -> bool;
 };
 } // namespace server

--- a/src/rate-limiter.hpp
+++ b/src/rate-limiter.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+
+namespace flight_safety_system {
+
+class rate_limiter {
+    uint64_t tokens;
+    uint64_t max_tokens;
+    uint64_t refill_per_s;
+    uint64_t last_refill_ms{0};
+    bool initialized{false};
+public:
+    rate_limiter(uint64_t capacity, uint64_t t_refill_per_s)
+        : tokens(capacity), max_tokens(capacity), refill_per_s(t_refill_per_s) {}
+
+    auto consume(uint64_t now_ms, uint64_t cost = 1) -> bool
+    {
+        if (!initialized) { initialized = true; last_refill_ms = now_ms; }
+        if (now_ms > last_refill_ms) {
+            uint64_t elapsed = now_ms - last_refill_ms;
+            uint64_t new_tokens = (refill_per_s > 0) ? (elapsed * refill_per_s / 1000) : 0;
+            if (new_tokens > 0) {
+                tokens = std::min(max_tokens, tokens + new_tokens);
+                last_refill_ms += new_tokens * 1000 / refill_per_s;
+            }
+        }
+        if (tokens < cost) { return false; }
+        tokens -= cost;
+        return true;
+    }
+};
+
+} // namespace flight_safety_system

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -36,6 +36,8 @@ private:
     uint32_t total_clients{0};
     std::atomic<bool> shutting_down{false};
     uint64_t client_timeout_ms{30000};
+    uint64_t rate_capacity{100};
+    uint64_t rate_refill_per_s{20};
 public:
     server_clients() = default;
     ~server_clients() override {
@@ -61,9 +63,15 @@ public:
         }
     };
     void setClientTimeoutMs(uint64_t ms) { this->client_timeout_ms = ms; }
+    void setClientRateLimits(uint64_t capacity, uint64_t refill_per_s)
+    {
+        this->rate_capacity = capacity;
+        this->rate_refill_per_s = refill_per_s;
+    }
     void clientConnected(std::shared_ptr<flight_safety_system::server::fss_client> client)
     {
         client->setTimeoutMs(this->client_timeout_ms);
+        client->setRateLimits(this->rate_capacity, this->rate_refill_per_s);
         std::lock_guard<std::mutex> guard(this->lock);
         this->total_clients++;
         this->clients.push_back(std::move(client));
@@ -203,6 +211,12 @@ main(int argc, char *argv[]) -> int
     constexpr int msec_per_sec = 1000;
     uint64_t client_timeout_sec = config.isMember("client_timeout") ? config["client_timeout"].asUInt64() : default_client_timeout_sec;
     clients->setClientTimeoutMs(client_timeout_sec * msec_per_sec);
+
+    constexpr uint64_t default_rate_capacity = 100;
+    constexpr uint64_t default_rate_refill_per_s = 20;
+    uint64_t rate_capacity = config.isMember("message_rate_capacity") ? config["message_rate_capacity"].asUInt64() : default_rate_capacity;
+    uint64_t rate_refill = config.isMember("message_rate_refill") ? config["message_rate_refill"].asUInt64() : default_rate_refill_per_s;
+    clients->setClientRateLimits(rate_capacity, rate_refill);
 
     std::shared_ptr<flight_safety_system::transport::fss_listen> listen;
     FSS_LOG_INFO("server", "Starting fss server in TLS mode");

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -404,6 +404,64 @@ TEST_CASE("session: version handshake rejects incompatible peer")
     REQUIRE(handler.disconnects > 0);
 }
 
+TEST_CASE("rate limiter: drops messages beyond burst capacity without disconnecting")
+{
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto clock = std::make_shared<FakeClock>();
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->setClock(clock);
+    session->setRateLimits(100, 0);  // 100-message burst, no refill
+
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    auto pos = std::make_shared<fss::transport::fss_message_position_report>(
+        0.0, 0.0, 0U, 0U, 0U, int16_t{0}, 0U, std::string{}, 0U, uint8_t{0}, 0U, uint8_t{0}, uint8_t{0}, uint64_t{0});
+    for (int i = 0; i < 200; ++i)
+    {
+        session->processMessage(pos);
+    }
+
+    REQUIRE(handler.disconnects == 0);
+    REQUIRE(handler.broadcasts.size() == 100);
+}
+
+TEST_CASE("rate limiter: refill allows messages after bucket drains")
+{
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto clock = std::make_shared<FakeClock>();
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->setClock(clock);
+    session->setRateLimits(5, 10);  // 5-message burst, 10/s refill
+
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    auto pos = std::make_shared<fss::transport::fss_message_position_report>(
+        0.0, 0.0, 0U, 0U, 0U, int16_t{0}, 0U, std::string{}, 0U, uint8_t{0}, 0U, uint8_t{0}, uint8_t{0}, uint64_t{0});
+    for (int i = 0; i < 10; ++i) { session->processMessage(pos); }
+    // 5 go through, 5 dropped
+    REQUIRE(handler.broadcasts.size() == 5);
+
+    // Advance 1 second → 10 new tokens (capped at 5)
+    clock->advance(1000);
+    for (int i = 0; i < 10; ++i) { session->processMessage(pos); }
+    REQUIRE(handler.broadcasts.size() == 10);
+    REQUIRE(handler.disconnects == 0);
+}
+
 TEST_CASE("session: legacy client (no version handshake) is accepted")
 {
     /* todo02: pre-versioning clients send identity directly. The server


### PR DESCRIPTION
## Description

Add a header-only rate_limiter (src/rate-limiter.hpp) using a token-bucket algorithm. Each fss_client holds a msg_rate instance; processMessage consumes one token per post-identification message and drops (without disconnecting) any message that arrives when the bucket is empty. Capacity and refill rate are configurable via message_rate_capacity / message_rate_refill in the server JSON config; defaults are 100-message burst at 20 msg/s sustained.

## Summary by Sourcery

Introduce per-client token-bucket rate limiting for post-identification messages and wire it into the server session lifecycle with configurable defaults.

New Features:
- Add a reusable header-only token-bucket rate_limiter utility for controlling message throughput.
- Apply per-client rate limiting to non-identity messages in fss_client, dropping excess messages without disconnecting clients.
- Make message rate capacity and refill rate configurable via server JSON config with sensible defaults.

Enhancements:
- Add logging and counters to track and periodically report dropped messages due to rate limiting.

Tests:
- Add server session tests to verify burst capacity enforcement, non-disconnecting drops, and refill behavior of the rate limiter.