### PR TITLE
fix: clamp reconnect backoff to the cap instead of overshooting

### DIFF
--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -303,7 +303,10 @@ auto flight_safety_system::client_ssl::fss_server::reconnect() -> bool
         this->retry_count++;
         if (this->retry_delay < retry_delay_cap)
         {
-            this->retry_delay += this->retry_delay;
+            /* Exponential backoff, clamped to the cap. Plain doubling would
+             * overshoot (e.g. 16000 -> 32000 with a 30000 cap) before the
+             * guard stops it on the next iteration. */
+            this->retry_delay = std::min(this->retry_delay * 2, retry_delay_cap);
         }
         int64_t jitter_range = static_cast<int64_t>(this->retry_delay) / 4;
         std::uniform_int_distribution<int64_t> dist(-jitter_range, jitter_range);

--- a/tests/reconnect_test.cpp
+++ b/tests/reconnect_test.cpp
@@ -238,6 +238,32 @@ TEST_CASE("reconnect: jitter keeps effective delay within 25% of base")
     REQUIRE(any_differ);
 }
 
+TEST_CASE("reconnect: backoff base delay never overshoots the cap")
+{
+    auto client = std::make_shared<flight_safety_system::client_ssl::fss_client>(CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE,
+                                                                                 CLIENT_PUBLIC_FILE);
+    auto server = std::make_shared<CountingServer>(client.get(), "127.0.0.1", static_cast<uint16_t>(20602),
+                                                   CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+    auto fake = std::make_shared<FakeClock>();
+    server->setClock(fake);
+
+    constexpr uint64_t retry_delay_cap = 30000;
+    /* effective_delay = base (capped) + jitter, where jitter is at most
+     * base/4 (±25%). With the base clamped to the cap, effective_delay can
+     * never exceed cap * 1.25. The pre-fix code doubled the base past the cap
+     * (16000 -> 32000), pushing effective_delay above this bound. */
+    constexpr uint64_t effective_upper_bound = retry_delay_cap + retry_delay_cap / 4;
+
+    /* 1000ms -> 30000ms is five doublings; 20 iterations saturates the base.
+     * Advancing by more than the cap each time guarantees the throttle fires. */
+    for (int i = 0; i < 20; ++i)
+    {
+        fake->advance(retry_delay_cap * 2);
+        server->reconnect();
+        REQUIRE(server->getEffectiveDelay() <= effective_upper_bound);
+    }
+}
+
 TEST_CASE("reconnect: multi-server failover keeps secondary reachable")
 {
     constexpr uint16_t port_primary = 20507;


### PR DESCRIPTION
## Description

fss_server::reconnect doubled retry_delay with `retry_delay += retry_delay` while the value was still below retry_delay_cap. Starting at 1000ms with a 30000ms cap, the sequence reached 16000 (< cap) and then doubled to 32000, overshooting the cap by 2000ms before the guard stopped further growth.

Clamp the doubling to the cap with std::min, and add a regression test that drives the backoff to saturation and asserts effective_delay (base + up to 25% jitter) never exceeds cap * 1.25.

## Summary by Sourcery

Clamp reconnect backoff delays to the configured cap and add coverage to ensure the effective delay remains within the expected bound.

Bug Fixes:
- Prevent reconnect retry_delay from overshooting the configured cap during exponential backoff.

Tests:
- Add regression test that drives reconnect backoff to saturation and asserts effective delay never exceeds the capped upper bound with jitter.