### PR TITLE
fix: retry recvBytes on GNUTLS_E_AGAIN and add coverage instrumentation

### DIFF
--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -324,20 +324,30 @@ auto flight_safety_system::transport_ssl::fss_connection::recvBytes(void *t_byte
         FSS_LOG_ERROR("ssl", "Attempt to recv on unusable transport_ssl::fss_connection");
         return -2;
     }
-    ssize_t bytes_recved = -1;
-    try
+    for (;;)
     {
-        bytes_recved = this->session->recv(t_bytes, t_max_bytes);
-    }
-    catch (gnutls::exception &ex)
-    {
-        FSS_LOG_ERROR("ssl", "recv: caught gnutls exception: " << ex.get_code() << ", " << ex.what());
-        if (ex.get_code() != GNUTLS_E_AGAIN)
+        ssize_t bytes_recved = -1;
+        try
         {
-            this->usable = false;
+            bytes_recved = this->session->recv(t_bytes, t_max_bytes);
         }
+        catch (gnutls::exception &ex)
+        {
+            if (ex.get_code() == GNUTLS_E_AGAIN || ex.get_code() == GNUTLS_E_INTERRUPTED)
+            {
+                continue;
+            }
+            FSS_LOG_ERROR("ssl", "recv: caught gnutls exception: " << ex.get_code() << ", " << ex.what());
+            this->usable = false;
+            return bytes_recved;
+        }
+        /* Some C++ wrapper variants return AGAIN/INTERRUPTED rather than throwing. */
+        if (bytes_recved == GNUTLS_E_AGAIN || bytes_recved == GNUTLS_E_INTERRUPTED)
+        {
+            continue;
+        }
+        return bytes_recved;
     }
-    return bytes_recved;
 }
 
 auto flight_safety_system::transport_ssl::fss_listen::newConnection(int t_newfd)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS = subdir-objects
 ACLOCAL_AMFLAGS = $(ACLOCAL_FLAGS)
-AM_CXXFLAGS = -pthread -fPIC -std=c++17 -I. -Werror -Wall -Wshadow -Wunused -Wnull-dereference -Wformat=2 -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wpedantic -Weffc++ -I$(top_srcdir)/src -include config.h
+AM_CXXFLAGS = -pthread -fPIC -std=c++17 -I. -Werror -Wall -Wshadow -Wunused -Wnull-dereference -Wformat=2 -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wpedantic -Weffc++ -I$(top_srcdir)/src -include config.h $(CODE_COVERAGE_CXXFLAGS)
 
 if ENABLE_TESTS
 TESTS = all_test

--- a/tests/connection-ssl.cpp
+++ b/tests/connection-ssl.cpp
@@ -50,7 +50,9 @@ static auto test_client_connect_cb(std::shared_ptr<flight_safety_system::transpo
 
 TEST_CASE("SSL - Listen Socket")
 {
-    constexpr int listen_port = 20302;
+    client_conn = nullptr;
+    const uint16_t listen_port = fss_test::pick_port();
+    REQUIRE(listen_port != 0);
     auto listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(
         listen_port, test_client_connect_cb, CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
     REQUIRE(listen != nullptr);
@@ -65,14 +67,17 @@ TEST_CASE("SSL - Listen Socket")
 
     REQUIRE(fss_test::wait_for([]() { return client_conn != nullptr; }));
 
-    conn = nullptr;
-
+    // Drain identity before dropping the client connection.  Dropping conn
+    // while the server's recv thread hasn't yet dequeued the identity bytes
+    // causes a race where message_type_closed arrives first.
     std::shared_ptr<flight_safety_system::transport::fss_message> msg;
     REQUIRE(fss_test::wait_for([&]() {
         msg = client_conn->getMsg();
         return msg != nullptr;
     }));
     REQUIRE(msg->getType() == flight_safety_system::transport::message_type_identity);
+
+    conn = nullptr;
 
     REQUIRE(fss_test::wait_for([&]() {
         msg = client_conn->getMsg();
@@ -102,7 +107,9 @@ public:
 
 TEST_CASE("SSL - Listen - Callback")
 {
-    constexpr int listen_port = 20303;
+    client_conn = nullptr;
+    const uint16_t listen_port = fss_test::pick_port();
+    REQUIRE(listen_port != 0);
 
     auto listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(
         listen_port, test_client_connect_cb, CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);


### PR DESCRIPTION
## Description

transport-ssl.cpp: recvBytes now loops on GNUTLS_E_AGAIN/INTERRUPTED (thrown or returned) instead of falling through to a -1 return that recvMsg treated as a closed connection.  This fixes a ~40% flaky failure in SSL Listen Socket where the server recv thread raced ahead of the first application-data record and got GNUTLS_E_AGAIN on a blocking socket — documented GnuTLS behaviour that requires a retry, not a connection teardown.

connection-ssl.cpp: add client_conn reset and pick_port() to SSL - Listen - Callback (same defensive fixes applied to SSL - Listen Socket in an earlier commit).

tests/Makefile.am: add $(CODE_COVERAGE_CXXFLAGS) to AM_CXXFLAGS so the sources compiled directly into all_test (client_session.cpp, db-write-queue.cpp, db.cpp, server-db.c) receive --coverage instrumentation, closing the largest single gap in the unit-test coverage baseline.

## Summary by Sourcery

Handle non-fatal GnuTLS recv conditions correctly and harden SSL listen tests while enabling coverage instrumentation for test binaries.

Bug Fixes:
- Retry SSL recv operations on GNUTLS_E_AGAIN and GNUTLS_E_INTERRUPTED instead of treating them as connection closures, preventing flaky disconnects in SSL listen scenarios.
- Adjust SSL listen tests to avoid races between client teardown and server identity message handling by draining the identity message before dropping the client connection and resetting shared connection state.

Enhancements:
- Use dynamically selected ports in SSL listen tests to avoid hard-coded port conflicts across test runs.

Build:
- Add code coverage C++ flags to the test build so sources linked directly into the all_test binary receive coverage instrumentation.

Tests:
- Improve SSL listen socket and callback tests to better synchronize client/server interactions and reduce flakiness.