### PR TITLE
refactor: use emplace_back, remove modernize-use-emplace suppression

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,7 +14,6 @@ Checks: >-
   -modernize-pass-by-value,
   -modernize-avoid-c-style-cast,
   -modernize-avoid-c-arrays,
-  -modernize-use-emplace,
   -bugprone-implicit-widening-of-multiplication-result,
   -bugprone-easily-swappable-parameters,
   -bugprone-multi-level-implicit-pointer-conversion,

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -254,7 +254,7 @@ flight_safety_system::transport_ssl::fss_connection_server::setupSSL() -> bool
                                                  0, 0, name_buf, &name_len);
         if (rc == GNUTLS_E_SUCCESS && name_len > 0)
         {
-            this->possible_names.push_back(std::string(name_buf, name_len));
+            this->possible_names.emplace_back(name_buf, name_len);
         }
         gnutls_x509_crt_deinit(cert_data);
     }


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Use emplace_back instead of push_back when appending certificate names to avoid unnecessary string construction.