### PR TITLE
refactor: replace C-array with std::array in transport-ssl

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,8 +9,6 @@ Checks: >-
   modernize-*,
   cppcoreguidelines-pro-type-*,
   -readability-magic-numbers,
-  -modernize-pass-by-value,
-  -modernize-avoid-c-arrays,
   -bugprone-easily-swappable-parameters,
   -cppcoreguidelines-pro-type-reinterpret-cast,
   -clang-analyzer-optin.cplusplus.VirtualCall

--- a/.cppcheck-suppress
+++ b/.cppcheck-suppress
@@ -177,5 +177,5 @@ cstyleCast:src/transport-messages.cpp:934
 
 # transport-ssl.cpp — Guard destructor null checks are false positives;
 # cppcheck can't see that gnutls_x509_crl_init/crt_init mutate the pointer via &
-knownConditionTrueFalse:src/transport-ssl.cpp:350
 knownConditionTrueFalse:src/transport-ssl.cpp:351
+knownConditionTrueFalse:src/transport-ssl.cpp:352

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -3,6 +3,7 @@
 #include "fss-log.hpp"
 #include "transport.hpp"
 
+#include <array>
 #include <cstdint>
 #include <gnutls/gnutls.h>
 #include <gnutls/gnutlsxx.h>
@@ -247,14 +248,14 @@ flight_safety_system::transport_ssl::fss_connection_server::setupSSL() -> bool
             return false;
         }
 
-        const size_t dn_max_len = 512;
-        char name_buf[dn_max_len];
+        constexpr size_t dn_max_len = 512;
+        std::array<char, dn_max_len> name_buf{};
         size_t name_len = dn_max_len;
         rc = gnutls_x509_crt_get_dn_by_oid(cert_data, GNUTLS_OID_X520_COMMON_NAME,
-                                                 0, 0, name_buf, &name_len);
+                                                 0, 0, name_buf.data(), &name_len);
         if (rc == GNUTLS_E_SUCCESS && name_len > 0)
         {
-            this->possible_names.emplace_back(name_buf, name_len);
+            this->possible_names.emplace_back(name_buf.data(), name_len);
         }
         gnutls_x509_crt_deinit(cert_data);
     }


### PR DESCRIPTION
## Description

remove modernize-pass-by-value and modernize-avoid-c-arrays suppressions

## Summary by Sourcery

Enhancements:
- Replace fixed-size C-style buffer with std::array for storing certificate distinguished name data in SSL transport.