### PR TITLE
test: cover base isPeerCertRevoked and db-write-queue catch-all handler

### DIFF
--- a/tests/async_db_write_test.cpp
+++ b/tests/async_db_write_test.cpp
@@ -234,6 +234,19 @@ TEST_CASE("db_write_queue: write_failure_count tracks sink exceptions")
     REQUIRE(q.write_failure_count() == task_count);
 }
 
+TEST_CASE("db_write_queue: catch-all handler counts non-exception throws")
+{
+    auto weird_sink = [](const fss::server::db_write_task &) -> void { throw 42; };
+
+    fss::server::db_write_queue q(100, weird_sink);
+    q.enqueue(fss::server::rtt_write{1, 0});
+
+    REQUIRE(fss_test::wait_for([&]() -> bool { return q.write_failure_count() == 1; }));
+    q.stop();
+
+    REQUIRE(q.write_failure_count() == 1);
+}
+
 TEST_CASE("db_write_queue: destructor without explicit stop drains pending work")
 {
     auto cap = std::make_shared<CapturingSink>();

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -134,6 +134,13 @@ TEST_CASE("Queue overflow drops oldest messages")
     client_conn = nullptr;
 }
 
+TEST_CASE("fss_connection: base isPeerCertRevoked always returns false")
+{
+    auto conn = std::make_shared<flight_safety_system::transport::fss_connection>();
+    REQUIRE_FALSE(conn->isPeerCertRevoked(""));
+    REQUIRE_FALSE(conn->isPeerCertRevoked("/any/path.pem"));
+}
+
 TEST_CASE("Listen - Callback")
 {
     constexpr int listen_port = 20203;


### PR DESCRIPTION
## Description

- connection.cpp: test that fss_connection base isPeerCertRevoked returns false
- async_db_write_test.cpp: throw non-std::exception from sink to cover the catch(...) handler in db-write-queue.cpp

## Summary by Sourcery

Extend test coverage for connection certificate revocation behavior and db write queue error handling.

Tests:
- Add a test verifying the fss_connection base implementation of isPeerCertRevoked always returns false for any input path.
- Add a test ensuring db_write_queue correctly counts failures when the sink throws a non-std::exception via the catch-all handler.