### PR TITLE
refactor: use qualified disconnect() call in destructor

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,8 +9,7 @@ Checks: >-
   modernize-*,
   cppcoreguidelines-pro-type-*,
   -readability-magic-numbers,
-  -bugprone-easily-swappable-parameters,
-  -clang-analyzer-optin.cplusplus.VirtualCall
+  -bugprone-easily-swappable-parameters
 
 # Headers under src/ are part of the project; include findings from them.
 HeaderFilterRegex: "src/.*"

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -136,7 +136,7 @@ flight_safety_system::transport::fss_connection::disconnect()
 
 flight_safety_system::transport::fss_connection::~fss_connection()
 {
-    this->disconnect();
+    fss_connection::disconnect();
     while(!this->messages.empty())
     {
         auto msg = this->messages.front();


### PR DESCRIPTION
## Description

remove clang-analyzer-optin.cplusplus.VirtualCall suppression

## Summary by Sourcery

Qualify the disconnect call in the fss_connection destructor and adjust static analysis configuration accordingly.