### PR TITLE
refactor: replace todo0x comment labels with plain prose

### DIFF
--- a/e2e/test_command_latency.py
+++ b/e2e/test_command_latency.py
@@ -1,8 +1,7 @@
-"""todo09: the server polls for new commands every 100ms, so an injected row
-must reach the aircraft session in well under a second. This test inserts a
-TERM row and asserts the server's "dispatched command" log line appears in
-under 1 second — the pre-todo09 loop would have taken up to 1000ms plus the
-per-iteration body before sending."""
+"""The server polls for new commands every 100ms, so an injected row must
+reach the aircraft session in well under a second. This test inserts a TERM
+row and asserts the server's "dispatched command" log line appears in under
+1 second."""
 from __future__ import annotations
 
 import re

--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -318,7 +318,7 @@ flight_safety_system::client_ssl::fss_server::reconnect() -> bool
         else
         {
             this->getConnection()->setHandler(this);
-            /* todo02: protocol version handshake must be the first message
+            /* Protocol version handshake must be the first message
              * exchanged after TLS connect, before identity. */
             this->sendVersion();
             this->sendIdentify();

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -281,9 +281,9 @@ fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss_mess
     }
     if (!this->identified)
     {
-        /* todo02: legacy clients (pre-version-handshake) send identity
-         * directly. Log once so the legacy connection is visible, then
-         * fall through with negotiated_version = LEGACY (0). */
+        /* Legacy clients (pre-version-handshake) send identity directly.
+         * Log once so the connection is visible, then fall through with
+         * negotiated_version = LEGACY (0). */
         if (!this->version_received)
         {
             FSS_LOG_WARN("server", "Legacy client: no protocol version handshake (assuming version 0)");

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -17,7 +17,7 @@ namespace transport {
 
 static constexpr double FSS_COORD_SCALE = 0.0000001;
 
-/* Wire-protocol version handshake (todo02).
+/* Wire-protocol version handshake.
  * - FSS_PROTOCOL_VERSION_LEGACY (0): unversioned protocol that pre-dates the
  *   handshake. Used as the negotiated value when the peer never sends a
  *   version message (e.g. an old client still in the field).
@@ -66,8 +66,8 @@ using fss_message_type = enum fss_message_type_e {
     /* Please send identity */
     message_type_identity_required,
 
-    /* Protocol version handshake (todo02). Sent first by both peers after
-     * TLS handshake; the negotiated version is min(peer max, our max). */
+    /* Protocol version handshake. Sent first by both peers after the TLS
+     * handshake; the negotiated version is min(peer max, our max). */
     message_type_version,
 };
 

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -93,7 +93,7 @@ public:
 
 TEST_CASE("session: rejects identify when claimed name does not match cert CN")
 {
-    /* todo15: identity name must match a CN from the peer certificate.
+    /* Identity name must match a CN from the peer certificate.
      * A client presenting cert CN=craft must not be allowed to claim
      * identity "imposter" — that would let any holder of any valid
      * client cert masquerade as any aircraft. */
@@ -120,10 +120,10 @@ TEST_CASE("session: rejects identify when claimed name does not match cert CN")
 
 TEST_CASE("session: rejects identify when no cert CN present")
 {
-    /* todo15: getClientNames() returns empty when the peer presented no
-     * cert (or the leaf had no CN). The server must refuse to identify
-     * such a connection rather than treating absence of a CN as
-     * permission to claim any name. */
+    /* getClientNames() returns empty when the peer presented no cert (or
+     * the leaf had no CN). The server must refuse to identify such a
+     * connection rather than treating absence of a CN as permission to
+     * claim any name. */
     fss_test::MockDatabase mock;
     mock.asset_ids["craft"] = 1;
 
@@ -293,11 +293,11 @@ TEST_CASE("session: server list sent on identify contains seeded servers")
 
 TEST_CASE("session: rapid sendCommand does not duplicate a single pending command")
 {
-    /* todo09: the main loop now calls sendCommand every 100ms to drop
-     * command delivery latency. That is only safe if repeated calls with
-     * the same pending row do not resend the message. Verify idempotency
-     * by driving sendCommand for 2s worth of ticks against one
-     * queued command and counting command messages on the wire. */
+    /* sendCommand is called every 100ms to minimise command delivery
+     * latency. That is only safe if repeated calls with the same pending
+     * row do not resend the message. Verify idempotency by driving
+     * sendCommand for 2s worth of ticks against one queued command and
+     * counting command messages on the wire. */
     fss_test::MockDatabase mock;
     constexpr uint64_t asset_id = 7;
     mock.asset_ids["craft"] = asset_id;
@@ -384,9 +384,9 @@ TEST_CASE("session: RTT timeout disconnects client")
 
 TEST_CASE("session: version handshake stores negotiated version and replies")
 {
-    /* todo02: version exchange — when the client opens with a version
-     * message, the server records the negotiated version on the
-     * connection and replies with its own version. */
+    /* Version exchange: when the client opens with a version message,
+     * the server records the negotiated version on the connection and
+     * replies with its own version. */
     fss_test::MockDatabase mock;
     mock.asset_ids["craft"] = 1;
 
@@ -418,9 +418,8 @@ TEST_CASE("session: version handshake stores negotiated version and replies")
 
 TEST_CASE("session: version handshake rejects incompatible peer")
 {
-    /* todo02: when the client's max version is below our minimum, the
-     * server disconnects rather than continuing in an unsupported
-     * dialect. */
+    /* When the client's max version is below our minimum, the server
+     * disconnects rather than continuing in an unsupported dialect. */
     fss_test::MockDatabase mock;
     mock.asset_ids["craft"] = 1;
 
@@ -500,8 +499,8 @@ TEST_CASE("rate limiter: refill allows messages after bucket drains")
 
 TEST_CASE("session: legacy client (no version handshake) is accepted")
 {
-    /* todo02: pre-versioning clients send identity directly. The server
-     * must accept this and treat the connection as legacy (version 0). */
+    /* Pre-versioning clients send identity directly. The server must
+     * accept this and treat the connection as legacy (version 0). */
     fss_test::MockDatabase mock;
     mock.asset_ids["craft"] = 1;
 


### PR DESCRIPTION
## Description

Comments referencing internal tracking numbers (todo02, todo09, todo15) are meaningless to future readers. Replace each with a direct description of the invariant or reason the code exists.

## Summary by Sourcery

Replace internal todoXX tags in comments with clear, self-contained prose explaining protocol invariants and behaviors in session, transport, and SSL code and tests.

Enhancements:
- Clarify session-related test comments to describe identity, certificate CN, and command idempotency behavior without referencing internal todo labels.
- Improve protocol version handshake documentation in transport, client session, and client SSL comments to describe legacy handling and handshake ordering explicitly.