### PR TITLE
test: add unit tests for secure_string, rate_limiter, and server_clients

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -22,6 +22,9 @@ all_test_SOURCES = main.cpp messages.cpp connection.cpp client.cpp \
 	timeout_test.cpp \
 	db_connection_test.cpp \
 	crl_revocation_test.cpp \
+	secure_string_test.cpp \
+	rate_limiter_test.cpp \
+	server_clients_test.cpp \
 	../src/client_session.cpp \
 	../src/db-write-queue.cpp \
 	../src/db.cpp \

--- a/tests/rate_limiter_test.cpp
+++ b/tests/rate_limiter_test.cpp
@@ -1,0 +1,103 @@
+#ifdef HAVE_CATCH2_CATCH_ALL_HPP
+#include <catch2/catch_all.hpp>
+#elif HAVE_CATCH2_CATCH_HPP
+#include <catch2/catch.hpp>
+#elif HAVE_CATCH_CATCH_HPP
+#include <catch/catch.hpp>
+#elif HAVE_CATCH_HPP
+#include <catch.hpp>
+#else
+#error No catch header
+#endif
+
+#include "rate-limiter.hpp"
+
+namespace fss = flight_safety_system;
+
+TEST_CASE("rate_limiter: consumes tokens when bucket is full")
+{
+    fss::rate_limiter rl(10, 5);
+    REQUIRE(rl.consume(0));
+    REQUIRE(rl.consume(0));
+}
+
+TEST_CASE("rate_limiter: returns false when bucket is empty")
+{
+    fss::rate_limiter rl(2, 1);
+    REQUIRE(rl.consume(0));
+    REQUIRE(rl.consume(0));
+    REQUIRE(!rl.consume(0));
+}
+
+TEST_CASE("rate_limiter: refills tokens after time passes")
+{
+    fss::rate_limiter rl(1, 10);
+    REQUIRE(rl.consume(0));
+    REQUIRE(!rl.consume(0));
+    // refill_per_s=10 means 1 token per 100ms
+    REQUIRE(rl.consume(100));
+}
+
+TEST_CASE("rate_limiter: does not refill beyond capacity")
+{
+    fss::rate_limiter rl(3, 10);
+    rl.consume(0);
+    rl.consume(0);
+    rl.consume(0);
+    REQUIRE(!rl.consume(0));
+    // 1000ms at 10/s = 10 tokens refilled, but capped at capacity=3
+    REQUIRE(rl.consume(1000));
+    REQUIRE(rl.consume(1000));
+    REQUIRE(rl.consume(1000));
+    REQUIRE(!rl.consume(1000));
+}
+
+TEST_CASE("rate_limiter: zero refill rate never refills")
+{
+    fss::rate_limiter rl(2, 0);
+    REQUIRE(rl.consume(0));
+    REQUIRE(rl.consume(0));
+    REQUIRE(!rl.consume(10000));
+    REQUIRE(!rl.consume(10000));
+}
+
+TEST_CASE("rate_limiter: first consume initializes the refill clock")
+{
+    fss::rate_limiter rl(1, 10);
+    // First consume at t=5000 should initialize last_refill_ms to 5000
+    REQUIRE(rl.consume(5000));
+    REQUIRE(!rl.consume(5000));
+    // At t=5100 (100ms later, 1 token refilled)
+    REQUIRE(rl.consume(5100));
+}
+
+TEST_CASE("rate_limiter: large elapsed time refills up to capacity")
+{
+    fss::rate_limiter rl(5, 1);
+    // drain the bucket
+    for (int i = 0; i < 5; i++) { rl.consume(0); }
+    REQUIRE(!rl.consume(0));
+    // 1 hour later: 3600 tokens would be added but capped at 5
+    REQUIRE(rl.consume(3600000));
+    REQUIRE(rl.consume(3600000));
+    REQUIRE(rl.consume(3600000));
+    REQUIRE(rl.consume(3600000));
+    REQUIRE(rl.consume(3600000));
+    REQUIRE(!rl.consume(3600000));
+}
+
+TEST_CASE("rate_limiter: cost > 1 consumes multiple tokens")
+{
+    fss::rate_limiter rl(5, 1);
+    REQUIRE(rl.consume(0, 3));
+    REQUIRE(rl.consume(0, 2));
+    REQUIRE(!rl.consume(0, 1));
+}
+
+TEST_CASE("rate_limiter: cost greater than available tokens is rejected")
+{
+    fss::rate_limiter rl(3, 1);
+    REQUIRE(!rl.consume(0, 4));
+    // Bucket still has 3 tokens (none were consumed by the failed attempt)
+    REQUIRE(rl.consume(0, 3));
+}

--- a/tests/secure_string_test.cpp
+++ b/tests/secure_string_test.cpp
@@ -1,0 +1,117 @@
+#ifdef HAVE_CATCH2_CATCH_ALL_HPP
+#include <catch2/catch_all.hpp>
+#elif HAVE_CATCH2_CATCH_HPP
+#include <catch2/catch.hpp>
+#elif HAVE_CATCH_CATCH_HPP
+#include <catch/catch.hpp>
+#elif HAVE_CATCH_HPP
+#include <catch.hpp>
+#else
+#error No catch header
+#endif
+
+#include <string_view>
+
+#include "secure-string.hpp"
+
+namespace fss = flight_safety_system;
+
+TEST_CASE("secure_string: default construction yields empty string")
+{
+    fss::secure_string s;
+    REQUIRE(s.empty());
+    REQUIRE(s.size() == 0);
+}
+
+TEST_CASE("secure_string: construction from string_view")
+{
+    fss::secure_string s(std::string_view{"hello"});
+    REQUIRE(!s.empty());
+    REQUIRE(s.size() == 5);
+    REQUIRE(s == std::string_view{"hello"});
+}
+
+TEST_CASE("secure_string: copy constructor")
+{
+    fss::secure_string a(std::string_view{"secret"});
+    fss::secure_string b(a);
+    REQUIRE(b == std::string_view{"secret"});
+    REQUIRE(b.size() == a.size());
+}
+
+TEST_CASE("secure_string: move constructor leaves source empty")
+{
+    fss::secure_string a(std::string_view{"move-me"});
+    fss::secure_string b(std::move(a));
+    REQUIRE(b == std::string_view{"move-me"});
+    REQUIRE(a.empty());
+}
+
+TEST_CASE("secure_string: copy assignment")
+{
+    fss::secure_string a(std::string_view{"alpha"});
+    fss::secure_string b(std::string_view{"beta"});
+    b = a;
+    REQUIRE(b == std::string_view{"alpha"});
+}
+
+TEST_CASE("secure_string: move assignment leaves source empty")
+{
+    fss::secure_string a(std::string_view{"data"});
+    fss::secure_string b;
+    b = std::move(a);
+    REQUIRE(b == std::string_view{"data"});
+    REQUIRE(a.empty());
+}
+
+TEST_CASE("secure_string: assign(ptr, n) replaces content")
+{
+    fss::secure_string s(std::string_view{"old"});
+    constexpr std::string_view newval{"newvalue"};
+    s.assign(newval.data(), newval.size());
+    REQUIRE(s.size() == newval.size());
+    REQUIRE(s == newval);
+}
+
+TEST_CASE("secure_string: clear makes string empty")
+{
+    fss::secure_string s(std::string_view{"sensitive"});
+    REQUIRE(!s.empty());
+    s.clear();
+    REQUIRE(s.empty());
+    REQUIRE(s.size() == 0);
+}
+
+TEST_CASE("secure_string: operator== and operator!= between secure_strings")
+{
+    fss::secure_string a(std::string_view{"abc"});
+    fss::secure_string b(std::string_view{"abc"});
+    fss::secure_string c(std::string_view{"xyz"});
+    REQUIRE(a == b);
+    REQUIRE(!(a != b));
+    REQUIRE(a != c);
+    REQUIRE(!(a == c));
+}
+
+TEST_CASE("secure_string: operator== and operator!= against string_view")
+{
+    fss::secure_string s(std::string_view{"hello"});
+    REQUIRE(s == std::string_view{"hello"});
+    REQUIRE(!(s != std::string_view{"hello"}));
+    REQUIRE(s != std::string_view{"world"});
+    REQUIRE(!(s == std::string_view{"world"}));
+}
+
+TEST_CASE("secure_string: string_view comparison with different length is not equal")
+{
+    fss::secure_string s(std::string_view{"hi"});
+    REQUIRE(s != std::string_view{"hix"});
+    REQUIRE(s != std::string_view{"h"});
+}
+
+TEST_CASE("secure_string: data() returns pointer to content")
+{
+    fss::secure_string s(std::string_view{"test"});
+    REQUIRE(s.data() != nullptr);
+    REQUIRE(std::string_view(s.data(), s.size()) == "test");
+}

--- a/tests/server_clients_test.cpp
+++ b/tests/server_clients_test.cpp
@@ -1,0 +1,222 @@
+#ifdef HAVE_CATCH2_CATCH_ALL_HPP
+#include <catch2/catch_all.hpp>
+#elif HAVE_CATCH2_CATCH_HPP
+#include <catch2/catch.hpp>
+#elif HAVE_CATCH_CATCH_HPP
+#include <catch/catch.hpp>
+#elif HAVE_CATCH_HPP
+#include <catch.hpp>
+#else
+#error No catch header
+#endif
+
+#include <list>
+#include <memory>
+#include <string>
+
+#include "fss-transport.hpp"
+#include "fss-server.hpp"
+#include "fss.hpp"
+#include "db-write-queue.hpp"
+#include "mock_database.hpp"
+#include "server-clients.hpp"
+
+namespace fss = flight_safety_system;
+
+namespace {
+
+class FakeConnection : public fss::transport::fss_connection {
+public:
+    std::list<std::string> cert_names{};
+    bool revoked{false};
+
+    FakeConnection() = default;
+    FakeConnection(const FakeConnection &) = delete;
+    FakeConnection(FakeConnection &&) = delete;
+    auto operator=(const FakeConnection &) -> FakeConnection & = delete;
+    auto operator=(FakeConnection &&) -> FakeConnection & = delete;
+    ~FakeConnection() override = default;
+
+    auto getClientNames() -> std::list<std::string> override { return cert_names; }
+    auto isPeerCertRevoked(const std::string & /*crl_file*/) const -> bool override { return revoked; }
+
+protected:
+    auto sendMsg(const std::shared_ptr<fss::transport::buf_len> & /*bl*/) -> bool override { return true; }
+};
+
+struct FakeClock : public fss::IClock {
+    uint64_t t{0};
+    auto now_ms() const -> uint64_t override { return t; }
+    void advance(uint64_t ms) { t += ms; }
+};
+
+auto make_null_writer() -> std::shared_ptr<fss::server::db_write_queue>
+{
+    return std::make_shared<fss::server::db_write_queue>(
+        std::size_t{16},
+        [](const fss::server::db_write_task &) {}
+    );
+}
+
+/* Build a client that has completed the identity handshake as an aircraft. */
+auto make_aircraft_client(
+    const std::string &name,
+    fss_test::MockDatabase &mock,
+    server_clients &handler
+) -> std::shared_ptr<fss::server::fss_client>
+{
+    mock.asset_ids[name] = static_cast<uint64_t>(mock.asset_ids.size() + 1);
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back(name);
+    auto writer = make_null_writer();
+    auto client = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    client->processMessage(std::make_shared<fss::transport::fss_message_identity>(name));
+    return client;
+}
+
+} // namespace
+
+TEST_CASE("server_clients: clientConnected increments client count")
+{
+    server_clients sc;
+    fss_test::MockDatabase mock;
+    auto conn = std::make_shared<FakeConnection>();
+    auto writer = make_null_writer();
+    auto client = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &sc);
+    sc.clientConnected(client);
+    // No direct count accessor; verify cleanupRemovableClients runs without crash
+    sc.cleanupRemovableClients();
+}
+
+TEST_CASE("server_clients: clientDisconnected moves client to removable queue")
+{
+    server_clients sc;
+    fss_test::MockDatabase mock;
+    auto conn = std::make_shared<FakeConnection>();
+    auto writer = make_null_writer();
+    auto client = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &sc);
+    sc.clientConnected(client);
+    sc.clientDisconnected(client.get());
+    // After cleanup the disconnected queue should be empty (no crash or assertion)
+    sc.cleanupRemovableClients();
+    sc.cleanupRemovableClients(); // idempotent
+}
+
+TEST_CASE("server_clients: disconnecting unknown client is a no-op")
+{
+    server_clients sc;
+    fss_test::MockDatabase mock;
+    auto conn = std::make_shared<FakeConnection>();
+    auto writer = make_null_writer();
+    auto client = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &sc);
+    // Not registered — should not crash
+    sc.clientDisconnected(client.get());
+    sc.cleanupRemovableClients();
+}
+
+TEST_CASE("server_clients: broadcastMsg reaches aircraft clients only")
+{
+    server_clients sc;
+    fss_test::MockDatabase mock;
+
+    // Aircraft client
+    auto aircraft = make_aircraft_client("craft1", mock, sc);
+    sc.clientConnected(aircraft);
+
+    // Non-aircraft client (no identity sent → isAircraft() == false)
+    auto conn2 = std::make_shared<FakeConnection>();
+    auto writer2 = make_null_writer();
+    auto ground = std::make_shared<fss::server::fss_client>(conn2, &mock, writer2, &sc);
+    sc.clientConnected(ground);
+
+    // Broadcast should not crash and should only target aircraft
+    auto msg = std::make_shared<fss::transport::fss_message_rtt_request>();
+    sc.broadcastMsg(msg);
+}
+
+TEST_CASE("server_clients: broadcastMsg skips the 'except' client")
+{
+    server_clients sc;
+    fss_test::MockDatabase mock;
+
+    auto aircraft = make_aircraft_client("craft1", mock, sc);
+    sc.clientConnected(aircraft);
+
+    auto msg = std::make_shared<fss::transport::fss_message_rtt_request>();
+    // Passing aircraft as the 'except' client — should send to 0 clients (no crash)
+    sc.broadcastMsg(msg, aircraft.get());
+}
+
+TEST_CASE("server_clients: checkTimeouts disconnects timed-out client")
+{
+    server_clients sc;
+    sc.setClientTimeoutMs(1000);
+
+    fss_test::MockDatabase mock;
+    auto conn = std::make_shared<FakeConnection>();
+    auto writer = make_null_writer();
+    auto client = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &sc);
+
+    auto clock = std::make_shared<FakeClock>();
+    client->setClock(clock);
+    client->setTimeoutMs(1000);
+
+    sc.clientConnected(client);
+
+    // Advance time past the timeout threshold
+    clock->advance(2000);
+    sc.checkTimeouts();
+    sc.cleanupRemovableClients();
+}
+
+TEST_CASE("server_clients: checkTimeouts leaves non-timed-out clients connected")
+{
+    server_clients sc;
+    sc.setClientTimeoutMs(10000);
+
+    fss_test::MockDatabase mock;
+    auto conn = std::make_shared<FakeConnection>();
+    auto writer = make_null_writer();
+    auto client = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &sc);
+
+    auto clock = std::make_shared<FakeClock>();
+    client->setClock(clock);
+    client->setTimeoutMs(10000);
+    sc.clientConnected(client);
+
+    // Time has not advanced — no timeout
+    sc.checkTimeouts();
+    // No clients moved to disconnected, cleanupRemovableClients is a no-op
+    sc.cleanupRemovableClients();
+}
+
+TEST_CASE("server_clients: disconnectRevokedClients drops revoked connections")
+{
+    server_clients sc;
+    fss_test::MockDatabase mock;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->revoked = true;
+    auto writer = make_null_writer();
+    auto client = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &sc);
+    sc.clientConnected(client);
+
+    sc.disconnectRevokedClients("any.crl");
+    sc.cleanupRemovableClients();
+}
+
+TEST_CASE("server_clients: disconnectRevokedClients leaves non-revoked clients")
+{
+    server_clients sc;
+    fss_test::MockDatabase mock;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->revoked = false;
+    auto writer = make_null_writer();
+    auto client = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &sc);
+    sc.clientConnected(client);
+
+    sc.disconnectRevokedClients("any.crl");
+    // Client should remain connected — cleanupRemovableClients is a no-op
+    sc.cleanupRemovableClients();
+}


### PR DESCRIPTION
## Description

secure_string_test: ctor, copy/move, assign, clear, operator==/!= rate_limiter_test: token consumption, refill, capacity cap, zero refill, large elapsed time server_clients_test: connect/disconnect lifecycle, cleanupRemovableClients, broadcastMsg
  aircraft filter, checkTimeouts, disconnectRevokedClients

## Summary by Sourcery

Add unit test coverage for secure string handling, rate limiting behavior, and server client lifecycle and filtering logic.

Tests:
- Add tests for secure_string construction, assignment, clearing, and equality/inequality operations.
- Add tests for rate_limiter token consumption, refill timing, capacity capping, zero-refill behavior, and multi-token costs.
- Add tests for server_clients covering connect/disconnect lifecycle, broadcast targeting, timeout handling, and revocation-based disconnection.