### PR TITLE
refactor: replace lock_guard with scoped_lock

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,7 +9,6 @@ Checks: >-
   modernize-*,
   cppcoreguidelines-pro-type-*,
   -readability-magic-numbers,
-  -modernize-use-scoped-lock,
   -modernize-pass-by-value,
   -modernize-avoid-c-arrays,
   -bugprone-easily-swappable-parameters,

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -80,14 +80,14 @@ fss::server::fss_client::isAircraft() -> bool
 auto
 fss::server::fss_client::getName() -> std::string
 {
-    std::lock_guard<std::mutex> guard(this->client_lock);
+    std::scoped_lock guard(this->client_lock);
     return this->name;
 }
 
 void
 fss::server::fss_client::sendCommand()
 {
-    std::lock_guard<std::mutex> guard(this->client_lock);
+    std::scoped_lock guard(this->client_lock);
     uint64_t ts = fss_current_timestamp();
     uint64_t asset_id = this->dbc->getAssetId(this->name);
     if (asset_id == 0) { return; }
@@ -129,7 +129,7 @@ fss::server::fss_client::setClock(std::shared_ptr<fss::IClock> t_clock)
 void
 fss::server::fss_client::setTimeoutMs(uint64_t ms)
 {
-    std::lock_guard<std::mutex> guard(this->client_lock);
+    std::scoped_lock guard(this->client_lock);
     this->client_timeout_ms = ms;
 }
 
@@ -142,7 +142,7 @@ fss::server::fss_client::setRateLimits(uint64_t capacity, uint64_t refill_per_s)
 auto
 fss::server::fss_client::isTimedOut() -> bool
 {
-    std::lock_guard<std::mutex> guard(this->client_lock);
+    std::scoped_lock guard(this->client_lock);
     if (!this->liveness_active) { return false; }
     return (this->clock->now_ms() - this->last_rtt_response_time) > this->client_timeout_ms;
 }
@@ -152,7 +152,7 @@ fss::server::fss_client::sendRTTRequest(const std::shared_ptr<fss::transport::fs
 {
     bool timed_out = false;
     {
-        std::lock_guard<std::mutex> guard(this->client_lock);
+        std::scoped_lock guard(this->client_lock);
         uint64_t now = this->clock->now_ms();
         if (!this->outstanding_rtt_requests.empty())
         {
@@ -182,7 +182,7 @@ fss::server::fss_client::sendSMMSettings()
 {
     std::string client_name;
     {
-        std::lock_guard<std::mutex> guard(this->client_lock);
+        std::scoped_lock guard(this->client_lock);
         client_name = this->name;
     }
     uint64_t asset_id = this->dbc->getAssetId(client_name);
@@ -306,7 +306,7 @@ fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss_mess
                     return;
                 }
                 {
-                    std::lock_guard<std::mutex> guard(this->client_lock);
+                    std::scoped_lock guard(this->client_lock);
                     this->name = std::move(client_name);
                     this->liveness_active = true;
                     this->last_rtt_response_time = this->clock->now_ms();
@@ -333,7 +333,7 @@ fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss_mess
                 return;
             }
             {
-                std::lock_guard<std::mutex> guard(this->client_lock);
+                std::scoped_lock guard(this->client_lock);
                 this->name = possible_names.front();
             }
             this->aircraft = false;
@@ -391,7 +391,7 @@ fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss_mess
                 auto rtt_resp_msg = std::dynamic_pointer_cast<fss::transport::fss_message_rtt_response>(msg);
                 if (rtt_resp_msg != nullptr)
                 {
-                    std::lock_guard<std::mutex> guard(this->client_lock);
+                    std::scoped_lock guard(this->client_lock);
                     for(const auto &req : this->outstanding_rtt_requests)
                     {
                         if(req->getRequestId() == rtt_resp_msg->getRequestId())

--- a/src/db-write-queue.cpp
+++ b/src/db-write-queue.cpp
@@ -24,7 +24,7 @@ db_write_queue::enqueue(db_write_task task)
     bool did_drop = false;
     uint64_t total_dropped = 0;
     {
-        std::lock_guard<std::mutex> guard(this->mtx);
+        std::scoped_lock guard(this->mtx);
         if (this->stopping) { return; }
         if (this->q.size() >= this->max_depth)
         {
@@ -52,7 +52,7 @@ void
 db_write_queue::stop()
 {
     {
-        std::lock_guard<std::mutex> guard(this->mtx);
+        std::scoped_lock guard(this->mtx);
         if (this->stopping) { return; }
         this->stopping = true;
     }
@@ -78,7 +78,7 @@ db_write_queue::write_failure_count() const -> uint64_t
 auto
 db_write_queue::pending_count() const -> std::size_t
 {
-    std::lock_guard<std::mutex> guard(this->mtx);
+    std::scoped_lock guard(this->mtx);
     return this->q.size();
 }
 

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -31,35 +31,35 @@ flight_safety_system::server::db_connection::~db_connection()
 auto
 flight_safety_system::server::db_connection::getAssetId(const std::string &name) -> uint64_t
 {
-    std::lock_guard<std::mutex> guard(this->db_lock);
+    std::scoped_lock guard(this->db_lock);
     return db_get_asset_id(name.c_str());
 }
 
 void
 flight_safety_system::server::db_connection::recordRtt(uint64_t asset_id, uint64_t rtt_ms)
 {
-    std::lock_guard<std::mutex> guard(this->db_lock);
+    std::scoped_lock guard(this->db_lock);
     db_rtt_create_entry(asset_id, rtt_ms);
 }
 
 void
 flight_safety_system::server::db_connection::recordStatus(uint64_t asset_id, uint8_t bat_percent, uint32_t bat_mah_used, double bat_voltage)
 {
-    std::lock_guard<std::mutex> guard(this->db_lock);
+    std::scoped_lock guard(this->db_lock);
     db_status_create_entry(asset_id, bat_percent, bat_mah_used, bat_voltage);
 }
 
 void
 flight_safety_system::server::db_connection::recordSearchStatus(uint64_t asset_id, uint64_t search_id, uint64_t completed, uint64_t total)
 {
-    std::lock_guard<std::mutex> guard(this->db_lock);
+    std::scoped_lock guard(this->db_lock);
     db_search_status_create_entry(asset_id, search_id, completed, total);
 }
 
 void
 flight_safety_system::server::db_connection::recordPosition(uint64_t asset_id, double latitude, double longitude, uint32_t altitude)
 {
-    std::lock_guard<std::mutex> guard(this->db_lock);
+    std::scoped_lock guard(this->db_lock);
     assert(altitude <= static_cast<uint32_t>(std::numeric_limits<int>::max()));
     db_position_create_entry(asset_id, latitude, longitude, static_cast<int>(altitude));
 }
@@ -69,7 +69,7 @@ flight_safety_system::server::db_connection::getCommand(uint64_t asset_id) -> st
 {
     std::shared_ptr<asset_command> res = nullptr;
     {
-        std::lock_guard<std::mutex> guard(this->db_lock);
+        std::scoped_lock guard(this->db_lock);
         struct asset_command_s *command = db_asset_command_get(asset_id);
         if (command)
         {
@@ -86,7 +86,7 @@ flight_safety_system::server::db_connection::getSmmSettings(uint64_t asset_id) -
 {
     std::shared_ptr<smm_settings> res = nullptr;
     {
-        std::lock_guard<std::mutex> guard(this->db_lock);
+        std::scoped_lock guard(this->db_lock);
         struct smm_settings_s *settings = db_asset_smm_settings_get(asset_id);
         if (settings)
         {
@@ -106,7 +106,7 @@ flight_safety_system::server::db_connection::getActiveServers() -> std::vector<f
     std::vector<fss_server_details> res;
     struct fss_server_s **servers = nullptr;
     {
-        std::lock_guard<std::mutex> guard(this->db_lock);
+        std::scoped_lock guard(this->db_lock);
         servers = db_active_fss_servers_get();
     }
     if (servers)

--- a/src/fss-log.hpp
+++ b/src/fss-log.hpp
@@ -69,7 +69,7 @@ inline void set_level(const std::string &lvl_str)
 
 inline void write(level lvl, const char *component, const std::string &msg)
 {
-    std::lock_guard<std::mutex> guard(detail::log_mutex());
+    std::scoped_lock guard(detail::log_mutex());
     auto now = std::chrono::system_clock::now();
     std::time_t t = std::chrono::system_clock::to_time_t(now);
     char buf[21]{};

--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -24,7 +24,7 @@ public:
     server_clients() = default;
     ~server_clients() override {
         this->shutting_down = true;
-        std::lock_guard<std::mutex> guard(this->lock);
+        std::scoped_lock guard(this->lock);
         for (const auto &c: this->clients)
         {
             c->disconnect();
@@ -36,7 +36,7 @@ public:
     auto operator=(server_clients&&) -> server_clients& = delete;
     void cleanupRemovableClients()
     {
-        std::lock_guard<std::mutex> guard(this->lock);
+        std::scoped_lock guard(this->lock);
         while(!this->disconnected.empty())
         {
             auto client = this->disconnected.front();
@@ -54,13 +54,13 @@ public:
     {
         client->setTimeoutMs(this->client_timeout_ms);
         client->setRateLimits(this->rate_capacity, this->rate_refill_per_s);
-        std::lock_guard<std::mutex> guard(this->lock);
+        std::scoped_lock guard(this->lock);
         this->total_clients++;
         this->clients.push_back(std::move(client));
     };
     void clientDisconnected(flight_safety_system::server::fss_client *client) override
     {
-        std::lock_guard<std::mutex> guard(this->lock);
+        std::scoped_lock guard(this->lock);
         if (this->shutting_down) return;
         auto it = std::find_if(this->clients.begin(), this->clients.end(), [client](const auto &c) -> auto {
             return c.get() == client;
@@ -73,7 +73,7 @@ public:
     };
     void broadcastMsg(const std::shared_ptr<flight_safety_system::transport::fss_message> &msg, flight_safety_system::server::fss_client *except = nullptr) override
     {
-        std::lock_guard<std::mutex> guard(this->lock);
+        std::scoped_lock guard(this->lock);
         for (const auto &client : this->clients)
         {
             if (client->isAircraft() && client.get() != except)
@@ -86,7 +86,7 @@ public:
     {
         std::vector<std::shared_ptr<flight_safety_system::server::fss_client>> snapshot;
         {
-            std::lock_guard<std::mutex> guard(this->lock);
+            std::scoped_lock guard(this->lock);
             std::copy(this->clients.begin(), this->clients.end(), std::back_inserter(snapshot));
         }
         for (const auto &client : snapshot)
@@ -100,7 +100,7 @@ public:
     };
     void sendSMMSettings()
     {
-        std::lock_guard<std::mutex> guard(this->lock);
+        std::scoped_lock guard(this->lock);
         for(const auto &client: this->clients)
         {
             client->sendSMMSettings();
@@ -108,7 +108,7 @@ public:
     };
     void sendRTTRequest(const std::shared_ptr<flight_safety_system::transport::fss_message_rtt_request> &rtt_req)
     {
-        std::lock_guard<std::mutex> guard(this->lock);
+        std::scoped_lock guard(this->lock);
         for(const auto &client: this->clients)
         {
             client->sendRTTRequest(rtt_req);
@@ -116,7 +116,7 @@ public:
     };
     void sendCommand()
     {
-        std::lock_guard<std::mutex> guard(this->lock);
+        std::scoped_lock guard(this->lock);
         for(const auto &client: this->clients)
         {
             client->sendCommand();
@@ -126,7 +126,7 @@ public:
     {
         std::vector<std::shared_ptr<flight_safety_system::server::fss_client>> snapshot;
         {
-            std::lock_guard<std::mutex> guard(this->lock);
+            std::scoped_lock guard(this->lock);
             std::copy(this->clients.begin(), this->clients.end(), std::back_inserter(snapshot));
         }
         for (const auto &client : snapshot)

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -166,7 +166,7 @@ flight_safety_system::transport::fss_connection::processMessages()
             FSS_LOG_INFO("transport", "Remote closed the connection");
             this->run.store(false);
             {
-                std::lock_guard<std::mutex> lock_holder(this->msg_lock);
+                std::scoped_lock lock_holder(this->msg_lock);
                 if (this->handler != nullptr)
                 {
                     this->handler->processMessage(msg);
@@ -179,7 +179,7 @@ flight_safety_system::transport::fss_connection::processMessages()
             break;
         }
         {
-            std::lock_guard<std::mutex> lock_holder(this->msg_lock);
+            std::scoped_lock lock_holder(this->msg_lock);
             if (this->handler != nullptr)
             {
                 this->handler->processMessage(msg);
@@ -204,7 +204,7 @@ flight_safety_system::transport::fss_connection::processMessages()
 auto
 flight_safety_system::transport::fss_connection::getMsg() -> std::shared_ptr<flight_safety_system::transport::fss_message>
 {
-    std::lock_guard<std::mutex> lock_holder(this->msg_lock);
+    std::scoped_lock lock_holder(this->msg_lock);
     if (this->handler == nullptr)
     {
         if (!this->messages.empty())
@@ -267,7 +267,7 @@ flight_safety_system::transport::fss_connection::connectTo(const std::string &ad
 auto
 flight_safety_system::transport::fss_connection::sendMsg(const std::shared_ptr<fss_message> &msg) -> bool
 {
-    std::lock_guard<std::mutex> lock_holder(this->send_lock);
+    std::scoped_lock lock_holder(this->send_lock);
     msg->setId(this->getMessageId());
     auto bl = msg->getPacked();
 #ifdef DEBUG
@@ -324,7 +324,7 @@ flight_safety_system::transport::fss_connection::sendMsg(const std::shared_ptr<b
 void
 flight_safety_system::transport::fss_connection::setHandler(fss_message_cb *cb)
 {
-    std::lock_guard<std::mutex> lock_holder(this->msg_lock);
+    std::scoped_lock lock_holder(this->msg_lock);
     this->handler = cb;
     if (this->handler != nullptr)
     {


### PR DESCRIPTION
## Description

remove modernize-use-scoped-lock suppression

## Summary by Sourcery

Enhancements:
- Replace std::lock_guard with std::scoped_lock across server client management, client sessions, DB connection operations, transport connection handling, DB write queue, and logging to modernize synchronization primitives and support potential future multi-mutex locking.