### PR TITLE
fix(transport): guard coordinate/voltage packing against NaN and overflow

### DIFF
--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -2,6 +2,7 @@
 #include "fss-endian.hpp"
 #include "fss-log.hpp"
 
+#include <cmath>
 #include <limits>
 #include <memory>
 
@@ -13,6 +14,28 @@ using flight_safety_system::fss_htobe64;
 using flight_safety_system::fss_be64toh;
 using flight_safety_system::transport::FSS_COORD_SCALE;
 using flight_safety_system::transport::FSS_VOLTAGE_SCALE;
+
+/* Guard a double->int32_t conversion against NaN, Inf, and out-of-range values.
+ * NaN maps to 0 (the defined sentinel — decodes back to 0.0 degrees/volts).
+ * Finite values outside [INT32_MIN, INT32_MAX] are clamped rather than
+ * allowing undefined behaviour in the cast. */
+static auto pack_scaled_coord(double value, double scale) -> int32_t
+{
+    if (!std::isfinite(value))
+    {
+        return 0;
+    }
+    const double scaled = value / scale;
+    if (scaled <= static_cast<double>(std::numeric_limits<int32_t>::min()))
+    {
+        return std::numeric_limits<int32_t>::min();
+    }
+    if (scaled >= static_cast<double>(std::numeric_limits<int32_t>::max()))
+    {
+        return std::numeric_limits<int32_t>::max();
+    }
+    return static_cast<int32_t>(scaled);
+}
 
 static void packStringRaw(const std::shared_ptr<flight_safety_system::transport::buf_len> &bl, const char *data,
                           size_t str_len)
@@ -507,8 +530,8 @@ void flight_safety_system::transport::fss_message_position_report::packData(std:
 {
     uint64_t ts = fss_htobe64(this->getTimeStamp());
     /* Convert the lat/long to fixed decimal for transport */
-    const auto lat_host = static_cast<int32_t>(this->getLatitude() / FSS_COORD_SCALE);
-    const auto lng_host = static_cast<int32_t>(this->getLongitude() / FSS_COORD_SCALE);
+    const auto lat_host = pack_scaled_coord(this->getLatitude(), FSS_COORD_SCALE);
+    const auto lng_host = pack_scaled_coord(this->getLongitude(), FSS_COORD_SCALE);
     const auto lat = static_cast<int32_t>(fss_htobe32(static_cast<uint32_t>(lat_host)));
     const auto lng = static_cast<int32_t>(fss_htobe32(static_cast<uint32_t>(lng_host)));
     uint32_t alt = fss_htobe32(this->getAltitude());
@@ -649,7 +672,7 @@ void flight_safety_system::transport::fss_message_system_status::packData(std::s
     uint8_t bat_percent_n = this->getBatRemaining();
     uint32_t mah_used_n = fss_htobe32(this->getBatMAHUsed());
     uint32_t voltage_n =
-        fss_htobe32(static_cast<uint32_t>(static_cast<int32_t>(this->getBatVoltage() / FSS_VOLTAGE_SCALE)));
+        fss_htobe32(static_cast<uint32_t>(pack_scaled_coord(this->getBatVoltage(), FSS_VOLTAGE_SCALE)));
 
     bl->addData(&bat_percent_n, sizeof(uint8_t));
     bl->addData(&mah_used_n, sizeof(uint32_t));
@@ -773,8 +796,8 @@ void flight_safety_system::transport::fss_message_asset_command::packData(std::s
 {
     uint64_t ts = fss_htobe64(this->getTimeStamp());
     /* Convert the lat/long to fixed decimal for transport */
-    const auto lat_host = static_cast<int32_t>(this->getLatitude() / FSS_COORD_SCALE);
-    const auto lng_host = static_cast<int32_t>(this->getLongitude() / FSS_COORD_SCALE);
+    const auto lat_host = pack_scaled_coord(this->getLatitude(), FSS_COORD_SCALE);
+    const auto lng_host = pack_scaled_coord(this->getLongitude(), FSS_COORD_SCALE);
     const auto lat = static_cast<int32_t>(fss_htobe32(static_cast<uint32_t>(lat_host)));
     const auto lng = static_cast<int32_t>(fss_htobe32(static_cast<uint32_t>(lng_host)));
     uint32_t alt = fss_htobe32(this->getAltitude());

--- a/tests/coordinate_precision_test.cpp
+++ b/tests/coordinate_precision_test.cpp
@@ -11,6 +11,7 @@
 #endif
 
 #include <cmath>
+#include <limits>
 #include <memory>
 #include <string>
 #include <tuple>
@@ -19,7 +20,10 @@
 #include "fss-transport.hpp"
 
 using flight_safety_system::transport::fss_message;
+using flight_safety_system::transport::fss_message_asset_command;
 using flight_safety_system::transport::fss_message_position_report;
+using flight_safety_system::transport::asset_command_hold;
+using flight_safety_system::transport::asset_command_rtl;
 
 /* Regression for todo/11-coordinate-constant.md
  *
@@ -118,4 +122,105 @@ TEST_CASE("coord: 7-decimal-place precision preserved")
     std::tie(lat, lng) = round_trip(-43.5000001, 172.5000001);
     REQUIRE(std::fabs(lat - (-43.5000001)) < 1e-7);
     REQUIRE(std::fabs(lng - 172.5000001) < 1e-7);
+}
+
+/* Regression for pack_scaled_coord NaN/Inf/out-of-range guard.
+ *
+ * Before the fix, passing NaN or Inf lat/long to pack_scaled_coord triggered
+ * undefined behaviour in the double->int32_t cast.  After the fix NaN/Inf map
+ * to 0 on the wire (decoding to 0.0), and finite out-of-range values are
+ * clamped to INT32_MIN / INT32_MAX rather than wrapping.
+ */
+
+TEST_CASE("coord: asset_command RTL (NaN lat/lng) packs and decodes to defined value")
+{
+    /* RTL constructed with (command, timestamp) leaves latitude and longitude
+     * as NaN.  Before the fix this was UB; after the fix 0 is placed on the
+     * wire and the decoded coordinates must be exactly 0.0. */
+    auto orig = std::make_shared<fss_message_asset_command>(asset_command_rtl, /*timestamp*/ 0ULL);
+    orig->setId(1);
+    auto bl = orig->getPacked();
+    auto decoded = std::dynamic_pointer_cast<fss_message_asset_command>(fss_message::decode(bl));
+    REQUIRE(decoded != nullptr);
+    /* Round-tripped coordinates must be a defined, finite value. */
+    REQUIRE(std::isfinite(decoded->getLatitude()));
+    REQUIRE(std::isfinite(decoded->getLongitude()));
+    /* The sentinel value for NaN input is 0.0. */
+    REQUIRE(decoded->getLatitude() == 0.0);
+    REQUIRE(decoded->getLongitude() == 0.0);
+}
+
+TEST_CASE("coord: asset_command HOLD (NaN lat/lng) packs and decodes to defined value")
+{
+    auto orig = std::make_shared<fss_message_asset_command>(asset_command_hold, /*timestamp*/ 12345ULL);
+    orig->setId(2);
+    auto bl = orig->getPacked();
+    auto decoded = std::dynamic_pointer_cast<fss_message_asset_command>(fss_message::decode(bl));
+    REQUIRE(decoded != nullptr);
+    REQUIRE(std::isfinite(decoded->getLatitude()));
+    REQUIRE(std::isfinite(decoded->getLongitude()));
+    REQUIRE(decoded->getLatitude() == 0.0);
+    REQUIRE(decoded->getLongitude() == 0.0);
+}
+
+TEST_CASE("coord: position_report NaN lat/lng packs and decodes to defined value")
+{
+    /* NAN passed as latitude and longitude must not trigger UB on pack. */
+    auto orig = std::make_shared<fss_message_position_report>(
+        std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(),
+        /*altitude*/ 0U, /*heading*/ 0U, /*hor_vel*/ 0U, /*ver_vel*/ 0,
+        /*icao*/ 0U, std::string{"T0"},
+        /*squawk*/ 0U, /*tslc*/ 0U, /*flags*/ 0U,
+        /*alt_type*/ 0U, /*emitter*/ 0U, /*timestamp*/ 0ULL);
+    orig->setId(3);
+    auto bl = orig->getPacked();
+    auto decoded = std::dynamic_pointer_cast<fss_message_position_report>(fss_message::decode(bl));
+    REQUIRE(decoded != nullptr);
+    REQUIRE(std::isfinite(decoded->getLatitude()));
+    REQUIRE(std::isfinite(decoded->getLongitude()));
+    REQUIRE(decoded->getLatitude() == 0.0);
+    REQUIRE(decoded->getLongitude() == 0.0);
+}
+
+TEST_CASE("coord: position_report Inf lat/lng packs and decodes to defined value")
+{
+    /* Positive infinity must also map to a defined (finite) wire value. */
+    auto orig = std::make_shared<fss_message_position_report>(
+        std::numeric_limits<double>::infinity(), -std::numeric_limits<double>::infinity(),
+        /*altitude*/ 0U, /*heading*/ 0U, /*hor_vel*/ 0U, /*ver_vel*/ 0,
+        /*icao*/ 0U, std::string{"T0"},
+        /*squawk*/ 0U, /*tslc*/ 0U, /*flags*/ 0U,
+        /*alt_type*/ 0U, /*emitter*/ 0U, /*timestamp*/ 0ULL);
+    orig->setId(4);
+    auto bl = orig->getPacked();
+    auto decoded = std::dynamic_pointer_cast<fss_message_position_report>(fss_message::decode(bl));
+    REQUIRE(decoded != nullptr);
+    REQUIRE(std::isfinite(decoded->getLatitude()));
+    REQUIRE(std::isfinite(decoded->getLongitude()));
+    REQUIRE(decoded->getLatitude() == 0.0);
+    REQUIRE(decoded->getLongitude() == 0.0);
+}
+
+TEST_CASE("coord: out-of-range latitude clamps rather than wrapping")
+{
+    /* A coordinate of 1e12 degrees scaled by 1e-7 exceeds INT32_MAX.
+     * pack_scaled_coord must clamp to INT32_MAX rather than invoking UB. */
+    double large = 1e12;
+    double lat = 0.0, lng = 0.0;
+    std::tie(lat, lng) = round_trip(large, 0.0);
+    /* Must be finite and bounded by the valid coordinate space. */
+    REQUIRE(std::isfinite(lat));
+    /* Clamped to INT32_MAX * FSS_COORD_SCALE ≈ 214.748 degrees. */
+    REQUIRE(lat <= 215.0);
+    REQUIRE(lat > 0.0);
+}
+
+TEST_CASE("coord: large negative out-of-range latitude clamps rather than wrapping")
+{
+    double neg_large = -1e12;
+    double lat = 0.0, lng = 0.0;
+    std::tie(lat, lng) = round_trip(neg_large, 0.0);
+    REQUIRE(std::isfinite(lat));
+    REQUIRE(lat >= -215.0);
+    REQUIRE(lat < 0.0);
 }


### PR DESCRIPTION
## Description

Converting a NaN, Inf, or out-of-int32-range double to int32_t is undefined behaviour. Commands such as RTL/HOLD/TERM construct with latitude/longitude left as NaN, so packing them was UB; out-of-range finite coordinates also wrapped instead of clamping.

Add a pack_scaled_coord() helper that maps non-finite values to the 0 sentinel and clamps finite values to [INT32_MIN, INT32_MAX] before the cast, and route the position-report, asset-command, and system-status voltage pack sites through it. Add round-trip regression tests covering NaN, Inf, and out-of-range inputs for both message types.

## Summary by Sourcery

Guard coordinate and voltage packing against NaN, infinities, and overflow and add regression tests to ensure defined round-trip behaviour.

Bug Fixes:
- Prevent undefined behaviour when packing NaN, infinite, or out-of-range coordinates and voltages into int32 transport fields by clamping and using a sentinel value.

Enhancements:
- Introduce a shared helper for safely scaling and packing coordinates and voltages into int32 ranges.

Tests:
- Add regression tests covering NaN, infinity, and out-of-range latitude/longitude values for position reports and asset commands, ensuring they decode to finite, clamped values.