### PR TITLE
feat: implement todo s3.4 — CRL reload and revocation of existing connections

### DIFF
--- a/src/fss-transport-ssl.hpp
+++ b/src/fss-transport-ssl.hpp
@@ -65,6 +65,7 @@ public:
     ~fss_connection_server() override;
     static auto create(int t_fd, std::string t_ca, std::string t_private_key, std::string t_public_key, std::string t_crl) -> std::shared_ptr<fss_connection_server>;
     auto getClientNames() -> std::list<std::string> override;
+    auto isPeerCertRevoked(const std::string &t_crl_file) const -> bool override;
 };
 
 class fss_listen : public flight_safety_system::transport::fss_listen {

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -165,6 +165,7 @@ public:
     virtual void processMessages();
     virtual void disconnect();
     virtual auto getClientNames() -> std::list<std::string>;
+    virtual auto isPeerCertRevoked(const std::string &) const -> bool { return false; }
 };
 
 class fss_listen : public fss_connection {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -140,13 +140,37 @@ public:
             client->sendCommand();
         }
     };
+    void disconnectRevokedClients(const std::string &crl_file)
+    {
+        std::vector<std::shared_ptr<flight_safety_system::server::fss_client>> snapshot;
+        {
+            std::lock_guard<std::mutex> guard(this->lock);
+            std::copy(this->clients.begin(), this->clients.end(), std::back_inserter(snapshot));
+        }
+        for (const auto &client : snapshot)
+        {
+            auto conn = client->getConnection();
+            if (conn && conn->isPeerCertRevoked(crl_file))
+            {
+                FSS_LOG_WARN("server", "Disconnecting client with revoked certificate after CRL reload");
+                client->disconnect();
+                this->clientDisconnected(client.get());
+            }
+        }
+    };
 };
 
 volatile sig_atomic_t running = 1;
+volatile sig_atomic_t reload_crl = 0;
 
 void sigIntHandler(int signum __attribute__((unused)))
 {
     running = 0;
+}
+
+void sigHupHandler(int signum __attribute__((unused)))
+{
+    reload_crl = 1;
 }
 
 auto
@@ -157,6 +181,11 @@ main(int argc, char *argv[]) -> int
     sigemptyset(&sa_int.sa_mask);
     sa_int.sa_flags = 0;
     sigaction(SIGINT, &sa_int, nullptr);
+    struct sigaction sa_hup = {};
+    sa_hup.sa_handler = sigHupHandler;
+    sigemptyset(&sa_hup.sa_mask);
+    sa_hup.sa_flags = 0;
+    sigaction(SIGHUP, &sa_hup, nullptr);
     struct sigaction sa_pipe = {};
     sa_pipe.sa_handler = SIG_IGN;
     sigemptyset(&sa_pipe.sa_mask);
@@ -233,15 +262,16 @@ main(int argc, char *argv[]) -> int
     {
         FSS_LOG_INFO("server", "CRL file configured: " << crl_file);
     }
-    listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(config["port"].asInt(),
+    flight_safety_system::transport::fss_connect_cb connect_cb =
         [dbc, writer, &clients](std::shared_ptr<flight_safety_system::transport::fss_connection> conn) -> bool {
 #ifdef DEBUG
             std::cout << "New client connected" << std::endl;
 #endif
             clients->clientConnected(std::make_shared<flight_safety_system::server::fss_client>(std::move(conn), dbc.get(), writer, clients.get()));
             return true;
-        },
-        config["ssl"]["ca_public_key"].asString(), config["ssl"]["server_private_key"].asString(), config["ssl"]["server_public_key"].asString(), crl_file);
+        };
+    listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(config["port"].asInt(),
+        connect_cb, ca_public_key, server_private_key, server_public_key, crl_file);
 
     /* Split tick: sendCommand runs every command_poll_ms so safety-critical
      * commands (TERM, DISARM) reach aircraft in <=100ms instead of <=1s.
@@ -257,6 +287,18 @@ main(int argc, char *argv[]) -> int
     uint64_t tick_counter = 0;
     while (running == 1)
     {
+        if (reload_crl == 1)
+        {
+            reload_crl = 0;
+            FSS_LOG_INFO("server", "SIGHUP received — reloading CRL, rebuilding listener");
+            listen.reset();
+            listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(
+                config["port"].asInt(), connect_cb, ca_public_key, server_private_key, server_public_key, crl_file);
+            if (!crl_file.empty())
+            {
+                clients->disconnectRevokedClients(crl_file);
+            }
+        }
         usleep(command_poll_ms * usec_per_msec);
         clients->sendCommand();
         if ((tick_counter % ticks_per_sec) == 0)

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -335,6 +335,47 @@ auto flight_safety_system::transport_ssl::fss_connection_server::getClientNames(
     return this->possible_names;
 }
 
+auto flight_safety_system::transport_ssl::fss_connection_server::isPeerCertRevoked(const std::string &t_crl_file) const -> bool
+{
+    if (t_crl_file.empty() || !this->session) { return false; }
+
+    std::vector<gnutls_datum_t> cert_list;
+    if (!this->session->get_peers_certificate(cert_list) || cert_list.empty()) { return false; }
+
+    gnutls_x509_crt_t cert = nullptr;
+    gnutls_x509_crt_init(&cert);
+    if (gnutls_x509_crt_import(cert, &cert_list[0], GNUTLS_X509_FMT_DER) < 0)
+    {
+        gnutls_x509_crt_deinit(cert);
+        return false;
+    }
+
+    gnutls_datum_t crl_data = {};
+    if (gnutls_load_file(t_crl_file.c_str(), &crl_data) < 0)
+    {
+        FSS_LOG_ERROR("ssl", "Failed to load CRL file: " << t_crl_file);
+        gnutls_x509_crt_deinit(cert);
+        return false;
+    }
+
+    gnutls_x509_crl_t crl = nullptr;
+    gnutls_x509_crl_init(&crl);
+    int rc = gnutls_x509_crl_import(crl, &crl_data, GNUTLS_X509_FMT_PEM);
+    gnutls_free(crl_data.data);
+    if (rc < 0)
+    {
+        FSS_LOG_ERROR("ssl", "Failed to parse CRL file: " << t_crl_file << ": " << gnutls_strerror(rc));
+        gnutls_x509_crl_deinit(crl);
+        gnutls_x509_crt_deinit(cert);
+        return false;
+    }
+
+    int revoked = gnutls_x509_crt_check_revocation(cert, &crl, 1);
+    gnutls_x509_crl_deinit(crl);
+    gnutls_x509_crt_deinit(cert);
+    return revoked > 0;
+}
+
 auto flight_safety_system::transport_ssl::fss_connection::getSessionDesc() -> std::string
 {
     if (!this->session) { return {}; }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -28,12 +28,12 @@ all_test_SOURCES = main.cpp messages.cpp connection.cpp client.cpp \
 all_test_CFLAGS = $(ECPG_CFLAGS)
 all_test_LDADD = ../src/libfss-transport.la ../src/libfss-client-ssl.la ../src/libfss.la $(JSONCPP_LIBS) $(ECPG_LIBS)
 
-all_test_SOURCES += connection-ssl.cpp certs certs-alt certs/expired
+all_test_SOURCES += connection-ssl.cpp certs certs-alt certs/expired certs/client.crl.pem certs/empty.crl.pem
 all_test_LDADD += ../src/libfss-transport-ssl.la $(GNUTLS_LIBS) $(CATCH2_LIBS)
 
 EXTRA_DIST = test_helpers.hpp mock_database.hpp
 
-BUILT_SOURCES += certs certs-alt certs/expired
+BUILT_SOURCES += certs certs-alt certs/expired certs/client.crl.pem certs/empty.crl.pem
 
 certs:
 	mkdir certs
@@ -52,4 +52,21 @@ certs/expired: certs
 	 certtool --generate-certificate --load-privkey client.private.pem \
 	   --load-ca-certificate ca.public.pem --load-ca-privkey ca.private.pem \
 	   --template client.tmpl --outfile client.public.pem)
+
+certs/client.crl.pem: certs
+	printf 'crl_next_update = 3650\ncrl_number = 1\n' > certs/crl.tmpl
+	certtool --generate-crl \
+	  --load-ca-privkey certs/ca.private.pem \
+	  --load-ca-certificate certs/ca.public.pem \
+	  --load-certificate certs/client.public.pem \
+	  --template certs/crl.tmpl \
+	  --outfile certs/client.crl.pem
+
+certs/empty.crl.pem: certs
+	printf 'crl_next_update = 3650\ncrl_number = 1\n' > certs/crl.tmpl
+	certtool --generate-crl \
+	  --load-ca-privkey certs/ca.private.pem \
+	  --load-ca-certificate certs/ca.public.pem \
+	  --template certs/crl.tmpl \
+	  --outfile certs/empty.crl.pem
 endif

--- a/tests/connection-ssl.cpp
+++ b/tests/connection-ssl.cpp
@@ -23,6 +23,8 @@ constexpr const char * SERVER_PRIVATE_FILE = "certs/localhost.private.pem";
 constexpr const char * SERVER_PUBLIC_FILE = "certs/localhost.public.pem";
 constexpr const char * CLIENT_PRIVATE_FILE = "certs/client.private.pem";
 constexpr const char * CLIENT_PUBLIC_FILE = "certs/client.public.pem";
+constexpr const char * CLIENT_CRL_FILE = "certs/client.crl.pem";
+constexpr const char * EMPTY_CRL_FILE = "certs/empty.crl.pem";
 
 
 TEST_CASE("SSL - Connection Create (failure)") {
@@ -123,6 +125,65 @@ TEST_CASE("SSL - Listen - Callback")
     REQUIRE(!cb->connected());
 
     client_conn = nullptr;
+}
+
+TEST_CASE("ssl: isPeerCertRevoked detects revoked cert via CRL")
+{
+    const uint16_t port = fss_test::pick_port();
+    REQUIRE(port != 0);
+    std::shared_ptr<flight_safety_system::transport::fss_connection> server_conn;
+
+    auto listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(
+        port,
+        [&server_conn](std::shared_ptr<flight_safety_system::transport::fss_connection> c) -> bool {
+            server_conn = std::move(c);
+            return true;
+        },
+        CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
+    REQUIRE(listen != nullptr);
+
+    auto client = std::make_shared<flight_safety_system::transport_ssl::fss_connection_client>(
+        CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+    REQUIRE(client->connectTo("localhost", port));
+
+    REQUIRE(fss_test::wait_for([&] { return server_conn != nullptr; }));
+
+    REQUIRE(server_conn->isPeerCertRevoked(CLIENT_CRL_FILE));
+    REQUIRE_FALSE(server_conn->isPeerCertRevoked(EMPTY_CRL_FILE));
+    REQUIRE_FALSE(server_conn->isPeerCertRevoked(""));
+
+    server_conn = nullptr;
+}
+
+TEST_CASE("ssl: disconnect after CRL revocation terminates client session")
+{
+    const uint16_t port = fss_test::pick_port();
+    REQUIRE(port != 0);
+    std::shared_ptr<flight_safety_system::transport::fss_connection> server_conn;
+
+    auto listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(
+        port,
+        [&server_conn](std::shared_ptr<flight_safety_system::transport::fss_connection> c) -> bool {
+            server_conn = std::move(c);
+            return true;
+        },
+        CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
+    REQUIRE(listen != nullptr);
+
+    auto client = flight_safety_system::transport_ssl::fss_connection_client::create(
+        CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE, "localhost", port);
+    REQUIRE(client != nullptr);
+    REQUIRE(fss_test::wait_for([&] { return server_conn != nullptr; }));
+
+    REQUIRE(server_conn->isPeerCertRevoked(CLIENT_CRL_FILE));
+    server_conn->disconnect();
+
+    REQUIRE(fss_test::wait_for([&] {
+        auto msg = client->getMsg();
+        return msg != nullptr && msg->getType() == flight_safety_system::transport::message_type_closed;
+    }));
+
+    server_conn = nullptr;
 }
 
 TEST_CASE("SSL - Negotiated cipher suite is AEAD (TLS 1.2+)")


### PR DESCRIPTION
## Description

On SIGHUP, tear down and rebuild the fss_listen so its GnuTLS credentials re-read the CRL file from disk, ensuring new connections respect the updated revocation list.  After the listener is rebuilt, iterate existing clients and disconnect any whose peer certificate now appears in the CRL.

Add fss_connection::isPeerCertRevoked (virtual, false by default) overridden in fss_connection_server: re-extracts the peer cert from the active TLS session, loads the CRL file with gnutls_load_file, and calls gnutls_x509_crt_check_revocation.

Add server_clients::disconnectRevokedClients which snapshots the client list outside the lock, calls isPeerCertRevoked on each connection, and closes + removes any revoked sessions.

Extract the accept callback into connect_cb so the listener can be reconstructed in one place without duplicating the lambda.

Tests: two new cases in connection-ssl.cpp verify isPeerCertRevoked returns true for a cert listed in a CRL and false for an empty CRL or no CRL path, and that disconnecting after a positive check causes the client to see message_type_closed.  CRL fixtures (certs/client.crl.pem, certs/empty.crl.pem) are generated non-interactively via a certtool template in tests/Makefile.am.

## Summary by Sourcery

Handle CRL reloads on SIGHUP and disconnect clients whose certificates become revoked.

New Features:
- Add TLS peer-certificate revocation checking via a virtual isPeerCertRevoked API on connections.
- Introduce server-side logic to rebuild the SSL listener and re-evaluate existing clients against an updated CRL on SIGHUP.

Enhancements:
- Refactor listener construction to use a reusable connect callback for easier reconstruction.

Tests:
- Add SSL tests covering CRL-based revocation detection and client session termination after revocation.
- Extend test certificate generation to create CRL fixtures (revoking and empty) for automated revocation testing.