### PR TITLE
fix(transport): reject out-of-range asset command bytes

### DIFF
--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -37,6 +37,35 @@ static auto pack_scaled_coord(double value, double scale) -> int32_t
     return static_cast<int32_t>(scaled);
 }
 
+/* Validate an untrusted wire byte and map it to the matching fss_asset_command
+ * enumerator.  Any value that is not a defined enumerator maps to
+ * asset_command_unknown so that out-of-range bytes from a peer can never
+ * produce undefined behaviour via an out-of-range enum cast. */
+static auto decode_asset_command(uint8_t cmd) -> flight_safety_system::transport::fss_asset_command
+{
+    using flight_safety_system::transport::fss_asset_command;
+    switch (cmd)
+    {
+        case static_cast<uint8_t>(flight_safety_system::transport::asset_command_rtl):
+            return flight_safety_system::transport::asset_command_rtl;
+        case static_cast<uint8_t>(flight_safety_system::transport::asset_command_hold):
+            return flight_safety_system::transport::asset_command_hold;
+        case static_cast<uint8_t>(flight_safety_system::transport::asset_command_goto):
+            return flight_safety_system::transport::asset_command_goto;
+        case static_cast<uint8_t>(flight_safety_system::transport::asset_command_resume):
+            return flight_safety_system::transport::asset_command_resume;
+        case static_cast<uint8_t>(flight_safety_system::transport::asset_command_terminate):
+            return flight_safety_system::transport::asset_command_terminate;
+        case static_cast<uint8_t>(flight_safety_system::transport::asset_command_disarm):
+            return flight_safety_system::transport::asset_command_disarm;
+        case static_cast<uint8_t>(flight_safety_system::transport::asset_command_altitude):
+            return flight_safety_system::transport::asset_command_altitude;
+        case static_cast<uint8_t>(flight_safety_system::transport::asset_command_manual):
+            return flight_safety_system::transport::asset_command_manual;
+        default: return flight_safety_system::transport::asset_command_unknown;
+    }
+}
+
 static void packStringRaw(const std::shared_ptr<flight_safety_system::transport::buf_len> &bl, const char *data,
                           size_t str_len)
 {
@@ -823,7 +852,7 @@ void flight_safety_system::transport::fss_message_asset_command::unpackData(cons
     uint8_t cmd = 0;
     if (reader.readUint8(cmd))
     {
-        this->command = static_cast<fss_asset_command>(cmd);
+        this->command = decode_asset_command(cmd);
     }
     this->latitude = lat * FSS_COORD_SCALE;
     this->longitude = lng * FSS_COORD_SCALE;

--- a/tests/malformed_message_test.cpp
+++ b/tests/malformed_message_test.cpp
@@ -30,6 +30,7 @@ using flight_safety_system::transport::fss_message_server_list;
 using flight_safety_system::transport::fss_message_smm_settings;
 using flight_safety_system::transport::fss_message_system_status;
 using flight_safety_system::transport::asset_command_rtl;
+using flight_safety_system::transport::asset_command_unknown;
 using flight_safety_system::transport::message_type_command;
 using flight_safety_system::transport::message_type_identity;
 using flight_safety_system::transport::message_type_identity_non_aircraft;
@@ -213,6 +214,38 @@ TEST_CASE("decode type consistency: identity_required")
     REQUIRE(decoded != nullptr);
     REQUIRE(decoded->getType() == message_type_identity_required);
     REQUIRE(std::dynamic_pointer_cast<fss_message_identity_required>(decoded) != nullptr);
+}
+
+/* Regression for UB in fss_message_asset_command::unpackData: casting an
+ * out-of-range wire byte to fss_asset_command was undefined behaviour.
+ * After the fix decode_asset_command() validates the byte first and maps
+ * any unrecognised value to asset_command_unknown. */
+TEST_CASE("malformed: out-of-range asset command byte decodes to asset_command_unknown")
+{
+    /* Build a valid asset_command message via getPacked(), then replace the
+     * last byte (the command byte on the wire) with an out-of-range value.
+     * Copy the buffer into a mutable std::string first so the modification
+     * is well-defined (getData() returns const char *). */
+    auto orig = std::make_shared<fss_message_asset_command>(asset_command_rtl, 0ULL);
+    orig->setId(1);
+    auto packed = orig->getPacked();
+
+    std::string wire(packed->getData(), packed->getLength());
+    /* The asset_command payload layout (after the 12-byte header) is:
+     *   8 bytes timestamp + 4 bytes lat + 4 bytes lng + 4 bytes alt + 1 byte cmd
+     * The command byte is therefore at offset 12 + 8 + 4 + 4 + 4 = 32.
+     * (The buffer is padded to a multiple of 8 bytes, so it is 40 bytes total;
+     * the trailing 7 bytes are zero-padding and must not be confused with cmd.)
+     * Overwrite the command byte with 200, which is not a defined
+     * fss_asset_command enumerator. */
+    static constexpr size_t cmd_offset = 12U + 8U + 4U + 4U + 4U;
+    REQUIRE(wire.size() > cmd_offset);
+    wire[cmd_offset] = static_cast<char>(200);
+
+    auto bl = std::make_shared<buf_len>(wire.data(), static_cast<uint16_t>(wire.size()));
+    auto decoded = std::dynamic_pointer_cast<fss_message_asset_command>(fss_message::decode(bl));
+    REQUIRE(decoded != nullptr);
+    REQUIRE(decoded->getCommand() == asset_command_unknown);
 }
 
 /* Regression for todo/13: a cast to the wrong subclass must yield nullptr,


### PR DESCRIPTION
## Description

fss_message_asset_command::unpackData cast an untrusted wire byte directly to the unscoped fss_asset_command enum. A peer could send any of 256 values while only 0-8 are defined enumerators; casting an out-of-range integer to the enum is undefined behaviour.

Add a decode_asset_command() helper that switches over the defined enumerators and maps any unrecognised byte to asset_command_unknown, which the dispatch path already refuses to act on. Add a regression test that decodes a message with command byte 200 and asserts it becomes asset_command_unknown.

## Summary by Sourcery

Handle out-of-range asset command bytes safely when decoding asset command messages.

Bug Fixes:
- Guard asset command decoding against undefined behaviour by validating the command byte and mapping unknown values to asset_command_unknown.

Tests:
- Add a regression test ensuring an out-of-range asset command byte (e.g., 200) decodes to asset_command_unknown instead of causing undefined behaviour.