### PR TITLE
fix: handle SIGTERM for graceful shutdown (systemd/docker stop)

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -51,6 +51,11 @@ main(int argc, char *argv[]) -> int
     sigemptyset(&sa_int.sa_mask);
     sa_int.sa_flags = 0;
     sigaction(SIGINT, &sa_int, nullptr);
+    struct sigaction sa_term = {};
+    sa_term.sa_handler = sigIntHandler;
+    sigemptyset(&sa_term.sa_mask);
+    sa_term.sa_flags = 0;
+    sigaction(SIGTERM, &sa_term, nullptr);
     struct sigaction sa_hup = {};
     sa_hup.sa_handler = sigHupHandler;
     sigemptyset(&sa_hup.sa_mask);


### PR DESCRIPTION
## Description

SIGTERM was not registered, so systemd and docker sent SIGTERM and the process was immediately killed with no clean shutdown — DB write queue abandoned, command poller thread not joined. Wire SIGTERM to the same sigIntHandler that SIGINT uses.

## Summary by Sourcery

Bug Fixes:
- Ensure SIGTERM triggers the same graceful shutdown path as SIGINT to avoid abrupt termination and incomplete cleanup.