### PR TITLE
Switch to using the develop branch for building docker images

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,7 +3,7 @@ name: Docker Build and Push
 on:
   push:
     branches:
-      - master
+      - develop
       - 'release/[0-9]*'
     tags:
       - 'v[0-9]*'
@@ -40,7 +40,7 @@ jobs:
         run: |
           IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/flight-safety-system-server"
           ref="${GITHUB_REF}"
-          if [[ "$ref" == "refs/heads/master" ]]; then
+          if [[ "$ref" == "refs/heads/develop" ]]; then
             echo "tags=${IMAGE}:latest-${DISTRO}" >> "$GITHUB_OUTPUT"
           elif [[ "$ref" == refs/heads/release/* ]]; then
             ver="${ref#refs/heads/release/}"


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Change GitHub Actions Docker build workflow triggers and tagging logic to use the develop branch in place of master.