### PR TITLE
Switch to postgis/postgis and use latest

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -165,7 +165,7 @@ jobs:
 
     services:
       postgres:
-        image: mdillon/postgis:11-alpine
+        image: postgis/postgis:18-3.6-alpine
         env:
           POSTGRES_PASSWORD: e2e
         ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
     volumes:
       - "./certs:/certs:rw"
   db:
-    image: mdillon/postgis
+    image: postgis/postgis:18-3.6-alpine
     healthcheck:
       test: "pg_isready --username=postgres"
       timeout: 10s

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -5,7 +5,7 @@ database, with real fake-client processes driving traffic over TLS.
 
 ## Prerequisites
 
-- `docker` daemon reachable (pulls `mdillon/postgis:11-alpine` on first run)
+- `docker` daemon reachable (pulls `postgis/postgis:18-3.6-alpine` on first run)
 - Python 3.9+
 - The project built with `--enable-server --enable-fake-client`:
 

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -32,7 +32,7 @@ FAKE_CLIENT_BIN = REPO_ROOT / "examples" / "fss-fake-client"
 CERT_SCRIPTS = REPO_ROOT / "certs"
 SCHEMA_DIR = E2E_ROOT / "schema"
 
-POSTGIS_IMAGE = "mdillon/postgis:11-alpine"
+POSTGIS_IMAGE = "postgis/postgis:18-3.6-alpine"
 STARTUP_TIMEOUT_S = 60
 
 
@@ -68,9 +68,9 @@ def pg_container() -> Iterator[Dict[str, object]]:
     Three modes (checked in order):
     1. FSS_E2E_EXTERNAL_DB is set — use an already-running Postgres (e.g.
        a GitHub Actions service container).  No Docker is started.
-    2. FSS_E2E_DOCKER_HOST_NET=1 — start mdillon/postgis with --network=host
+    2. FSS_E2E_DOCKER_HOST_NET=1 — start postgis/postgis with --network=host
        so the container shares the host network (needed on some sandboxes).
-    3. Default — start mdillon/postgis with a mapped port.
+    3. Default — start postgis/postgis with a mapped port.
     """
     external = os.environ.get("FSS_E2E_EXTERNAL_DB")
     if external:

--- a/e2e/pytest.ini
+++ b/e2e/pytest.ini
@@ -4,4 +4,4 @@ addopts = -v --tb=short --strict-markers
 timeout = 60
 markers =
     slow: long-running (>30s) tests
-    requires_docker: needs docker + the mdillon/postgis image reachable
+    requires_docker: needs docker + the postgis/postgis image reachable


### PR DESCRIPTION
## Description

mdillion/postgis has been deprecated for a while, switch to the official postgis/postgis image.

## Summary by Sourcery

Switch all PostGIS Docker image references to the maintained postgis/postgis image and update them to the latest tagged version used by the project.

Build:
- Update docker-compose database service to use the postgis/postgis:18-3.6-alpine image instead of the deprecated mdillon/postgis image.

CI:
- Update GitHub Actions CI Postgres service to use the postgis/postgis:18-3.6-alpine image.

Documentation:
- Refresh end-to-end testing documentation to reference the new postgis/postgis image and tag.

Tests:
- Update end-to-end test configuration to use the postgis/postgis:18-3.6-alpine image and adjust related descriptions.