### PR TITLE
refactor: explicit cast in free() call

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,7 +13,6 @@ Checks: >-
   -modernize-pass-by-value,
   -modernize-avoid-c-arrays,
   -bugprone-easily-swappable-parameters,
-  -bugprone-multi-level-implicit-pointer-conversion,
   -cppcoreguidelines-pro-type-reinterpret-cast,
   -clang-analyzer-optin.cplusplus.VirtualCall
 

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -117,7 +117,7 @@ flight_safety_system::server::db_connection::getActiveServers() -> std::vector<f
             free (servers[i]->address);
             free (servers[i]);
         }
-        free (servers);
+        free(reinterpret_cast<void *>(servers));
     }
     return res;
 }


### PR DESCRIPTION
## Description

remove bugprone-multi-level-implicit-pointer-conversion suppression

## Summary by Sourcery

Enhancements:
- Replace implicit pointer-to-void conversion in a free() call with an explicit cast to align with clang-tidy guidance.