### PR TITLE
fix: reconnect to PostgreSQL when connection is lost after startup

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -1,5 +1,6 @@
 #include "fss-server.hpp"
 #include "fss.hpp"
+#include "fss-log.hpp"
 
 extern "C" {
 #include "server-db.h"
@@ -13,15 +14,38 @@ extern "C" {
 #include <string_view>
 #include <vector>
 
-flight_safety_system::server::db_connection::db_connection(const std::string &host, const std::string &user, const std::string &pass, const std::string &db) : db_lock()
+flight_safety_system::server::db_connection::db_connection(std::string host, std::string user, std::string pass, std::string db) // NOLINT(bugprone-easily-swappable-parameters)
+    : db_lock(), host_(std::move(host)), user_(std::move(user)), pass_(std::move(pass)), db_(std::move(db))
 {
-    connected_ = (db_connect(host.c_str(), user.c_str(), pass.c_str(), db.c_str()) == 1);
+    connected_ = (db_connect(host_.c_str(), user_.c_str(), pass_.c_str(), db_.c_str()) == 1);
 }
 
 auto
 flight_safety_system::server::db_connection::isConnected() const -> bool
 {
     return connected_;
+}
+
+void
+flight_safety_system::server::db_connection::tryReconnectIfNeeded()
+{
+    std::scoped_lock guard(this->db_lock);
+    if (db_ping() != 0)
+    {
+        connected_ = true;
+        return;
+    }
+    FSS_LOG_WARN("db", "Database connection lost, attempting reconnect");
+    db_disconnect();
+    connected_ = (db_connect(host_.c_str(), user_.c_str(), pass_.c_str(), db_.c_str()) == 1);
+    if (connected_)
+    {
+        FSS_LOG_INFO("db", "Database reconnected successfully");
+    }
+    else
+    {
+        FSS_LOG_ERROR("db", "Database reconnect failed");
+    }
 }
 
 flight_safety_system::server::db_connection::~db_connection()

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -78,14 +78,19 @@ public:
     virtual auto getActiveServers() -> std::vector<fss_server_details> = 0;
     virtual auto getSmmSettings(uint64_t asset_id) -> std::shared_ptr<smm_settings> = 0;
     virtual auto isConnected() const -> bool = 0;
+    virtual void tryReconnectIfNeeded() = 0;
 };
 
 class db_connection: public IDatabase {
 private:
     std::mutex db_lock;
     bool connected_{false};
+    std::string host_;
+    std::string user_;
+    std::string pass_;
+    std::string db_;
 public:
-    db_connection(const std::string &host, const std::string &user, const std::string &pass, const std::string &db);
+    db_connection(std::string host, std::string user, std::string pass, std::string db);
     db_connection(db_connection&) = delete;
     db_connection(db_connection&&) = delete;
     auto operator=(db_connection&) -> db_connection& = delete;
@@ -100,6 +105,7 @@ public:
     auto getActiveServers() -> std::vector<fss_server_details> override;
     auto getSmmSettings(uint64_t asset_id) -> std::shared_ptr<smm_settings> override;
     auto isConnected() const -> bool override;
+    void tryReconnectIfNeeded() override;
 };
 
 class fss_client_rtt {

--- a/src/server-db.h
+++ b/src/server-db.h
@@ -1,5 +1,6 @@
 int db_connect(const char *host, const char *user, const char *pass, const char *db);
 void db_disconnect(void);
+int db_ping(void);
 
 unsigned long long db_get_asset_id(const char *asset_name);
 void db_rtt_create_entry(unsigned long long asset_id, unsigned long long delta);

--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -300,6 +300,15 @@ void db_disconnect(void)
     EXEC SQL DISCONNECT ALL;
 }
 
+int db_ping(void)
+{
+    EXEC SQL BEGIN DECLARE SECTION;
+    int x = 0;
+    EXEC SQL END DECLARE SECTION;
+    EXEC SQL SELECT 1 INTO :x;
+    return (sqlca.sqlcode >= 0) ? 1 : 0;
+}
+
 void db_free_fss_servers(struct fss_server_s **servers)
 {
     free(servers);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -222,6 +222,7 @@ main(int argc, char *argv[]) -> int
                 FSS_LOG_ERROR("server", "DB write failures since start: " << current_failures);
                 last_failure_count = current_failures;
             }
+            dbc->tryReconnectIfNeeded();
         }
         if ((tick_counter % send_config_period_ticks) == 0)
         {

--- a/tests/mock_database.hpp
+++ b/tests/mock_database.hpp
@@ -91,6 +91,7 @@ public:
     }
 
     auto isConnected() const -> bool override { return true; }
+    void tryReconnectIfNeeded() override {}
 
     void pushCommand(uint64_t asset_id, std::shared_ptr<flight_safety_system::server::asset_command> cmd)
     {


### PR DESCRIPTION
## Description

If PostgreSQL became unavailable after the server started, all command polls silently returned nullptr and write-queue failures accumulated, but no reconnect was attempted. Aircraft would not receive updated commands until the server was restarted.

Add db_ping() (SELECT 1) to the ECPG layer, store connection credentials in db_connection, and implement tryReconnectIfNeeded() which pings then disconnects/reconnects on failure. The server main loop calls it once per second alongside the existing write-failure check.

MockDatabase gains a no-op tryReconnectIfNeeded() to satisfy IDatabase.

## Summary by Sourcery

Ensure the server detects and attempts to recover from lost PostgreSQL connections during runtime.

Bug Fixes:
- Restore command handling by reconnecting to PostgreSQL when the database becomes unavailable after server startup instead of silently failing queries.

Enhancements:
- Add a periodic database health check and reconnect logic to the database connection layer, with logging of reconnect attempts and outcomes.
- Extend the IDatabase interface and concrete implementations to support conditional database reconnection without impacting existing tests.