### PR TITLE
test: extract live_db_or_skip helper to remove db_connection boilerplate

### DIFF
--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -31,14 +31,16 @@ TEST_CASE("db_connection: invalid host reports not connected")
 
 namespace {
 
-/* Build a db_connection from TEST_DB_* env vars.
- * Returns nullptr when TEST_DB_HOST is unset; callers should SKIP in that case. */
-auto make_test_db() -> std::unique_ptr<flight_safety_system::server::db_connection>
+/* SKIP the test if TEST_DB_HOST is unset; otherwise build a db_connection from
+ * the TEST_DB_* env vars and REQUIRE it has connected.  Returns a connection
+ * the caller can use directly — no further SKIP/isConnected boilerplate. */
+auto live_db_or_skip() -> std::unique_ptr<flight_safety_system::server::db_connection>
 {
     const char *host = std::getenv("TEST_DB_HOST");
     if (host == nullptr)
     {
-        return nullptr;
+        SKIP("TEST_DB_HOST not set");
+        return nullptr; /* unreachable — SKIP throws */
     }
     int port = 5432;
     if (const char *p = std::getenv("TEST_DB_PORT"))
@@ -48,42 +50,30 @@ auto make_test_db() -> std::unique_ptr<flight_safety_system::server::db_connecti
     const char *user = std::getenv("TEST_DB_USER");
     const char *pass = std::getenv("TEST_DB_PASS");
     const char *dbname = std::getenv("TEST_DB_NAME");
-    return std::make_unique<flight_safety_system::server::db_connection>(
+    auto dbc = std::make_unique<flight_safety_system::server::db_connection>(
         host, port, user != nullptr ? user : "postgres", pass != nullptr ? pass : "password",
         dbname != nullptr ? dbname : "postgres");
+    REQUIRE(dbc->isConnected());
+    return dbc;
 }
 
 } // namespace
 
 TEST_CASE("db_connection: connects to live database")
 {
-    auto dbc = make_test_db();
-    if (!dbc)
-    {
-        SKIP("TEST_DB_HOST not set");
-    }
+    auto dbc = live_db_or_skip();
     REQUIRE(dbc->isConnected());
 }
 
 TEST_CASE("db_connection: getAssetId returns non-zero for pre-inserted asset")
 {
-    auto dbc = make_test_db();
-    if (!dbc)
-    {
-        SKIP("TEST_DB_HOST not set");
-    }
-    REQUIRE(dbc->isConnected());
+    auto dbc = live_db_or_skip();
     REQUIRE(dbc->getAssetId("test-asset") != 0);
 }
 
 TEST_CASE("db_connection: recordRtt writes a row without error")
 {
-    auto dbc = make_test_db();
-    if (!dbc)
-    {
-        SKIP("TEST_DB_HOST not set");
-    }
-    REQUIRE(dbc->isConnected());
+    auto dbc = live_db_or_skip();
     auto asset_id = dbc->getAssetId("test-asset");
     REQUIRE(asset_id != 0);
     dbc->recordRtt(asset_id, uint64_t{42});
@@ -91,12 +81,7 @@ TEST_CASE("db_connection: recordRtt writes a row without error")
 
 TEST_CASE("db_connection: recordStatus writes a row without error")
 {
-    auto dbc = make_test_db();
-    if (!dbc)
-    {
-        SKIP("TEST_DB_HOST not set");
-    }
-    REQUIRE(dbc->isConnected());
+    auto dbc = live_db_or_skip();
     auto asset_id = dbc->getAssetId("test-asset");
     REQUIRE(asset_id != 0);
     dbc->recordStatus(asset_id, uint8_t{80}, uint32_t{1000}, 12.4);
@@ -104,12 +89,7 @@ TEST_CASE("db_connection: recordStatus writes a row without error")
 
 TEST_CASE("db_connection: recordSearchStatus writes a row without error")
 {
-    auto dbc = make_test_db();
-    if (!dbc)
-    {
-        SKIP("TEST_DB_HOST not set");
-    }
-    REQUIRE(dbc->isConnected());
+    auto dbc = live_db_or_skip();
     auto asset_id = dbc->getAssetId("test-asset");
     REQUIRE(asset_id != 0);
     dbc->recordSearchStatus(asset_id, uint64_t{1}, uint64_t{50}, uint64_t{100});
@@ -117,12 +97,7 @@ TEST_CASE("db_connection: recordSearchStatus writes a row without error")
 
 TEST_CASE("db_connection: recordPosition with valid altitude inserts row")
 {
-    auto dbc = make_test_db();
-    if (!dbc)
-    {
-        SKIP("TEST_DB_HOST not set");
-    }
-    REQUIRE(dbc->isConnected());
+    auto dbc = live_db_or_skip();
     auto asset_id = dbc->getAssetId("test-asset");
     REQUIRE(asset_id != 0);
     dbc->recordPosition(asset_id, -43.5, 172.6, uint32_t{100});
@@ -130,12 +105,7 @@ TEST_CASE("db_connection: recordPosition with valid altitude inserts row")
 
 TEST_CASE("db_connection: recordPosition with overflow altitude is discarded")
 {
-    auto dbc = make_test_db();
-    if (!dbc)
-    {
-        SKIP("TEST_DB_HOST not set");
-    }
-    REQUIRE(dbc->isConnected());
+    auto dbc = live_db_or_skip();
     auto asset_id = dbc->getAssetId("test-asset");
     REQUIRE(asset_id != 0);
     constexpr auto huge_alt = static_cast<uint32_t>(std::numeric_limits<int>::max()) + uint32_t{1};
@@ -144,12 +114,7 @@ TEST_CASE("db_connection: recordPosition with overflow altitude is discarded")
 
 TEST_CASE("db_connection: getSmmSettings returns non-null for configured asset")
 {
-    auto dbc = make_test_db();
-    if (!dbc)
-    {
-        SKIP("TEST_DB_HOST not set");
-    }
-    REQUIRE(dbc->isConnected());
+    auto dbc = live_db_or_skip();
     auto asset_id = dbc->getAssetId("test-asset");
     REQUIRE(asset_id != 0);
     auto settings = dbc->getSmmSettings(asset_id);
@@ -161,23 +126,13 @@ TEST_CASE("db_connection: getSmmSettings returns non-null for configured asset")
 
 TEST_CASE("db_connection: getSmmSettings returns null for asset with no config")
 {
-    auto dbc = make_test_db();
-    if (!dbc)
-    {
-        SKIP("TEST_DB_HOST not set");
-    }
-    REQUIRE(dbc->isConnected());
+    auto dbc = live_db_or_skip();
     REQUIRE(dbc->getSmmSettings(uint64_t{999999}) == nullptr);
 }
 
 TEST_CASE("db_connection: getActiveServers returns pre-configured server")
 {
-    auto dbc = make_test_db();
-    if (!dbc)
-    {
-        SKIP("TEST_DB_HOST not set");
-    }
-    REQUIRE(dbc->isConnected());
+    auto dbc = live_db_or_skip();
     auto servers = dbc->getActiveServers();
     REQUIRE_FALSE(servers.empty());
     bool found = false;
@@ -193,24 +148,14 @@ TEST_CASE("db_connection: getActiveServers returns pre-configured server")
 
 TEST_CASE("db_connection: tryReconnectIfNeeded returns when connection is healthy")
 {
-    auto dbc = make_test_db();
-    if (!dbc)
-    {
-        SKIP("TEST_DB_HOST not set");
-    }
-    REQUIRE(dbc->isConnected());
+    auto dbc = live_db_or_skip();
     dbc->tryReconnectIfNeeded();
     REQUIRE(dbc->isConnected());
 }
 
 TEST_CASE("db_connection: tryReconnectIfNeeded reconnects after underlying disconnect")
 {
-    auto dbc = make_test_db();
-    if (!dbc)
-    {
-        SKIP("TEST_DB_HOST not set");
-    }
-    REQUIRE(dbc->isConnected());
+    auto dbc = live_db_or_skip();
     /* Force the underlying ECPG connection closed so db_ping() will fail,
      * which triggers the reconnect branch in tryReconnectIfNeeded(). */
     db_disconnect();
@@ -222,12 +167,7 @@ TEST_CASE("db_connection: getCommand returns non-null for asset with pending com
 {
     /* The test fixture inserts an RTL command for test-asset before the test
      * suite runs.  getCommand() must find it and return a non-null result. */
-    auto dbc = make_test_db();
-    if (!dbc)
-    {
-        SKIP("TEST_DB_HOST not set");
-    }
-    REQUIRE(dbc->isConnected());
+    auto dbc = live_db_or_skip();
     auto asset_id = dbc->getAssetId("test-asset");
     REQUIRE(asset_id != 0);
     auto cmd = dbc->getCommand(asset_id);


### PR DESCRIPTION
## Description

Each of the 13 live-DB tests in db_connection_test.cpp opened with the same five-line ritual: make_test_db(), nullptr-check + SKIP, REQUIRE isConnected.  Fold all three steps into a single live_db_or_skip() helper so each test body starts directly with the work it cares about.

No behavioural change — SKIP still fires from the same env-var check, isConnected is still required before the test body runs.

## Summary by Sourcery

Tests:
- Introduce a live_db_or_skip helper that encapsulates env-based skipping and connection checks for live DB tests.