### PR TITLE
fix: reject oversized messages before allocation (C2.1)

### DIFF
--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -28,6 +28,11 @@ static constexpr uint16_t FSS_PROTOCOL_VERSION_LEGACY = 0;
 static constexpr uint16_t FSS_PROTOCOL_VERSION = 2;
 static constexpr uint16_t FSS_PROTOCOL_MIN_VERSION = 1;
 
+/* Maximum payload length accepted from the wire. Anything larger is rejected
+ * before allocation to prevent memory exhaustion attacks. Sized well above the
+ * largest legitimate message (server_list with many entries) with headroom. */
+static constexpr uint16_t FSS_MAX_MESSAGE_BYTES = 8192;
+
 class fss_connection;
 class fss_listen;
 class fss_message;

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -393,6 +393,12 @@ flight_safety_system::transport::fss_connection::recvMsg() -> std::shared_ptr<fl
     uint16_t data_length_n;
     memcpy(&data_length_n, header.data(), sizeof(uint16_t));
     uint16_t data_length = ntohs(data_length_n);
+    if (data_length > FSS_MAX_MESSAGE_BYTES)
+    {
+        FSS_LOG_ERROR("transport", "Message too large (" << data_length << " bytes), closing connection");
+        this->disconnect();
+        return std::make_shared<flight_safety_system::transport::fss_message_closed>();
+    }
     auto total_length = static_cast<ssize_t>(data_length);
     if (data_length % sizeof(uint64_t) != 0)
     {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -16,6 +16,7 @@ all_test_SOURCES = main.cpp messages.cpp connection.cpp client.cpp \
 	queue_test.cpp \
 	reconnect_test.cpp \
 	connection_negative_test.cpp \
+	oversized_message_test.cpp \
 	ssl_failure_test.cpp \
 	server_session_test.cpp \
 	async_db_write_test.cpp \

--- a/tests/oversized_message_test.cpp
+++ b/tests/oversized_message_test.cpp
@@ -1,0 +1,88 @@
+#ifdef HAVE_CATCH2_CATCH_ALL_HPP
+#include <catch2/catch_all.hpp>
+#elif HAVE_CATCH2_CATCH_HPP
+#include <catch2/catch.hpp>
+#elif HAVE_CATCH_CATCH_HPP
+#include <catch/catch.hpp>
+#elif HAVE_CATCH_HPP
+#include <catch.hpp>
+#else
+#error No catch header
+#endif
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <memory>
+
+#include "fss-transport.hpp"
+#include "test_helpers.hpp"
+
+using flight_safety_system::transport::fss_connection;
+using flight_safety_system::transport::fss_listen;
+using flight_safety_system::transport::fss_message;
+using flight_safety_system::transport::message_type_closed;
+
+namespace {
+
+std::shared_ptr<fss_connection> accepted_oversized;
+
+auto accept_oversized_cb(std::shared_ptr<fss_connection> new_conn) -> bool
+{
+    accepted_oversized = std::move(new_conn);
+    return true;
+}
+
+auto raw_connect_oversized(uint16_t port) -> int
+{
+    int s = ::socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
+    if (s < 0) { return -1; }
+    sockaddr_in6 addr{};
+    addr.sin6_family = AF_INET6;
+    addr.sin6_port = htons(port);
+    ::inet_pton(AF_INET6, "::1", &addr.sin6_addr);
+    if (::connect(s, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0)
+    {
+        ::close(s);
+        return -1;
+    }
+    return s;
+}
+
+} // namespace
+
+TEST_CASE("negative: oversized declared length closes connection")
+{
+    accepted_oversized = nullptr;
+    uint16_t port = fss_test::pick_port();
+    REQUIRE(port != 0);
+    auto listen = std::make_shared<fss_listen>(port, accept_oversized_cb);
+    REQUIRE(listen != nullptr);
+
+    int fd = raw_connect_oversized(port);
+    REQUIRE(fd >= 0);
+
+    REQUIRE(fss_test::wait_for([]() { return accepted_oversized != nullptr; }));
+
+    /* Declare 0xFFFF bytes — well over FSS_MAX_MESSAGE_BYTES. */
+    const uint8_t header[2] = {0xFF, 0xFF};
+    REQUIRE(::send(fd, header, sizeof(header), 0) == static_cast<ssize_t>(sizeof(header)));
+
+    std::shared_ptr<fss_message> msg;
+    REQUIRE(fss_test::wait_for([&]() {
+        msg = accepted_oversized->getMsg();
+        return msg != nullptr;
+    }));
+    REQUIRE(msg->getType() == message_type_closed);
+
+    /* Server must have closed its side; client recv returns 0. */
+    uint8_t buf[1];
+    ssize_t n = ::recv(fd, buf, sizeof(buf), 0);
+    REQUIRE(n == 0);
+
+    ::close(fd);
+    accepted_oversized = nullptr;
+}


### PR DESCRIPTION
## Description

Add FSS_MAX_MESSAGE_BYTES = 8192 to fss-transport.hpp and guard in recvMsg() that disconnects and returns fss_message_closed immediately when the wire-declared length exceeds the limit, preventing a memory-exhaustion DoS via back-to-back max-sized messages.

Add oversized_message_test.cpp verifying the server closes its side of the connection and delivers a closed sentinel to the caller.

## Summary by Sourcery

Enforce a maximum wire message size and close connections that declare larger payloads to prevent memory exhaustion attacks.

Bug Fixes:
- Reject messages with declared lengths exceeding a fixed upper bound before allocating buffers, returning a closed message sentinel instead.

Tests:
- Add an oversized message test that sends an over-limit declared length and verifies the server closes the connection and reports a closed message to the application.