### PR TITLE
refactor: use a dedicated wire scale for battery voltage

### DIFF
--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -17,6 +17,12 @@ namespace transport {
 
 static constexpr double FSS_COORD_SCALE = 0.0000001;
 
+/* Fixed-point scale for battery voltage on the wire (volts per LSB). Held
+ * separate from FSS_COORD_SCALE — they share a value today but are unrelated
+ * quantities; changing coordinate precision must not silently rescale
+ * voltages. */
+static constexpr double FSS_VOLTAGE_SCALE = 0.0000001;
+
 /* Wire-protocol version handshake.
  * - FSS_PROTOCOL_VERSION_LEGACY (0): unversioned protocol that pre-dates the
  *   handshake. Used as the negotiated value when the peer never sends a

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -10,6 +10,7 @@ using flight_safety_system::fss_be32toh;
 using flight_safety_system::fss_htobe64;
 using flight_safety_system::fss_be64toh;
 using flight_safety_system::transport::FSS_COORD_SCALE;
+using flight_safety_system::transport::FSS_VOLTAGE_SCALE;
 
 static void packStringRaw(const std::shared_ptr<flight_safety_system::transport::buf_len> &bl, const char *data,
                           size_t str_len)
@@ -626,7 +627,7 @@ void flight_safety_system::transport::fss_message_system_status::packData(std::s
     uint8_t bat_percent_n = this->getBatRemaining();
     uint32_t mah_used_n = fss_htobe32(this->getBatMAHUsed());
     uint32_t voltage_n =
-        fss_htobe32(static_cast<uint32_t>(static_cast<int32_t>(this->getBatVoltage() / FSS_COORD_SCALE)));
+        fss_htobe32(static_cast<uint32_t>(static_cast<int32_t>(this->getBatVoltage() / FSS_VOLTAGE_SCALE)));
 
     bl->addData(&bat_percent_n, sizeof(uint8_t));
     bl->addData(&mah_used_n, sizeof(uint32_t));
@@ -644,7 +645,7 @@ void flight_safety_system::transport::fss_message_system_status::unpackData(cons
     uint32_t voltage_n = 0;
     if (reader.readUint32(voltage_n))
     {
-        this->voltage = static_cast<double>(voltage_n) * FSS_COORD_SCALE;
+        this->voltage = static_cast<double>(voltage_n) * FSS_VOLTAGE_SCALE;
     }
 }
 


### PR DESCRIPTION
## Description

system_status packed and unpacked battery voltage using FSS_COORD_SCALE, the latitude/longitude fixed-point constant. The two are unrelated quantities that happen to share a scale today; coupling them means a future change to coordinate precision would silently corrupt voltages.

Introduce FSS_VOLTAGE_SCALE (same value, so the wire format is unchanged) and use it for the voltage field.

## Summary by Sourcery

Decouple battery voltage fixed-point scaling from coordinate scaling in the wire protocol while preserving the existing on-the-wire representation.

Enhancements:
- Introduce a dedicated FSS_VOLTAGE_SCALE constant for battery voltage serialization.
- Update system_status packing and unpacking to use the voltage scale instead of the coordinate scale for the battery voltage field.