### PR TITLE
Improve building of dist tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ depcomp
 *.lo
 *.o
 *.pc
+# Local working notes
+todo/
 # Editor backups
 *~
 # Clang tooling

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,15 @@ depcomp
 *.lo
 *.o
 *.pc
+# Editor backups
+*~
+# Clang tooling
+clang-tidy.log
+compile_commands.json
+# Python
+__pycache__/
+# Automake
+.dirstamp
+# gcov coverage artefacts
+*.gcno
+*.gcda

--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,12 @@ clang-tidy.log
 compile_commands.json
 # Python
 __pycache__/
+.venv/
+.pytest_cache/
 # Automake
 .dirstamp
+# Dist tarballs
+*.tar.gz
 # gcov coverage artefacts
 *.gcno
 *.gcda

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,10 +1,27 @@
 AUTOMAKE_OPTIONS = foreign
 ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = src examples tests
-EXTRA_DIST = debian e2e
+EXTRA_DIST = debian e2e .clang-format certs
+
+# `make distcheck` must build everything the release ships — the server,
+# the tests, and the example client — so a header missing from the tarball
+# (e.g. one only reached via --enable-server) fails the check. The systemd
+# unit directory is an absolute path; redirect it under the distcheck install
+# tree so `make install` does not try to write to the real /usr/lib.
+DISTCHECK_CONFIGURE_FLAGS = \
+	--enable-server --enable-tests --enable-fake-client \
+	--with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir)
 
 # Opt-in end-to-end tests. Requires Docker + Python; see e2e/README.md.
 # Deliberately not wired into `make check` — CI has a separate job for this.
-.PHONY: e2e
-e2e:
+# Target is named `e2e-test` (not `e2e`) so it does not collide with the
+# `e2e` directory in EXTRA_DIST, which would make `make dist` run pytest.
+.PHONY: e2e-test
+e2e-test:
 	cd $(srcdir)/e2e && pytest
+
+# EXTRA_DIST copies the e2e/ tree recursively; strip developer-local Python
+# cruft (virtualenvs, caches) so it never lands in the release tarball.
+dist-hook:
+	rm -rf $(distdir)/e2e/.venv $(distdir)/e2e/.pytest_cache
+	find $(distdir)/e2e -name __pycache__ -type d -prune -exec rm -rf {} +

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -26,10 +26,10 @@ pytest
 Or from the repo root:
 
 ```sh
-make e2e
+make e2e-test
 ```
 
-`make e2e` is opt-in and is **not** part of `make check`.
+`make e2e-test` is opt-in and is **not** part of `make check`.
 
 ## How it works
 

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS = subdir-objects
 ACLOCAL_AMFLAGS = $(ACLOCAL_FLAGS)
-AM_CXXFLAGS = -pthread -fPIC -std=c++17 -I. -Werror -Wall -Wshadow -Wunused -Wnull-dereference -Wformat=2 -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wpedantic -Weffc++ -I../src -include config.h
+AM_CXXFLAGS = -pthread -fPIC -std=c++17 -I. -Werror -Wall -Wshadow -Wunused -Wnull-dereference -Wformat=2 -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wpedantic -Weffc++ -I$(top_srcdir)/src -include config.h
 
 bin_PROGRAMS =
 
@@ -15,14 +15,13 @@ fss_fake_client_LDADD += ../src/libfss-client-ssl.la ../src/libfss-transport-ssl
 endif
 
 if HAVE_SYSTEMD
-systemdsystemunit_DATA =
-nodist_systemdsystemunit_DATA =
-dist_systemdsystemunit_DATA =
-
 if SERVER
-systemdsystemunit_DATA += fss-server.service
-nodist_systemdsystemunit_DATA += fss-server.service
-dist_systemdsystemunit_DATA += fss-server.service.in
+# fss-server.service is generated from the .in template: install it but do not
+# distribute it (nodist_). The template itself ships in the tarball via
+# EXTRA_DIST and must never be installed into the unit directory.
+nodist_systemdsystemunit_DATA = fss-server.service
+EXTRA_DIST += fss-server.service.in
+CLEANFILES = fss-server.service
 
 SERVICE_SUBS = \
     s,[@]PREFIX[@],${sbindir},g
@@ -30,5 +29,4 @@ SERVICE_SUBS = \
 fss-server.service: fss-server.service.in
 	$(SED) -e '$(SERVICE_SUBS)' < $< > $@
 endif
-
 endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -48,7 +48,7 @@ pkgconfig_DATA += fss-client-ssl.pc
 if SERVER
 sbin_PROGRAMS += fss-server
 
-fss_server_SOURCES = server.cpp client_session.cpp fss-server.hpp db.cpp server-db.pgc server-db.h db-write-queue.cpp db-write-queue.hpp
+fss_server_SOURCES = server.cpp client_session.cpp fss-server.hpp rate-limiter.hpp server-clients.hpp db.cpp server-db.pgc server-db.h db-write-queue.cpp db-write-queue.hpp
 fss_server_CXXFLAGS = $(AM_CXXFLAGS) $(JSONCPP_CFLAGS)
 fss_server_CFLAGS = $(AM_CFLAGS) $(ECPG_CFLAGS)
 fss_server_LDADD = libfss.la libfss-transport.la $(JSONCPP_LIBS) $(ECPG_LIBS)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS = subdir-objects
 ACLOCAL_AMFLAGS = $(ACLOCAL_FLAGS)
-AM_CXXFLAGS = -pthread -fPIC -std=c++17 -I. -Werror -Wall -Wshadow -Wunused -Wnull-dereference -Wformat=2 -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wpedantic -Weffc++ -I../src -include config.h
+AM_CXXFLAGS = -pthread -fPIC -std=c++17 -I. -Werror -Wall -Wshadow -Wunused -Wnull-dereference -Wformat=2 -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wpedantic -Weffc++ -I$(top_srcdir)/src -include config.h
 
 if ENABLE_TESTS
 TESTS = all_test
@@ -33,20 +33,25 @@ all_test_SOURCES = main.cpp messages.cpp connection.cpp client.cpp \
 all_test_CFLAGS = $(ECPG_CFLAGS)
 all_test_LDADD = ../src/libfss-transport.la ../src/libfss-client-ssl.la ../src/libfss.la $(JSONCPP_LIBS) $(ECPG_LIBS)
 
-all_test_SOURCES += connection-ssl.cpp certs certs-alt certs/expired certs/ghost certs/client.crl.pem certs/empty.crl.pem
+all_test_SOURCES += connection-ssl.cpp
 all_test_LDADD += ../src/libfss-transport-ssl.la $(GNUTLS_LIBS) $(CATCH2_LIBS)
 
 EXTRA_DIST = test_helpers.hpp mock_database.hpp
 
 BUILT_SOURCES += certs certs-alt certs/expired certs/ghost certs/client.crl.pem certs/empty.crl.pem
 
+# Generated TLS fixtures live only in the build tree; remove them on clean
+# so `make distcheck` sees a pristine tree after distclean.
+clean-local:
+	rm -rf certs certs-alt
+
 certs:
 	mkdir certs
-	(cd certs; ../../certs/generate-ca.sh; ../../certs/generate-server.sh localhost; ../../certs/generate-client.sh client)
+	(cd certs; $(abs_top_srcdir)/certs/generate-ca.sh; $(abs_top_srcdir)/certs/generate-server.sh localhost; $(abs_top_srcdir)/certs/generate-client.sh client)
 
 certs-alt:
 	mkdir certs-alt
-	(cd certs-alt; ../../certs/generate-ca.sh; ../../certs/generate-server.sh localhost; ../../certs/generate-client.sh client)
+	(cd certs-alt; $(abs_top_srcdir)/certs/generate-ca.sh; $(abs_top_srcdir)/certs/generate-server.sh localhost; $(abs_top_srcdir)/certs/generate-client.sh client)
 
 certs/expired: certs
 	mkdir -p certs/expired


### PR DESCRIPTION
## Summary by Sourcery

Improve distribution tarball correctness and distcheck behavior by including all required resources, adjusting build flags, and cleaning generated artifacts.

New Features:
- Add distcheck configuration to build server, tests, and example client with appropriate systemd unit directory settings.

Enhancements:
- Include additional files such as .clang-format and cert generation scripts in source distributions.
- Adjust include paths in example and test builds to use top_srcdir for out-of-tree and distcheck compatibility.
- Treat fss-server.service as a generated file installed but not distributed, while shipping its template via EXTRA_DIST.
- Ensure server sources list all required headers like rate-limiter and server-clients for proper distribution.

Tests:
- Generate and clean TLS certificate fixtures in the build tree so distcheck runs on a clean source tree.
- Rename the end-to-end test make target to e2e-test and document the new target in e2e/README.md.
- Avoid packaging virtualenvs and Python cache artifacts from e2e tests into the release tarball.

Chores:
- Update .gitignore (content not shown in diff) as part of build-related housekeeping.