### PR TITLE
refactor: collapse nested namespaces

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,7 +10,6 @@ Checks: >-
   cppcoreguidelines-pro-type-*,
   -readability-magic-numbers,
   -modernize-use-scoped-lock,
-  -modernize-concat-nested-namespaces,
   -modernize-use-override,
   -modernize-pass-by-value,
   -modernize-avoid-c-style-cast,

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -460,13 +460,11 @@ fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss_mess
     }
 }
 
-namespace flight_safety_system {
-namespace server {
+namespace flight_safety_system::server {
 /* Exposed so server.cpp can broadcast the server list without duplicating
  * the helper. Not in the public header — only the server binary uses it. */
 auto build_server_list_msg(IDatabase *dbc) -> std::shared_ptr<transport::fss_message_server_list>
 {
     return getServersListMsg(dbc);
 }
-} // namespace server
-} // namespace flight_safety_system
+} // namespace flight_safety_system::server

--- a/src/db-write-queue.cpp
+++ b/src/db-write-queue.cpp
@@ -5,8 +5,7 @@
 #include <exception>
 #include <utility>
 
-namespace flight_safety_system {
-namespace server {
+namespace flight_safety_system::server {
 
 db_write_queue::db_write_queue(std::size_t t_max_depth, db_write_sink t_sink)
     : max_depth(std::max<std::size_t>(1, t_max_depth)), sink(std::move(t_sink))
@@ -121,5 +120,4 @@ db_write_queue::run()
     }
 }
 
-} // namespace server
-} // namespace flight_safety_system
+} // namespace flight_safety_system::server

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -21,13 +21,11 @@
 
 #include <unistd.h>
 
-namespace flight_safety_system {
-namespace server {
+namespace flight_safety_system::server {
 /* Defined in client_session.cpp. Exposed here so the periodic broadcast
  * of the active server list can reuse the helper. */
 auto build_server_list_msg(IDatabase *dbc) -> std::shared_ptr<transport::fss_message_server_list>;
-} // namespace server
-} // namespace flight_safety_system
+} // namespace flight_safety_system::server
 
 
 volatile sig_atomic_t running = 1;


### PR DESCRIPTION
## Description

remove modernize-concat-nested-namespaces suppression

## Summary by Sourcery

Enhancements:
- Simplify namespace declarations in server-related implementation files by using a single nested namespace syntax.