### PR TITLE
fix: guard 16-bit length truncation when packing

### DIFF
--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -1,6 +1,8 @@
 #include "fss-transport.hpp"
 #include "fss-endian.hpp"
+#include "fss-log.hpp"
 
+#include <limits>
 #include <memory>
 
 using flight_safety_system::fss_htobe16;
@@ -15,7 +17,17 @@ using flight_safety_system::transport::FSS_VOLTAGE_SCALE;
 static void packStringRaw(const std::shared_ptr<flight_safety_system::transport::buf_len> &bl, const char *data,
                           size_t str_len)
 {
-    uint16_t len = fss_htobe16(str_len);
+    /* The on-wire length prefix is 16-bit. Clamp so the prefix can never
+     * disagree with the bytes actually written; a mismatch would desync the
+     * decoder. Legitimate strings are far below this (the receive path caps
+     * whole messages at FSS_MAX_MESSAGE_BYTES), so clamping only guards
+     * against an upstream programming error. */
+    if (str_len > std::numeric_limits<uint16_t>::max())
+    {
+        FSS_LOG_ERROR("transport", "String of " << str_len << " bytes exceeds 16-bit length prefix; truncating");
+        str_len = std::numeric_limits<uint16_t>::max();
+    }
+    uint16_t len = fss_htobe16(static_cast<uint16_t>(str_len));
     bl->addData(&len, sizeof(uint16_t));
     bl->addData(data, str_len);
     /* align to 8-byte boundary */
@@ -330,16 +342,26 @@ void flight_safety_system::transport::fss_message::createHeader(const std::share
 
 void flight_safety_system::transport::fss_message::updateSize(const std::shared_ptr<buf_len> &bl)
 {
-    uint16_t length = bl->getLength();
+    size_t length = bl->getLength();
     if (length > sizeof(uint16_t))
     {
-        /* Set the length */
+        /* The header length field is 16-bit. A message larger than that cannot
+         * be framed; emitting a truncated length would corrupt the stream, so
+         * log and leave the placeholder rather than writing a bogus value. The
+         * receive side independently rejects anything over FSS_MAX_MESSAGE_BYTES. */
+        if (length > std::numeric_limits<uint16_t>::max())
+        {
+            FSS_LOG_ERROR("transport", "Message of " << length << " bytes exceeds 16-bit length field; not framing");
+            return;
+        }
+        /* Set the length (the unpadded content length; the receiver re-derives
+         * the padded size). */
         if (length % sizeof(uint64_t) != 0)
         {
             uint64_t blank = 0;
             bl->addData(&blank, sizeof(uint64_t) - (length % sizeof(uint64_t)));
         }
-        uint16_t length_n = fss_htobe16(length);
+        uint16_t length_n = fss_htobe16(static_cast<uint16_t>(length));
         bl->writeAt(0, &length_n, sizeof(uint16_t));
     }
 }


### PR DESCRIPTION
## Description

packStringRaw cast a size_t string length straight into the 16-bit on-wire length prefix, and updateSize captured buf_len::getLength() (a size_t) in a uint16_t. A string or message over 65535 bytes would write a prefix/length that disagreed with the bytes present, desyncing the decoder.

Both paths are currently unreachable (the receive side caps whole messages at FSS_MAX_MESSAGE_BYTES), but the truncation was silent. Clamp the string length so prefix and data always agree, and have updateSize refuse to frame an oversized message rather than write a bogus length. Both log an error so an upstream bug surfaces instead of corrupting the stream.

## Summary by Sourcery

Guard 16-bit length-prefixed transport messages against silent truncation and ensure oversized payloads are handled safely.

Bug Fixes:
- Clamp string length prefixes to the 16-bit on-wire maximum and log when truncation occurs to prevent encoder/decoder desynchronization.
- Reject framing of messages whose size exceeds the 16-bit header length field and log an error instead of emitting a corrupted length.

Enhancements:
- Add logging and limit checks around transport message packing to surface upstream size bugs without corrupting the stream.