### PR TITLE
fix: reject asset_command_unknown at construction and before dispatch

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -47,6 +47,8 @@ fss::server::asset_command::asset_command(uint64_t t_dbid, uint64_t t_timestamp,
         this->command = transport::asset_command_terminate;
     } else if (t_cmd == "MAN") {
         this->command = transport::asset_command_manual;
+    } else {
+        FSS_LOG_ERROR("server", "Unrecognised command string from DB: '" << t_cmd << "' (dbid=" << t_dbid << ")");
     }
 }
 
@@ -103,8 +105,13 @@ fss::server::fss_client::sendCommand()
     {
         this->last_command_send_ts = ts;
         this->last_command_dbid = ac->getDBId();
-        std::shared_ptr<fss::transport::fss_message_asset_command> msg = nullptr;
         auto command = ac->getCommand();
+        if (command == fss::transport::asset_command_unknown)
+        {
+            FSS_LOG_ERROR("server", "Refusing to dispatch unknown command type to " << this->name << " (dbid=" << ac->getDBId() << ")");
+            return;
+        }
+        std::shared_ptr<fss::transport::fss_message_asset_command> msg = nullptr;
         switch (command)
         {
             case fss::transport::asset_command_goto:


### PR DESCRIPTION
## Description

An unrecognised DB command string (e.g. from truncation at COMMAND_LEN=7 or a future command not yet in this build) left asset_command.command as asset_command_unknown. The default switch arm in sendCommand then forwarded that type to the aircraft with only an INFO log.

Log an ERROR at construction when the DB string is unrecognised, and add an explicit guard in sendCommand to refuse dispatch of unknown commands.

## Summary by Sourcery

Bug Fixes:
- Fix handling of unrecognised DB command strings so they are logged as errors and never dispatched as asset commands.