### PR TITLE
test(e2e): add log diagnostics on command-delivery failure

### DIFF
--- a/e2e/test_command_read_under_write_stall.py
+++ b/e2e/test_command_read_under_write_stall.py
@@ -18,6 +18,7 @@ duplicating the EXCLUSIVE-lock plumbing.
 from __future__ import annotations
 
 import time
+from pathlib import Path
 
 import pytest
 
@@ -51,7 +52,7 @@ def test_command_read_not_blocked_by_write_stall(db_conn, fake_client, migrated_
         asset_id = cur.fetchone()[0]
 
     client = fake_client(asset_name)
-    log_path = client["log"]
+    log_path = Path(client["log"])
 
     # Poll until the client has connected, identified, and landed at least one
     # position row — proof it is up and the writer has telemetry to stall on.
@@ -87,10 +88,17 @@ def test_command_read_not_blocked_by_write_stall(db_conn, fake_client, migrated_
                 break
             time.sleep(0.2)
 
-        assert found, (
-            "command was not delivered while a telemetry write was stalled — "
-            "the command read path appears blocked behind writes"
-        )
+        if not found:
+            # Capture log context to make timing-sensitive CI flakes diagnosable.
+            tail = 2000
+            client_log = log_path.read_text(errors="replace")
+            server_log = Path(server_proc["log"]).read_text(errors="replace")
+            pytest.fail(
+                "command was not delivered while a telemetry write was stalled — "
+                "the command read path appears blocked behind writes.\n"
+                f"--- client log (last {tail} chars) ---\n{client_log[-tail:]}\n"
+                f"--- server log (last {tail} chars) ---\n{server_log[-tail:]}"
+            )
 
         # Both processes must still be alive during the stall.
         assert server_proc["proc"].poll() is None, "server died during the write stall"


### PR DESCRIPTION
## Description

Addresses sourcery feedback on PR #171:
- On the timing-sensitive command-delivery assertion, dump the tail of both the client and server logs via pytest.fail() so a CI flake is diagnosable from the failure output rather than just "command not observed".
- Wrap client["log"]/server_proc["log"] in Path(...) before read_text() so the test is robust whether the fixture yields a Path or a string.

Happy path unchanged; re-validated against the Docker postgis harness (1 passed in ~15s).

## Summary by Sourcery

Tests:
- Add client and server log tail dumping to the command-delivery e2e test when the command is not observed, to aid CI flake diagnosis.