### PR TITLE
refactor: add default case to switch

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,7 +15,6 @@ Checks: >-
   -bugprone-implicit-widening-of-multiplication-result,
   -bugprone-easily-swappable-parameters,
   -bugprone-multi-level-implicit-pointer-conversion,
-  -bugprone-switch-missing-default-case,
   -cppcoreguidelines-pro-type-reinterpret-cast,
   -performance-no-int-to-ptr,
   -clang-analyzer-deadcode.DeadStores,

--- a/src/transport-helpers.cpp
+++ b/src/transport-helpers.cpp
@@ -64,7 +64,8 @@ convert_str_to_sa(const std::string &addr, uint16_t port, struct sockaddr_storag
         {
             auto sa_in = reinterpret_cast<struct sockaddr_in6 *>(sa);
             sa_in->sin6_port = htons(port);
-        }
+        } break;
+        default: break;
     }
     
     return family != AF_UNSPEC;


### PR DESCRIPTION
## Description

remove bugprone-switch-missing-default-case suppression

## Summary by Sourcery

Ensure switch handling in socket address conversion covers all cases and no longer relies on a missing-default clang-tidy suppression.

Bug Fixes:
- Prevent potential fallthrough in the address family switch when handling IPv6 socket addresses by terminating the case explicitly.

Enhancements:
- Add a default branch to the address family switch to make control flow explicit and future-proof against unhandled families.