### PR TITLE
test: add Docker-isolated DB unit tests for db.cpp and server-db.pgc

### DIFF
--- a/docker-compose.db-unit-tests.yaml
+++ b/docker-compose.db-unit-tests.yaml
@@ -1,0 +1,42 @@
+# Run unit tests that require PostgreSQL+PostGIS in an isolated Docker network.
+# Neither postgres nor the test runner exposes ports to the host.
+#
+# Usage:
+#   docker compose -f docker-compose.db-unit-tests.yaml up --build --exit-code-from test-runner
+#
+# The exit code mirrors the test binary exit code (0 = all passed).
+# Add "--abort-on-container-exit" so the db service stops when tests finish.
+services:
+  db:
+    image: postgis/postgis:18-3.6-alpine
+    networks:
+      - test-net
+    environment:
+      POSTGRES_PASSWORD: password
+    volumes:
+      - ./e2e/schema:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready --username=postgres"]
+      interval: 2s
+      timeout: 5s
+      retries: 20
+
+  test-runner:
+    build:
+      context: .
+      dockerfile: docker/db-unit-test.Dockerfile
+    networks:
+      - test-net
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      TEST_DB_HOST: db
+      TEST_DB_PORT: "5432"
+      TEST_DB_USER: postgres
+      TEST_DB_PASS: password
+      TEST_DB_NAME: postgres
+
+networks:
+  test-net:
+    driver: bridge

--- a/docker/db-unit-test-entrypoint.sh
+++ b/docker/db-unit-test-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Entrypoint for the db-unit-test container.
+#
+# Pre-populates the test database with fixtures that the DB unit tests
+# expect to find, then runs the full test binary.  The Docker healthcheck
+# on the db service guarantees Postgres is accepting connections before
+# this script runs, so no additional wait loop is needed.
+set -euo pipefail
+
+PGPASSWORD="${TEST_DB_PASS:-password}" psql \
+    -h "${TEST_DB_HOST:-db}" \
+    -p "${TEST_DB_PORT:-5432}" \
+    -U "${TEST_DB_USER:-postgres}" \
+    -d "${TEST_DB_NAME:-postgres}" \
+    <<'SQL'
+INSERT INTO assets_asset (name) VALUES ('test-asset');
+
+INSERT INTO config_smmconfig (address, port, https)
+    VALUES ('smm.example.com', 80, false);
+
+INSERT INTO config_assetconfig (asset_id, smm_id, smm_login, smm_password)
+    SELECT a.id, s.id, 'testuser', 'testpass'
+    FROM   assets_asset a, config_smmconfig s
+    WHERE  a.name = 'test-asset';
+
+INSERT INTO config_serverconfig (address, client_port, active, name, config_port, https)
+    VALUES ('fss.example.com', 20202, true, 'test-server', 8090, false);
+SQL
+
+exec /code/tests/all_test "$@"

--- a/docker/db-unit-test.Dockerfile
+++ b/docker/db-unit-test.Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+#
+# Builds the unit-test binary with coverage instrumentation and runs all
+# tests against a PostgreSQL+PostGIS database reachable via the test-net
+# Docker network.  Use docker-compose.db-unit-tests.yaml to orchestrate.
+
+FROM debian:trixie
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential automake libtool pkg-config \
+    libecpg-dev libjsoncpp-dev libgnutls28-dev gnutls-bin \
+    catch2 postgresql-client lcov \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . /code/
+WORKDIR /code
+
+RUN ./autogen.sh \
+    && ./configure --enable-tests --enable-server --enable-coverage \
+    && make -j"$(nproc)"
+
+WORKDIR /code/tests
+
+ENTRYPOINT ["/code/docker/db-unit-test-entrypoint.sh"]

--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -10,7 +10,16 @@
 #error No catch header
 #endif
 
+#include <cstdlib>
+#include <limits>
+#include <memory>
+#include <string>
+
 #include "fss-server.hpp"
+
+extern "C" {
+#include "server-db.h"
+}
 
 TEST_CASE("db_connection: invalid host reports not connected")
 {
@@ -18,4 +27,193 @@ TEST_CASE("db_connection: invalid host reports not connected")
      * does not depend on a running PostgreSQL instance. */
     flight_safety_system::server::db_connection dbc("db.invalid", 5432, "user", "pass", "db");
     REQUIRE_FALSE(dbc.isConnected());
+}
+
+namespace {
+
+/* Build a db_connection from TEST_DB_* env vars.
+ * Returns nullptr when TEST_DB_HOST is unset; callers should SKIP in that case. */
+auto make_test_db() -> std::unique_ptr<flight_safety_system::server::db_connection>
+{
+    const char *host = std::getenv("TEST_DB_HOST");
+    if (host == nullptr)
+    {
+        return nullptr;
+    }
+    int port = 5432;
+    if (const char *p = std::getenv("TEST_DB_PORT"))
+    {
+        port = std::stoi(p);
+    }
+    const char *user = std::getenv("TEST_DB_USER");
+    const char *pass = std::getenv("TEST_DB_PASS");
+    const char *dbname = std::getenv("TEST_DB_NAME");
+    return std::make_unique<flight_safety_system::server::db_connection>(
+        host, port, user != nullptr ? user : "postgres", pass != nullptr ? pass : "password",
+        dbname != nullptr ? dbname : "postgres");
+}
+
+} // namespace
+
+TEST_CASE("db_connection: connects to live database")
+{
+    auto dbc = make_test_db();
+    if (!dbc)
+    {
+        SKIP("TEST_DB_HOST not set");
+    }
+    REQUIRE(dbc->isConnected());
+}
+
+TEST_CASE("db_connection: getAssetId returns non-zero for pre-inserted asset")
+{
+    auto dbc = make_test_db();
+    if (!dbc)
+    {
+        SKIP("TEST_DB_HOST not set");
+    }
+    REQUIRE(dbc->isConnected());
+    REQUIRE(dbc->getAssetId("test-asset") != 0);
+}
+
+TEST_CASE("db_connection: recordRtt writes a row without error")
+{
+    auto dbc = make_test_db();
+    if (!dbc)
+    {
+        SKIP("TEST_DB_HOST not set");
+    }
+    REQUIRE(dbc->isConnected());
+    auto asset_id = dbc->getAssetId("test-asset");
+    REQUIRE(asset_id != 0);
+    dbc->recordRtt(asset_id, uint64_t{42});
+}
+
+TEST_CASE("db_connection: recordStatus writes a row without error")
+{
+    auto dbc = make_test_db();
+    if (!dbc)
+    {
+        SKIP("TEST_DB_HOST not set");
+    }
+    REQUIRE(dbc->isConnected());
+    auto asset_id = dbc->getAssetId("test-asset");
+    REQUIRE(asset_id != 0);
+    dbc->recordStatus(asset_id, uint8_t{80}, uint32_t{1000}, 12.4);
+}
+
+TEST_CASE("db_connection: recordSearchStatus writes a row without error")
+{
+    auto dbc = make_test_db();
+    if (!dbc)
+    {
+        SKIP("TEST_DB_HOST not set");
+    }
+    REQUIRE(dbc->isConnected());
+    auto asset_id = dbc->getAssetId("test-asset");
+    REQUIRE(asset_id != 0);
+    dbc->recordSearchStatus(asset_id, uint64_t{1}, uint64_t{50}, uint64_t{100});
+}
+
+TEST_CASE("db_connection: recordPosition with valid altitude inserts row")
+{
+    auto dbc = make_test_db();
+    if (!dbc)
+    {
+        SKIP("TEST_DB_HOST not set");
+    }
+    REQUIRE(dbc->isConnected());
+    auto asset_id = dbc->getAssetId("test-asset");
+    REQUIRE(asset_id != 0);
+    dbc->recordPosition(asset_id, -43.5, 172.6, uint32_t{100});
+}
+
+TEST_CASE("db_connection: recordPosition with overflow altitude is discarded")
+{
+    auto dbc = make_test_db();
+    if (!dbc)
+    {
+        SKIP("TEST_DB_HOST not set");
+    }
+    REQUIRE(dbc->isConnected());
+    auto asset_id = dbc->getAssetId("test-asset");
+    REQUIRE(asset_id != 0);
+    constexpr auto huge_alt = static_cast<uint32_t>(std::numeric_limits<int>::max()) + uint32_t{1};
+    dbc->recordPosition(asset_id, -43.5, 172.6, huge_alt);
+}
+
+TEST_CASE("db_connection: getSmmSettings returns non-null for configured asset")
+{
+    auto dbc = make_test_db();
+    if (!dbc)
+    {
+        SKIP("TEST_DB_HOST not set");
+    }
+    REQUIRE(dbc->isConnected());
+    auto asset_id = dbc->getAssetId("test-asset");
+    REQUIRE(asset_id != 0);
+    auto settings = dbc->getSmmSettings(asset_id);
+    REQUIRE(settings != nullptr);
+    REQUIRE_FALSE(settings->getAddress().empty());
+    REQUIRE(settings->getUsername() == "testuser");
+    REQUIRE_FALSE(settings->getPassword().empty());
+}
+
+TEST_CASE("db_connection: getSmmSettings returns null for asset with no config")
+{
+    auto dbc = make_test_db();
+    if (!dbc)
+    {
+        SKIP("TEST_DB_HOST not set");
+    }
+    REQUIRE(dbc->isConnected());
+    REQUIRE(dbc->getSmmSettings(uint64_t{999999}) == nullptr);
+}
+
+TEST_CASE("db_connection: getActiveServers returns pre-configured server")
+{
+    auto dbc = make_test_db();
+    if (!dbc)
+    {
+        SKIP("TEST_DB_HOST not set");
+    }
+    REQUIRE(dbc->isConnected());
+    auto servers = dbc->getActiveServers();
+    REQUIRE_FALSE(servers.empty());
+    bool found = false;
+    for (auto &s : servers)
+    {
+        if (s.getAddress() == "fss.example.com" && s.getPort() == 20202)
+        {
+            found = true;
+        }
+    }
+    REQUIRE(found);
+}
+
+TEST_CASE("db_connection: tryReconnectIfNeeded returns when connection is healthy")
+{
+    auto dbc = make_test_db();
+    if (!dbc)
+    {
+        SKIP("TEST_DB_HOST not set");
+    }
+    REQUIRE(dbc->isConnected());
+    dbc->tryReconnectIfNeeded();
+    REQUIRE(dbc->isConnected());
+}
+
+TEST_CASE("db_connection: tryReconnectIfNeeded reconnects after underlying disconnect")
+{
+    auto dbc = make_test_db();
+    if (!dbc)
+    {
+        SKIP("TEST_DB_HOST not set");
+    }
+    REQUIRE(dbc->isConnected());
+    /* Force the underlying ECPG connection closed so db_ping() will fail,
+     * which triggers the reconnect branch in tryReconnectIfNeeded(). */
+    db_disconnect();
+    dbc->tryReconnectIfNeeded();
+    REQUIRE(dbc->isConnected());
 }


### PR DESCRIPTION
## Description

Adds a docker-compose.db-unit-tests.yaml + docker/db-unit-test.Dockerfile that spin up PostgreSQL+PostGIS on an isolated Docker network (no host port exposure) and run the test binary against it.

db_connection_test.cpp gains 12 new test cases that exercise:
- isConnected / getAssetId (live path)
- recordRtt, recordStatus, recordSearchStatus, recordPosition (all variants)
- recordPosition overflow guard (altitude > INT_MAX → discarded)
- getSmmSettings returning non-null and null
- getActiveServers with a pre-inserted server row
- tryReconnectIfNeeded healthy path and reconnect-after-disconnect path

All new tests SKIP automatically when TEST_DB_HOST is not set, so the local make check continues to pass without any database.

## Summary by Sourcery

Add Docker-based infrastructure and fixtures to run database integration tests for db_connection against a live PostgreSQL/PostGIS instance, and extend db_connection tests to cover core CRUD and reconnect behaviors while remaining optional via environment gating.

Tests:
- Extend db_connection tests to exercise live connectivity, asset lookup, RTT/status/search-status recording, position handling with overflow guard, SMM settings retrieval, active server discovery, and reconnect logic against a real database.
- Introduce a Dockerized PostgreSQL/PostGIS test environment and entrypoint script that seeds required fixtures and runs the full test binary, orchestrated via a dedicated docker-compose file for DB-dependent unit tests.