### PR TITLE
refactor: fix range-copy and value-param, remove performance suppression

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,8 +20,6 @@ Checks: >-
   -bugprone-switch-missing-default-case,
   -cppcoreguidelines-pro-type-reinterpret-cast,
   -cppcoreguidelines-pro-type-cstyle-cast,
-  -performance-unnecessary-value-param,
-  -performance-for-range-copy,
   -performance-no-int-to-ptr,
   -clang-analyzer-deadcode.DeadStores,
   -clang-analyzer-optin.cplusplus.VirtualCall

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -875,7 +875,7 @@ packServer(const std::shared_ptr<flight_safety_system::transport::buf_len> &bl, 
 void
 flight_safety_system::transport::fss_message_server_list::packData(std::shared_ptr<buf_len> bl)
 {
-    for(auto server : this->servers)
+    for(const auto& server : this->servers)
     {
         packServer(bl, server);
     }

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -326,7 +326,7 @@ flight_safety_system::transport_ssl::fss_listen::newConnection(int t_newfd) -> s
     return flight_safety_system::transport_ssl::fss_connection_server::create(t_newfd, this->ca_file, this->private_key_file, this->public_key_file, this->crl_file);
 }
 
-flight_safety_system::transport_ssl::fss_listen::fss_listen(uint16_t t_port, flight_safety_system::transport::fss_connect_cb t_cb, std::string t_ca, std::string t_private_key, std::string t_public_key, std::string t_crl) : flight_safety_system::transport::fss_listen(t_port, t_cb), ca_file(std::move(t_ca)), private_key_file(std::move(t_private_key)), public_key_file(std::move(t_public_key)), crl_file(std::move(t_crl))
+flight_safety_system::transport_ssl::fss_listen::fss_listen(uint16_t t_port, flight_safety_system::transport::fss_connect_cb t_cb, std::string t_ca, std::string t_private_key, std::string t_public_key, std::string t_crl) : flight_safety_system::transport::fss_listen(t_port, std::move(t_cb)), ca_file(std::move(t_ca)), private_key_file(std::move(t_private_key)), public_key_file(std::move(t_public_key)), crl_file(std::move(t_crl))
 {
 }
 

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -442,7 +442,7 @@ flight_safety_system::transport::fss_connection::getClientNames() -> std::list<s
     return ret;
 }
 
-flight_safety_system::transport::fss_listen::fss_listen(uint16_t t_port, fss_connect_cb t_cb) : fss_connection(), port(t_port), cb(t_cb)
+flight_safety_system::transport::fss_listen::fss_listen(uint16_t t_port, fss_connect_cb t_cb) : fss_connection(), port(t_port), cb(std::move(t_cb))
 {
     this->startListening();
 }


### PR DESCRIPTION
## Description

- Use const& in range-for in fss_message_server_list::packData
- Move fss_connect_cb into member initialisation in fss_listen constructors

## Summary by Sourcery

Refine transport message packing and SSL listener construction to avoid unnecessary copying and improve callback ownership.

Enhancements:
- Avoid copying server entries when packing server lists by iterating over them as const references.
- Adjust transport and SSL listener constructors to move the connection callback into member initialization for more efficient ownership handling.