### PR TITLE
test: cover set_level warn branch and level_str all four levels

### DIFF
--- a/tests/log_test.cpp
+++ b/tests/log_test.cpp
@@ -127,3 +127,32 @@ TEST_CASE("log: concurrent writers produce no interleaved lines")
     }
     REQUIRE(count == static_cast<size_t>(thread_count * lines_per_thread));
 }
+
+TEST_CASE("log: set_level covers all four string variants")
+{
+    namespace fss_log = flight_safety_system::log;
+
+    fss_test::scoped_log_level guard("info");
+
+    fss_log::set_level("warn");
+    REQUIRE(fss_log::detail::current_level().load() == fss_log::level::Warn);
+
+    fss_log::set_level("error");
+    REQUIRE(fss_log::detail::current_level().load() == fss_log::level::Error);
+
+    fss_log::set_level("info");
+    REQUIRE(fss_log::detail::current_level().load() == fss_log::level::Info);
+
+    fss_log::set_level("debug");
+    REQUIRE(fss_log::detail::current_level().load() == fss_log::level::Debug);
+}
+
+TEST_CASE("log: level_str returns expected tag for each level")
+{
+    namespace fss_log = flight_safety_system::log;
+
+    REQUIRE(std::string(fss_log::detail::level_str(fss_log::level::Error)) == "ERROR");
+    REQUIRE(std::string(fss_log::detail::level_str(fss_log::level::Warn)) == "WARN ");
+    REQUIRE(std::string(fss_log::detail::level_str(fss_log::level::Info)) == "INFO ");
+    REQUIRE(std::string(fss_log::detail::level_str(fss_log::level::Debug)) == "DEBUG");
+}


### PR DESCRIPTION
## Description

Add two tests to log_test.cpp (commit 2 of the coverage plan):
- set_level covers all four string variants, including the previously uncovered "warn" branch (line 85 of fss-log.hpp)
- level_str returns the correct tag string for each of the four levels

## Summary by Sourcery

Extend log component test coverage for log level configuration and string representation.

Tests:
- Add coverage for log::set_level across all four log levels, including the previously uncovered warn branch.
- Verify log::detail::level_str returns the expected tag string for each log level.