### PR TITLE
fix: check strdup return values in server-db.pgc

### DIFF
--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -137,8 +137,13 @@ db_asset_command_get(unsigned long long asset_id_arg)
         res = malloc(sizeof(struct asset_command_s));
         if (res != NULL)
         {
-            res->dbid = id;
             res->command = strdup(command);
+            if (res->command == NULL)
+            {
+                free(res);
+                return NULL;
+            }
+            res->dbid = id;
             res->timestamp = ts;
             res->latitude = lat;
             res->longitude = lng;
@@ -206,6 +211,14 @@ db_asset_smm_settings_get(unsigned long long asset_id_arg)
             settings->address = convert_to_http(server_address, server_port, server_https);
             settings->username = strdup(smm_login);
             settings->password = strdup(smm_password);
+            if (settings->address == NULL || settings->username == NULL || settings->password == NULL)
+            {
+                free(settings->address);
+                free(settings->username);
+                free(settings->password);
+                free(settings);
+                settings = NULL;
+            }
         }
     }
     return settings;
@@ -240,7 +253,15 @@ db_active_fss_servers_get(void)
         if (s != NULL)
         {
             s->address = strdup(server_address);
-            s->port = server_port;
+            if (s->address == NULL)
+            {
+                free(s);
+                s = NULL;
+            }
+            else
+            {
+                s->port = server_port;
+            }
         }
         struct fss_server_s **old = res;
         res = (struct fss_server_s **)realloc(res, sizeof(struct fss_server_s *) * (len + 2));


### PR DESCRIPTION
## Description

All four strdup() calls were unguarded against NULL (OOM). On failure:
- db_asset_command_get: free the partially-constructed result and return NULL
- db_asset_smm_settings_get: free all partially-allocated strings and return NULL
- db_active_fss_servers_get: skip the entry by freeing the server struct

## Summary by Sourcery

Bug Fixes:
- Handle NULL returns from strdup() in asset and server database helpers to avoid dereferencing failed allocations and leaking partial results.