### PR TITLE
refactor: add explicit casts for narrowing conversions, 

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,7 +16,6 @@ Checks: >-
   -bugprone-implicit-widening-of-multiplication-result,
   -bugprone-easily-swappable-parameters,
   -bugprone-multi-level-implicit-pointer-conversion,
-  -bugprone-narrowing-conversions,
   -bugprone-switch-missing-default-case,
   -cppcoreguidelines-pro-type-reinterpret-cast,
   -cppcoreguidelines-pro-type-cstyle-cast,

--- a/.cppcheck-suppress
+++ b/.cppcheck-suppress
@@ -43,10 +43,6 @@ knownConditionTrueFalse:src/transport-helpers.cpp:18
 # transport-messages.cpp — wire-protocol packing; C-style casts are intentional
 functionStatic:src/transport-messages.cpp:185
 functionStatic:src/transport-messages.cpp:239
-cstyleCast:src/transport-messages.cpp:423
-cstyleCast:src/transport-messages.cpp:424
-cstyleCast:src/transport-messages.cpp:612
-cstyleCast:src/transport-messages.cpp:748
 dangerousTypeCast:src/transport-messages.cpp:18
 cstyleCast:src/transport-messages.cpp:18
 dangerousTypeCast:src/transport-messages.cpp:25
@@ -77,6 +73,10 @@ dangerousTypeCast:src/transport-messages.cpp:420
 cstyleCast:src/transport-messages.cpp:420
 dangerousTypeCast:src/transport-messages.cpp:422
 cstyleCast:src/transport-messages.cpp:422
+dangerousTypeCast:src/transport-messages.cpp:423
+cstyleCast:src/transport-messages.cpp:423
+dangerousTypeCast:src/transport-messages.cpp:424
+cstyleCast:src/transport-messages.cpp:424
 dangerousTypeCast:src/transport-messages.cpp:613
 cstyleCast:src/transport-messages.cpp:613
 dangerousTypeCast:src/transport-messages.cpp:614
@@ -152,6 +152,30 @@ unreadVariable:src/transport-messages.cpp:439
 unreadVariable:src/transport-messages.cpp:526
 unreadVariable:src/transport-messages.cpp:644
 functionStatic:src/transport-messages.cpp:244
+# Updated line numbers after code-review refactor (split chained casts, fix lat/lng scope)
+cstyleCast:src/transport-messages.cpp:431
+cstyleCast:src/transport-messages.cpp:432
+dangerousTypeCast:src/transport-messages.cpp:426
+dangerousTypeCast:src/transport-messages.cpp:428
+dangerousTypeCast:src/transport-messages.cpp:430
+dangerousTypeCast:src/transport-messages.cpp:620
+dangerousTypeCast:src/transport-messages.cpp:682
+dangerousTypeCast:src/transport-messages.cpp:753
+dangerousTypeCast:src/transport-messages.cpp:754
+dangerousTypeCast:src/transport-messages.cpp:755
+cstyleCast:src/transport-messages.cpp:756
+dangerousTypeCast:src/transport-messages.cpp:874
+dangerousTypeCast:src/transport-messages.cpp:934
+unreadVariable:src/transport-messages.cpp:527
+unreadVariable:src/transport-messages.cpp:645
+cstyleCast:src/transport-messages.cpp:426
+cstyleCast:src/transport-messages.cpp:430
+cstyleCast:src/transport-messages.cpp:620
+cstyleCast:src/transport-messages.cpp:682
+cstyleCast:src/transport-messages.cpp:754
+cstyleCast:src/transport-messages.cpp:755
+cstyleCast:src/transport-messages.cpp:874
+cstyleCast:src/transport-messages.cpp:934
 
 # transport-ssl.cpp — Guard destructor null checks are false positives;
 # cppcheck can't see that gnutls_x509_crl_init/crt_init mutate the pointer via &

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -5,6 +5,8 @@ extern "C" {
 #include "server-db.h"
 }
 
+#include <cassert>
+#include <limits>
 #include <mutex>
 #include <string>
 #include <string_view>
@@ -58,7 +60,8 @@ void
 flight_safety_system::server::db_connection::recordPosition(uint64_t asset_id, double latitude, double longitude, uint32_t altitude)
 {
     std::lock_guard<std::mutex> guard(this->db_lock);
-    db_position_create_entry(asset_id, latitude, longitude, altitude);
+    assert(altitude <= static_cast<uint32_t>(std::numeric_limits<int>::max()));
+    db_position_create_entry(asset_id, latitude, longitude, static_cast<int>(altitude));
 }
 
 auto

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -404,13 +404,16 @@ flight_safety_system::transport::fss_message_position_report::packData(std::shar
 {
     uint64_t ts = fss_htobe64(this->getTimeStamp());
     /* Convert the lat/long to fixed decimal for transport */
-    int32_t lat = fss_htobe32((int32_t) (this->getLatitude() / FSS_COORD_SCALE));
-    int32_t lng = fss_htobe32((int32_t) (this->getLongitude() / FSS_COORD_SCALE));
+    const auto lat_host = static_cast<int32_t>(this->getLatitude() / FSS_COORD_SCALE);
+    const auto lng_host = static_cast<int32_t>(this->getLongitude() / FSS_COORD_SCALE);
+    const auto lat = static_cast<int32_t>(fss_htobe32(static_cast<uint32_t>(lat_host)));
+    const auto lng = static_cast<int32_t>(fss_htobe32(static_cast<uint32_t>(lng_host)));
     uint32_t alt = fss_htobe32(this->getAltitude());
     uint32_t icao_id = fss_htobe32(this->getICAOAddress());
     uint16_t head = fss_htobe16(this->getHeading());
     uint16_t hor_vel = fss_htobe16(this->getHorzVel());
-    int16_t ver_vel = fss_htobe16(this->getVertVel());
+    const auto vv_host = static_cast<int16_t>(this->getVertVel());
+    const auto ver_vel = static_cast<int16_t>(fss_htobe16(static_cast<uint16_t>(vv_host)));
     uint16_t squawk_code = fss_htobe16(this->getSquawk());
     uint16_t enc_flags = fss_htobe16(this->getFlags());
 
@@ -435,8 +438,6 @@ flight_safety_system::transport::fss_message_position_report::unpackData(const s
     size_t offset = this->headerLength();
     const char *data = bl->getData();
     size_t length = bl->getLength();
-    int32_t lat = 0;
-    int32_t lng = 0;
     this->altitude = 0;
     this->timestamp = 0;
     if (length - offset >= sizeof(uint64_t))
@@ -450,7 +451,7 @@ flight_safety_system::transport::fss_message_position_report::unpackData(const s
     {
         int32_t tmp;
         memcpy(&tmp, data + offset, sizeof(int32_t));
-        lat = fss_be32toh(tmp);
+        const auto lat = static_cast<int32_t>(fss_be32toh(static_cast<uint32_t>(tmp)));
         offset += sizeof(int32_t);
         this->latitude = ((double)lat) * FSS_COORD_SCALE;
     }
@@ -458,7 +459,7 @@ flight_safety_system::transport::fss_message_position_report::unpackData(const s
     {
         int32_t tmp;
         memcpy(&tmp, data + offset, sizeof(int32_t));
-        lng = fss_be32toh(tmp);
+        const auto lng = static_cast<int32_t>(fss_be32toh(static_cast<uint32_t>(tmp)));
         offset += sizeof(int32_t);
         this->longitude = ((double)lng) * FSS_COORD_SCALE;
     }
@@ -494,7 +495,7 @@ flight_safety_system::transport::fss_message_position_report::unpackData(const s
     {
         int16_t tmp;
         memcpy(&tmp, data + offset, sizeof(int16_t));
-        this->vertical_velocity = fss_be16toh(tmp);
+        this->vertical_velocity = static_cast<int16_t>(fss_be16toh(static_cast<uint16_t>(tmp)));
         offset += sizeof(int16_t);
     }
     if (length - offset >= sizeof(uint16_t))
@@ -742,8 +743,10 @@ flight_safety_system::transport::fss_message_asset_command::packData(std::shared
 {
     uint64_t ts = fss_htobe64(this->getTimeStamp());
     /* Convert the lat/long to fixed decimal for transport */
-    int32_t lat = fss_htobe32((int32_t) (this->getLatitude() / FSS_COORD_SCALE));
-    int32_t lng = fss_htobe32((int32_t) (this->getLongitude() / FSS_COORD_SCALE));
+    const auto lat_host = static_cast<int32_t>(this->getLatitude() / FSS_COORD_SCALE);
+    const auto lng_host = static_cast<int32_t>(this->getLongitude() / FSS_COORD_SCALE);
+    const auto lat = static_cast<int32_t>(fss_htobe32(static_cast<uint32_t>(lat_host)));
+    const auto lng = static_cast<int32_t>(fss_htobe32(static_cast<uint32_t>(lng_host)));
     uint32_t alt = fss_htobe32(this->getAltitude());
     auto cmd = (uint8_t) this->getCommand();
     bl->addData((char *)&ts, sizeof(uint64_t));
@@ -771,10 +774,10 @@ flight_safety_system::transport::fss_message_asset_command::unpackData(const std
         offset += sizeof(uint64_t);
         int32_t tmp32;
         memcpy(&tmp32, data + offset, sizeof(int32_t));
-        lat = fss_be32toh(tmp32);
+        lat = static_cast<int32_t>(fss_be32toh(static_cast<uint32_t>(tmp32)));
         offset += sizeof(int32_t);
         memcpy(&tmp32, data + offset, sizeof(int32_t));
-        lng = fss_be32toh(tmp32);
+        lng = static_cast<int32_t>(fss_be32toh(static_cast<uint32_t>(tmp32)));
         offset += sizeof(int32_t);
         uint32_t tmpu32;
         memcpy(&tmpu32, data + offset, sizeof(uint32_t));

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -394,7 +394,7 @@ flight_safety_system::transport::fss_connection::recvMsg() -> std::shared_ptr<fl
     auto total_length = static_cast<ssize_t>(data_length);
     if (data_length % sizeof(uint64_t) != 0)
     {
-        total_length = data_length + sizeof(uint64_t) - (data_length % sizeof(uint64_t));
+        total_length += static_cast<ssize_t>(sizeof(uint64_t)) - (total_length % static_cast<ssize_t>(sizeof(uint64_t)));
     }
     if (total_length < static_cast<ssize_t>(sizeof(uint16_t)))
     {


### PR DESCRIPTION
## Description

remove bugprone-narrowing-conversions suppression

All cases are intentional signed/unsigned reinterpretations at the same bit-width in wire-protocol encode/decode paths. Use static_cast to make the intent explicit; use auto where modernize-use-auto requires it.

## Summary by Sourcery

Clarify and make explicit all intentional narrowing and signed/unsigned conversions in transport encoding/decoding and database/transport logic, and remove static-analysis suppressions that are no longer needed.

Enhancements:
- Make latitude, longitude, and vertical velocity packing/unpacking paths use explicit intermediate host types and static_casts for endian conversions in transport messages.
- Adjust recvMsg buffer length alignment logic to perform size calculations using ssize_t-safe arithmetic in transport.
- Record position altitude in the database via an explicit, range-checked cast from uint32_t to int.

Chores:
- Remove or update static-analysis suppression configuration related to narrowing-conversion warnings in clang-tidy and cppcheck.