### PR TITLE
refactor: drop unused <iostream> include from fss.hpp

### DIFF
--- a/src/fss.hpp
+++ b/src/fss.hpp
@@ -8,8 +8,6 @@
 #include <thread>
 #include <mutex>
 
-#include <iostream>
-
 #include <sys/socket.h>
 #include <netinet/in.h>
 


### PR DESCRIPTION
## Description

fss.hpp declares IClock, WallClock, and fss_current_timestamp() — no stream usage. Every TU that includes fss.hpp was paying the <iostream> static-init cost for nothing.

## Summary by Sourcery

Enhancements:
- Clean up fss.hpp header dependencies by dropping an unused iostream include.