### PR TITLE
packaging: fill in debian/copyright with real upstream and license info

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -1,20 +1,16 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: flight-safety-system
-Source: <url://example.com>
+Source: https://github.com/canterbury-air-patrol/flight-safety-system
 
 Files: *
-Copyright: <years> <put author's name and email here>
-           <years> <likewise for another author>
-License: <special license>
- <Put the license of the package here indented by 1 space>
- <This follows the format of Description: lines in control file>
- .
- <Including paragraphs>
+Copyright: 2020-2026 Scott Parlane <sjp@canterburyairpatrol.org>
+           2020-2026 Canterbury Air Patrol <http://www.canterburyairpatrol.org>
+License: GPL-2+
 
-# If you want to use GPL v2 or later for the /debian/* files use 
-# the following clauses, or change it to suit. Delete these two lines
 Files: debian/*
-Copyright: 2020 unknown <sjp@canterburyairpatrol.org>
+Copyright: 2020-2026 Scott Parlane <sjp@canterburyairpatrol.org>
+License: GPL-2+
+
 License: GPL-2+
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -31,8 +27,3 @@ License: GPL-2+
  .
  On Debian systems, the complete text of the GNU General
  Public License version 2 can be found in "/usr/share/common-licenses/GPL-2".
-
-# Please also look if there are files or directories which have a
-# different copyright/license attached and list them here.
-# Please avoid picking licenses with terms that are more restrictive than the
-# packaged work, as it may make Debian's contributions unacceptable upstream.


### PR DESCRIPTION
## Description

Replace dh_make template placeholders (<url://example.com>, <years> <put author's name and email here>, <special license>, plus the boilerplate comment blocks) with a proper machine-readable DEP-5 copyright file declaring GPL-2+ for the whole tree.

Why: the placeholder text would trip helper-templates-in-copyright, copyright-has-url-from-dh_make-boilerplate, and similar Lintian errors on a 1.0.0 release build.

## Summary by Sourcery

Chores:
- Replace dh_make placeholder content in debian/copyright with a proper machine-readable DEP-5 file declaring GPL-2+ for the project.