### PR TITLE
refactor: add per-function NOLINT for wire-protocol ctors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,8 +8,7 @@ Checks: >-
   performance-*,
   modernize-*,
   cppcoreguidelines-pro-type-*,
-  -readability-magic-numbers,
-  -bugprone-easily-swappable-parameters
+  -readability-magic-numbers
 
 # Headers under src/ are part of the project; include findings from them.
 HeaderFilterRegex: "src/.*"

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -29,7 +29,7 @@ fss::server::fss_server_details::fss_server_details(std::string t_address, uint1
 auto fss::server::fss_server_details::getAddress() -> std::string { return this->address; }
 auto fss::server::fss_server_details::getPort() -> uint16_t { return this->port; }
 
-fss::server::asset_command::asset_command(uint64_t t_dbid, uint64_t t_timestamp, const std::string &t_cmd, double t_latitude, double t_longitude, uint16_t t_altitude) : dbid(t_dbid), timestamp(t_timestamp), latitude(t_latitude), longitude(t_longitude), altitude(t_altitude)
+fss::server::asset_command::asset_command(uint64_t t_dbid, uint64_t t_timestamp, const std::string &t_cmd, double t_latitude, double t_longitude, uint16_t t_altitude) : dbid(t_dbid), timestamp(t_timestamp), latitude(t_latitude), longitude(t_longitude), altitude(t_altitude) // NOLINT(bugprone-easily-swappable-parameters)
 {
     if (t_cmd == "RTL") {
         this->command = transport::asset_command_rtl;
@@ -57,7 +57,7 @@ auto fss::server::asset_command::getLatitude() -> double { return this->latitude
 auto fss::server::asset_command::getLongitude() -> double { return this->longitude; }
 auto fss::server::asset_command::getAltitude() -> uint16_t { return this->altitude; }
 
-fss::server::fss_client_rtt::fss_client_rtt(uint64_t t_timestamp, uint64_t t_reqid) : timestamp(t_timestamp), reqid(t_reqid)
+fss::server::fss_client_rtt::fss_client_rtt(uint64_t t_timestamp, uint64_t t_reqid) : timestamp(t_timestamp), reqid(t_reqid) // NOLINT(bugprone-easily-swappable-parameters)
 {
 }
 

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -398,10 +398,10 @@ flight_safety_system::transport::fss_message_rtt_response::getRequestId() -> uin
     return this->request_id;
 }
 
-flight_safety_system::transport::fss_message_position_report::fss_message_position_report(double t_latitude, double t_longitude, uint32_t t_altitude,
+flight_safety_system::transport::fss_message_position_report::fss_message_position_report(double t_latitude, double t_longitude, uint32_t t_altitude, // NOLINT(bugprone-easily-swappable-parameters)
                                                                                           uint16_t t_heading, uint16_t t_hor_vel, int16_t t_ver_vel,
                                                                                           uint32_t t_icao_address, std::string t_callsign,
-                                                                                          uint16_t t_squawk, uint8_t t_tslc, uint16_t t_flags, uint8_t t_alt_type,
+                                                                                          uint16_t t_squawk, uint8_t t_tslc, uint16_t t_flags, uint8_t t_alt_type, // NOLINT(bugprone-easily-swappable-parameters)
                                                                                           uint8_t t_emitter_type, uint64_t t_timestamp) :
     fss_message(message_type_position_report), latitude(t_latitude), longitude(t_longitude),
     altitude(t_altitude), heading(t_heading), horizontal_velocity(t_hor_vel), vertical_velocity(t_ver_vel),
@@ -615,7 +615,7 @@ flight_safety_system::transport::fss_message_position_report::getEmitterType() -
     return this->emitter_type;
 }
 
-flight_safety_system::transport::fss_message_system_status::fss_message_system_status(uint8_t bat_remaining_percent, uint32_t bat_mah_used, double bat_voltage) : fss_message(message_type_system_status), bat_percent(bat_remaining_percent), mah_used(bat_mah_used), voltage(bat_voltage)
+flight_safety_system::transport::fss_message_system_status::fss_message_system_status(uint8_t bat_remaining_percent, uint32_t bat_mah_used, double bat_voltage) : fss_message(message_type_system_status), bat_percent(bat_remaining_percent), mah_used(bat_mah_used), voltage(bat_voltage) // NOLINT(bugprone-easily-swappable-parameters)
 {
 }
 
@@ -677,7 +677,7 @@ auto flight_safety_system::transport::fss_message_system_status::getBatVoltage()
     return this->voltage;
 }
 
-flight_safety_system::transport::fss_message_search_status::fss_message_search_status(uint64_t t_search_id, uint64_t last_point_completed, uint64_t total_search_points) : fss_message(message_type_search_status), search_id(t_search_id), point_completed(last_point_completed), points_total(total_search_points)
+flight_safety_system::transport::fss_message_search_status::fss_message_search_status(uint64_t t_search_id, uint64_t last_point_completed, uint64_t total_search_points) : fss_message(message_type_search_status), search_id(t_search_id), point_completed(last_point_completed), points_total(total_search_points) // NOLINT(bugprone-easily-swappable-parameters)
 {
 }
 
@@ -740,11 +740,11 @@ flight_safety_system::transport::fss_message_asset_command::fss_message_asset_co
 {
 }
 
-flight_safety_system::transport::fss_message_asset_command::fss_message_asset_command(fss_asset_command t_command, uint64_t t_timestamp, double t_latitude, double t_longitude) : fss_message(message_type_command), command(t_command), latitude(t_latitude), longitude(t_longitude), altitude(0), timestamp(t_timestamp)
+flight_safety_system::transport::fss_message_asset_command::fss_message_asset_command(fss_asset_command t_command, uint64_t t_timestamp, double t_latitude, double t_longitude) : fss_message(message_type_command), command(t_command), latitude(t_latitude), longitude(t_longitude), altitude(0), timestamp(t_timestamp) // NOLINT(bugprone-easily-swappable-parameters)
 {
 }
 
-flight_safety_system::transport::fss_message_asset_command::fss_message_asset_command(fss_asset_command t_command, uint64_t t_timestamp, uint32_t t_altitude) : fss_message(message_type_command), command(t_command), latitude(NAN), longitude(NAN), altitude(t_altitude), timestamp(t_timestamp)
+flight_safety_system::transport::fss_message_asset_command::fss_message_asset_command(fss_asset_command t_command, uint64_t t_timestamp, uint32_t t_altitude) : fss_message(message_type_command), command(t_command), latitude(NAN), longitude(NAN), altitude(t_altitude), timestamp(t_timestamp) // NOLINT(bugprone-easily-swappable-parameters)
 {
 }
 
@@ -1001,7 +1001,7 @@ flight_safety_system::transport::fss_message_version::fss_message_version() : fs
 {
 }
 
-flight_safety_system::transport::fss_message_version::fss_message_version(uint16_t t_version, uint16_t t_min_version, uint32_t t_flags) : fss_message(message_type_version), protocol_version(t_version), min_supported_version(t_min_version), feature_flags(t_flags)
+flight_safety_system::transport::fss_message_version::fss_message_version(uint16_t t_version, uint16_t t_min_version, uint32_t t_flags) : fss_message(message_type_version), protocol_version(t_version), min_supported_version(t_min_version), feature_flags(t_flags) // NOLINT(bugprone-easily-swappable-parameters)
 {
 }
 

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -114,7 +114,7 @@ flight_safety_system::transport_ssl::fss_connection_client::connectTo(const std:
 }
 
 auto
-flight_safety_system::transport_ssl::fss_connection_client::create(std::string t_ca, std::string t_private_key, std::string t_public_key, const std::string &address, uint16_t port) -> std::shared_ptr<fss_connection_client>
+flight_safety_system::transport_ssl::fss_connection_client::create(std::string t_ca, std::string t_private_key, std::string t_public_key, const std::string &address, uint16_t port) -> std::shared_ptr<fss_connection_client> // NOLINT(bugprone-easily-swappable-parameters)
 {
     auto conn = std::make_shared<fss_connection_client>(std::move(t_ca), std::move(t_private_key), std::move(t_public_key));
     if (!conn->connectTo(address, port))

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -88,7 +88,7 @@ inet_ntop_stor(struct sockaddr_storage *src, char *dst, size_t dstlen, uint16_t 
 
 flight_safety_system::transport::fss_connection::fss_connection() = default;
 
-flight_safety_system::transport::fss_connection::fss_connection(int t_fd, size_t t_max_queue_size)
+flight_safety_system::transport::fss_connection::fss_connection(int t_fd, size_t t_max_queue_size) // NOLINT(bugprone-easily-swappable-parameters)
     : fd(t_fd), max_queue_size(t_max_queue_size)
 {
 }


### PR DESCRIPTION
## Description

remove bugprone-easily-swappable-parameters suppression

Wire-protocol message constructors have multiple adjacent parameters of the same C++ type (latitude/longitude, timestamps, etc.) by design; strong-type wrappers would require a major API redesign out of scope here. Suppress with targeted NOLINT at each constructor rather than a blanket check-wide suppression.

## Summary by Sourcery

Add targeted clang-tidy suppressions for wire-protocol and client constructors that intentionally use adjacent same-typed parameters, replacing blanket configuration-level suppression of the corresponding check.

Enhancements:
- Annotate specific message and command constructors with NOLINT for bugprone-easily-swappable-parameters to document intentional parameter ordering.

Build:
- Adjust clang-tidy configuration to rely on per-function NOLINT annotations instead of a global suppression for bugprone-easily-swappable-parameters.