### PR TITLE
fix: check setsockopt/freeaddrinfo returns in transport-helpers.cpp

### DIFF
--- a/.cppcheck-suppress
+++ b/.cppcheck-suppress
@@ -30,15 +30,15 @@ cstyleCast:src/transport.cpp:243
 constVariablePointer:src/transport.cpp:243
 
 # transport-helpers.cpp — network address utility C-style casts + AF_UNSPEC tautology
-dangerousTypeCast:src/transport-helpers.cpp:23
-cstyleCast:src/transport-helpers.cpp:23
-dangerousTypeCast:src/transport-helpers.cpp:36
-cstyleCast:src/transport-helpers.cpp:36
+dangerousTypeCast:src/transport-helpers.cpp:24
+cstyleCast:src/transport-helpers.cpp:24
+dangerousTypeCast:src/transport-helpers.cpp:37
+cstyleCast:src/transport-helpers.cpp:37
 dangerousTypeCast:src/transport-helpers.cpp:60
 cstyleCast:src/transport-helpers.cpp:60
 dangerousTypeCast:src/transport-helpers.cpp:65
 cstyleCast:src/transport-helpers.cpp:65
-knownConditionTrueFalse:src/transport-helpers.cpp:17
+knownConditionTrueFalse:src/transport-helpers.cpp:18
 
 # transport-messages.cpp — wire-protocol packing; C-style casts are intentional
 functionStatic:src/transport-messages.cpp:185

--- a/src/transport-helpers.cpp
+++ b/src/transport-helpers.cpp
@@ -2,6 +2,7 @@
 #include <cstring>
 
 #include "transport.hpp"
+#include "fss-log.hpp"
 
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -48,9 +49,8 @@ convert_str_to_sa(const std::string &addr, uint16_t port, struct sockaddr_storag
         {
             memcpy (sa, ai->ai_addr, ai->ai_addrlen);
             family = ai->ai_family;
+            freeaddrinfo(ai);
         }
-        
-        freeaddrinfo(ai);
     }
 
     switch (family)
@@ -74,11 +74,23 @@ void
 set_tcp_keepalive(int fd)
 {
     int val = 1;
-    setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &val, sizeof(val));
+    if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &val, sizeof(val)) < 0)
+    {
+        FSS_PERROR("transport", "setsockopt SO_KEEPALIVE failed");
+    }
     val = 15;
-    setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &val, sizeof(val));
+    if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &val, sizeof(val)) < 0)
+    {
+        FSS_PERROR("transport", "setsockopt TCP_KEEPIDLE failed");
+    }
     val = 5;
-    setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &val, sizeof(val));
+    if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &val, sizeof(val)) < 0)
+    {
+        FSS_PERROR("transport", "setsockopt TCP_KEEPINTVL failed");
+    }
     val = 3;
-    setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &val, sizeof(val));
+    if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &val, sizeof(val)) < 0)
+    {
+        FSS_PERROR("transport", "setsockopt TCP_KEEPCNT failed");
+    }
 }


### PR DESCRIPTION
## Description

Log failures for all four setsockopt calls in set_tcp_keepalive(). Move freeaddrinfo() inside the getaddrinfo() success guard to avoid calling it with nullptr (POSIX UB).

## Summary by Sourcery

Improve TCP transport robustness and logging around socket options and address handling.

Bug Fixes:
- Avoid calling freeaddrinfo with a null pointer by only freeing results when getaddrinfo succeeds.

Enhancements:
- Add error logging for all TCP keepalive-related setsockopt calls in set_tcp_keepalive().