### PR TITLE
fix: time out dead non-aircraft clients

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -438,6 +438,12 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
             {
                 std::scoped_lock guard(this->client_lock);
                 this->name = client_name;
+                /* Enable liveness tracking so a dead non-aircraft client is
+                 * reaped on RTT timeout, the same as an aircraft. RTT requests
+                 * already go to every client and responses update
+                 * last_rtt_response_time regardless of type. */
+                this->liveness_active = true;
+                this->last_rtt_response_time = this->clock->now_ms();
             }
             this->aircraft = false;
             this->identified = true;

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -230,6 +230,38 @@ TEST_CASE("session: accepts non-aircraft identify when cert CN is not a known ai
     REQUIRE(cap.str().find("Non-aircraft client identified: ground-station-1") != std::string::npos);
 }
 
+TEST_CASE("session: identified non-aircraft client times out on liveness loss")
+{
+    /* A non-aircraft client must be reaped on RTT timeout just like an
+     * aircraft; before liveness tracking was enabled for non-aircraft
+     * identify, isTimedOut() always returned false for them. */
+    fss_test::MockDatabase mock;
+    auto clock = std::make_shared<FakeClock>();
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("ground-station-1");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->setClock(clock);
+    session->setTimeoutMs(1000);
+
+    /* Not timed out before identify (liveness inactive). */
+    REQUIRE_FALSE(session->isTimedOut());
+
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity_non_aircraft>());
+    REQUIRE_FALSE(session->isAircraft());
+
+    /* Just under the threshold: still alive. */
+    clock->advance(999);
+    REQUIRE_FALSE(session->isTimedOut());
+
+    /* Past the threshold with no RTT response: timed out. */
+    clock->advance(2);
+    REQUIRE(session->isTimedOut());
+}
+
 TEST_CASE("session: logs when an identified non-aircraft client disconnects")
 {
     fss_test::MockDatabase mock;


### PR DESCRIPTION
## Description

liveness_active was only set during aircraft identify, so isTimedOut() always returned false for non-aircraft (ground-station) clients. A hung or dead non-aircraft client was never reaped and held its slot indefinitely, even though RTT requests were already being sent to it.

Enable liveness tracking on non-aircraft identify too; RTT responses already update last_rtt_response_time regardless of client type, so the existing timeout sweep now covers both. Add a regression test driving a non-aircraft client past the timeout threshold.

## Summary by Sourcery

Ensure non-aircraft clients are subject to liveness timeouts and add test coverage for this behavior.

Bug Fixes:
- Activate liveness tracking for identified non-aircraft clients so they are correctly timed out and reaped on RTT inactivity.

Tests:
- Add a regression test verifying that identified non-aircraft clients time out after the configured RTT liveness threshold.