### PR TITLE
add missing columns to config_serverconfig e2e schema

### DIFF
--- a/e2e/schema/001_init.sql
+++ b/e2e/schema/001_init.sql
@@ -74,5 +74,8 @@ CREATE TABLE config_serverconfig (
     id           BIGSERIAL PRIMARY KEY,
     address      VARCHAR(255) NOT NULL,
     client_port  INTEGER NOT NULL,
-    active       BOOLEAN NOT NULL DEFAULT TRUE
+    active       BOOLEAN NOT NULL DEFAULT TRUE,
+    name         VARCHAR(25)  NOT NULL DEFAULT '',
+    config_port  INTEGER      NOT NULL DEFAULT 8090,
+    https        BOOLEAN      NOT NULL DEFAULT FALSE
 );

--- a/e2e/test_server_list.py
+++ b/e2e/test_server_list.py
@@ -38,3 +38,37 @@ def test_server_list_does_not_disrupt_session(db_conn, fake_client):
         )
         count = cur.fetchone()[0]
     assert count >= 1, "no positions after server_list delivery"
+
+
+@pytest.mark.requires_docker
+def test_server_list_with_full_serverconfig_columns(db_conn, fake_client):
+    """Rows with name/config_port/https populated must not break server_list delivery.
+
+    Regression for TEST-02: e2e schema previously omitted these three Django
+    columns; any INSERT that included them would fail at schema creation time.
+    """
+    with db_conn.cursor() as cur:
+        cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
+        asset_id = cur.fetchone()[0]
+        cur.execute(
+            "INSERT INTO config_serverconfig "
+            "  (address, client_port, active, name, config_port, https) "
+            "VALUES ('primary.example', 20202, TRUE, 'primary', 8090, FALSE)"
+        )
+
+    client = fake_client("test1")
+
+    time.sleep(12)
+
+    assert client["proc"].poll() is None, (
+        "fake-client exited after server_list with full-column row:\n"
+        + client["log"].read_text(errors="replace")
+    )
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM assets_assetposition WHERE asset_id = %s",
+            (asset_id,),
+        )
+        count = cur.fetchone()[0]
+    assert count >= 1, "no positions recorded after server_list with full-column row"


### PR DESCRIPTION
## Description

The e2e schema for config_serverconfig was missing name, config_port, and https — the three columns present in the Django ServerConfig model. Any INSERT or test that specified those columns would fail at schema creation time, and the schema would not match what Django expects.

Add the three columns with the same defaults as the Django migration, and add test_server_list_with_full_serverconfig_columns to confirm a full-column row does not break server_list delivery to clients.

## Summary by Sourcery

Align the e2e config_serverconfig schema with the Django ServerConfig model and verify full-column rows do not break server_list delivery.

Bug Fixes:
- Add missing name, config_port, and https columns to the e2e config_serverconfig schema so inserts using the full Django ServerConfig model succeed.

Tests:
- Add an end-to-end test ensuring server_list delivery works when config_serverconfig rows populate all ServerConfig columns.