### PR TITLE
fix: do not let thread join() throw out of destructors

### DIFF
--- a/src/db-write-queue.cpp
+++ b/src/db-write-queue.cpp
@@ -63,7 +63,14 @@ void db_write_queue::stop()
     this->cv.notify_all();
     if (this->worker.joinable())
     {
-        this->worker.join();
+        try
+        {
+            this->worker.join();
+        }
+        catch (const std::exception &e)
+        {
+            FSS_LOG_ERROR("db-writer", "worker.join() failed: " << e.what());
+        }
     }
 }
 

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -128,7 +128,14 @@ void flight_safety_system::transport::fss_connection::disconnect()
         }
         else
         {
-            this->recv_thread.join();
+            try
+            {
+                this->recv_thread.join();
+            }
+            catch (const std::exception &e)
+            {
+                FSS_LOG_ERROR("transport", "recv_thread.join() failed: " << e.what());
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

fss_connection::disconnect() and db_write_queue::stop() are reached from their respective destructors, which are implicitly noexcept. A throwing std::thread::join() (std::system_error) would therefore call std::terminate. Guard both join() calls with a try/catch that logs and swallows the exception so cleanup can never abort the process.

## Summary by Sourcery

Prevent thread join failures from terminating the process during object destruction by making thread cleanup in db_write_queue and fss_connection robust to join exceptions.

Bug Fixes:
- Guard db_write_queue worker thread join with exception handling to avoid std::terminate when stop() is called from a destructor.
- Guard fss_connection receive thread join with exception handling to avoid std::terminate when disconnect() is called from a destructor.