### PR TITLE
fix: apply client config before wiring the message handler

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -136,6 +136,16 @@ fss::server::fss_client::fss_client(std::shared_ptr<fss::transport::fss_connecti
                                     std::shared_ptr<db_write_queue> t_writer, fss_client_handler *t_handler)
     : fss_message_cb(std::move(t_conn)), dbc(t_dbc), writer(std::move(t_writer)), client_handler(t_handler)
 {
+    /* The connection's recv thread may already be running (it is started by
+     * fss_connection_server::create before this client exists). The handler
+     * is wired separately, via activate(), only after per-client config
+     * (timeout, rate limits) has been applied — otherwise the recv thread
+     * could deliver a message and touch msg_rate while it is being
+     * reconfigured. Until then, inbound messages queue on the connection. */
+}
+
+void fss::server::fss_client::activate()
+{
     this->getConnection()->setHandler(this);
 }
 

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -160,6 +160,9 @@ public:
     auto operator=(fss_client &) -> fss_client & = delete;
     auto operator=(fss_client &&) -> fss_client & = delete;
     ~fss_client() override;
+    /* Wire this client as the connection's message handler. Call only after
+     * per-client config (timeout, rate limits) is set; see the constructor. */
+    void activate();
     void processMessage(std::shared_ptr<transport::fss_message> message) override;
     void sendRTTRequest(const std::shared_ptr<transport::fss_message_rtt_request> &rtt_req);
     void sendSMMSettings();

--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -53,11 +53,21 @@ public:
     }
     void clientConnected(std::shared_ptr<flight_safety_system::server::fss_client> client)
     {
+        /* Apply config before wiring the connection's message handler: the
+         * recv thread is already live, so activating the handler first would
+         * let a message reach the client (touching msg_rate) while the rate
+         * limiter is still being reconfigured. */
         client->setTimeoutMs(this->client_timeout_ms);
         client->setRateLimits(this->rate_capacity, this->rate_refill_per_s);
-        std::scoped_lock guard(this->lock);
-        this->total_clients++;
-        this->clients.push_back(std::move(client));
+        auto *raw = client.get();
+        {
+            std::scoped_lock guard(this->lock);
+            this->total_clients++;
+            this->clients.push_back(std::move(client));
+        }
+        /* Register only after the client is in the list, so a queued message
+         * flushed by activate() that triggers clientDisconnected can find it. */
+        raw->activate();
     };
     void clientDisconnected(flight_safety_system::server::fss_client *client) override
     {


### PR DESCRIPTION
## Description

fss_client wired itself as the connection's message handler from its constructor, but the connection's recv thread is already running (started by fss_connection_server::create before the client exists). clientConnected then applied the per-client timeout and rate limits afterwards. A message arriving in that window would run processMessage on the recv thread, calling msg_rate.consume() concurrently with setRateLimits() reassigning the non-atomic rate_limiter — a data race on a safety path, masked only by the sane defaults.

Split handler-wiring into a new activate() method. clientConnected now applies config, registers the client in the list, then activates — so the handler (and its flush of any queued messages) cannot run until config is in place, and a flushed message that triggers clientDisconnected can find the client already registered. Inbound messages queue on the connection until activation.

## Summary by Sourcery

Delay wiring fss_client as the connection's message handler until after per-client configuration is applied and the client is registered, preventing races between message handling and rate/timeout setup.

Bug Fixes:
- Ensure inbound messages are queued until per-client timeout and rate limits are configured to avoid data races on the rate limiter.
- Guarantee that clientDisconnected can find a client by registering it before activating the message handler.