### PR TITLE
fix: use jq to build server.json so env vars are JSON-safe

### DIFF
--- a/docker/fss-server.Dockerfile
+++ b/docker/fss-server.Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bookworm
 
 RUN apt update && apt upgrade -y
 RUN apt install -y build-essential automake libtool pkg-config
-RUN apt install -y libjsoncpp-dev libgnutlsxx30 libgnutls28-dev libecpg-dev gnutls-bin
+RUN apt install -y libjsoncpp-dev libgnutlsxx30 libgnutls28-dev libecpg-dev gnutls-bin jq
 
 COPY . /code/
 

--- a/docker/start-server.sh
+++ b/docker/start-server.sh
@@ -2,20 +2,17 @@
 
 CONFIG_FILE=/etc/fss/server.json
 
-echo "{" > ${CONFIG_FILE}
-echo "\"port\": ${LISTEN_PORT}," >> ${CONFIG_FILE}
-echo "\"ssl\": {" >> ${CONFIG_FILE}
-echo "\"ca_public_key\": \"/certs/ca.public.pem\"," >> ${CONFIG_FILE}
-echo "\"server_private_key\": \"/certs/${NAME}.private.pem\"," >> ${CONFIG_FILE}
-echo "\"server_public_key\": \"/certs/${NAME}.public.pem\"" >> ${CONFIG_FILE}
-echo "}," >>  ${CONFIG_FILE}
-echo "\"postgres\": {" >> ${CONFIG_FILE}
-echo "\"host\": \"${DB_HOST}\"," >> ${CONFIG_FILE}
-echo "\"user\": \"${DB_USER}\"," >> ${CONFIG_FILE}
-echo "\"db\": \"${DB_NAME}\"," >> ${CONFIG_FILE}
-echo "\"pass\": \"${DB_PASS}\"" >> ${CONFIG_FILE}
-echo "}" >> ${CONFIG_FILE}
-echo "}" >> ${CONFIG_FILE}
+jq -n \
+    --arg port "${LISTEN_PORT}" \
+    --arg ca "/certs/ca.public.pem" \
+    --arg priv "/certs/${NAME}.private.pem" \
+    --arg pub "/certs/${NAME}.public.pem" \
+    --arg host "${DB_HOST}" \
+    --arg user "${DB_USER}" \
+    --arg db "${DB_NAME}" \
+    --arg pass "${DB_PASS}" \
+    '{port: ($port|tonumber), ssl: {ca_public_key: $ca, server_private_key: $priv, server_public_key: $pub}, postgres: {host: $host, user: $user, db: $db, pass: $pass}}' \
+    > "${CONFIG_FILE}"
 
 cat /etc/fss/server.json
 


### PR DESCRIPTION
## Description

Raw echo interpolation silently produced invalid JSON if DB_PASS (or any other env var) contained a double-quote or backslash.  Replace the manual echo chain with a single jq -n call that passes each value via --arg, which handles all JSON escaping automatically.  Add jq to the Dockerfile apt-install list.

## Summary by Sourcery

Generate server configuration JSON using jq for safe env var interpolation and ensure jq is available in the server Docker image.

Bug Fixes:
- Prevent invalid server.json generation when environment variables contain characters that require JSON escaping.

Enhancements:
- Simplify server.json construction by replacing manual echo-based JSON assembly with a single jq invocation.

Build:
- Add jq to the fss-server Docker image dependencies.