### PR TITLE
fix: validate non-aircraft CN against aircraft DB

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -220,6 +220,10 @@ fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss_mess
 #endif
     if (msg->getType() == fss::transport::message_type_closed)
     {
+        if (this->identified && !this->aircraft)
+        {
+            FSS_LOG_INFO("server", "Non-aircraft client disconnected: " << this->getName());
+        }
         this->client_handler->clientDisconnected(this);
         return;
     }
@@ -324,11 +328,6 @@ fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss_mess
         }
         else if(msg->getType() == fss::transport::message_type_identity_non_aircraft)
         {
-            /* todo16: identify the non-aircraft client by its leaf cert CN.
-             * Without this check any holder of any cert valid against the
-             * CA could become a non-aircraft session anonymously, bypassing
-             * the per-asset identity contract aircraft connections enforce
-             * (todo15). */
             auto possible_names = this->getConnection()->getClientNames();
             if (possible_names.empty())
             {
@@ -336,12 +335,20 @@ fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss_mess
                 this->client_handler->clientDisconnected(this);
                 return;
             }
+            const auto &client_name = possible_names.front();
+            if (this->dbc->getAssetId(client_name) != 0)
+            {
+                FSS_LOG_ERROR("server", "Rejecting non-aircraft client: CN " << client_name << " belongs to a known aircraft");
+                this->client_handler->clientDisconnected(this);
+                return;
+            }
             {
                 std::scoped_lock guard(this->client_lock);
-                this->name = possible_names.front();
+                this->name = client_name;
             }
             this->aircraft = false;
             this->identified = true;
+            FSS_LOG_INFO("server", "Non-aircraft client identified: " << client_name);
         }
         else
         {

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -19,6 +19,7 @@
 #include "fss-server.hpp"
 #include "mock_database.hpp"
 #include "db-write-queue.hpp"
+#include "test_helpers.hpp"
 
 namespace fss = flight_safety_system;
 
@@ -139,10 +140,6 @@ TEST_CASE("session: rejects identify when no cert CN present")
 
 TEST_CASE("session: rejects non-aircraft identify when no cert CN present")
 {
-    /* todo16: a non-aircraft client with no cert CN must be rejected.
-     * Previously the non-aircraft branch accepted any cert valid against
-     * the CA without naming itself, bypassing the per-asset identity
-     * contract aircraft connections enforce (todo15). */
     fss_test::MockDatabase mock;
 
     auto conn = std::make_shared<FakeConnection>();
@@ -157,10 +154,44 @@ TEST_CASE("session: rejects non-aircraft identify when no cert CN present")
     REQUIRE_FALSE(session->isAircraft());
 }
 
-TEST_CASE("session: accepts non-aircraft identify when cert CN present")
+TEST_CASE("session: rejects non-aircraft identify when cert CN belongs to a known aircraft")
 {
-    /* todo16: with a leaf CN present, a non-aircraft identity is accepted
-     * and the connection is not torn down. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["aircraft-1"] = 42;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("aircraft-1");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity_non_aircraft>());
+
+    REQUIRE(handler.disconnects > 0);
+    REQUIRE_FALSE(session->isAircraft());
+}
+
+TEST_CASE("session: accepts non-aircraft identify when cert CN is not a known aircraft")
+{
+    fss_test::MockDatabase mock;
+    /* "ground-station-1" absent from asset_ids — not an aircraft */
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("ground-station-1");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    fss_test::capture_cerr cap;
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity_non_aircraft>());
+
+    REQUIRE(handler.disconnects == 0);
+    REQUIRE_FALSE(session->isAircraft());
+    REQUIRE(cap.str().find("Non-aircraft client identified: ground-station-1") != std::string::npos);
+}
+
+TEST_CASE("session: logs when an identified non-aircraft client disconnects")
+{
     fss_test::MockDatabase mock;
 
     auto conn = std::make_shared<FakeConnection>();
@@ -170,9 +201,12 @@ TEST_CASE("session: accepts non-aircraft identify when cert CN present")
     auto writer = make_mock_writer(mock);
     auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
     session->processMessage(std::make_shared<fss::transport::fss_message_identity_non_aircraft>());
-
     REQUIRE(handler.disconnects == 0);
-    REQUIRE_FALSE(session->isAircraft());
+
+    fss_test::capture_cerr cap;
+    session->processMessage(std::make_shared<fss::transport::fss_message_closed>());
+
+    REQUIRE(cap.str().find("Non-aircraft client disconnected: ground-station-1") != std::string::npos);
 }
 
 TEST_CASE("session: rejects identify when asset unknown to database")


### PR DESCRIPTION
## Description

add identify/disconnect logging

Reject a non-aircraft identity if the cert CN matches a known aircraft asset (getAssetId != 0), preventing an aircraft cert from being reused as a non-aircraft observer session. A missing cert CN was already rejected; this adds the role-confusion check.

Log at INFO level when a non-aircraft client successfully identifies and when it disconnects, making observer sessions visible in the server log.

Add tests: rejects aircraft CN, accepts non-aircraft CN (with log assertion), logs on disconnect.

## Summary by Sourcery

Validate non-aircraft client identities against known aircraft assets and add logging around non-aircraft identification and disconnect events.

Bug Fixes:
- Prevent reuse of an aircraft certificate CN for non-aircraft observer sessions by rejecting non-aircraft identities whose CN matches a known aircraft asset.

Enhancements:
- Log informational messages when a non-aircraft client successfully identifies and when it disconnects, making observer sessions visible in server logs.

Tests:
- Extend session tests to cover rejection of aircraft CNs for non-aircraft identities, acceptance and logging of valid non-aircraft CNs, and logging on non-aircraft client disconnect.