### PR TITLE
fix: make db_connection state flags atomic; address sourcery PR164 feedback

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -30,24 +30,35 @@ auto flight_safety_system::server::db_connection::connectOne(const char *conn_na
 
 auto flight_safety_system::server::db_connection::isConnected() const -> bool
 {
-    return read_connected_ && write_connected_;
+    return read_connected_.load() && write_connected_.load();
 }
 
-void flight_safety_system::server::db_connection::reconnectOne(const char *conn_name, bool &connected_flag)
+void flight_safety_system::server::db_connection::reconnectOne(const char *conn_name, std::atomic<bool> &connected_flag)
 {
     if (db_ping(conn_name) != 0)
     {
-        connected_flag = true;
+        /* Healthy. Log only on the down->up transition. */
+        if (!connected_flag.exchange(true))
+        {
+            FSS_LOG_INFO("db", "Database connection '" << conn_name << "' recovered");
+        }
         return;
     }
-    FSS_LOG_WARN("db", "Database connection '" << conn_name << "' lost, attempting reconnect");
+    /* Lost. Log the loss (and a failed retry) only on first detection so a
+     * persistently-down connection does not flood the log on every tick. */
+    bool was_connected = connected_flag.exchange(false);
+    if (was_connected)
+    {
+        FSS_LOG_WARN("db", "Database connection '" << conn_name << "' lost, attempting reconnect");
+    }
     db_disconnect(conn_name);
-    connected_flag = connectOne(conn_name);
-    if (connected_flag)
+    bool reconnected = connectOne(conn_name);
+    connected_flag.store(reconnected);
+    if (reconnected)
     {
         FSS_LOG_INFO("db", "Database connection '" << conn_name << "' reconnected successfully");
     }
-    else
+    else if (was_connected)
     {
         FSS_LOG_ERROR("db", "Database connection '" << conn_name << "' reconnect failed");
     }

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -89,20 +89,25 @@ private:
      * thread-safe usage pattern ECPG documents. read_lock covers getAssetId,
      * getCommand, getActiveServers and getSmmSettings; write_lock covers the
      * record* telemetry inserts. */
-    static constexpr const char *read_conn_name = "fss_read";
-    static constexpr const char *write_conn_name = "fss_write";
     std::mutex read_lock;
     std::mutex write_lock;
-    bool read_connected_{false};
-    bool write_connected_{false};
+    /* Read without holding either mutex by isConnected(), and written from
+     * reconnectOne() under the matching mutex, so they must be atomic to
+     * avoid a data race. */
+    std::atomic<bool> read_connected_{false};
+    std::atomic<bool> write_connected_{false};
     std::string host_;
     int port_{5432};
     std::string user_;
     std::string pass_;
     std::string db_;
     auto connectOne(const char *conn_name) -> bool;
-    void reconnectOne(const char *conn_name, bool &connected_flag);
+    void reconnectOne(const char *conn_name, std::atomic<bool> &connected_flag);
 public:
+    /* ECPG connection names, exposed so tests can target a specific
+     * connection (e.g. force one closed) without duplicating the literals. */
+    static constexpr const char *read_conn_name = "fss_read";
+    static constexpr const char *write_conn_name = "fss_write";
     db_connection(std::string host, int port, std::string user, std::string pass, std::string db);
     db_connection(db_connection &) = delete;
     db_connection(db_connection &&) = delete;

--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -156,10 +156,9 @@ TEST_CASE("db_connection: tryReconnectIfNeeded reconnects after underlying disco
 {
     auto dbc = live_db_or_skip();
     /* Force both underlying ECPG connections closed so db_ping() fails on
-     * each, triggering the reconnect branch in tryReconnectIfNeeded(). The
-     * names match db_connection's internal read/write connection names. */
-    db_disconnect("fss_read");
-    db_disconnect("fss_write");
+     * each, triggering the reconnect branch in tryReconnectIfNeeded(). */
+    db_disconnect(flight_safety_system::server::db_connection::read_conn_name);
+    db_disconnect(flight_safety_system::server::db_connection::write_conn_name);
     dbc->tryReconnectIfNeeded();
     REQUIRE(dbc->isConnected());
 }
@@ -175,7 +174,7 @@ TEST_CASE("db_connection: tryReconnectIfNeeded restores a single dropped connect
 
     SECTION("only the read connection drops")
     {
-        db_disconnect("fss_read");
+        db_disconnect(flight_safety_system::server::db_connection::read_conn_name);
         dbc->tryReconnectIfNeeded();
         REQUIRE(dbc->isConnected());
         /* A read must succeed again on the reconnected connection. */
@@ -187,7 +186,7 @@ TEST_CASE("db_connection: tryReconnectIfNeeded restores a single dropped connect
 
     SECTION("only the write connection drops")
     {
-        db_disconnect("fss_write");
+        db_disconnect(flight_safety_system::server::db_connection::write_conn_name);
         dbc->tryReconnectIfNeeded();
         REQUIRE(dbc->isConnected());
         /* A write must succeed again on the reconnected connection. */


### PR DESCRIPTION
## Description

Sourcery flagged a data race (bug_risk) on PR #164: isConnected() reads read_connected_/write_connected_ without synchronization while reconnectOne() writes them under a mutex — undefined behaviour. (The old single connected_ flag had the same latent race.) Make both flags std::atomic<bool>.

Also from PR #164 feedback:
- Expose read_conn_name/write_conn_name as public constants so the tests target a specific connection without duplicating the "fss_read"/ "fss_write" literals.
- Log connection loss/recovery only on a state transition, so a persistently-down connection no longer floods the log on every tryReconnectIfNeeded tick.

Validated against a live PostgreSQL+PostGIS (all 15 db_connection tests).

## Summary by Sourcery

Make database connection state tracking thread-safe and improve connection handling behavior.

Bug Fixes:
- Eliminate a data race on database connection state flags by making them atomic and updating isConnected to use atomic loads.
- Prevent repeated error logging for a persistently down database connection by logging connection loss and recovery only on state transitions.

Enhancements:
- Expose read and write database connection names as public constants for reuse by tests and other code.

Tests:
- Update db_connection tests to reference the public connection name constants instead of hard-coded literals.