### PR TITLE
docs: reframe sequence check as in-order/duplicate detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Per-client token-bucket rate limiting** — configurable `message_rate_capacity`
   and `message_rate_refill` protect the server from burst flooding by individual
   clients.
-- **Replay protection** — sequence numbers and timestamp staleness checks reject
-  replayed or heavily delayed messages.
+- **In-order delivery and staleness checks** — per-connection sequence numbers
+  reject out-of-order or duplicated messages within a session, and a timestamp
+  staleness check discards heavily delayed position reports. (TLS already
+  provides cryptographic replay/reorder protection at the record layer; these
+  are application-level integrity checks, not a security replay defence.)
 - **SMM credentials stored in `secure_string`** — SMM username and password are
   held in memory-locked, zero-on-free storage.
 - **TLS cipher priority hardened** — GnuTLS priority string tightened; minimum

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -344,6 +344,13 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
         }
         return;
     }
+    /* In-order / duplicate detection (v2+). Each peer numbers the messages it
+     * sends with a monotonic per-connection counter; we require the next id to
+     * match. This is an application-level integrity check that rejects
+     * reordered or duplicated messages within a session — it is NOT a security
+     * replay defence. TLS already provides cryptographic replay and reorder
+     * protection at the record layer; an attacker cannot inject a replayed
+     * message into the encrypted stream in the first place. */
     if (this->getConnection()->getNegotiatedVersion() >= 2)
     {
         uint64_t wanted = this->expected_seq.load();
@@ -352,7 +359,7 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
             if (msg->getSeq() != wanted)
             {
                 FSS_LOG_WARN("server",
-                             "Out-of-order or replayed message seq=" << msg->getSeq() << " expected=" << wanted);
+                             "Out-of-order or duplicate message seq=" << msg->getSeq() << " expected=" << wanted);
                 if (msg->getType() == fss::transport::message_type_identity ||
                     msg->getType() == fss::transport::message_type_identity_non_aircraft)
                 {

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -620,7 +620,9 @@ auto establish_v2_session(std::shared_ptr<fss::server::fss_client> &session, uin
 TEST_CASE("session: v2 replayed data message is dropped")
 {
     /* m7.1 phase 2: a position report whose seq matches a message the server
-     * already processed (replay) must be discarded. */
+     * already processed (a duplicate within the session) must be discarded.
+     * This is in-order/duplicate detection, not a security replay defence —
+     * TLS already prevents record-layer replay. */
     fss_test::MockDatabase mock;
     mock.asset_ids["craft"] = 1;
 


### PR DESCRIPTION
## Description

The v2 sequence-number check was described as "replay protection" in the changelog and logs. It runs inside the TLS session, which already provides cryptographic replay and reorder protection at the record layer, so an attacker cannot inject a replayed message into the stream. The check is really application-level in-order/duplicate detection.

Clarify the intent with a comment at the check, change the log wording from "replayed" to "duplicate", reword the changelog entry, and note the distinction in the relevant test comment. No behaviour change.

## Summary by Sourcery

Clarify that the v2 sequence-number check is in-order/duplicate detection rather than cryptographic replay protection, updating comments, logs, changelog wording, and related test descriptions to reflect this intent without changing behaviour.

Enhancements:
- Reword server log messages to describe out-of-order or duplicate messages instead of replayed messages.
- Document the in-order/duplicate detection semantics of the sequence check in code comments and tests.
- Update the changelog entry to explain the distinction between TLS-layer replay protection and application-level integrity checks.

Documentation:
- Revise changelog documentation to accurately describe sequence-number checks as in-order/duplicate detection and timestamp staleness handling.

Tests:
- Clarify test comments to describe duplicate detection within a session rather than generic replay protection.