### PR TITLE
ci: add AddressSanitizer + UndefinedBehaviorSanitizer job

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -237,3 +237,37 @@ jobs:
 
     - name: run thread sanitizer tests
       run: make -C tests check-tsan
+
+  # ─── 7. AddressSanitizer + UndefinedBehaviorSanitizer ────────────────────
+  sanitizers:
+    runs-on: ubuntu-latest
+    needs: build-and-check
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install deps
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y \
+          libjsoncpp-dev libecpg-dev catch2 libgnutls28-dev gnutls-bin
+
+    - name: autogen
+      run: ./autogen.sh
+
+    # ASan and UBSan are mutually exclusive with TSan; this is a separate job.
+    # -Wno-maybe-uninitialized suppresses a GCC false-positive in system
+    # headers (<regex> / std::function) triggered at -O1 in GCC 16+.
+    - name: configure with address and undefined-behaviour sanitizers
+      run: |
+        ./configure --enable-tests \
+          CXXFLAGS="-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer -O1 -g -Wno-maybe-uninitialized" \
+          LDFLAGS="-fsanitize=address,undefined"
+
+    - name: make
+      run: make -j$(nproc)
+
+    - name: make check (ASan + UBSan)
+      env:
+        ASAN_OPTIONS: detect_leaks=0
+        UBSAN_OPTIONS: print_stacktrace=1
+      run: make check

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -30,7 +30,7 @@ all_test_SOURCES = main.cpp messages.cpp connection.cpp client.cpp \
 	../src/db-write-queue.cpp \
 	../src/db.cpp \
 	../src/server-db.c
-all_test_CFLAGS = $(ECPG_CFLAGS)
+all_test_CFLAGS = $(ECPG_CFLAGS) -I$(top_srcdir)/src
 all_test_LDADD = ../src/libfss-transport.la ../src/libfss-client-ssl.la ../src/libfss.la $(JSONCPP_LIBS) $(ECPG_LIBS)
 
 all_test_SOURCES += connection-ssl.cpp


### PR DESCRIPTION
## Description

CI ran TSan, valgrind and coverage but no ASan/UBSan. UBSan in particular catches the float->int and out-of-range-enum undefined-behaviour class that several recent fixes addressed; ASan catches memory-safety errors faster than valgrind. Add a sanitizers job that builds the unit suite with -fsanitize=address,undefined -fno-sanitize-recover=all and runs make check (leak detection left to the existing valgrind job).

Also add -I$(top_srcdir)/src to all_test_CFLAGS so the C-compiled server-db.c finds server-db.h in out-of-tree (VPATH) builds, which the local sanitizer verification exercised.

## Summary by Sourcery

Add a CI job to run tests under AddressSanitizer and UndefinedBehaviorSanitizer and adjust test build flags to support out-of-tree builds.

CI:
- Add a GitHub Actions job that configures and runs the test suite with AddressSanitizer and UndefinedBehaviorSanitizer enabled.

Tests:
- Add an include path to the test suite CFLAGS so C sources compile correctly in out-of-tree builds.