### PR TITLE
test: address todo test-coverage-gaps (e2e DB negatives, TSan, wrong-CN)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,11 +28,30 @@ AC_ARG_ENABLE([server],AS_HELP_STRING([--enable-server], [Build the server (fss-
 AC_ARG_ENABLE([tests],AS_HELP_STRING([--enable-tests], [Build the tests (Requires catch2)]))
 AC_ARG_ENABLE([coverage],AS_HELP_STRING([--enable-coverage], [Build with coverage support (gcov)]))
 AC_ARG_ENABLE([fake-client],AS_HELP_STRING([--enable-fake-client], [Build the example client (fss-fake-client)]))
+AC_ARG_ENABLE([tsan],AS_HELP_STRING([--enable-tsan], [Build the ThreadSanitizer concurrency test binary (requires --enable-tests; mutually exclusive with --enable-coverage)]))
 
 AM_CONDITIONAL([SERVER], [test "x$enable_server" == "xyes"])
 AM_CONDITIONAL([ENABLE_TESTS], [test "x$enable_tests" == "xyes"])
 AM_CONDITIONAL([COVERAGE], [test "x$enable_coverage" == "xyes"])
 AM_CONDITIONAL([FAKE_CLIENT], [test "x$enable_fake_client" == "xyes"])
+AM_CONDITIONAL([ENABLE_TSAN], [test "x$enable_tsan" == "xyes"])
+
+AS_IF([test "x$enable_tsan" == "xyes" -a "x$enable_coverage" == "xyes"], [
+    AC_MSG_ERROR([--enable-tsan and --enable-coverage are mutually exclusive: TSan and gcov instrumentation cannot coexist in the same binary])
+])
+AS_IF([test "x$enable_tsan" == "xyes" -a "x$enable_tests" != "xyes"], [
+    AC_MSG_ERROR([--enable-tsan requires --enable-tests])
+])
+
+AS_IF([test "x$enable_tsan" == "xyes"], [
+    TSAN_CXXFLAGS="-fsanitize=thread -O1 -g -fno-omit-frame-pointer"
+    TSAN_LDFLAGS="-fsanitize=thread"
+], [
+    TSAN_CXXFLAGS=""
+    TSAN_LDFLAGS=""
+])
+AC_SUBST([TSAN_CXXFLAGS])
+AC_SUBST([TSAN_LDFLAGS])
 
 AS_IF([test "x$enable_coverage" == "xyes"], [
     CODE_COVERAGE_CFLAGS="--coverage"

--- a/e2e/test_db_negative.py
+++ b/e2e/test_db_negative.py
@@ -1,0 +1,138 @@
+"""End-to-end ECPG negative paths.
+
+Covers the gaps from todo/test-coverage-gaps.md Phase 2 that are not already
+exercised by the round-trip tests (test_position_flow.py, test_rtt.py):
+
+- The server must fail (exit non-zero) when configured with an unreachable
+  Postgres host. This is the B5.2 happy-shutdown contract: an unconnectable
+  DB is a fatal startup error, not a silent stall.
+- A client whose CN authenticates against the trusted CA but is not enrolled
+  in assets_asset must be rejected at identify; no rows may land for that
+  asset id.
+"""
+from __future__ import annotations
+
+import os
+import signal
+import socket
+import subprocess
+import time
+
+import pytest
+
+from conftest import (
+    E2E_ROOT,
+    REPO_ROOT,
+    SERVER_BIN,
+    _pick_port,
+    _render_template,
+)
+
+
+# RFC-5737 documentation block — guaranteed not to route to a real Postgres.
+UNREACHABLE_DB_HOST = "192.0.2.1"
+
+
+@pytest.mark.requires_docker
+def test_server_exits_when_db_host_invalid(certs_dir, tmp_path, migrated_db):
+    """fss-server must fail-stop when its configured DB host is unreachable.
+
+    We render a server config pointing at an RFC-5737 black-hole address and
+    spawn fss-server directly (the `server_proc` fixture would block waiting
+    for a listening socket that never appears). The process must exit with
+    non-zero status within DB_CONNECT_TIMEOUT_S; if it lingers, that's a
+    bug — the server should not enter the accept loop without a working DB.
+    """
+    if not SERVER_BIN.exists():
+        pytest.skip(f"fss-server not built at {SERVER_BIN}")
+
+    port = _pick_port()
+    config_path = tmp_path / "server-bad-db.json"
+    log_path = tmp_path / "server-bad-db.log"
+    _render_template(
+        E2E_ROOT / "fixtures" / "server.json.tmpl",
+        config_path,
+        SERVER_PORT=str(port),
+        DB_HOST=UNREACHABLE_DB_HOST,
+        DB_USER=migrated_db["user"],
+        DB_PASS=migrated_db["password"],
+        DB_NAME=migrated_db["dbname"],
+        CERTS_DIR=str(certs_dir),
+    )
+
+    env = os.environ.copy()
+    env["LD_LIBRARY_PATH"] = str(REPO_ROOT / "src" / ".libs")
+
+    log_fp = log_path.open("wb")
+    # sourcery skip: dangerous-subprocess-use-audit
+    proc = subprocess.Popen(
+        [str(SERVER_BIN), str(config_path)],
+        cwd=str(REPO_ROOT),
+        env=env,
+        stdout=log_fp,
+        stderr=subprocess.STDOUT,
+    )
+
+    # libpq's default connect timeout is long; give it ~25 s to give up.
+    DB_CONNECT_TIMEOUT_S = 25
+    try:
+        rc = proc.wait(timeout=DB_CONNECT_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        proc.send_signal(signal.SIGINT)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+        log_fp.close()
+        pytest.fail(
+            f"fss-server did not exit within {DB_CONNECT_TIMEOUT_S}s when "
+            f"pointed at unreachable DB host; log:\n{log_path.read_text()}"
+        )
+    log_fp.close()
+
+    assert rc != 0, (
+        f"fss-server exited 0 with unreachable DB host (expected non-zero); "
+        f"log:\n{log_path.read_text()}"
+    )
+
+    # Sanity: the chosen port should not be left listening after exit.
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(0.2)
+        with pytest.raises(OSError):
+            s.connect(("127.0.0.1", port))
+
+
+@pytest.mark.requires_docker
+def test_unknown_asset_name_persists_no_data(db_conn, fake_client):
+    """A client whose CN is signed by the trusted CA but not enrolled as an
+    asset must be rejected at identify, and no telemetry rows may land.
+
+    The certs_dir fixture pre-generates client certs named test1/test2/test3.
+    None of them are inserted into assets_asset, so any of them will
+    authenticate but fail the DB asset lookup. We use 'test1' here.
+
+    Mirrors test_cert_rejection.py's strategy: the contract under test is
+    purely behavioral (no rows persisted). Log-content checks are avoided
+    because they couple the test to the exact phrasing of an error message.
+    """
+    # Deliberately do NOT insert into assets_asset — the asset is unknown.
+    fake_client("test1")
+
+    # Give the client time to handshake, send identity, get rejected, and
+    # potentially retry a few times.
+    time.sleep(12)
+
+    # No rows should have landed for ANY asset, since no asset row exists.
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM assets_assetposition")
+        pos_count = cur.fetchone()[0]
+        cur.execute("SELECT COUNT(*) FROM assets_assetstatus")
+        status_count = cur.fetchone()[0]
+
+    assert pos_count == 0, (
+        f"expected 0 position rows for unknown asset, got {pos_count}"
+    )
+    assert status_count == 0, (
+        f"expected 0 status rows for unknown asset, got {status_count}"
+    )

--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -14,6 +14,10 @@ int db_connect(const char *host, const char *user, const char *pass, const char 
     {
         return 0;
     }
+    /* Without a connect timeout libpq blocks for the OS TCP retransmit timeout
+     * (~127 s) when the host is unreachable. setenv is safe here: db_connect is
+     * called once at startup before any threads exist. */
+    setenv("PGCONNECT_TIMEOUT", "10", 1);
     EXEC SQL BEGIN DECLARE SECTION;
     const char *db_target = target;
     const char *db_user = user;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -29,12 +29,12 @@ all_test_SOURCES = main.cpp messages.cpp connection.cpp client.cpp \
 all_test_CFLAGS = $(ECPG_CFLAGS)
 all_test_LDADD = ../src/libfss-transport.la ../src/libfss-client-ssl.la ../src/libfss.la $(JSONCPP_LIBS) $(ECPG_LIBS)
 
-all_test_SOURCES += connection-ssl.cpp certs certs-alt certs/expired certs/client.crl.pem certs/empty.crl.pem
+all_test_SOURCES += connection-ssl.cpp certs certs-alt certs/expired certs/ghost certs/client.crl.pem certs/empty.crl.pem
 all_test_LDADD += ../src/libfss-transport-ssl.la $(GNUTLS_LIBS) $(CATCH2_LIBS)
 
 EXTRA_DIST = test_helpers.hpp mock_database.hpp
 
-BUILT_SOURCES += certs certs-alt certs/expired certs/client.crl.pem certs/empty.crl.pem
+BUILT_SOURCES += certs certs-alt certs/expired certs/ghost certs/client.crl.pem certs/empty.crl.pem
 
 certs:
 	mkdir certs
@@ -50,6 +50,16 @@ certs/expired: certs
 	(cd certs/expired; \
 	 certtool --generate-privkey > client.private.pem; \
 	 printf '\norganization = Flight Safety System\ncn = expired-client\ntls_www_client\nencryption_key\nsigning_key\ndns_name = expired-client\nexpiration_days = -1\n' > client.tmpl; \
+	 certtool --generate-certificate --load-privkey client.private.pem \
+	   --load-ca-certificate ca.public.pem --load-ca-privkey ca.private.pem \
+	   --template client.tmpl --outfile client.public.pem)
+
+certs/ghost: certs
+	mkdir -p certs/ghost
+	cp certs/ca.public.pem certs/ca.private.pem certs/ghost/
+	(cd certs/ghost; \
+	 certtool --generate-privkey > client.private.pem; \
+	 printf '\norganization = Flight Safety System\ncn = ghost-asset\ntls_www_client\nencryption_key\nsigning_key\ndns_name = ghost-asset\nexpiration_days = 3650\n' > client.tmpl; \
 	 certtool --generate-certificate --load-privkey client.private.pem \
 	   --load-ca-certificate ca.public.pem --load-ca-privkey ca.private.pem \
 	   --template client.tmpl --outfile client.public.pem)
@@ -70,4 +80,28 @@ certs/empty.crl.pem: certs
 	  --load-ca-certificate certs/ca.public.pem \
 	  --template certs/crl.tmpl \
 	  --outfile certs/empty.crl.pem
+
+if ENABLE_TSAN
+# Separate binary built with -fsanitize=thread. NOT added to TESTS — it runs
+# only via `make check-tsan` so regular `make check` is unaffected. Shares no
+# objects with all_test because TSan instrumentation must reach into the
+# transport-layer sources (compiled in directly here, not linked via the .la
+# archive which is built without TSan flags).
+check_PROGRAMS += concurrency_tsan_test
+concurrency_tsan_test_SOURCES = main.cpp \
+	concurrency_connection_test.cpp \
+	../src/transport.cpp \
+	../src/transport-helpers.cpp \
+	../src/transport-messages.cpp
+concurrency_tsan_test_CXXFLAGS = $(AM_CXXFLAGS) $(TSAN_CXXFLAGS)
+concurrency_tsan_test_LDFLAGS = $(TSAN_LDFLAGS)
+concurrency_tsan_test_LDADD = $(CATCH2_LIBS) $(pthread_LIBS)
+
+EXTRA_DIST += tsan.supp
+
+.PHONY: check-tsan
+check-tsan:
+	$(MAKE) $(AM_MAKEFLAGS) concurrency_tsan_test
+	TSAN_OPTIONS="suppressions=$(srcdir)/tsan.supp halt_on_error=1" ./concurrency_tsan_test
+endif
 endif

--- a/tests/concurrency_connection_test.cpp
+++ b/tests/concurrency_connection_test.cpp
@@ -1,0 +1,99 @@
+#ifdef HAVE_CATCH2_CATCH_ALL_HPP
+#include <catch2/catch_all.hpp>
+#elif HAVE_CATCH2_CATCH_HPP
+#include <catch2/catch.hpp>
+#elif HAVE_CATCH_CATCH_HPP
+#include <catch/catch.hpp>
+#elif HAVE_CATCH_HPP
+#include <catch.hpp>
+#else
+#error No catch header
+#endif
+
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+
+#include "fss-transport.hpp"
+
+using flight_safety_system::transport::fss_connection;
+using flight_safety_system::transport::fss_message_identity;
+
+namespace {
+
+/* Build a Unix socketpair and return both fds; close the second so the
+ * first observes EOF and the recv thread exits naturally. */
+auto make_paired_eof_fd() -> int
+{
+    int fds[2];
+    if (::socketpair(AF_UNIX, SOCK_STREAM, 0, fds) != 0) { return -1; }
+    ::close(fds[1]);
+    return fds[0];
+}
+
+} // namespace
+
+/* Regression for the C2.3 fix: fss_connection::create() spawns a recv thread
+ * inside the static factory; the destructor must safely tear it down. Under
+ * tight create/destroy churn TSan must observe no race between the thread
+ * startup path and the dtor's disconnect()/join(). */
+TEST_CASE("tsan: fss_connection create + immediate destruct over many iterations")
+{
+    constexpr int iterations = 100;
+    for (int i = 0; i < iterations; ++i)
+    {
+        int fd = make_paired_eof_fd();
+        REQUIRE(fd >= 0);
+        auto conn = fss_connection::create(fd);
+        REQUIRE(conn != nullptr);
+        /* Drop the only owning shared_ptr — destructor runs, which calls
+         * disconnect() then joins the recv thread. */
+    }
+}
+
+/* Two threads racing on the same fss_connection: one calling sendMsg in a
+ * loop, the other calling disconnect() partway through. The send_lock and
+ * fd atomics inside fss_connection must serialize the two operations
+ * cleanly — TSan must not report a data race, and the process must not
+ * crash or deadlock. */
+TEST_CASE("tsan: concurrent sendMsg + disconnect on a connected pair")
+{
+    int fds[2];
+    REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+
+    /* Wrap one end in fss_connection; close the other end after a brief
+     * delay (handled by the recv thread observing EOF). The peer fd is
+     * left open here and closed only at scope exit so writes during the
+     * race do not all immediately fail with EPIPE. */
+    auto conn = fss_connection::create(fds[0]);
+    REQUIRE(conn != nullptr);
+
+    std::atomic<int> send_attempts{0};
+    std::atomic<int> send_successes{0};
+    std::thread sender([&]() {
+        for (int i = 0; i < 200; ++i)
+        {
+            auto msg = std::make_shared<fss_message_identity>("racer");
+            ++send_attempts;
+            if (conn->sendMsg(msg)) { ++send_successes; }
+            std::this_thread::sleep_for(std::chrono::microseconds(50));
+        }
+    });
+
+    /* Let the sender warm up briefly, then yank the connection. */
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    conn->disconnect();
+
+    sender.join();
+    /* No crash, no race: the test passes. The exact split between
+     * successes and failures depends on scheduling; both are valid. */
+    REQUIRE(send_attempts.load() == 200);
+    REQUIRE(send_successes.load() <= send_attempts.load());
+
+    ::close(fds[1]);
+}

--- a/tests/ssl_failure_test.cpp
+++ b/tests/ssl_failure_test.cpp
@@ -15,9 +15,12 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <list>
 #include <memory>
+#include <string>
 #include <thread>
 
 #include "fss-transport.hpp"
@@ -43,6 +46,9 @@ constexpr const char *ALT_CLIENT_PUBLIC_FILE  = "certs-alt/client.public.pem";
 
 constexpr const char *EXPIRED_CLIENT_PRIVATE_FILE = "certs/expired/client.private.pem";
 constexpr const char *EXPIRED_CLIENT_PUBLIC_FILE  = "certs/expired/client.public.pem";
+
+constexpr const char *GHOST_CLIENT_PRIVATE_FILE = "certs/ghost/client.private.pem";
+constexpr const char *GHOST_CLIENT_PUBLIC_FILE  = "certs/ghost/client.public.pem";
 
 std::shared_ptr<flight_safety_system::transport::fss_connection> accepted;
 
@@ -104,6 +110,42 @@ TEST_CASE("ssl: server rejects client presenting an expired certificate",
          * handshake. */
         REQUIRE(accepted->getMsg() == nullptr);
     }
+    accepted = nullptr;
+}
+
+TEST_CASE("ssl: server surfaces wrong-CN-but-CA-signed cert via getClientNames",
+          "[ssl_wrong_cn]")
+{
+    /* A cert validly signed by the trusted CA but whose CN is not on any
+     * asset list must complete the TLS handshake — that's what the trust
+     * chain proves — and the server-side accepted connection must surface
+     * the cert's CN to the application layer so the identity stage can
+     * reject by asset lookup.  The downstream rejection itself is unit-
+     * tested in tests/server_session_test.cpp ("session: rejects identify
+     * when claimed name does not match cert CN" and "session: rejects
+     * identify when asset unknown to database").
+     *
+     * Without this integration test, getClientNames() could regress
+     * silently and leave the asset-name check working only against the
+     * synthetic FakeConnection used in unit tests. */
+    accepted = nullptr;
+    constexpr uint16_t port = 20514;
+    auto listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(
+        port, accept_cb, CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
+    REQUIRE(listen != nullptr);
+
+    auto client = std::make_shared<flight_safety_system::transport_ssl::fss_connection_client>(
+        CA_PUBLIC_FILE, GHOST_CLIENT_PRIVATE_FILE, GHOST_CLIENT_PUBLIC_FILE);
+    REQUIRE(client->connectTo("localhost", port));
+
+    REQUIRE(fss_test::wait_for([]() { return accepted != nullptr; }));
+
+    std::list<std::string> names = accepted->getClientNames();
+    REQUIRE_FALSE(names.empty());
+    bool found = std::any_of(names.begin(), names.end(),
+        [](const std::string &n) { return n == "ghost-asset"; });
+    REQUIRE(found);
+
     accepted = nullptr;
 }
 

--- a/tests/tsan.supp
+++ b/tests/tsan.supp
@@ -1,0 +1,16 @@
+# ThreadSanitizer suppressions for concurrency_tsan_test.
+#
+# Format: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+#
+# Each entry below is a known false-positive: a kernel-synchronized pattern
+# that TSan's user-space-only data-flow tracking cannot prove safe.
+# Suppressions here must be narrowly scoped to specific symbols and
+# documented with a justification — not blanket ignores.
+
+# disconnect() shuts down then closes the socket fd while the recv thread is
+# inside recv() on the same fd. This is the conventional POSIX wake-from-blocked
+# -recv idiom; the kernel serializes the close() against the in-flight recv()
+# (recv returns -1/EBADF or 0 after the shutdown). TSan does not model kernel
+# fd-table locking, so it flags the user-space close() vs recv() as a race
+# even though it is well-defined.
+race:flight_safety_system::transport::fss_connection::disconnect


### PR DESCRIPTION
## Description

Fills three of the four phases from todo/test-coverage-gaps. Phase 1's two bug-blocked cases (oversized data_length closure, non-aircraft DB lookup) were pushed into todo/c2.1 and todo/s3.2 to ship with their respective fixes; nothing is added in this commit for those.

Phase 2 — ECPG negative paths via the e2e suite:

  e2e/test_db_negative.py
    - test_server_exits_when_db_host_invalid: server pointed at an RFC-5737 black-hole address must exit non-zero within ~25s and not leave its port listening.
    - test_unknown_asset_name_persists_no_data: a CA-signed but unenrolled client must persist zero rows. Mirrors the behavioral-only style of test_cert_rejection.py.

Phase 3 — ThreadSanitizer concurrency target:

  configure.ac: add --enable-tsan, mutually exclusive with --enable-coverage,
    requires --enable-tests. Substitutes TSAN_CXXFLAGS / TSAN_LDFLAGS. tests/Makefile.am: under ENABLE_TSAN, build concurrency_tsan_test from main.cpp + the new concurrency test + transport.cpp et al. compiled directly so TSan instrumentation reaches them (the libfss-transport.la archive is built without TSan). Add a check-tsan phony target that runs the binary with TSAN_OPTIONS=suppressions=tests/tsan.supp. tests/concurrency_connection_test.cpp: two TEST_CASEs — tight create+immediate-destruct loop (regression for the C2.3 recv-thread teardown fix), and concurrent sendMsg + disconnect on a connected socketpair. tests/tsan.supp: documents the kernel-synchronized close()-during-recv() pattern in fss_connection::disconnect as a known TSan false positive.

Phase 4 — wrong-CN integration test:

  tests/Makefile.am: new certs/ghost fixture rule (mirrors certs/expired)
    generating a CA-signed cert with cn=ghost-asset. tests/ssl_failure_test.cpp: TEST_CASE [ssl_wrong_cn] verifies that the TLS handshake succeeds and getClientNames() surfaces the ghost CN to the application layer — closing the integration gap between the transport-level CRL/expiry tests and the FakeConnection-driven identity-rejection unit tests in server_session_test.cpp.

Verification: make check passes (114 test cases). make check-tsan passes with no TSan warnings (204 assertions). e2e/test_db_negative.py passes both cases against the dockerised PostGIS fixture.

## Summary by Sourcery

Add end-to-end database negative-path coverage, introduce a ThreadSanitizer-focused concurrency test binary, and extend SSL tests and fixtures to cover CA-signed certificates with non-enrolled common names.

New Features:
- Add e2e tests verifying server behavior when configured with an unreachable Postgres host and when clients present CA-signed but unenrolled asset names.
- Introduce a ThreadSanitizer-enabled concurrency test binary exercising fss_connection creation/destruction and concurrent send/disconnect behavior.
- Add an SSL integration test and certificate fixture for CA-signed client certificates with a common name not present in the asset list.

Tests:
- Add e2e/test_db_negative.py to cover DB connectivity failures and ensure unknown assets persist no telemetry data.
- Add concurrency_connection_test.cpp and a dedicated TSan test binary with a check-tsan target to exercise fss_connection concurrency behavior under ThreadSanitizer.
- Extend ssl_failure_test.cpp with a wrong-CN integration test that verifies getClientNames surfaces the client certificate CN for downstream identity checks.