### PR TITLE
refactor: fix widening conversion and int-to-ptr cast

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,11 +12,9 @@ Checks: >-
   -modernize-use-scoped-lock,
   -modernize-pass-by-value,
   -modernize-avoid-c-arrays,
-  -bugprone-implicit-widening-of-multiplication-result,
   -bugprone-easily-swappable-parameters,
   -bugprone-multi-level-implicit-pointer-conversion,
   -cppcoreguidelines-pro-type-reinterpret-cast,
-  -performance-no-int-to-ptr,
   -clang-analyzer-optin.cplusplus.VirtualCall
 
 # Headers under src/ are part of the project; include findings from them.

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -11,7 +11,7 @@
 
 namespace fss = flight_safety_system;
 
-constexpr int sec_to_msec = 1000;
+constexpr uint64_t sec_to_msec = 1000;
 constexpr uint64_t rtt_retry_interval = 10 * sec_to_msec;
 
 fss::server::smm_settings::smm_settings(std::string t_address, fss::secure_string t_username, fss::secure_string t_password) : address(std::move(t_address)), username(std::move(t_username)), password(std::move(t_password))

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -158,7 +158,7 @@ flight_safety_system::transport_ssl::fss_connection::setupSession() -> bool
     }
     this->session->set_credentials(*this->credentials);
 
-    this->session->set_transport_ptr(reinterpret_cast<gnutls_transport_ptr_t>(static_cast<intptr_t>(this->getFd())));
+    gnutls_transport_set_int(this->session->ptr(), this->getFd());
     return true;
 }
 


### PR DESCRIPTION
## Description

remove suppressions

- client_session.cpp: constexpr sec_to_msec typed as uint64_t to avoid int widening in the rtt_retry_interval constant expression
- transport-ssl.cpp: use gnutls_transport_set_int() directly (C API) instead of converting the fd to a void* via reinterpret_cast

## Summary by Sourcery

Adjust client timing constant type and SSL transport setup to address static analysis warnings.

Bug Fixes:
- Prevent integer widening in RTT retry interval by using a 64-bit millisecond constant.
- Avoid unsafe int-to-pointer cast in SSL transport by using the dedicated GNUTLS transport setter API.

Enhancements:
- Clean up code by removing the need for clang-tidy suppressions related to these conversions.