### PR TITLE
fix: validate all required JSON config fields before use

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -71,7 +71,7 @@ main(int argc, char *argv[]) -> int
     if (!configfile.is_open())
     {
         FSS_LOG_ERROR("server", "Failed to load configuration: " << conf_file);
-        exit(-1);
+        return 1;
     }
     Json::Value config;
     configfile >> config;
@@ -79,6 +79,28 @@ main(int argc, char *argv[]) -> int
     if (config.isMember("log_level"))
     {
         flight_safety_system::log::set_level(config["log_level"].asString());
+    }
+
+    auto cfg_require = [&](const char *path, const Json::Value &node, const char *key) -> bool {
+        if (!node.isMember(key) || node[key].asString().empty())
+        {
+            FSS_LOG_ERROR("server", "Missing required config field: " << path << "." << key);
+            return false;
+        }
+        return true;
+    };
+    bool cfg_ok = true;
+    if (!config.isMember("port")) { FSS_LOG_ERROR("server", "Missing required config field: port"); cfg_ok = false; }
+    cfg_ok &= cfg_require("postgres", config["postgres"], "host");
+    cfg_ok &= cfg_require("postgres", config["postgres"], "user");
+    cfg_ok &= cfg_require("postgres", config["postgres"], "pass");
+    cfg_ok &= cfg_require("postgres", config["postgres"], "db");
+    cfg_ok &= cfg_require("ssl", config["ssl"], "ca_public_key");
+    cfg_ok &= cfg_require("ssl", config["ssl"], "server_private_key");
+    cfg_ok &= cfg_require("ssl", config["ssl"], "server_public_key");
+    if (!cfg_ok)
+    {
+        return 1;
     }
 
     auto dbc = std::make_shared<flight_safety_system::server::db_connection>(config["postgres"]["host"].asString(), config["postgres"]["user"].asString(), config["postgres"]["pass"].asString(), config["postgres"]["db"].asString());
@@ -127,11 +149,6 @@ main(int argc, char *argv[]) -> int
     std::string ca_public_key = config["ssl"]["ca_public_key"].asString();
     std::string server_private_key = config["ssl"]["server_private_key"].asString();
     std::string server_public_key = config["ssl"]["server_public_key"].asString();
-    if (ca_public_key == "" || server_private_key == "" || server_public_key == "")
-    {
-        FSS_LOG_ERROR("server", "Missing ssl parameter, all of these are required: 'ca_public_key', 'server_private_key', 'server_public_key'");
-        exit(-1);
-    }
     std::string crl_file = config["ssl"].isMember("crl_file") ? config["ssl"]["crl_file"].asString() : std::string{};
     if (!crl_file.empty())
     {


### PR DESCRIPTION
## Description

Required fields (port, postgres.{host,user,pass,db}, ssl.{ca_public_key,server_private_key,server_public_key}) were accessed directly via operator[] without isMember() checks; a missing or empty key would throw a jsoncpp exception with no useful diagnostic.

Add an upfront validation pass that names every missing field before returning 1. Also convert the remaining exit(-1) for a missing config file to return 1 so all early exits are consistent.

## Summary by Sourcery

Validate required JSON configuration fields on startup and standardize error exits when configuration is missing or incomplete.

Bug Fixes:
- Prevent crashes from accessing missing JSON configuration fields by performing upfront presence and non-empty checks for required keys.
- Ensure consistent non-zero return code (1) when the configuration file is missing or required configuration data is invalid.