### PR TITLE
Fix docker image pushing

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           DISTRO: ${{ matrix.distro }}
         run: |
-          IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/flight-safety-system-server"
+          IMAGE="canterburyairpatrol/flight-safety-system-server"
           ref="${GITHUB_REF}"
           if [[ "$ref" == "refs/heads/develop" ]]; then
             sha="${GITHUB_SHA::7}"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -41,7 +41,8 @@ jobs:
           IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/flight-safety-system-server"
           ref="${GITHUB_REF}"
           if [[ "$ref" == "refs/heads/develop" ]]; then
-            echo "tags=${IMAGE}:latest-${DISTRO}" >> "$GITHUB_OUTPUT"
+            sha="${GITHUB_SHA::7}"
+            printf "tags=${IMAGE}:latest-${DISTRO}\n${IMAGE}:${sha}-${DISTRO}\n" >> "$GITHUB_OUTPUT"
           elif [[ "$ref" == refs/heads/release/* ]]; then
             ver="${ref#refs/heads/release/}"
             echo "tags=${IMAGE}:${ver}-${DISTRO}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -42,7 +42,7 @@ jobs:
           ref="${GITHUB_REF}"
           if [[ "$ref" == "refs/heads/develop" ]]; then
             sha="${GITHUB_SHA::7}"
-            printf "tags=${IMAGE}:latest-${DISTRO}\n${IMAGE}:${sha}-${DISTRO}\n" >> "$GITHUB_OUTPUT"
+            echo "tags=${IMAGE}:latest-${DISTRO},${IMAGE}:${sha}-${DISTRO}" >> "$GITHUB_OUTPUT"
           elif [[ "$ref" == refs/heads/release/* ]]; then
             ver="${ref#refs/heads/release/}"
             echo "tags=${IMAGE}:${ver}-${DISTRO}" >> "$GITHUB_OUTPUT"
@@ -65,7 +65,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.distro }}
 
       - name: Verify push succeeded
-        if: steps.tags.outputs.tags == ''
+        if: ${{ steps.tags.outputs.tags == '' }}
         run: |
           echo "::error::No tags were computed for ref ${GITHUB_REF} — image was built but not pushed."
           exit 1

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -58,7 +58,13 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
-          push: true
+          push: ${{ steps.tags.outputs.tags != '' }}
           tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha,scope=${{ matrix.distro }}
           cache-to: type=gha,mode=max,scope=${{ matrix.distro }}
+
+      - name: Verify push succeeded
+        if: steps.tags.outputs.tags == ''
+        run: |
+          echo "::error::No tags were computed for ref ${GITHUB_REF} — image was built but not pushed."
+          exit 1


### PR DESCRIPTION
## Summary by Sourcery

Adjust Docker image build workflow to push images under the public repository and ensure correct tagging and failure when no tags are produced.

Build:
- Update GitHub Actions Docker build workflow to use the canterburyairpatrol/flight-safety-system-server image name instead of a secret-derived namespace.
- Add Git commit–based tag alongside latest tags for develop builds and only push images when tags are computed.
- Fail the workflow explicitly when no Docker tags are generated to avoid silent non-push scenarios.