### PR TITLE
test: factor duplicated sections in single-connection reconnect test

### DIFF
--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -172,28 +172,26 @@ TEST_CASE("db_connection: tryReconnectIfNeeded restores a single dropped connect
     auto asset_id = dbc->getAssetId("test-asset");
     REQUIRE(asset_id != 0);
 
-    SECTION("only the read connection drops")
-    {
-        db_disconnect(flight_safety_system::server::db_connection::read_conn_name);
+    /* Drop one connection by name, recover it, then exercise both a read
+     * (getAssetId) and a write (recordRtt): whichever connection was dropped
+     * must be restored, and the untouched one must keep working. */
+    auto recovers_after_dropping = [&](const char *conn_name) {
+        db_disconnect(conn_name);
         dbc->tryReconnectIfNeeded();
         REQUIRE(dbc->isConnected());
-        /* A read must succeed again on the reconnected connection. */
         REQUIRE(dbc->getAssetId("test-asset") == asset_id);
-        /* The write connection was never touched, so a write still works. */
         dbc->recordRtt(asset_id, uint64_t{7});
         REQUIRE(dbc->isConnected());
+    };
+
+    SECTION("only the read connection drops")
+    {
+        recovers_after_dropping(flight_safety_system::server::db_connection::read_conn_name);
     }
 
     SECTION("only the write connection drops")
     {
-        db_disconnect(flight_safety_system::server::db_connection::write_conn_name);
-        dbc->tryReconnectIfNeeded();
-        REQUIRE(dbc->isConnected());
-        /* A write must succeed again on the reconnected connection. */
-        dbc->recordRtt(asset_id, uint64_t{7});
-        REQUIRE(dbc->isConnected());
-        /* The read connection was never touched, so a read still works. */
-        REQUIRE(dbc->getAssetId("test-asset") == asset_id);
+        recovers_after_dropping(flight_safety_system::server::db_connection::write_conn_name);
     }
 }
 


### PR DESCRIPTION
## Description

Addresses sourcery feedback on PR #165: the read-drop and write-drop SECTIONs repeated the same disconnect / tryReconnectIfNeeded / isConnected / read+write checks. Extract a recovers_after_dropping(conn_name) lambda so each SECTION just names the connection to drop; the recovery assertions live in one place. (The connection-name literals were already replaced with db_connection's public constants in PR #166.)

Validated against a live PostgreSQL+PostGIS.

## Summary by Sourcery

Tests:
- Extract a shared helper in the reconnect test to verify that dropping either the read or write connection is recovered correctly while preserving the other connection.