### PR TITLE
fix: replace assert() with logged error/return in recordPosition

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -7,7 +7,6 @@ extern "C" {
 #include <string.h>
 }
 
-#include <cassert>
 #include <limits>
 #include <mutex>
 #include <string>
@@ -85,7 +84,11 @@ void
 flight_safety_system::server::db_connection::recordPosition(uint64_t asset_id, double latitude, double longitude, uint32_t altitude)
 {
     std::scoped_lock guard(this->db_lock);
-    assert(altitude <= static_cast<uint32_t>(std::numeric_limits<int>::max()));
+    if (altitude > static_cast<uint32_t>(std::numeric_limits<int>::max()))
+    {
+        FSS_LOG_ERROR("db", "Altitude " << altitude << " exceeds int range; discarding position record for asset " << asset_id);
+        return;
+    }
     db_position_create_entry(asset_id, latitude, longitude, static_cast<int>(altitude));
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -184,7 +184,7 @@ main(int argc, char *argv[]) -> int
     constexpr int ticks_per_sec = 1000 / command_poll_ms;
     constexpr int send_config_period_ticks = 15 * ticks_per_sec;
     std::atomic<bool> poll_running{true};
-    std::thread command_poller([&clients, &dbc, &poll_running, command_poll_ms]() {
+    std::thread command_poller([&clients, &dbc, &poll_running, command_poll_ms]() -> void {
         while (poll_running.load())
         {
             clients->pollCommands(dbc.get());


### PR DESCRIPTION
## Description

assert(altitude <= INT_MAX) was compiled away in release builds (-DNDEBUG), giving inconsistent behavior between debug and release. If an out-of-range altitude arrived it would silently proceed with an undefined cast in release, or abort the server in debug.

Replace with an explicit bounds check, an FSS_LOG_ERROR, and an early return so the record is dropped instead of corrupted or crashing.

Also apply clang-tidy cleanups to the db_connection constructor (pass-by- value + move, NOLINT for swappable-params) and add -> void to the command_poller lambda to keep check-code.sh clean.

## Summary by Sourcery

Replace an altitude range assertion in position recording with a logged error and safe early return, and apply minor code cleanups to keep static analysis tooling quiet.

Bug Fixes:
- Prevent out-of-range altitude values from causing undefined behavior or debug-only assertions by validating the altitude and dropping invalid position records.

Enhancements:
- Log an explicit error when an altitude exceeds the supported integer range instead of relying on assertions.
- Adjust the server command poller lambda signature to satisfy static analysis and style checks by explicitly specifying a void return type.