### PR TITLE
fix(server): stop recv thread before destroying a disconnected client

### DIFF
--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -35,15 +35,41 @@ public:
     server_clients(server_clients &&) = delete;
     auto operator=(server_clients &) -> server_clients & = delete;
     auto operator=(server_clients &&) -> server_clients & = delete;
-    void cleanupRemovableClients()
+    auto getTotalClients() -> uint32_t
     {
         std::scoped_lock guard(this->lock);
-        while (!this->disconnected.empty())
+        return this->total_clients;
+    }
+    void cleanupRemovableClients()
+    {
+        /* Drain the disconnected queue under the lock, then call disconnect()
+         * outside the lock.  This avoids a deadlock: the recv thread's
+         * processMessage can call clientDisconnected / broadcastMsg, both of
+         * which also take this->lock.  If we held this->lock while joining the
+         * recv thread, and that thread was blocked waiting for this->lock, we
+         * would deadlock.  By releasing the lock before joining we break the
+         * cycle.
+         *
+         * disconnect() joins the recv thread while the fss_client object is
+         * still fully alive (the shared_ptr keeps it alive until removable goes
+         * out of scope), so processMessage can never execute after any member
+         * of fss_client has been destroyed. */
+        std::vector<std::shared_ptr<flight_safety_system::server::fss_client>> removable;
         {
-            auto client = this->disconnected.front();
-            this->disconnected.pop();
-            total_clients--;
+            std::scoped_lock guard(this->lock);
+            while (!this->disconnected.empty())
+            {
+                removable.push_back(this->disconnected.front());
+                this->disconnected.pop();
+                total_clients--;
+            }
         }
+        for (auto &client : removable)
+        {
+            client->disconnect();
+        }
+        /* removable goes out of scope here; clients are destroyed with the
+         * recv thread already stopped. */
     };
     void setClientTimeoutMs(uint64_t ms) { this->client_timeout_ms = ms; }
     void setClientRateLimits(uint64_t capacity, uint64_t refill_per_s)

--- a/tests/server_clients_test.cpp
+++ b/tests/server_clients_test.cpp
@@ -81,6 +81,38 @@ TEST_CASE("server_clients: clientConnected increments client count")
     sc.cleanupRemovableClients();
 }
 
+TEST_CASE("server_clients: cleanupRemovableClients decrements total count and is idempotent")
+{
+    server_clients sc;
+    fss_test::MockDatabase mock;
+
+    auto conn1 = std::make_shared<FakeConnection>();
+    auto writer1 = make_null_writer();
+    auto client1 = std::make_shared<fss::server::fss_client>(conn1, &mock, writer1, &sc);
+
+    auto conn2 = std::make_shared<FakeConnection>();
+    auto writer2 = make_null_writer();
+    auto client2 = std::make_shared<fss::server::fss_client>(conn2, &mock, writer2, &sc);
+
+    sc.clientConnected(client1);
+    sc.clientConnected(client2);
+    REQUIRE(sc.getTotalClients() == 2);
+
+    sc.clientDisconnected(client1.get());
+    REQUIRE(sc.getTotalClients() == 2); // still 2 until cleanup runs
+
+    sc.cleanupRemovableClients();
+    REQUIRE(sc.getTotalClients() == 1); // one removed
+
+    sc.clientDisconnected(client2.get());
+    sc.cleanupRemovableClients();
+    REQUIRE(sc.getTotalClients() == 0); // both removed
+
+    // Second cleanup on empty queue must be a no-op
+    sc.cleanupRemovableClients();
+    REQUIRE(sc.getTotalClients() == 0);
+}
+
 TEST_CASE("server_clients: clientDisconnected moves client to removable queue")
 {
     server_clients sc;


### PR DESCRIPTION
## Description

An fss_client is kept alive only by server_clients (the clients list, then the disconnected queue); the connection's recv thread holds no reference to it. cleanupRemovableClients() released the last reference and destroyed the fss_client, but the recv thread is only joined later in ~fss_connection (the base subobject), after the derived members are already gone. If the recv thread was still in processMessage(), it touched destroyed members -- undefined behaviour avoided only by a timing gap.

Drain the disconnected queue under the lock, then call disconnect() on each client outside the lock (joining the recv thread while the client is still fully alive) before the shared_ptrs are released. Releasing the lock before joining avoids deadlocking against the recv thread's clientDisconnected / broadcastMsg callbacks, which also take the lock. disconnect() is idempotent, so the later destructor join is a safe no-op. Add a test for cleanup bookkeeping and idempotency.

## Summary by Sourcery

Ensure disconnected server clients fully stop their receive threads before destruction to avoid undefined behavior and deadlocks.

Bug Fixes:
- Prevent use-after-destruction of fss_client by stopping the receive thread before shared_ptr references are released during cleanup.

Enhancements:
- Expose a getter for the total client count on server_clients for introspection and testing.

Tests:
- Add tests verifying cleanupRemovableClients correctly updates total client count and behaves idempotently when the disconnected queue is empty.