### PR TITLE
fix(transport): re-check fd each send iteration to avoid stale descriptor

### DIFF
--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -314,6 +314,15 @@ auto flight_safety_system::transport::fss_connection::sendMsg(const std::shared_
 #endif
     while (sent < to_send)
     {
+        /* Re-load fd every iteration: a concurrent disconnect() does
+         * fd.exchange(-1) then closes the descriptor.  If that races with
+         * a multi-iteration send we must stop rather than write into a
+         * stale (possibly reused) descriptor. */
+        current_fd = this->fd.load();
+        if (current_fd == -1)
+        {
+            return false;
+        }
         ssize_t transfered = send(current_fd, &data[sent], to_send - sent, 0);
         if (transfered < 0)
         {

--- a/tests/connection_negative_test.cpp
+++ b/tests/connection_negative_test.cpp
@@ -33,6 +33,19 @@ using flight_safety_system::transport::fss_message_identity;
 using flight_safety_system::transport::message_type_closed;
 using flight_safety_system::transport::message_type_identity;
 
+/* Thin wrapper that promotes the protected sendMsg(buf_len) overload and
+ * setFd() to public so unit tests can exercise the base-class send path
+ * without a real socket. */
+class SendTestConnection : public fss_connection {
+public:
+    SendTestConnection() = default;
+    auto callSendMsg(const std::shared_ptr<flight_safety_system::transport::buf_len> &bl) -> bool
+    {
+        return sendMsg(bl);
+    }
+    void callSetFd(int t_fd) { setFd(t_fd); }
+};
+
 namespace {
 
 std::shared_ptr<fss_connection> accepted;
@@ -202,4 +215,17 @@ TEST_CASE("negative: zero-length message header is skipped and next message deco
 
     ::close(fd);
     accepted = nullptr;
+}
+
+TEST_CASE("sendMsg(buf_len): returns false immediately when fd is -1")
+{
+    /* Deterministic check for the stale-fd guard: the base-class
+     * sendMsg(buf_len) must return false when fd == -1 without touching
+     * any socket.  The default ctor leaves fd at -1, so no real fd is
+     * needed. */
+    SendTestConnection conn;
+    auto msg = std::make_shared<fss_message_identity>("probe");
+    auto bl = msg->getPacked();
+    REQUIRE(bl != nullptr);
+    REQUIRE(!conn.callSendMsg(bl));
 }


### PR DESCRIPTION
## Description

sendMsg(buf_len) loaded this->fd once and reused it for the whole send loop. A concurrent disconnect() does fd.exchange(-1) then closes the descriptor, so a multi-iteration send could keep writing to a closed and possibly reused fd (cross-connection data leak).

Re-load this->fd at the top of each loop iteration and bail out if it has become -1, so a disconnect during a send stops promptly instead of writing into a stale descriptor. Add a deterministic test that sendMsg(buf_len) returns false when fd is -1.

## Summary by Sourcery

Ensure sendMsg() stops immediately when the underlying file descriptor becomes invalid during a multi-iteration send, and add coverage for this behavior.

Bug Fixes:
- Reload the connection file descriptor on each sendMsg(buf_len) loop iteration and abort when it becomes -1 to avoid writing to a closed or reused descriptor.

Tests:
- Add a unit test that verifies sendMsg(buf_len) returns false without performing any socket I/O when the file descriptor is -1 by default.