### PR TITLE
fix: use snapshot in sendRTTRequest to avoid deadlock

### DIFF
--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -108,8 +108,12 @@ public:
     };
     void sendRTTRequest(const std::shared_ptr<flight_safety_system::transport::fss_message_rtt_request> &rtt_req)
     {
-        std::scoped_lock guard(this->lock);
-        for(const auto &client: this->clients)
+        std::vector<std::shared_ptr<flight_safety_system::server::fss_client>> snapshot;
+        {
+            std::scoped_lock guard(this->lock);
+            std::copy(this->clients.begin(), this->clients.end(), std::back_inserter(snapshot));
+        }
+        for (const auto &client : snapshot)
         {
             client->sendRTTRequest(rtt_req);
         }


### PR DESCRIPTION
## Description

server_clients::sendRTTRequest() held server_clients::lock while iterating, then called fss_client::sendRTTRequest().  When that client detected an RTT timeout (oldest outstanding request > 30 s), it called clientDisconnected() — which also tries to acquire server_clients::lock. The result was a deadlock.

The window is narrow but real: checkTimeouts() uses a different time reference (last_rtt_response_time) than sendRTTRequest's internal check (oldest request timestamp), so the two conditions can disagree for one tick, causing sendRTTRequest to fire the disconnect path while the lock is still held.

Fix: apply the same snapshot pattern already used by checkTimeouts() — take the client list under the lock, release the lock, then iterate. clientDisconnected() can now safely acquire the lock from within the callback.

## Summary by Sourcery

Bug Fixes:
- Prevent a deadlock between sendRTTRequest and clientDisconnected by releasing the server_clients lock before invoking client callbacks.