### PR TITLE
feat(server): reject out-of-range inbound position reports

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -4,12 +4,19 @@
 #include "fss-server.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 #include <memory>
 #include <mutex>
 #include <utility>
 
 namespace fss = flight_safety_system;
+
+static auto is_valid_coordinate(double latitude, double longitude) -> bool
+{
+    return std::isfinite(latitude) && std::isfinite(longitude) && latitude >= -90.0 && latitude <= 90.0 &&
+           longitude >= -180.0 && longitude <= 180.0;
+}
 
 constexpr uint64_t sec_to_msec = 1000;
 constexpr uint64_t rtt_retry_interval = 10 * sec_to_msec;
@@ -538,6 +545,13 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                         FSS_LOG_WARN("server", "Stale position report (age=" << (now - report_ts) << "ms), discarding");
                         return;
                     }
+                }
+                if (!is_valid_coordinate(msg->getLatitude(), msg->getLongitude()))
+                {
+                    FSS_LOG_WARN("server", "Invalid position report coordinates (lat=" << msg->getLatitude()
+                                                                                       << " lon=" << msg->getLongitude()
+                                                                                       << "), discarding");
+                    return;
                 }
                 if (this->aircraft && asset_id != 0)
                 {

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -921,6 +921,51 @@ TEST_CASE("session: rtt_request from client triggers rtt_response reply")
     REQUIRE(find_sent<fss::transport::fss_message_rtt_response>(conn->sent) != nullptr);
 }
 
+TEST_CASE("session: position report with out-of-range latitude is rejected")
+{
+    /* A position report whose latitude is outside [-90, 90] must be silently
+     * dropped: it must neither be written to the database nor broadcast to
+     * other connected clients. The connection itself stays up. */
+    fss_test::MockDatabase mock;
+    constexpr uint64_t asset_id = 20;
+    mock.asset_ids["craft"] = asset_id;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+    REQUIRE(handler.disconnects == 0);
+
+    /* Send a position report with latitude=200.0 (well outside [-90,90]). */
+    auto bad_pos = std::make_shared<fss::transport::fss_message_position_report>(
+        200.0, 0.0, 0U, 0U, 0U, int16_t{0}, 0U, std::string{}, 0U, uint8_t{0}, 0U, uint8_t{0}, uint8_t{0},
+        fss::fss_current_timestamp());
+    fss_test::capture_cerr cap;
+    session->processMessage(bad_pos);
+
+    /* Must not be broadcast. */
+    REQUIRE(handler.broadcasts.empty());
+    /* Must not be written to the database. */
+    REQUIRE(mock.positions.empty());
+    /* Connection must stay up. */
+    REQUIRE(handler.disconnects == 0);
+    /* A warning must be logged. */
+    REQUIRE(cap.str().find("Invalid position report coordinates") != std::string::npos);
+
+    /* A follow-up report with valid coordinates must be accepted. */
+    auto good_pos = std::make_shared<fss::transport::fss_message_position_report>(
+        -43.5, 172.6, 100U, 0U, 0U, int16_t{0}, 0U, std::string{}, 0U, uint8_t{0}, 0U, uint8_t{0}, uint8_t{0},
+        fss::fss_current_timestamp());
+    session->processMessage(good_pos);
+
+    REQUIRE(handler.broadcasts.size() == 1);
+    REQUIRE(fss_test::wait_for([&]() { return !mock.positions.empty(); }));
+    REQUIRE(mock.positions.front().asset_id == asset_id);
+}
+
 TEST_CASE("session: unidentified client receives identity_required for non-identity message")
 {
     fss_test::MockDatabase mock;


### PR DESCRIPTION
## Description

Inbound position reports were enqueued to PostGIS and broadcast to other clients without any coordinate validation. The wire format permits roughly +/-214 degrees, so a buggy or hostile peer could store garbage geometry and corrupt the shared situational picture.

Validate latitude in [-90, 90] and longitude in [-180, 180] (and finiteness) before storing or broadcasting a position report; discard with a warning otherwise. Add a regression test covering rejection (no store, no broadcast, connection stays up) and acceptance of a subsequent valid report.

## Summary by Sourcery

Validate inbound position report coordinates on the server and reject invalid ones without disconnecting the client, while covering the behavior with tests.

Bug Fixes:
- Prevent storage and broadcast of position reports with out-of-range or non-finite latitude/longitude values by discarding them with a warning.

Tests:
- Add regression test ensuring out-of-range position reports are neither stored nor broadcast, that a warning is logged, and that subsequent valid reports are accepted.