### PR TITLE
refactor: remove clang-analyzer-deadcode.DeadStores suppression

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,7 +17,6 @@ Checks: >-
   -bugprone-multi-level-implicit-pointer-conversion,
   -cppcoreguidelines-pro-type-reinterpret-cast,
   -performance-no-int-to-ptr,
-  -clang-analyzer-deadcode.DeadStores,
   -clang-analyzer-optin.cplusplus.VirtualCall
 
 # Headers under src/ are part of the project; include findings from them.

--- a/.cppcheck-suppress
+++ b/.cppcheck-suppress
@@ -113,8 +113,6 @@ cstyleCast:src/transport-messages.cpp:357
 dangerousTypeCast:src/transport-messages.cpp:357
 cstyleCast:src/transport-messages.cpp:421
 dangerousTypeCast:src/transport-messages.cpp:421
-dangerousTypeCast:src/transport-messages.cpp:423
-dangerousTypeCast:src/transport-messages.cpp:424
 cstyleCast:src/transport-messages.cpp:425
 dangerousTypeCast:src/transport-messages.cpp:425
 cstyleCast:src/transport-messages.cpp:427

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -524,7 +524,6 @@ flight_safety_system::transport::fss_message_position_report::unpackData(const s
     if (offset <= length && length - offset >= sizeof(uint8_t))
     {
         this->emitter_type = static_cast<uint8_t>(data[offset]);
-        offset += sizeof(uint8_t);
     }
 }
 
@@ -642,7 +641,6 @@ flight_safety_system::transport::fss_message_system_status::unpackData(const std
         int32_t tmp;
         memcpy(&tmp, data + offset, sizeof(int32_t));
         uint32_t voltage_n = fss_be32toh(tmp);
-        offset += sizeof(int32_t);
         this->voltage = static_cast<double>(voltage_n) * FSS_COORD_SCALE;
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update .clang-tidy configuration to no longer suppress clang-analyzer-deadcode.DeadStores warnings.