### PR TITLE
docs: address remaining sourcery review comments

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -348,9 +348,9 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
      * sends with a monotonic per-connection counter; we require the next id to
      * match. This is an application-level integrity check that rejects
      * reordered or duplicated messages within a session — it is NOT a security
-     * replay defence. TLS already provides cryptographic replay and reorder
-     * protection at the record layer; an attacker cannot inject a replayed
-     * message into the encrypted stream in the first place. */
+     * replay defence. Under its security assumptions TLS already provides
+     * replay and reorder protection at the record layer, so this check is not
+     * relied upon to stop an attacker. */
     if (this->getConnection()->getNegotiatedVersion() >= 2)
     {
         uint64_t wanted = this->expected_seq.load();

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -314,7 +314,13 @@ auto flight_safety_system::transport::fss_connection::sendMsg(const std::shared_
              * that is not a connection failure, so retry rather than dropping
              * the peer. SIGPIPE is ignored process-wide, so a genuinely broken
              * connection surfaces here as EPIPE (or similar) and falls through
-             * to return false. */
+             * to return false.
+             *
+             * These sockets are always blocking — O_NONBLOCK is never set —
+             * so send() does not return EAGAIN/EWOULDBLOCK here; it blocks
+             * until buffer space is available. If a socket is ever made
+             * non-blocking, this loop must also retry (with backoff) on
+             * EAGAIN/EWOULDBLOCK to avoid dropping the connection. */
             if (errno == EINTR)
             {
                 continue;


### PR DESCRIPTION
## Description

- transport.cpp send(): document that these sockets are always blocking, so send() does not return EAGAIN/EWOULDBLOCK, and note what would need to change if a socket were ever made non-blocking (PR #157 feedback).
- client_session.cpp: soften the security wording on the sequence check to describe TLS replay protection as holding under its security assumptions rather than absolutely (PR #163 feedback).

## Summary by Sourcery

Clarify documentation comments around transport socket blocking behavior and TLS replay protection assumptions in client session sequence checks.

Documentation:
- Explain that transport sockets are always blocking, that send() will not return EAGAIN/EWOULDBLOCK, and what would be required if sockets became non-blocking.
- Clarify client session documentation to describe TLS replay protection in terms of its security assumptions and to de-emphasize the application-level sequence check as a security mechanism.