### PR TITLE
ci: run ThreadSanitizer concurrency tests

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -210,3 +210,30 @@ jobs:
       run: |
         cd e2e
         .venv/bin/pytest -v --timeout=120
+
+  # ─── 6. ThreadSanitizer concurrency tests ────────────────────────────────
+  thread-sanitizer:
+    runs-on: ubuntu-latest
+    needs: build-and-check
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install deps
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y \
+          libjsoncpp-dev libecpg-dev catch2 libgnutls28-dev gnutls-bin
+
+    - name: autogen
+      run: ./autogen.sh
+
+    # --enable-tsan is mutually exclusive with --enable-coverage; this job is
+    # separate from the coverage job for that reason.
+    - name: configure with thread sanitizer
+      run: ./configure --enable-tests --enable-tsan
+
+    - name: make
+      run: make -j$(nproc)
+
+    - name: run thread sanitizer tests
+      run: make -C tests check-tsan


### PR DESCRIPTION
## Description

The concurrency_tsan_test binary (transport-layer races plus the new fss_client config/activation ordering guard) was never exercised in CI, so those guards protected nothing on an ongoing basis. Add a thread-sanitizer job that configures --enable-tests --enable-tsan (kept separate from the coverage job, with which it is mutually exclusive) and runs `make -C tests check-tsan`.

Verified locally by running the exact job steps in-tree: 3 test cases, 205 assertions, no ThreadSanitizer warnings.

## Summary by Sourcery

CI:
- Introduce a thread-sanitizer GitHub Actions job that configures the project with tests and TSAN enabled and executes the TSAN test suite.