### PR TITLE
perf: decouple DB command reads from telemetry writes

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -16,87 +16,112 @@ extern "C" {
 flight_safety_system::server::db_connection::db_connection(
     std::string host, int port, std::string user, std::string pass,
     std::string db) // NOLINT(bugprone-easily-swappable-parameters)
-    : db_lock(), host_(std::move(host)), port_(port), user_(std::move(user)), pass_(std::move(pass)), db_(std::move(db))
+    : read_lock(), write_lock(), host_(std::move(host)), port_(port), user_(std::move(user)), pass_(std::move(pass)),
+      db_(std::move(db))
 {
-    connected_ = (db_connect(host_.c_str(), port_, user_.c_str(), pass_.c_str(), db_.c_str()) == 1);
+    read_connected_ = connectOne(read_conn_name);
+    write_connected_ = connectOne(write_conn_name);
+}
+
+auto flight_safety_system::server::db_connection::connectOne(const char *conn_name) -> bool
+{
+    return db_connect(conn_name, host_.c_str(), port_, user_.c_str(), pass_.c_str(), db_.c_str()) == 1;
 }
 
 auto flight_safety_system::server::db_connection::isConnected() const -> bool
 {
-    return connected_;
+    return read_connected_ && write_connected_;
+}
+
+void flight_safety_system::server::db_connection::reconnectOne(const char *conn_name, bool &connected_flag)
+{
+    if (db_ping(conn_name) != 0)
+    {
+        connected_flag = true;
+        return;
+    }
+    FSS_LOG_WARN("db", "Database connection '" << conn_name << "' lost, attempting reconnect");
+    db_disconnect(conn_name);
+    connected_flag = connectOne(conn_name);
+    if (connected_flag)
+    {
+        FSS_LOG_INFO("db", "Database connection '" << conn_name << "' reconnected successfully");
+    }
+    else
+    {
+        FSS_LOG_ERROR("db", "Database connection '" << conn_name << "' reconnect failed");
+    }
 }
 
 void flight_safety_system::server::db_connection::tryReconnectIfNeeded()
 {
-    std::scoped_lock guard(this->db_lock);
-    if (db_ping() != 0)
     {
-        connected_ = true;
-        return;
+        std::scoped_lock guard(this->read_lock);
+        reconnectOne(read_conn_name, this->read_connected_);
     }
-    FSS_LOG_WARN("db", "Database connection lost, attempting reconnect");
-    db_disconnect();
-    connected_ = (db_connect(host_.c_str(), port_, user_.c_str(), pass_.c_str(), db_.c_str()) == 1);
-    if (connected_)
     {
-        FSS_LOG_INFO("db", "Database reconnected successfully");
-    }
-    else
-    {
-        FSS_LOG_ERROR("db", "Database reconnect failed");
+        std::scoped_lock guard(this->write_lock);
+        reconnectOne(write_conn_name, this->write_connected_);
     }
 }
 
 flight_safety_system::server::db_connection::~db_connection()
 {
-    db_disconnect();
+    {
+        std::scoped_lock guard(this->read_lock);
+        db_disconnect(read_conn_name);
+    }
+    {
+        std::scoped_lock guard(this->write_lock);
+        db_disconnect(write_conn_name);
+    }
 }
 
 auto flight_safety_system::server::db_connection::getAssetId(const std::string &name) -> uint64_t
 {
-    std::scoped_lock guard(this->db_lock);
-    return db_get_asset_id(name.c_str());
+    std::scoped_lock guard(this->read_lock);
+    return db_get_asset_id(read_conn_name, name.c_str());
 }
 
 void flight_safety_system::server::db_connection::recordRtt(uint64_t asset_id, uint64_t rtt_ms)
 {
-    std::scoped_lock guard(this->db_lock);
-    db_rtt_create_entry(asset_id, rtt_ms);
+    std::scoped_lock guard(this->write_lock);
+    db_rtt_create_entry(write_conn_name, asset_id, rtt_ms);
 }
 
 void flight_safety_system::server::db_connection::recordStatus(uint64_t asset_id, uint8_t bat_percent,
                                                                uint32_t bat_mah_used, double bat_voltage)
 {
-    std::scoped_lock guard(this->db_lock);
-    db_status_create_entry(asset_id, bat_percent, bat_mah_used, bat_voltage);
+    std::scoped_lock guard(this->write_lock);
+    db_status_create_entry(write_conn_name, asset_id, bat_percent, bat_mah_used, bat_voltage);
 }
 
 void flight_safety_system::server::db_connection::recordSearchStatus(uint64_t asset_id, uint64_t search_id,
                                                                      uint64_t completed, uint64_t total)
 {
-    std::scoped_lock guard(this->db_lock);
-    db_search_status_create_entry(asset_id, search_id, completed, total);
+    std::scoped_lock guard(this->write_lock);
+    db_search_status_create_entry(write_conn_name, asset_id, search_id, completed, total);
 }
 
 void flight_safety_system::server::db_connection::recordPosition(uint64_t asset_id, double latitude, double longitude,
                                                                  uint32_t altitude)
 {
-    std::scoped_lock guard(this->db_lock);
+    std::scoped_lock guard(this->write_lock);
     if (altitude > static_cast<uint32_t>(std::numeric_limits<int>::max()))
     {
         FSS_LOG_ERROR("db", "Altitude " << altitude << " exceeds int range; discarding position record for asset "
                                         << asset_id);
         return;
     }
-    db_position_create_entry(asset_id, latitude, longitude, static_cast<int>(altitude));
+    db_position_create_entry(write_conn_name, asset_id, latitude, longitude, static_cast<int>(altitude));
 }
 
 auto flight_safety_system::server::db_connection::getCommand(uint64_t asset_id) -> std::shared_ptr<asset_command>
 {
     std::shared_ptr<asset_command> res = nullptr;
     {
-        std::scoped_lock guard(this->db_lock);
-        struct asset_command_s *command = db_asset_command_get(asset_id);
+        std::scoped_lock guard(this->read_lock);
+        struct asset_command_s *command = db_asset_command_get(read_conn_name, asset_id);
         if (command)
         {
             res = std::make_shared<asset_command>(command->dbid, command->timestamp, std::string(command->command),
@@ -112,8 +137,8 @@ auto flight_safety_system::server::db_connection::getSmmSettings(uint64_t asset_
 {
     std::shared_ptr<smm_settings> res = nullptr;
     {
-        std::scoped_lock guard(this->db_lock);
-        struct smm_settings_s *settings = db_asset_smm_settings_get(asset_id);
+        std::scoped_lock guard(this->read_lock);
+        struct smm_settings_s *settings = db_asset_smm_settings_get(read_conn_name, asset_id);
         if (settings)
         {
             res = std::make_shared<smm_settings>(
@@ -136,8 +161,8 @@ auto flight_safety_system::server::db_connection::getActiveServers() -> std::vec
     std::vector<fss_server_details> res;
     struct fss_server_s **servers = nullptr;
     {
-        std::scoped_lock guard(this->db_lock);
-        servers = db_active_fss_servers_get();
+        std::scoped_lock guard(this->read_lock);
+        servers = db_active_fss_servers_get(read_conn_name);
     }
     if (servers)
     {

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -83,13 +83,25 @@ public:
 
 class db_connection : public IDatabase {
 private:
-    std::mutex db_lock;
-    bool connected_{false};
+    /* Two independent ECPG connections so a stalled telemetry write cannot
+     * block a command/config read. Each connection is guarded by its own
+     * mutex and therefore only ever used by one thread at a time — the
+     * thread-safe usage pattern ECPG documents. read_lock covers getAssetId,
+     * getCommand, getActiveServers and getSmmSettings; write_lock covers the
+     * record* telemetry inserts. */
+    static constexpr const char *read_conn_name = "fss_read";
+    static constexpr const char *write_conn_name = "fss_write";
+    std::mutex read_lock;
+    std::mutex write_lock;
+    bool read_connected_{false};
+    bool write_connected_{false};
     std::string host_;
     int port_{5432};
     std::string user_;
     std::string pass_;
     std::string db_;
+    auto connectOne(const char *conn_name) -> bool;
+    void reconnectOne(const char *conn_name, bool &connected_flag);
 public:
     db_connection(std::string host, int port, std::string user, std::string pass, std::string db);
     db_connection(db_connection &) = delete;

--- a/src/server-db.h
+++ b/src/server-db.h
@@ -1,14 +1,18 @@
-int db_connect(const char *host, int port, const char *user, const char *pass, const char *db);
-void db_disconnect(void);
-int db_ping(void);
+/* Every entry point takes the name of the ECPG connection to run on, so the
+ * caller can keep telemetry writes and command/config reads on separate
+ * connections (see db.cpp). */
+int db_connect(const char *conn, const char *host, int port, const char *user, const char *pass, const char *db);
+void db_disconnect(const char *conn);
+int db_ping(const char *conn);
 
-unsigned long long db_get_asset_id(const char *asset_name);
-void db_rtt_create_entry(unsigned long long asset_id, unsigned long long delta);
-void db_status_create_entry(unsigned long long asset_id, unsigned short bat_percent, unsigned int bat_mah_used,
-                            double bat_voltage);
-void db_search_status_create_entry(unsigned long long asset_id, unsigned long long search_id,
+unsigned long long db_get_asset_id(const char *conn, const char *asset_name);
+void db_rtt_create_entry(const char *conn, unsigned long long asset_id, unsigned long long delta);
+void db_status_create_entry(const char *conn, unsigned long long asset_id, unsigned short bat_percent,
+                            unsigned int bat_mah_used, double bat_voltage);
+void db_search_status_create_entry(const char *conn, unsigned long long asset_id, unsigned long long search_id,
                                    unsigned long long search_completed, unsigned long long search_total);
-void db_position_create_entry(unsigned long long asset_id, double latitude, double longitude, int altitude);
+void db_position_create_entry(const char *conn, unsigned long long asset_id, double latitude, double longitude,
+                              int altitude);
 
 struct asset_command_s {
     char *command;
@@ -19,7 +23,7 @@ struct asset_command_s {
     unsigned short altitude;
 };
 
-struct asset_command_s *db_asset_command_get(unsigned long long asset_id_arg);
+struct asset_command_s *db_asset_command_get(const char *conn, unsigned long long asset_id_arg);
 
 struct smm_settings_s {
     char *address;
@@ -27,13 +31,13 @@ struct smm_settings_s {
     char *password;
 };
 
-struct smm_settings_s *db_asset_smm_settings_get(unsigned long long asset_id_arg);
+struct smm_settings_s *db_asset_smm_settings_get(const char *conn, unsigned long long asset_id_arg);
 
 struct fss_server_s {
     char *address;
     int port;
 };
 
-struct fss_server_s **db_active_fss_servers_get(void);
+struct fss_server_s **db_active_fss_servers_get(const char *conn);
 
 void db_free_fss_servers(struct fss_server_s **servers);

--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -8,7 +8,14 @@
 #define SMM_SERVER_LEN 256
 #define SMM_PASSWORD_LEN 256
 
-int db_connect(const char *host, int port, const char *user, const char *pass, const char *db)
+/* Every statement is qualified with `AT :conn` so the caller chooses which
+ * named connection it runs on. The server opens two connections — one for
+ * telemetry writes, one for command/config reads — so a stalled write cannot
+ * block a command read (see db.cpp). Each connection is used by at most one
+ * thread at a time (the C++ layer guards each with its own mutex), which is
+ * the thread-safe usage pattern ECPG documents. */
+
+int db_connect(const char *conn_arg, const char *host, int port, const char *user, const char *pass, const char *db)
 {
     /* Set connect_timeout and TCP keepalives via environment variables.
      * overwrite=0 so this is a no-op on reconnects; the first call happens
@@ -30,12 +37,13 @@ int db_connect(const char *host, int port, const char *user, const char *pass, c
     }
 
     EXEC SQL BEGIN DECLARE SECTION;
+    const char *conn     = conn_arg;
     const char *db_target = target;
     const char *db_user   = user;
     const char *db_pass   = pass;
     EXEC SQL END DECLARE SECTION;
 
-    EXEC SQL CONNECT TO :db_target AS conn USER :db_user USING :db_pass;
+    EXEC SQL CONNECT TO :db_target AS :conn USER :db_user USING :db_pass;
 
     free(target);
 
@@ -45,7 +53,7 @@ int db_connect(const char *host, int port, const char *user, const char *pass, c
         return 0;
     }
 
-    EXEC SQL SET AUTOCOMMIT TO ON;
+    EXEC SQL AT :conn SET AUTOCOMMIT TO ON;
 
     if (sqlca.sqlcode < 0)
     {
@@ -56,68 +64,74 @@ int db_connect(const char *host, int port, const char *user, const char *pass, c
     return 1;
 }
 
-unsigned long long db_get_asset_id(const char *asset_name_arg)
+unsigned long long db_get_asset_id(const char *conn_arg, const char *asset_name_arg)
 {
     EXEC SQL BEGIN DECLARE SECTION;
+    const char *conn = conn_arg;
     const char *asset_name = asset_name_arg;
     unsigned long long asset_id = 0;
     EXEC SQL END DECLARE SECTION;
 
-    EXEC SQL SELECT id INTO :asset_id FROM assets_asset WHERE name = :asset_name;
-    
+    EXEC SQL AT :conn SELECT id INTO :asset_id FROM assets_asset WHERE name = :asset_name;
+
     return asset_id;
 }
 
-void db_rtt_create_entry(unsigned long long asset_id_arg, unsigned long long delta)
+void db_rtt_create_entry(const char *conn_arg, unsigned long long asset_id_arg, unsigned long long delta)
 {
     EXEC SQL BEGIN DECLARE SECTION;
+    const char *conn = conn_arg;
     unsigned long long asset_id = asset_id_arg;
     unsigned long long rtt = delta;
     EXEC SQL END DECLARE SECTION;
-    
-    EXEC SQL INSERT INTO assets_assetrtt (asset_id, rtt, timestamp) VALUES (:asset_id, :rtt, NOW());
+
+    EXEC SQL AT :conn INSERT INTO assets_assetrtt (asset_id, rtt, timestamp) VALUES (:asset_id, :rtt, NOW());
 }
 
-void db_status_create_entry(unsigned long long asset_id_arg, unsigned short bat_percent, unsigned int bat_mah_used, double bat_voltage)
+void db_status_create_entry(const char *conn_arg, unsigned long long asset_id_arg, unsigned short bat_percent, unsigned int bat_mah_used, double bat_voltage)
 {
     EXEC SQL BEGIN DECLARE SECTION;
+    const char *conn = conn_arg;
     unsigned long long asset_id = asset_id_arg;
     unsigned short bp = bat_percent;
     unsigned long bu = bat_mah_used;
     double voltage = bat_voltage;
     EXEC SQL END DECLARE SECTION;
-    
-    EXEC SQL INSERT INTO assets_assetstatus (asset_id, bat_percent, bat_used_mah, bat_volt, timestamp) VALUES (:asset_id, :bp, :bu, :voltage, NOW());
+
+    EXEC SQL AT :conn INSERT INTO assets_assetstatus (asset_id, bat_percent, bat_used_mah, bat_volt, timestamp) VALUES (:asset_id, :bp, :bu, :voltage, NOW());
 }
 
-void db_search_status_create_entry(unsigned long long asset_id_arg, unsigned long long search_id, unsigned long long search_completed, unsigned long long search_total)
+void db_search_status_create_entry(const char *conn_arg, unsigned long long asset_id_arg, unsigned long long search_id, unsigned long long search_completed, unsigned long long search_total)
 {
     EXEC SQL BEGIN DECLARE SECTION;
+    const char *conn = conn_arg;
     unsigned long long asset_id = asset_id_arg;
     unsigned long long s = search_id;
     unsigned long long sp = search_completed;
     unsigned long long spo = search_total;
     EXEC SQL END DECLARE SECTION;
-    
-    EXEC SQL INSERT INTO assets_assetsearchprogress (asset_id, search, search_progress, search_progress_of, timestamp) VALUES (:asset_id, :s, :sp, :spo, NOW());
+
+    EXEC SQL AT :conn INSERT INTO assets_assetsearchprogress (asset_id, search, search_progress, search_progress_of, timestamp) VALUES (:asset_id, :s, :sp, :spo, NOW());
 }
 
-void db_position_create_entry(unsigned long long asset_id_arg, double latitude, double longitude, int altitude)
+void db_position_create_entry(const char *conn_arg, unsigned long long asset_id_arg, double latitude, double longitude, int altitude)
 {
     EXEC SQL BEGIN DECLARE SECTION;
+    const char *conn = conn_arg;
     unsigned long long asset_id = asset_id_arg;
     double lat = latitude;
     double lng = longitude;
     int alt = altitude;
     EXEC SQL END DECLARE SECTION;
 
-    EXEC SQL INSERT INTO assets_assetposition (asset_id, position, altitude, timestamp) VALUES (:asset_id, ST_SetSRID(ST_MakePoint(:lng, :lat), 4326), :alt, NOW());
+    EXEC SQL AT :conn INSERT INTO assets_assetposition (asset_id, position, altitude, timestamp) VALUES (:asset_id, ST_SetSRID(ST_MakePoint(:lng, :lat), 4326), :alt, NOW());
 }
 
 struct asset_command_s *
-db_asset_command_get(unsigned long long asset_id_arg)
+db_asset_command_get(const char *conn_arg, unsigned long long asset_id_arg)
 {
     EXEC SQL BEGIN DECLARE SECTION;
+    const char *conn = conn_arg;
     unsigned long long asset_id = asset_id_arg;
     unsigned long long id = 0;
     unsigned long long ts = 0;
@@ -131,7 +145,7 @@ db_asset_command_get(unsigned long long asset_id_arg)
     int alt_ind = 0;
     EXEC SQL END DECLARE SECTION;
 
-    EXEC SQL SELECT 1, AC.id, (extract(epoch from AC.timestamp) * 1000)::bigint, AC.command, ST_Y(AC.position::geometry), ST_X(AC.position::geometry), AC.altitude INTO :success, :id, :ts, :command, :lat :lat_ind, :lng :lng_ind, :alt :alt_ind FROM assets_assetcommand AS AC WHERE AC.asset_id = :asset_id ORDER BY AC.timestamp DESC LIMIT 1;
+    EXEC SQL AT :conn SELECT 1, AC.id, (extract(epoch from AC.timestamp) * 1000)::bigint, AC.command, ST_Y(AC.position::geometry), ST_X(AC.position::geometry), AC.altitude INTO :success, :id, :ts, :command, :lat :lat_ind, :lng :lng_ind, :alt :alt_ind FROM assets_assetcommand AS AC WHERE AC.asset_id = :asset_id ORDER BY AC.timestamp DESC LIMIT 1;
 
 
     struct asset_command_s *res = NULL;
@@ -190,9 +204,10 @@ convert_to_http(const char *address, int port, bool https)
 }
 
 struct smm_settings_s *
-db_asset_smm_settings_get(unsigned long long asset_id_arg)
+db_asset_smm_settings_get(const char *conn_arg, unsigned long long asset_id_arg)
 {
     EXEC SQL BEGIN DECLARE SECTION;
+    const char *conn = conn_arg;
     unsigned long long asset_id = asset_id_arg;
     char server_address[SMM_SERVER_LEN];
     int server_port = 0;
@@ -202,7 +217,7 @@ db_asset_smm_settings_get(unsigned long long asset_id_arg)
     int success = 0;
     EXEC SQL END DECLARE SECTION;
 
-    EXEC SQL SELECT 1, SMM.address, SMM.port, SMM.https, A.smm_login, A.smm_password A INTO :success, :server_address, :server_port, :server_https, :smm_login, :smm_password FROM config_assetconfig AS A, config_smmconfig AS SMM WHERE A.asset_id = :asset_id AND A.smm_id = SMM.id;
+    EXEC SQL AT :conn SELECT 1, SMM.address, SMM.port, SMM.https, A.smm_login, A.smm_password A INTO :success, :server_address, :server_port, :server_https, :smm_login, :smm_password FROM config_assetconfig AS A, config_smmconfig AS SMM WHERE A.asset_id = :asset_id AND A.smm_id = SMM.id;
 
 
     struct smm_settings_s *settings = NULL;
@@ -232,7 +247,7 @@ db_asset_smm_settings_get(unsigned long long asset_id_arg)
 }
 
 struct fss_server_s **
-db_active_fss_servers_get(void)
+db_active_fss_servers_get(const char *conn_arg)
 {
     size_t len = 0;
     struct fss_server_s **res = (struct fss_server_s **)malloc(sizeof(struct fss_server_s *) * (len + 1));
@@ -242,20 +257,21 @@ db_active_fss_servers_get(void)
     }
 
     EXEC SQL BEGIN DECLARE SECTION;
+    const char *conn = conn_arg;
     char server_address[SMM_SERVER_LEN];
     int server_port = 0;
     EXEC SQL END DECLARE SECTION;
 
-    EXEC SQL SET AUTOCOMMIT TO OFF;
-    EXEC SQL DECLARE cur1 CURSOR FOR SELECT address, client_port FROM config_serverconfig WHERE active = TRUE;
-    EXEC SQL OPEN cur1;
+    EXEC SQL AT :conn SET AUTOCOMMIT TO OFF;
+    EXEC SQL AT :conn DECLARE cur1 CURSOR FOR SELECT address, client_port FROM config_serverconfig WHERE active = TRUE;
+    EXEC SQL AT :conn OPEN cur1;
 
     EXEC SQL WHENEVER NOT FOUND DO BREAK;
     EXEC SQL WHENEVER SQLERROR DO BREAK;
     EXEC SQL WHENEVER SQLWARNING DO BREAK;
     while (1)
     {
-        EXEC SQL FETCH FROM cur1 INTO :server_address, :server_port;
+        EXEC SQL AT :conn FETCH FROM cur1 INTO :server_address, :server_port;
         struct fss_server_s *s = (struct fss_server_s *)malloc(sizeof(struct fss_server_s));
         if (s != NULL)
         {
@@ -291,23 +307,27 @@ db_active_fss_servers_get(void)
     EXEC SQL WHENEVER SQLERROR CONTINUE;
     EXEC SQL WHENEVER SQLWARNING CONTINUE;
 
-    EXEC SQL CLOSE cur1;
-    EXEC SQL SET AUTOCOMMIT TO ON;
+    EXEC SQL AT :conn CLOSE cur1;
+    EXEC SQL AT :conn SET AUTOCOMMIT TO ON;
 
     return res;
 }
 
-void db_disconnect(void)
-{
-    EXEC SQL DISCONNECT ALL;
-}
-
-int db_ping(void)
+void db_disconnect(const char *conn_arg)
 {
     EXEC SQL BEGIN DECLARE SECTION;
+    const char *conn = conn_arg;
+    EXEC SQL END DECLARE SECTION;
+    EXEC SQL DISCONNECT :conn;
+}
+
+int db_ping(const char *conn_arg)
+{
+    EXEC SQL BEGIN DECLARE SECTION;
+    const char *conn = conn_arg;
     int x = 0;
     EXEC SQL END DECLARE SECTION;
-    EXEC SQL SELECT 1 INTO :x;
+    EXEC SQL AT :conn SELECT 1 INTO :x;
     return (sqlca.sqlcode >= 0) ? 1 : 0;
 }
 

--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -155,9 +155,11 @@ TEST_CASE("db_connection: tryReconnectIfNeeded returns when connection is health
 TEST_CASE("db_connection: tryReconnectIfNeeded reconnects after underlying disconnect")
 {
     auto dbc = live_db_or_skip();
-    /* Force the underlying ECPG connection closed so db_ping() will fail,
-     * which triggers the reconnect branch in tryReconnectIfNeeded(). */
-    db_disconnect();
+    /* Force both underlying ECPG connections closed so db_ping() fails on
+     * each, triggering the reconnect branch in tryReconnectIfNeeded(). The
+     * names match db_connection's internal read/write connection names. */
+    db_disconnect("fss_read");
+    db_disconnect("fss_write");
     dbc->tryReconnectIfNeeded();
     REQUIRE(dbc->isConnected());
 }


### PR DESCRIPTION
## Description

The server used a single ECPG connection guarded by one mutex for every database operation. The async write-queue worker and the command poller therefore contended on the same lock: a slow or blocked telemetry INSERT held db_lock and stalled getCommand, delaying dispatch of safety-critical commands (TERM, DISARM) — undermining the 100ms command-poll design. The existing slow-DB e2e test only proves the write queue keeps the recv thread responsive; it does not cover command reads stalling behind writes.

A single ECPG connection cannot run statements concurrently, so two mutexes over one connection would be unsafe — the fix needs a second connection. Parameterise server-db.pgc on a connection name (every statement now uses `AT :conn`) and have db_connection open two connections: "fss_read" (getAssetId, getCommand, getActiveServers, getSmmSettings) and "fss_write" (the record* inserts), each with its own mutex. A stalled write on fss_write can no longer block a read on fss_read. Each connection is only ever touched by one thread at a time, the usage pattern ECPG documents as thread-safe.

Validated against a live PostgreSQL+PostGIS: all 14 db_connection tests pass, including independent reconnect of both connections, and the full suite is green with zero skips.

## Summary by Sourcery

Decouple database reads and telemetry writes onto separate ECPG connections so stalled writes no longer block command/config reads, and adjust connection management and tests accordingly.

Enhancements:
- Introduce separate read and write ECPG connections in db_connection, each guarded by its own mutex and tracked connection state.
- Extend the server DB interface to require an explicit connection name for all operations to support multiple underlying connections.
- Refine reconnect and disconnect logic to operate independently on read and write connections with clearer logging.

Tests:
- Update db_connection reconnect tests to close both named connections and verify successful reconnection of the new dual-connection setup.