### PR TITLE
fix: retry send() on EINTR instead of dropping the connection

### DIFF
--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -310,6 +310,15 @@ auto flight_safety_system::transport::fss_connection::sendMsg(const std::shared_
         ssize_t transfered = send(current_fd, &data[sent], to_send - sent, 0);
         if (transfered < 0)
         {
+            /* A signal can interrupt send() before any bytes are written;
+             * that is not a connection failure, so retry rather than dropping
+             * the peer. SIGPIPE is ignored process-wide, so a genuinely broken
+             * connection surfaces here as EPIPE (or similar) and falls through
+             * to return false. */
+            if (errno == EINTR)
+            {
+                continue;
+            }
             return false;
         }
         sent += transfered;


### PR DESCRIPTION
## Description

The plain-TCP send loop treated any negative send() return as fatal and returned false, tearing down the peer. A signal interrupting send() before any bytes are written yields EINTR, which is not a connection failure. Retry on EINTR; SIGPIPE is ignored process-wide, so a genuinely broken connection still surfaces (e.g. EPIPE) and returns false.

## Summary by Sourcery

Bug Fixes:
- Retry send() on EINTR in the TCP send loop instead of treating it as a fatal error that tears down the peer.