### PR TITLE
ci: run check-code.sh in the static-analysis job

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -137,7 +137,14 @@ jobs:
         sudo apt-get update -qq
         sudo apt-get install -y \
           libjsoncpp-dev libecpg-dev catch2 libgnutls28-dev gnutls-bin \
-          cppcheck clang-tidy clang-format bear
+          cppcheck clang-tidy bear
+
+    # clang-format output is version-dependent; pin the exact version the
+    # tree is formatted with so the formatting gate is reproducible.
+    - name: Install pinned clang-format
+      run: |
+        python3 -m venv /tmp/clang-format-venv
+        /tmp/clang-format-venv/bin/pip install -q clang-format==22.1.5
 
     - name: autogen
       run: ./autogen.sh
@@ -149,7 +156,7 @@ jobs:
       run: bear -- make -j$(nproc)
 
     - name: code checks (clang-format, cppcheck, clang-tidy)
-      run: ./check-code.sh
+      run: CLANG_FORMAT=/tmp/clang-format-venv/bin/clang-format ./check-code.sh
 
   # ─── 5. End-to-end tests ─────────────────────────────────────────────────
   e2e:

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -137,7 +137,7 @@ jobs:
         sudo apt-get update -qq
         sudo apt-get install -y \
           libjsoncpp-dev libecpg-dev catch2 libgnutls28-dev gnutls-bin \
-          cppcheck clang-tidy bear
+          cppcheck clang-tidy clang-format bear
 
     - name: autogen
       run: ./autogen.sh
@@ -148,22 +148,8 @@ jobs:
     - name: build with compile DB
       run: bear -- make -j$(nproc)
 
-    - name: cppcheck
-      run: |
-        cppcheck \
-          --enable=warning,performance,portability,style \
-          --error-exitcode=1 \
-          --suppress=knownConditionTrueFalse:src/transport-ssl.cpp \
-          src/*.cpp
-
-    - name: clang-tidy
-      run: |
-        run-clang-tidy \
-          -p . \
-          'src/(?!server-db).*\.cpp$' \
-          2>&1 | tee clang-tidy.log
-        # Fail if any warnings were emitted
-        ! grep -q "warning:" clang-tidy.log
+    - name: code checks (clang-format, cppcheck, clang-tidy)
+      run: ./check-code.sh
 
   # ─── 5. End-to-end tests ─────────────────────────────────────────────────
   e2e:

--- a/check-code.sh
+++ b/check-code.sh
@@ -2,7 +2,12 @@
 
 set -euo pipefail
 
-clang-format --dry-run -Werror src/*.cpp src/*.hpp src/server-db.h tests/*.cpp tests/*.hpp examples/*.cpp
+# clang-format output is not stable across major versions. The tree is
+# formatted with clang-format 22.1.x; CI pins that exact version and points
+# CLANG_FORMAT at it. Locally, set CLANG_FORMAT if your system clang-format
+# is a different major version.
+clang_format="${CLANG_FORMAT:-clang-format}"
+"$clang_format" --dry-run -Werror src/*.cpp src/*.hpp src/server-db.h tests/*.cpp tests/*.hpp examples/*.cpp
 
 # knownConditionTrueFalse in transport-ssl.cpp is a false positive emitted by
 # some cppcheck versions (notably the one on the CI runners); suppress it so

--- a/check-code.sh
+++ b/check-code.sh
@@ -4,7 +4,11 @@ set -euo pipefail
 
 clang-format --dry-run -Werror src/*.cpp src/*.hpp src/server-db.h tests/*.cpp tests/*.hpp examples/*.cpp
 
-cppcheck --enable=warning,performance,portability,style --error-exitcode=1 src/*.cpp
+# knownConditionTrueFalse in transport-ssl.cpp is a false positive emitted by
+# some cppcheck versions (notably the one on the CI runners); suppress it so
+# this script behaves identically locally and in CI.
+cppcheck --enable=warning,performance,portability,style --error-exitcode=1 \
+	--suppress=knownConditionTrueFalse:src/transport-ssl.cpp src/*.cpp
 
 run-clang-tidy -p . 'src/(?!server-db).*\.cpp$' 2>&1 | tee clang-tidy.log
 ! grep -q "warning:" clang-tidy.log


### PR DESCRIPTION
## Description

The static-analysis job duplicated cppcheck and clang-tidy inline but never ran clang-format, so formatting drift passed CI even though check-code.sh enforces it locally. Point the job at check-code.sh so CI and local runs check exactly the same things.

check-code.sh gains the knownConditionTrueFalse:transport-ssl.cpp cppcheck suppression that the CI job already carried (a false positive on the CI runner's cppcheck version), so the script behaves identically in both places.

## Summary by Sourcery

Run the unified check-code.sh script in the static-analysis CI job to keep local and CI code checks consistent.

Enhancements:
- Update check-code.sh to suppress the known false-positive cppcheck warning on transport-ssl.cpp so behavior matches the CI configuration.

Build:
- Add clang-format to CI build dependencies for the C/C++ workflow.

CI:
- Replace inline cppcheck and clang-tidy steps in the static-analysis job with a single invocation of check-code.sh to align CI with local checks.