### PR TITLE
fix: zero SMM credentials in memory before freeing (S4.2)

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -3,6 +3,7 @@
 
 extern "C" {
 #include "server-db.h"
+#include <string.h>
 }
 
 #include <cassert>
@@ -91,10 +92,12 @@ flight_safety_system::server::db_connection::getSmmSettings(uint64_t asset_id) -
         if (settings)
         {
             res = std::make_shared<smm_settings>(std::string(settings->address), flight_safety_system::secure_string(std::string_view(settings->username)), flight_safety_system::secure_string(std::string_view(settings->password)));
-            free (settings->address);
-            free (settings->username);
-            free (settings->password);
-            free (settings);
+            free(settings->address);
+            explicit_bzero(settings->username, strlen(settings->username));
+            free(settings->username);
+            explicit_bzero(settings->password, strlen(settings->password));
+            free(settings->password);
+            free(settings);
         }
     }
     return res;

--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -1,6 +1,7 @@
 #include "server-db.h"
 
 #include <stdlib.h>
+#include <string.h>
 
 #define COMMAND_LEN 7
 #define SMM_LOGIN_LEN 51
@@ -214,13 +215,17 @@ db_asset_smm_settings_get(unsigned long long asset_id_arg)
             if (settings->address == NULL || settings->username == NULL || settings->password == NULL)
             {
                 free(settings->address);
+                if (settings->username != NULL) explicit_bzero(settings->username, strlen(settings->username));
                 free(settings->username);
+                if (settings->password != NULL) explicit_bzero(settings->password, strlen(settings->password));
                 free(settings->password);
                 free(settings);
                 settings = NULL;
             }
         }
     }
+    explicit_bzero(smm_login, sizeof(smm_login));
+    explicit_bzero(smm_password, sizeof(smm_password));
     return settings;
 }
 


### PR DESCRIPTION
## Description

Stack-allocated ECPG buffers smm_login/smm_password were left uncleared after use, and strdup'd heap copies were freed without zeroing. Add explicit_bzero calls in db_asset_smm_settings_get (both the error path and before return) and in getSmmSettings before freeing the C strings.

## Summary by Sourcery

Bug Fixes:
- Zeroize stack- and heap-allocated SMM username and password buffers before freeing to prevent sensitive data from lingering in memory.