### PR TITLE
ci: make e2e test job a hard gate

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -165,11 +165,10 @@ jobs:
         # Fail if any warnings were emitted
         ! grep -q "warning:" clang-tidy.log
 
-  # ─── 5. End-to-end tests (continue-on-error while flakes settle) ─────────
+  # ─── 5. End-to-end tests ─────────────────────────────────────────────────
   e2e:
     runs-on: ubuntu-latest
     needs: build-and-check
-    continue-on-error: true
 
     services:
       postgres:


### PR DESCRIPTION
## Description

The e2e job ran with continue-on-error: true, meaning a server regression could merge to develop undetected. Remove the flag so a failing e2e suite blocks the PR.

## Summary by Sourcery

CI:
- Remove continue-on-error from the e2e GitHub Actions job so failures block merges.