### PR TITLE
feat: log aircraft identify and client disconnect events

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -220,9 +220,9 @@ fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss_mess
 #endif
     if (msg->getType() == fss::transport::message_type_closed)
     {
-        if (this->identified && !this->aircraft)
+        if (this->identified)
         {
-            FSS_LOG_INFO("server", "Non-aircraft client disconnected: " << this->getName());
+            FSS_LOG_INFO("server", (this->aircraft ? "Aircraft" : "Non-aircraft") << " client disconnected: " << this->getName());
         }
         this->client_handler->clientDisconnected(this);
         return;
@@ -321,6 +321,7 @@ fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss_mess
                 }
                 this->aircraft = true;
                 this->identified = true;
+                FSS_LOG_INFO("server", "Aircraft client identified: " << this->getName());
                 this->sendCommand();
                 this->sendSMMSettings();
                 this->getConnection()->sendMsg(getServersListMsg(this->dbc));


### PR DESCRIPTION
## Description

Mirror the non-aircraft identify/disconnect logging for aircraft clients. Both roles now log at INFO on successful identity and on connection close, making it straightforward to trace client lifecycle in the server log.

## Summary by Sourcery

Log aircraft and non-aircraft client lifecycle events consistently when they identify and disconnect.

New Features:
- Add INFO-level logging when an aircraft client successfully identifies.
- Extend disconnect logging to include identified aircraft clients with role-specific labels.