### PR TITLE
test: add end-to-end test for disconnectRevokedClients

### DIFF
--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -1,0 +1,143 @@
+#pragma once
+
+#include "fss-server.hpp"
+#include "fss-log.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <list>
+#include <mutex>
+#include <queue>
+#include <vector>
+
+class server_clients : public flight_safety_system::server::fss_client_handler {
+private:
+    std::mutex lock{};
+    std::list<std::shared_ptr<flight_safety_system::server::fss_client>> clients{};
+    std::queue<std::shared_ptr<flight_safety_system::server::fss_client>> disconnected{};
+    uint32_t total_clients{0};
+    std::atomic<bool> shutting_down{false};
+    uint64_t client_timeout_ms{30000};
+    uint64_t rate_capacity{100};
+    uint64_t rate_refill_per_s{20};
+public:
+    server_clients() = default;
+    ~server_clients() override {
+        this->shutting_down = true;
+        std::lock_guard<std::mutex> guard(this->lock);
+        for (const auto &c: this->clients)
+        {
+            c->disconnect();
+        }
+    }
+    server_clients(server_clients&) = delete;
+    server_clients(server_clients&&) = delete;
+    auto operator=(server_clients&) -> server_clients& = delete;
+    auto operator=(server_clients&&) -> server_clients& = delete;
+    void cleanupRemovableClients()
+    {
+        std::lock_guard<std::mutex> guard(this->lock);
+        while(!this->disconnected.empty())
+        {
+            auto client = this->disconnected.front();
+            this->disconnected.pop();
+            total_clients--;
+        }
+    };
+    void setClientTimeoutMs(uint64_t ms) { this->client_timeout_ms = ms; }
+    void setClientRateLimits(uint64_t capacity, uint64_t refill_per_s)
+    {
+        this->rate_capacity = capacity;
+        this->rate_refill_per_s = refill_per_s;
+    }
+    void clientConnected(std::shared_ptr<flight_safety_system::server::fss_client> client)
+    {
+        client->setTimeoutMs(this->client_timeout_ms);
+        client->setRateLimits(this->rate_capacity, this->rate_refill_per_s);
+        std::lock_guard<std::mutex> guard(this->lock);
+        this->total_clients++;
+        this->clients.push_back(std::move(client));
+    };
+    void clientDisconnected(flight_safety_system::server::fss_client *client) override
+    {
+        std::lock_guard<std::mutex> guard(this->lock);
+        if (this->shutting_down) return;
+        auto it = std::find_if(this->clients.begin(), this->clients.end(), [client](const auto &c) -> auto {
+            return c.get() == client;
+        });
+        if (it != this->clients.end())
+        {
+            this->disconnected.push(*it);
+            this->clients.erase(it);
+        }
+    };
+    void broadcastMsg(const std::shared_ptr<flight_safety_system::transport::fss_message> &msg, flight_safety_system::server::fss_client *except = nullptr) override
+    {
+        std::lock_guard<std::mutex> guard(this->lock);
+        for (const auto &client : this->clients)
+        {
+            if (client->isAircraft() && client.get() != except)
+            {
+                client->sendMsg(msg);
+            }
+        }
+    }
+    void checkTimeouts()
+    {
+        std::vector<std::shared_ptr<flight_safety_system::server::fss_client>> snapshot;
+        {
+            std::lock_guard<std::mutex> guard(this->lock);
+            std::copy(this->clients.begin(), this->clients.end(), std::back_inserter(snapshot));
+        }
+        for (const auto &client : snapshot)
+        {
+            if (client->isTimedOut())
+            {
+                FSS_LOG_WARN("server", "Client timed out, disconnecting");
+                this->clientDisconnected(client.get());
+            }
+        }
+    };
+    void sendSMMSettings()
+    {
+        std::lock_guard<std::mutex> guard(this->lock);
+        for(const auto &client: this->clients)
+        {
+            client->sendSMMSettings();
+        }
+    };
+    void sendRTTRequest(const std::shared_ptr<flight_safety_system::transport::fss_message_rtt_request> &rtt_req)
+    {
+        std::lock_guard<std::mutex> guard(this->lock);
+        for(const auto &client: this->clients)
+        {
+            client->sendRTTRequest(rtt_req);
+        }
+    };
+    void sendCommand()
+    {
+        std::lock_guard<std::mutex> guard(this->lock);
+        for(const auto &client: this->clients)
+        {
+            client->sendCommand();
+        }
+    };
+    void disconnectRevokedClients(const std::string &crl_file)
+    {
+        std::vector<std::shared_ptr<flight_safety_system::server::fss_client>> snapshot;
+        {
+            std::lock_guard<std::mutex> guard(this->lock);
+            std::copy(this->clients.begin(), this->clients.end(), std::back_inserter(snapshot));
+        }
+        for (const auto &client : snapshot)
+        {
+            auto conn = client->getConnection();
+            if (conn && conn->isPeerCertRevoked(crl_file))
+            {
+                FSS_LOG_WARN("server", "Disconnecting client with revoked certificate after CRL reload");
+                client->disconnect();
+                this->clientDisconnected(client.get());
+            }
+        }
+    };
+};

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3,6 +3,7 @@
 #include "fss-log.hpp"
 #include "fss.hpp"
 #include "fss-server.hpp"
+#include "server-clients.hpp"
 
 #include <algorithm>
 #include <iostream>
@@ -28,137 +29,6 @@ auto build_server_list_msg(IDatabase *dbc) -> std::shared_ptr<transport::fss_mes
 } // namespace server
 } // namespace flight_safety_system
 
-class server_clients : public flight_safety_system::server::fss_client_handler {
-private:
-    std::mutex lock{};
-    std::list<std::shared_ptr<flight_safety_system::server::fss_client>> clients{};
-    std::queue<std::shared_ptr<flight_safety_system::server::fss_client>> disconnected{};
-    uint32_t total_clients{0};
-    std::atomic<bool> shutting_down{false};
-    uint64_t client_timeout_ms{30000};
-    uint64_t rate_capacity{100};
-    uint64_t rate_refill_per_s{20};
-public:
-    server_clients() = default;
-    ~server_clients() override {
-        this->shutting_down = true;
-        std::lock_guard<std::mutex> guard(this->lock);
-        for (const auto &c: this->clients)
-        {
-            c->disconnect();
-        }
-    }
-    server_clients(server_clients&) = delete;
-    server_clients(server_clients&&) = delete;
-    auto operator=(server_clients&) -> server_clients& = delete;
-    auto operator=(server_clients&&) -> server_clients& = delete;
-    void cleanupRemovableClients()
-    {
-        std::lock_guard<std::mutex> guard(this->lock);
-        while(!this->disconnected.empty())
-        {
-            auto client = this->disconnected.front();
-            this->disconnected.pop();
-            total_clients--;
-        }
-    };
-    void setClientTimeoutMs(uint64_t ms) { this->client_timeout_ms = ms; }
-    void setClientRateLimits(uint64_t capacity, uint64_t refill_per_s)
-    {
-        this->rate_capacity = capacity;
-        this->rate_refill_per_s = refill_per_s;
-    }
-    void clientConnected(std::shared_ptr<flight_safety_system::server::fss_client> client)
-    {
-        client->setTimeoutMs(this->client_timeout_ms);
-        client->setRateLimits(this->rate_capacity, this->rate_refill_per_s);
-        std::lock_guard<std::mutex> guard(this->lock);
-        this->total_clients++;
-        this->clients.push_back(std::move(client));
-    };
-    void clientDisconnected(flight_safety_system::server::fss_client *client) override
-    {
-        std::lock_guard<std::mutex> guard(this->lock);
-        if (this->shutting_down) return;
-        auto it = std::find_if(this->clients.begin(), this->clients.end(), [client](const auto &c) -> auto {
-            return c.get() == client;
-        });
-        if (it != this->clients.end())
-        {
-            this->disconnected.push(*it);
-            this->clients.erase(it);
-        }
-    };
-    void broadcastMsg(const std::shared_ptr<flight_safety_system::transport::fss_message> &msg, flight_safety_system::server::fss_client *except = nullptr) override
-    {
-        std::lock_guard<std::mutex> guard(this->lock);
-        for (const auto &client : this->clients)
-        {
-            if (client->isAircraft() && client.get() != except)
-            {
-                client->sendMsg(msg);
-            }
-        }
-    }
-    void checkTimeouts()
-    {
-        std::vector<std::shared_ptr<flight_safety_system::server::fss_client>> snapshot;
-        {
-            std::lock_guard<std::mutex> guard(this->lock);
-            std::copy(this->clients.begin(), this->clients.end(), std::back_inserter(snapshot));
-        }
-        for (const auto &client : snapshot)
-        {
-            if (client->isTimedOut())
-            {
-                FSS_LOG_WARN("server", "Client timed out, disconnecting");
-                this->clientDisconnected(client.get());
-            }
-        }
-    };
-    void sendSMMSettings()
-    {
-        std::lock_guard<std::mutex> guard(this->lock);
-        for(const auto &client: this->clients)
-        {
-            client->sendSMMSettings();
-        }
-    };
-    void sendRTTRequest(const std::shared_ptr<flight_safety_system::transport::fss_message_rtt_request> &rtt_req)
-    {
-        std::lock_guard<std::mutex> guard(this->lock);
-        for(const auto &client: this->clients)
-        {
-            client->sendRTTRequest(rtt_req);
-        }
-    };
-    void sendCommand()
-    {
-        std::lock_guard<std::mutex> guard(this->lock);
-        for(const auto &client: this->clients)
-        {
-            client->sendCommand();
-        }
-    };
-    void disconnectRevokedClients(const std::string &crl_file)
-    {
-        std::vector<std::shared_ptr<flight_safety_system::server::fss_client>> snapshot;
-        {
-            std::lock_guard<std::mutex> guard(this->lock);
-            std::copy(this->clients.begin(), this->clients.end(), std::back_inserter(snapshot));
-        }
-        for (const auto &client : snapshot)
-        {
-            auto conn = client->getConnection();
-            if (conn && conn->isPeerCertRevoked(crl_file))
-            {
-                FSS_LOG_WARN("server", "Disconnecting client with revoked certificate after CRL reload");
-                client->disconnect();
-                this->clientDisconnected(client.get());
-            }
-        }
-    };
-};
 
 volatile sig_atomic_t running = 1;
 volatile sig_atomic_t reload_crl = 0;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -21,6 +21,7 @@ all_test_SOURCES = main.cpp messages.cpp connection.cpp client.cpp \
 	async_db_write_test.cpp \
 	timeout_test.cpp \
 	db_connection_test.cpp \
+	crl_revocation_test.cpp \
 	../src/client_session.cpp \
 	../src/db-write-queue.cpp \
 	../src/db.cpp \

--- a/tests/crl_revocation_test.cpp
+++ b/tests/crl_revocation_test.cpp
@@ -1,0 +1,83 @@
+#ifdef HAVE_CATCH2_CATCH_ALL_HPP
+#include <catch2/catch_all.hpp>
+#elif HAVE_CATCH2_CATCH_HPP
+#include <catch2/catch.hpp>
+#elif HAVE_CATCH_CATCH_HPP
+#include <catch/catch.hpp>
+#elif HAVE_CATCH_HPP
+#include <catch.hpp>
+#else
+#error No catch header
+#endif
+
+#include <atomic>
+#include <memory>
+
+#include "fss-transport-ssl.hpp"
+#include "fss-server.hpp"
+#include "server-clients.hpp"
+#include "db-write-queue.hpp"
+#include "mock_database.hpp"
+#include "test_helpers.hpp"
+
+namespace fss = flight_safety_system;
+
+namespace {
+
+constexpr const char *CA_PUBLIC_FILE      = "certs/ca.public.pem";
+constexpr const char *SERVER_PRIVATE_FILE = "certs/localhost.private.pem";
+constexpr const char *SERVER_PUBLIC_FILE  = "certs/localhost.public.pem";
+constexpr const char *CLIENT_PRIVATE_FILE = "certs/client.private.pem";
+constexpr const char *CLIENT_PUBLIC_FILE  = "certs/client.public.pem";
+constexpr const char *CLIENT_CRL_FILE     = "certs/client.crl.pem";
+
+auto make_writer(fss_test::MockDatabase &mock) -> std::shared_ptr<fss::server::db_write_queue>
+{
+    auto sink = [&mock](const fss::server::db_write_task &task) -> void {
+        std::visit(fss::server::overloaded{
+            [&](const fss::server::rtt_write &w) -> void { mock.recordRtt(w.asset_id, w.rtt_ms); },
+            [&](const fss::server::position_write &w) -> void { mock.recordPosition(w.asset_id, w.latitude, w.longitude, w.altitude); },
+            [&](const fss::server::status_write &w) -> void { mock.recordStatus(w.asset_id, w.bat_percent, w.bat_mah_used, w.bat_voltage); },
+            [&](const fss::server::search_status_write &w) -> void { mock.recordSearchStatus(w.asset_id, w.search_id, w.completed, w.total); },
+        }, task);
+    };
+    return std::make_shared<fss::server::db_write_queue>(std::size_t{1024}, sink);
+}
+
+} // namespace
+
+TEST_CASE("ssl: disconnectRevokedClients terminates sessions with revoked certs")
+{
+    const uint16_t port = fss_test::pick_port();
+    REQUIRE(port != 0);
+
+    fss_test::MockDatabase mock;
+    auto writer = make_writer(mock);
+    auto clients = std::make_shared<server_clients>();
+
+    std::atomic<bool> client_registered{false};
+    auto connect_cb = [&clients, &mock, &writer, &client_registered](
+            std::shared_ptr<fss::transport::fss_connection> conn) -> bool {
+        clients->clientConnected(std::make_shared<fss::server::fss_client>(
+            std::move(conn), &mock, writer, clients.get()));
+        client_registered = true;
+        return true;
+    };
+
+    auto listen = std::make_shared<fss::transport_ssl::fss_listen>(
+        port, connect_cb, CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
+    REQUIRE(listen != nullptr);
+
+    auto client = fss::transport_ssl::fss_connection_client::create(
+        CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE, "localhost", port);
+    REQUIRE(client != nullptr);
+
+    REQUIRE(fss_test::wait_for([&] { return client_registered.load(); }));
+
+    clients->disconnectRevokedClients(CLIENT_CRL_FILE);
+
+    REQUIRE(fss_test::wait_for([&] {
+        auto msg = client->getMsg();
+        return msg != nullptr && msg->getType() == fss::transport::message_type_closed;
+    }));
+}


### PR DESCRIPTION
## Description

Extract server_clients to src/server-clients.hpp so tests can include it without pulling in the server main(). Add crl_revocation_test.cpp which creates a real TLS server/client pair, wraps the server-side connection in an fss_client managed by server_clients, then calls disconnectRevokedClients with a CRL that revokes the client cert and asserts the client observes message_type_closed. The [WARN] log line confirms the code path through isPeerCertRevoked → disconnect → clientDisconnected is exercised end-to-end.

## Summary by Sourcery

Add an end-to-end TLS test validating that clients with revoked certificates are disconnected and expose the server client management to a reusable header for testing.

Enhancements:
- Extract the server_clients handler class into a dedicated header so it can be reused in tests without depending on the server main.

Tests:
- Introduce an SSL end-to-end test that verifies disconnectRevokedClients closes sessions when the client certificate is revoked via a CRL.