### PR TITLE
fix(server): widen asset_command altitude to 32 bits

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -49,7 +49,7 @@ auto fss::server::fss_server_details::getPort() -> uint16_t
 
 // NOLINTBEGIN(bugprone-easily-swappable-parameters)
 fss::server::asset_command::asset_command(uint64_t t_dbid, uint64_t t_timestamp, const std::string &t_cmd,
-                                          double t_latitude, double t_longitude, uint16_t t_altitude)
+                                          double t_latitude, double t_longitude, uint32_t t_altitude)
     : dbid(t_dbid), timestamp(t_timestamp), latitude(t_latitude), longitude(t_longitude), altitude(t_altitude)
 // NOLINTEND(bugprone-easily-swappable-parameters)
 {
@@ -111,7 +111,7 @@ auto fss::server::asset_command::getLongitude() -> double
 {
     return this->longitude;
 }
-auto fss::server::asset_command::getAltitude() -> uint16_t
+auto fss::server::asset_command::getAltitude() -> uint32_t
 {
     return this->altitude;
 }

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -46,16 +46,16 @@ private:
     transport::fss_asset_command command{transport::fss_asset_command::asset_command_unknown};
     double latitude;
     double longitude;
-    uint16_t altitude;
+    uint32_t altitude;
 public:
     asset_command(uint64_t t_dbid, uint64_t t_timestamp, const std::string &t_cmd, double t_latitude,
-                  double t_longitude, uint16_t t_altitude);
+                  double t_longitude, uint32_t t_altitude);
     auto getDBId() -> uint64_t;
     auto getTimeStamp() -> uint64_t;
     auto getCommand() -> transport::fss_asset_command;
     auto getLatitude() -> double;
     auto getLongitude() -> double;
-    auto getAltitude() -> uint16_t;
+    auto getAltitude() -> uint32_t;
 };
 
 /* Pure-virtual database seam: lets ClientSession be unit-tested against

--- a/src/server-db.h
+++ b/src/server-db.h
@@ -20,7 +20,7 @@ struct asset_command_s {
     unsigned long long dbid;
     double latitude;
     double longitude;
-    unsigned short altitude;
+    unsigned int altitude;
 };
 
 struct asset_command_s *db_asset_command_get(const char *conn, unsigned long long asset_id_arg);

--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -138,7 +138,7 @@ db_asset_command_get(const char *conn_arg, unsigned long long asset_id_arg)
     char command[COMMAND_LEN];
     double lat = 0.0;
     double lng = 0.0;
-    int alt = 0;
+    unsigned int alt = 0;
     int success = 0;
     int lat_ind = 0;
     int lng_ind = 0;

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -775,7 +775,7 @@ TEST_CASE("asset_command: all command-string branches and getAltitude")
     auto cmd_disarm = fss::server::asset_command(3, 100, "DISARM", 0.0, 0.0, 0);
     REQUIRE(cmd_disarm.getCommand() == asset_command_disarm);
 
-    auto cmd_alt = fss::server::asset_command(4, 100, "ALT", 0.0, 0.0, uint16_t{150});
+    auto cmd_alt = fss::server::asset_command(4, 100, "ALT", 0.0, 0.0, uint32_t{150});
     REQUIRE(cmd_alt.getCommand() == asset_command_altitude);
     REQUIRE(cmd_alt.getAltitude() == 150);
 
@@ -804,7 +804,7 @@ TEST_CASE("session: sendCommand dispatches altitude message for ALT command")
     session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
     conn->sent.clear();
 
-    auto alt_cmd = std::make_shared<fss::server::asset_command>(42, 1000, "ALT", 0.0, 0.0, uint16_t{300});
+    auto alt_cmd = std::make_shared<fss::server::asset_command>(42, 1000, "ALT", 0.0, 0.0, uint32_t{300});
     session->setPendingCommand(alt_cmd);
     session->sendCommand();
 
@@ -995,7 +995,7 @@ TEST_CASE("session: GOTO command dispatch sends lat/lon asset_command message")
     session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
 
     const std::size_t before = conn->sent.size();
-    auto cmd = std::make_shared<fss::server::asset_command>(/*dbid*/ 5, /*ts*/ 200, "GOTO", -43.5, 172.6, uint16_t{0});
+    auto cmd = std::make_shared<fss::server::asset_command>(/*dbid*/ 5, /*ts*/ 200, "GOTO", -43.5, 172.6, uint32_t{0});
     mock.pushCommand(asset_id, cmd);
     session->setPendingCommand(cmd);
     session->sendCommand();
@@ -1073,4 +1073,53 @@ TEST_CASE("session: sendRTTRequest skips second request within retry interval")
     /* Only one rtt_request should appear on the wire. */
     REQUIRE(count_sent<fss::transport::fss_message_rtt_request>(conn->sent) == 1);
     REQUIRE(handler.disconnects == 0);
+}
+
+TEST_CASE("asset_command: altitude above uint16_t max survives pack/decode round-trip")
+{
+    /* Regression: altitude was stored as uint16_t, silently truncating any
+     * value above 65535 before it reached the wire. Verify that a value of
+     * 100000 (well above 65535) flows through asset_command -> getAltitude()
+     * -> fss_message_asset_command (pack) -> decode without truncation. */
+    constexpr uint32_t high_alt = 100000U;
+
+    /* 1. asset_command stores and returns the full 32-bit value. */
+    fss::server::asset_command ac(/*dbid*/ 1, /*ts*/ 1000, "ALT", 0.0, 0.0, high_alt);
+    REQUIRE(ac.getAltitude() == high_alt);
+
+    /* 2. The wire message is constructed from the getter and survives a
+     *    pack -> decode round-trip without truncation. */
+    auto msg_out = std::make_shared<fss::transport::fss_message_asset_command>(fss::transport::asset_command_altitude,
+                                                                               ac.getTimeStamp(), ac.getAltitude());
+
+    auto bl = msg_out->getPacked();
+    auto msg_in = fss::transport::fss_message::decode(bl);
+
+    auto cmd_in = std::dynamic_pointer_cast<fss::transport::fss_message_asset_command>(msg_in);
+    REQUIRE(cmd_in != nullptr);
+    REQUIRE(cmd_in->getCommand() == fss::transport::asset_command_altitude);
+    REQUIRE(cmd_in->getAltitude() == high_alt);
+
+    /* 3. Full dispatch path: session delivers the command with the correct
+     *    altitude on the wire. */
+    fss_test::MockDatabase mock;
+    constexpr uint64_t asset_id = 50;
+    mock.asset_ids["craft"] = asset_id;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+    conn->sent.clear();
+
+    auto alt_cmd = std::make_shared<fss::server::asset_command>(/*dbid*/ 7, /*ts*/ 2000, "ALT", 0.0, 0.0, high_alt);
+    session->setPendingCommand(alt_cmd);
+    session->sendCommand();
+
+    auto dispatched = find_sent<fss::transport::fss_message_asset_command>(conn->sent);
+    REQUIRE(dispatched != nullptr);
+    REQUIRE(dispatched->getCommand() == fss::transport::asset_command_altitude);
+    REQUIRE(dispatched->getAltitude() == high_alt);
 }


### PR DESCRIPTION
## Description

The server-side asset_command stored altitude as uint16_t while the wire message (fss_message_asset_command) and the assets_assetcommand table both carry 32 bits. An altitude command above 65535 read from the database was silently truncated before being dispatched to the aircraft.

Widen the asset_command member, constructor parameter and getter to uint32_t, and widen the ECPG read path (asset_command_s.altitude and the db_asset_command_get host variable) to unsigned int so the full value survives from the database to the wire. Add a regression test asserting an altitude of 100000 round-trips through pack/decode and the session dispatch path without truncation.

## Summary by Sourcery

Allow server-side asset altitude commands to carry full 32-bit altitude values end-to-end instead of truncating to 16 bits.

Bug Fixes:
- Prevent truncation of asset ALT commands above 65535 by widening the server-side altitude field and related interfaces to 32 bits.

Tests:
- Extend existing asset_command and session dispatch tests to use 32-bit altitude values and add a regression test verifying high altitudes survive pack/decode and dispatch paths without truncation.