### PR TITLE
fix+test: cover client-ssl disconnect, base handlers, JSON config, and iterator-safety fix

### DIFF
--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -64,7 +64,10 @@ flight_safety_system::client_ssl::fss_client::~fss_client()
 
 void flight_safety_system::client_ssl::fss_client::disconnect()
 {
-    for (const auto &server : this->servers)
+    /* Snapshot the list so that serverRequiresReconnect callbacks fired by
+     * the recv thread during disconnect() cannot invalidate our iterator. */
+    auto snapshot = this->servers;
+    for (const auto &server : snapshot)
     {
         server->disconnect();
     }

--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -1,3 +1,5 @@
+#include <cstdio>
+#include <fstream>
 #include <memory>
 #include <string_view>
 #ifdef HAVE_CATCH2_CATCH_ALL_HPP
@@ -142,4 +144,62 @@ TEST_CASE("client: processMessage version incompatibility triggers serverRequire
     constexpr uint16_t future_min = fss::transport::FSS_PROTOCOL_VERSION + 1;
     auto msg = std::make_shared<fss::transport::fss_message_version>(future_min, future_min, uint32_t{0});
     server->processMessage(msg); // serverRequiresReconnect called; no crash
+}
+
+TEST_CASE("client: JSON config with server entry parses name and creates reconnect entry")
+{
+    /* Exercise the file-based fss_client constructor body (lines 24-40) and
+     * the setAssetName helper. */
+    const char *tmppath = "/tmp/fss_test_client_cfg.json";
+    {
+        std::ofstream f(tmppath);
+        f << R"({"name":"test-asset",)"
+          << R"("ssl":{"ca_public_key":"ca.pem","client_private_key":"key.pem","client_public_key":"cert.pem"},)"
+          << R"("servers":[{"address":"127.0.0.1","port":9999}]})";
+    }
+    fss::client_ssl::fss_client client(tmppath);
+    REQUIRE(client.getAssetName() == "test-asset");
+    std::remove(tmppath);
+}
+
+TEST_CASE("client: disconnect closes all active server connections")
+{
+    /* connectTo with connect=true adds a server to the connected list.
+     * A subsequent disconnect() must iterate and close it (lines 65-71). */
+    constexpr uint16_t port = 20404;
+    client_conn = nullptr;
+    auto listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(
+        port, test_client_connect_cb, CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
+    REQUIRE(listen != nullptr);
+
+    auto client =
+        std::make_shared<fss::client_ssl::fss_client>(CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+    client->connectTo("localhost", port, true);
+    REQUIRE(fss_test::wait_for([]() { return client_conn != nullptr; }));
+
+    client->disconnect(); /* exercises lines 65-71 */
+    client_conn = nullptr;
+}
+
+TEST_CASE("client: base class handleCommand, handlePositionReport, handleSMMSettings are no-ops")
+{
+    /* The three virtual handlers have empty base-class bodies that are
+     * never reached when the TrackingClient override intercepts them.
+     * Drive them through processMessage on a plain fss_client. */
+    fss::client_ssl::fss_client client(CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+    auto server = std::make_shared<fss::client_ssl::fss_server>(&client, "localhost", uint16_t{0}, CA_PUBLIC_FILE,
+                                                                CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+
+    auto cmd =
+        std::make_shared<fss::transport::fss_message_asset_command>(fss::transport::asset_command_rtl, uint64_t{0});
+    server->processMessage(cmd); /* fss_client::handleCommand — no-op */
+
+    auto pos =
+        std::make_shared<fss::transport::fss_message_position_report>(0.0, 0.0, 0, 0, 0, 0, 0, "T", 0, 0, 0, 0, 0, 0);
+    server->processMessage(pos); /* fss_client::handlePositionReport — no-op */
+
+    auto smm = std::make_shared<fss::transport::fss_message_smm_settings>("https://smm.example/",
+                                                                          fss::secure_string(std::string_view{"user"}),
+                                                                          fss::secure_string(std::string_view{"pass"}));
+    server->processMessage(smm); /* fss_client::handleSMMSettings — no-op */
 }


### PR DESCRIPTION
## Description

- fix: fss_client::disconnect() snapshot this->servers before iterating so that a serverRequiresReconnect callback fired by the recv thread during disconnect() cannot invalidate the range-for iterator (iterator-safety match to the destructor which already uses splice+iterate).

- test: 'client: JSON config with server entry' exercises the file-based constructor (lines 15-41) and setAssetName (lines 73-76).

- test: 'client: disconnect closes all active server connections' drives disconnect() (lines 65-71) via a real TLS listener.

- test: 'client: base class handleCommand, handlePositionReport, handleSMMSettings are no-ops' reaches the three empty virtual overrides in fss_client (lines 212-225) via processMessage on a plain fss_client.

## Summary by Sourcery

Improve safety of SSL client disconnection while expanding test coverage for configuration parsing and base handler behavior.

Bug Fixes:
- Prevent iterator invalidation in fss_client::disconnect() by iterating over a snapshot of the server list.

Tests:
- Add test ensuring JSON config with a server entry parses the asset name and creates a reconnect entry.
- Add test verifying disconnect() closes all active TLS server connections.
- Add tests confirming base-class handleCommand, handlePositionReport, and handleSMMSettings handlers are no-ops when invoked via processMessage.