### PR TITLE
test: make global log-level changes hermetic

### DIFF
--- a/tests/async_db_write_test.cpp
+++ b/tests/async_db_write_test.cpp
@@ -19,7 +19,6 @@
 #include <vector>
 
 #include "db-write-queue.hpp"
-#include "fss-log.hpp"
 #include "test_helpers.hpp"
 
 namespace fss = flight_safety_system;
@@ -196,8 +195,8 @@ TEST_CASE("db_write_queue: drop log message appears on stderr when queue fills")
     auto cap = std::make_shared<CapturingSink>();
     cap->delay = std::chrono::milliseconds(50);
 
-    /* Earlier tests may have left level at ERROR; ensure WARN is visible. */
-    flight_safety_system::log::set_level("warn");
+    /* The drop notice is logged at WARN. */
+    fss_test::scoped_log_level guard("warn");
     fss_test::capture_cerr cerr_capture;
 
     {
@@ -214,7 +213,6 @@ TEST_CASE("db_write_queue: drop log message appears on stderr when queue fills")
     auto out = cerr_capture.str();
     REQUIRE(out.find("db-writer") != std::string::npos);
     REQUIRE(out.find("dropped") != std::string::npos);
-    flight_safety_system::log::set_level("info");
 }
 
 TEST_CASE("db_write_queue: write_failure_count tracks sink exceptions")

--- a/tests/log_test.cpp
+++ b/tests/log_test.cpp
@@ -23,7 +23,7 @@ TEST_CASE("log: level filter suppresses lower-severity lines")
 {
     fss_test::capture_cerr cap;
 
-    flight_safety_system::log::set_level("error");
+    fss_test::scoped_log_level guard("error");
     FSS_LOG_ERROR("t", "err-visible");
     FSS_LOG_WARN("t", "warn-hidden");
     FSS_LOG_INFO("t", "info-hidden");
@@ -40,7 +40,7 @@ TEST_CASE("log: debug level lets every severity through")
 {
     fss_test::capture_cerr cap;
 
-    flight_safety_system::log::set_level("debug");
+    fss_test::scoped_log_level guard("debug");
     FSS_LOG_ERROR("t", "e");
     FSS_LOG_WARN("t", "w");
     FSS_LOG_INFO("t", "i");
@@ -51,15 +51,12 @@ TEST_CASE("log: debug level lets every severity through")
     REQUIRE(out.find("[WARN ]") != std::string::npos);
     REQUIRE(out.find("[INFO ]") != std::string::npos);
     REQUIRE(out.find("[DEBUG]") != std::string::npos);
-
-    /* Restore default so later tests are unaffected. */
-    flight_safety_system::log::set_level("info");
 }
 
 TEST_CASE("log: FSS_PERROR appends strerror")
 {
     fss_test::capture_cerr cap;
-    flight_safety_system::log::set_level("error");
+    fss_test::scoped_log_level guard("error");
 
     errno = EACCES;
     FSS_PERROR("t", "open config");
@@ -67,14 +64,12 @@ TEST_CASE("log: FSS_PERROR appends strerror")
     auto out = cap.str();
     REQUIRE(out.find("open config") != std::string::npos);
     REQUIRE(out.find("Permission denied") != std::string::npos);
-
-    flight_safety_system::log::set_level("info");
 }
 
 TEST_CASE("log: emitted lines match expected format")
 {
     fss_test::capture_cerr cap;
-    flight_safety_system::log::set_level("info");
+    fss_test::scoped_log_level guard("info");
 
     FSS_LOG_INFO("component-name", "hello world");
 
@@ -86,7 +81,7 @@ TEST_CASE("log: emitted lines match expected format")
 TEST_CASE("log: concurrent writers produce no interleaved lines")
 {
     fss_test::capture_cerr cap;
-    flight_safety_system::log::set_level("info");
+    fss_test::scoped_log_level guard("info");
 
     constexpr int thread_count = 8;
     constexpr int lines_per_thread = 1000;

--- a/tests/test_helpers.hpp
+++ b/tests/test_helpers.hpp
@@ -17,6 +17,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "fss-log.hpp"
 #include "fss-transport.hpp"
 
 namespace fss_test {
@@ -85,6 +86,24 @@ public:
         sink.str("");
         sink.clear();
     }
+};
+
+/* RAII guard for the global log level. Saves the level on construction and
+ * restores it on destruction, so a test that changes the level cannot leak
+ * that change into later tests — even if a REQUIRE fails mid-test. */
+class scoped_log_level {
+private:
+    flight_safety_system::log::level saved;
+public:
+    explicit scoped_log_level(const std::string &lvl) : saved(flight_safety_system::log::detail::current_level().load())
+    {
+        flight_safety_system::log::set_level(lvl);
+    }
+    scoped_log_level(const scoped_log_level &) = delete;
+    scoped_log_level(scoped_log_level &&) = delete;
+    auto operator=(const scoped_log_level &) -> scoped_log_level & = delete;
+    auto operator=(scoped_log_level &&) -> scoped_log_level & = delete;
+    ~scoped_log_level() { flight_safety_system::log::detail::current_level().store(saved); }
 };
 
 /* Build a buf_len with a valid header (length/type/id) but a caller-specified


### PR DESCRIPTION
## Description

log::set_level() mutates global state. Several tests changed the level and relied on a later test changing it back; log_test.cpp's first case set it to "error" and never restored it. Under make distcheck the object link order differs, the execution order shifts, and the leaked level made an INFO-log assertion in server_session_test.cpp fail.

Add a scoped_log_level RAII guard to test_helpers.hpp that restores the previous level on destruction — even when a REQUIRE fails mid-test — and use it in log_test.cpp and async_db_write_test.cpp in place of bare set_level() calls.

## Summary by Sourcery

Introduce an RAII helper to keep test log-level changes hermetic and apply it across affected logging-related tests.

Enhancements:
- Add a scoped_log_level RAII helper in test_helpers.hpp to save and restore the global log level around tests that modify it.

Tests:
- Update logging and async DB write tests to use scoped_log_level instead of manual log::set_level calls, preventing log-level leakage between tests.