### PR TITLE
fix: check gnutls_x509_crt_init/crl_init returns in transport-ssl.cpp

### DIFF
--- a/.cppcheck-suppress
+++ b/.cppcheck-suppress
@@ -20,14 +20,14 @@ useStlAlgorithm:src/server.cpp:173
 useStlAlgorithm:src/server.cpp:349
 
 # transport.cpp — C-style casts in low-level network address handling
-dangerousTypeCast:src/transport.cpp:33
-dangerousTypeCast:src/transport.cpp:34
-dangerousTypeCast:src/transport.cpp:38
-dangerousTypeCast:src/transport.cpp:39
-duplicateBreak:src/transport.cpp:35
-duplicateBreak:src/transport.cpp:40
-cstyleCast:src/transport.cpp:255
-constVariablePointer:src/transport.cpp:255
+dangerousTypeCast:src/transport.cpp:76
+dangerousTypeCast:src/transport.cpp:77
+dangerousTypeCast:src/transport.cpp:81
+dangerousTypeCast:src/transport.cpp:82
+duplicateBreak:src/transport.cpp:78
+duplicateBreak:src/transport.cpp:83
+cstyleCast:src/transport.cpp:288
+constVariablePointer:src/transport.cpp:288
 
 # transport-helpers.cpp — network address utility C-style casts + AF_UNSPEC tautology
 dangerousTypeCast:src/transport-helpers.cpp:24
@@ -152,3 +152,8 @@ unreadVariable:src/transport-messages.cpp:439
 unreadVariable:src/transport-messages.cpp:526
 unreadVariable:src/transport-messages.cpp:644
 functionStatic:src/transport-messages.cpp:244
+
+# transport-ssl.cpp — Guard destructor null checks are false positives;
+# cppcheck can't see that gnutls_x509_crl_init/crt_init mutate the pointer via &
+knownConditionTrueFalse:src/transport-ssl.cpp:350
+knownConditionTrueFalse:src/transport-ssl.cpp:351

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -342,11 +342,24 @@ auto flight_safety_system::transport_ssl::fss_connection_server::isPeerCertRevok
     std::vector<gnutls_datum_t> cert_list;
     if (!this->session->get_peers_certificate(cert_list) || cert_list.empty()) { return false; }
 
-    gnutls_x509_crt_t cert = nullptr;
-    gnutls_x509_crt_init(&cert);
-    if (gnutls_x509_crt_import(cert, &cert_list[0], GNUTLS_X509_FMT_DER) < 0)
+    struct Guard {
+        gnutls_x509_crt_t cert = nullptr;
+        gnutls_x509_crl_t crl = nullptr;
+        ~Guard()
+        {
+            if (crl != nullptr) { gnutls_x509_crl_deinit(crl); }
+            if (cert != nullptr) { gnutls_x509_crt_deinit(cert); }
+        }
+    } guard;
+
+    int ret = gnutls_x509_crt_init(&guard.cert);
+    if (ret < 0)
     {
-        gnutls_x509_crt_deinit(cert);
+        FSS_LOG_ERROR("ssl", "Failed to initialise x509 certificate object: " << gnutls_strerror(ret));
+        return false;
+    }
+    if (gnutls_x509_crt_import(guard.cert, &cert_list[0], GNUTLS_X509_FMT_DER) < 0)
+    {
         return false;
     }
 
@@ -354,25 +367,25 @@ auto flight_safety_system::transport_ssl::fss_connection_server::isPeerCertRevok
     if (gnutls_load_file(t_crl_file.c_str(), &crl_data) < 0)
     {
         FSS_LOG_ERROR("ssl", "Failed to load CRL file: " << t_crl_file);
-        gnutls_x509_crt_deinit(cert);
         return false;
     }
 
-    gnutls_x509_crl_t crl = nullptr;
-    gnutls_x509_crl_init(&crl);
-    int rc = gnutls_x509_crl_import(crl, &crl_data, GNUTLS_X509_FMT_PEM);
+    ret = gnutls_x509_crl_init(&guard.crl);
+    if (ret < 0)
+    {
+        FSS_LOG_ERROR("ssl", "Failed to initialise x509 CRL object: " << gnutls_strerror(ret));
+        gnutls_free(crl_data.data);
+        return false;
+    }
+    int rc = gnutls_x509_crl_import(guard.crl, &crl_data, GNUTLS_X509_FMT_PEM);
     gnutls_free(crl_data.data);
     if (rc < 0)
     {
         FSS_LOG_ERROR("ssl", "Failed to parse CRL file: " << t_crl_file << ": " << gnutls_strerror(rc));
-        gnutls_x509_crl_deinit(crl);
-        gnutls_x509_crt_deinit(cert);
         return false;
     }
 
-    int revoked = gnutls_x509_crt_check_revocation(cert, &crl, 1);
-    gnutls_x509_crl_deinit(crl);
-    gnutls_x509_crt_deinit(cert);
+    int revoked = gnutls_x509_crt_check_revocation(guard.cert, &guard.crl, 1);
     return revoked > 0;
 }
 


### PR DESCRIPTION
## Description

Both GnuTLS init calls in isPeerCertRevoked() were silently discarding their return values. On failure, the cert/CRL object is in an indeterminate state and the subsequent import call would crash or produce undefined results. Now log the error, free any already-loaded data, and return false.

## Summary by Sourcery

Handle failures when initialising GnuTLS X.509 certificate and CRL objects in peer certificate revocation checks.

Bug Fixes:
- Prevent crashes and undefined behaviour by checking return values from gnutls_x509_crt_init and gnutls_x509_crl_init and aborting revocation checks on failure.

Enhancements:
- Add RAII-style cleanup for GnuTLS certificate and CRL objects in isPeerCertRevoked to ensure resources are always freed.
- Improve error logging for certificate and CRL initialisation and parsing failures during revocation checks.