### PR TITLE
fix: serialize tslc field in position reports

### DIFF
--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -510,6 +510,7 @@ void flight_safety_system::transport::fss_message_position_report::packData(std:
     bl->addData(&enc_flags, sizeof(uint16_t));
     bl->addData(&this->altitude_type, sizeof(uint8_t));
     bl->addData(&this->emitter_type, sizeof(uint8_t));
+    bl->addData(&this->tslc, sizeof(uint8_t));
 }
 
 void flight_safety_system::transport::fss_message_position_report::unpackData(const std::shared_ptr<buf_len> &bl)
@@ -525,6 +526,7 @@ void flight_safety_system::transport::fss_message_position_report::unpackData(co
     this->flags = 0;
     this->altitude_type = 0;
     this->emitter_type = 0;
+    this->tslc = 0;
     int32_t lat = 0;
     int32_t lng = 0;
     reader.readUint64(this->timestamp);
@@ -540,6 +542,7 @@ void flight_safety_system::transport::fss_message_position_report::unpackData(co
     reader.readUint16(this->flags);
     reader.readUint8(this->altitude_type);
     reader.readUint8(this->emitter_type);
+    reader.readUint8(this->tslc);
     this->latitude = static_cast<double>(lat) * FSS_COORD_SCALE;
     this->longitude = static_cast<double>(lng) * FSS_COORD_SCALE;
 }

--- a/tests/alignment_regression_test.cpp
+++ b/tests/alignment_regression_test.cpp
@@ -39,7 +39,7 @@ namespace {
  * appended after. All fixed pieces; callsign alone varies. */
 constexpr size_t header_bytes = 12;
 constexpr size_t fixed_before_cs = 8 + 4 + 4 + 4 + 4 + 2 + 2 + 2 + 2; /* = 32 */
-constexpr size_t fixed_after_cs = 2 + 1 + 1;                          /* = 4  */
+constexpr size_t fixed_after_cs = 2 + 1 + 1 + 1;                      /* = 5 (flags, alt_type, emitter, tslc) */
 constexpr size_t callsign_len_prefix = 2;
 constexpr size_t align = 8;
 

--- a/tests/messages.cpp
+++ b/tests/messages.cpp
@@ -144,10 +144,11 @@ TEST_CASE("Position Report Message Check")
     constexpr int vfr_squawk = 01200;
     constexpr int flags = 0xAA55;
     constexpr int emitter_type = 14;
+    constexpr uint8_t tslc = 7;
 
     /* Create a test position report */
     auto msg = std::make_shared<flight_safety_system::transport::fss_message_position_report>(
-        pos_lat, pos_lng, altitude, heading, hor_vel, vert_vel, icao_address, "ZK-ABC", vfr_squawk, 0, flags, 1,
+        pos_lat, pos_lng, altitude, heading, hor_vel, vert_vel, icao_address, "ZK-ABC", vfr_squawk, tslc, flags, 1,
         emitter_type, timestamp);
     /* Check the type */
     REQUIRE(msg->getType() == flight_safety_system::transport::message_type_position_report);
@@ -165,6 +166,7 @@ TEST_CASE("Position Report Message Check")
     REQUIRE(msg->getFlags() == flags);
     REQUIRE(msg->getAltitudeType() == 1);
     REQUIRE(msg->getEmitterType() == emitter_type);
+    REQUIRE(msg->getTSLC() == tslc);
     /* Convert to bl and back */
     msg->setId(msg_id);
     auto bl = msg->getPacked();
@@ -188,6 +190,7 @@ TEST_CASE("Position Report Message Check")
     REQUIRE(decoded->getFlags() == flags);
     REQUIRE(decoded->getAltitudeType() == 1);
     REQUIRE(decoded->getEmitterType() == emitter_type);
+    REQUIRE(decoded->getTSLC() == tslc);
     auto decoded_generic = flight_safety_system::transport::fss_message::decode(bl);
     /* Check the type */
     REQUIRE(decoded_generic->getType() == flight_safety_system::transport::message_type_position_report);


### PR DESCRIPTION
## Description

The time-since-last-communication (tslc) field was accepted by the position-report constructor and exposed via getTSLC(), but packData() never wrote it and unpackData() never read it. Any position report that round-tripped through the wire lost tslc, with getTSLC() always returning 0.

Append tslc after emitter_type so older senders (which omit it) still decode cleanly via BufferReader's short-read tolerance — the trailing alignment padding reads back as tslc=0, the correct default.

The existing getTSLC test only checked the in-memory accessor, never a round-trip, so it gave false confidence. Extend the Position Report round-trip test to carry a non-zero tslc and assert it survives encode /decode, and update the alignment regression's fixed-field size.

## Summary by Sourcery

Ensure the position report message correctly serializes and deserializes the time-since-last-communication (TSLC) field and adjust related tests and alignment constants.

Bug Fixes:
- Persist the TSLC field through position report pack/unpack so it no longer resets to zero after wire round-trips.

Tests:
- Extend the position report round-trip test to include a non-zero TSLC value and assert it is preserved.
- Update the alignment regression test to account for the additional TSLC byte in the fixed-size payload calculation.