### PR TITLE
feat: log received commands in fake_client, verify in e2e test (T1.1)

### DIFF
--- a/e2e/test_command_injection.py
+++ b/e2e/test_command_injection.py
@@ -9,10 +9,8 @@ import pytest
 @pytest.mark.requires_docker
 def test_goto_command_delivered(db_conn, fake_client):
     """Server polls assets_assetcommand and sends asset_command_goto to any
-    connected client. The fake client logs nothing distinctive on receipt, so
-    we assert via database side-effect that can only happen if the command was
-    dispatched: the server must keep talking to the client (no crash), and
-    subsequent position rows continue to arrive after the command is injected."""
+    connected client. Asserts the full path: DB row -> server -> wire ->
+    client parser -> handleCommand, verified by the RCVD_CMD log line."""
     with db_conn.cursor() as cur:
         cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
         asset_id = cur.fetchone()[0]
@@ -39,7 +37,16 @@ def test_goto_command_delivered(db_conn, fake_client):
         + client["log"].read_text(errors="replace")
     )
 
-    # And positions must keep flowing after the command landed.
+    log_content = client["log"].read_text(errors="replace")
+
+    # Verify the full delivery path: the client must have received, parsed,
+    # and handled the command (logged by the handleCommand override).
+    assert "RCVD_CMD: GOTO" in log_content, (
+        "fake-client did not log RCVD_CMD: GOTO — command may not have been "
+        "delivered or parsed correctly.\nClient log:\n" + log_content
+    )
+
+    # Positions must keep flowing after the command landed.
     with db_conn.cursor() as cur:
         cur.execute(
             "SELECT COUNT(*) FROM assets_assetposition WHERE asset_id = %s",

--- a/examples/fake_client.cpp
+++ b/examples/fake_client.cpp
@@ -1,8 +1,12 @@
 #include "fss-client-ssl.hpp"
 
 #include <csignal>
+#include <iostream>
+#include <string>
 
 #include <unistd.h>
+
+namespace fss = flight_safety_system;
 
 volatile sig_atomic_t running = 1;
 
@@ -10,6 +14,31 @@ void sigIntHandler(int signum __attribute__((unused)))
 {
     running = 0;
 }
+
+static auto commandName(fss::transport::fss_asset_command cmd) -> std::string
+{
+    switch (cmd)
+    {
+        case fss::transport::asset_command_rtl:       return "RTL";
+        case fss::transport::asset_command_hold:      return "HOLD";
+        case fss::transport::asset_command_goto:      return "GOTO";
+        case fss::transport::asset_command_resume:    return "RON";
+        case fss::transport::asset_command_terminate: return "TERM";
+        case fss::transport::asset_command_disarm:    return "DISARM";
+        case fss::transport::asset_command_altitude:  return "ALT";
+        case fss::transport::asset_command_manual:    return "MAN";
+        default:                                      return "UNKNOWN";
+    }
+}
+
+class logging_client : public fss::client_ssl::fss_client {
+public:
+    using fss::client_ssl::fss_client::fss_client;
+    void handleCommand(const std::shared_ptr<fss::transport::fss_message_asset_command> &msg) override
+    {
+        std::cout << "RCVD_CMD: " << commandName(msg->getCommand()) << std::endl;
+    }
+};
 
 auto
 main(int argc, char *argv[]) -> int
@@ -19,10 +48,9 @@ main(int argc, char *argv[]) -> int
         std::cout << "Insufficient arguments" << std::endl;
         return -1;
     }
-    /* Watch out for sigint */
-    signal (SIGINT, sigIntHandler);
+    signal(SIGINT, sigIntHandler);
 
-    auto client = std::make_shared<flight_safety_system::client_ssl::fss_client>(argv[1]);
+    auto client = std::make_shared<logging_client>(argv[1]);
 
     /* Connect to each server */
     /* Send reports:
@@ -39,25 +67,24 @@ main(int argc, char *argv[]) -> int
     /* Possible events:
        - Server reset
      */
-    
+
     constexpr int send_interval = 5;
     int counter = 0;
     while (running == 1)
     {
-        sleep (1);
+        sleep(1);
         client->attemptReconnect();
         counter++;
         if (counter % send_interval == 0)
         {
-            /* Send each server some fake details */
             constexpr int bat_remaining = 75;
             constexpr int bat_mah_used = 1000;
             constexpr double bat_voltage = 11.4;
-            auto msg_status = std::make_shared<flight_safety_system::transport::fss_message_system_status>(bat_remaining, bat_mah_used, bat_voltage);
+            auto msg_status = std::make_shared<fss::transport::fss_message_system_status>(bat_remaining, bat_mah_used, bat_voltage);
             constexpr int search_number = 1;
             constexpr int search_current_point = 23;
             constexpr int search_total_points = 100;
-            auto msg_search = std::make_shared<flight_safety_system::transport::fss_message_search_status>(search_number, search_current_point, search_total_points);
+            auto msg_search = std::make_shared<fss::transport::fss_message_search_status>(search_number, search_current_point, search_total_points);
             constexpr double lat = -43.5;
             constexpr double lng = 172.5;
             constexpr int alt = 300;
@@ -71,7 +98,7 @@ main(int argc, char *argv[]) -> int
             constexpr int flags = 1 | 2 | 4 | 8 | 16 | 32;
             constexpr int alt_type = 1;
             constexpr int emitter_type = 14;
-            auto msg_pos = std::make_shared<flight_safety_system::transport::fss_message_position_report>(lat, lng, alt, heading_cdeg, hor_vel, vert_vel, icao_address, callsign, squawk_code, time_since_last_contact, flags, alt_type, emitter_type, flight_safety_system::fss_current_timestamp());
+            auto msg_pos = std::make_shared<fss::transport::fss_message_position_report>(lat, lng, alt, heading_cdeg, hor_vel, vert_vel, icao_address, callsign, squawk_code, time_since_last_contact, flags, alt_type, emitter_type, fss::fss_current_timestamp());
             client->sendMsgAll(msg_status);
             client->sendMsgAll(msg_search);
             client->sendMsgAll(msg_pos);


### PR DESCRIPTION
## Description

Add logging_client subclass in fake_client.cpp that overrides handleCommand() to print "RCVD_CMD: <name>" to stdout on receipt of any asset command. This exercises the full client-library delivery path (wire decode -> fss_client::handleCommand virtual dispatch).

Update test_goto_command_delivered to assert "RCVD_CMD: GOTO" appears in the client log, verifying the complete path from DB row through server to client parser rather than only checking the server didn't crash and positions kept flowing.

## Summary by Sourcery

Log received asset commands in the fake client and extend the end-to-end command injection test to assert that the client logs receipt of a GOTO command, verifying the full delivery path from database to client handler.

New Features:
- Add a logging client variant that prints a standardized RCVD_CMD line for each received asset command in the fake client example.

Tests:
- Update the GOTO command end-to-end test to assert on the RCVD_CMD: GOTO log line, confirming the client received and handled the command while positions continue flowing.