### PR TITLE
feat(server): prune clients that never identify within a deadline

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -156,6 +156,7 @@ void fss::server::fss_client::activate()
     {
         std::scoped_lock guard(this->client_lock);
         this->activated_ms = this->clock->now_ms();
+        this->activated = true;
     }
     this->getConnection()->setHandler(this);
 }
@@ -259,9 +260,17 @@ auto fss::server::fss_client::isTimedOut() -> bool
     std::scoped_lock guard(this->client_lock);
     if (!this->identified)
     {
-        bool timed_out = (this->clock->now_ms() - this->activated_ms) > this->identify_timeout_ms;
-        if (timed_out)
+        /* Only meaningful once the client has been activated: before that
+         * activated_ms is unset, so a caller invoking isTimedOut() early must
+         * not see a spurious timeout against an epoch-zero activation time. */
+        if (!this->activated)
         {
+            return false;
+        }
+        bool timed_out = (this->clock->now_ms() - this->activated_ms) > this->identify_timeout_ms;
+        if (timed_out && !this->identify_timeout_logged)
+        {
+            this->identify_timeout_logged = true;
             FSS_LOG_WARN("server", "Client did not identify within deadline; pruning");
         }
         return timed_out;

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -153,6 +153,10 @@ fss::server::fss_client::fss_client(std::shared_ptr<fss::transport::fss_connecti
 
 void fss::server::fss_client::activate()
 {
+    {
+        std::scoped_lock guard(this->client_lock);
+        this->activated_ms = this->clock->now_ms();
+    }
     this->getConnection()->setHandler(this);
 }
 
@@ -239,6 +243,12 @@ void fss::server::fss_client::setTimeoutMs(uint64_t ms)
     this->client_timeout_ms = ms;
 }
 
+void fss::server::fss_client::setIdentifyTimeoutMs(uint64_t ms)
+{
+    std::scoped_lock guard(this->client_lock);
+    this->identify_timeout_ms = ms;
+}
+
 void fss::server::fss_client::setRateLimits(uint64_t capacity, uint64_t refill_per_s)
 {
     this->msg_rate = rate_limiter(capacity, refill_per_s);
@@ -247,6 +257,15 @@ void fss::server::fss_client::setRateLimits(uint64_t capacity, uint64_t refill_p
 auto fss::server::fss_client::isTimedOut() -> bool
 {
     std::scoped_lock guard(this->client_lock);
+    if (!this->identified)
+    {
+        bool timed_out = (this->clock->now_ms() - this->activated_ms) > this->identify_timeout_ms;
+        if (timed_out)
+        {
+            FSS_LOG_WARN("server", "Client did not identify within deadline; pruning");
+        }
+        return timed_out;
+    }
     if (!this->liveness_active)
     {
         return false;

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -162,6 +162,8 @@ private:
     bool liveness_active{false};
     uint64_t last_rtt_response_time{0};
     uint64_t client_timeout_ms{30000};
+    uint64_t activated_ms{0};
+    uint64_t identify_timeout_ms{30000};
     IDatabase *dbc;
     std::shared_ptr<db_write_queue> writer;
     fss_client_handler *client_handler;
@@ -189,6 +191,7 @@ public:
     void setPendingCommand(std::shared_ptr<asset_command> cmd);
     void setClock(std::shared_ptr<IClock> t_clock);
     void setTimeoutMs(uint64_t ms);
+    void setIdentifyTimeoutMs(uint64_t ms);
     void setRateLimits(uint64_t capacity, uint64_t refill_per_s); // must be called before any messages are processed
     auto isTimedOut() -> bool;
 };

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -162,8 +162,10 @@ private:
     bool liveness_active{false};
     uint64_t last_rtt_response_time{0};
     uint64_t client_timeout_ms{30000};
+    bool activated{false};
     uint64_t activated_ms{0};
     uint64_t identify_timeout_ms{30000};
+    bool identify_timeout_logged{false};
     IDatabase *dbc;
     std::shared_ptr<db_write_queue> writer;
     fss_client_handler *client_handler;

--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -18,6 +18,7 @@ private:
     uint32_t total_clients{0};
     std::atomic<bool> shutting_down{false};
     uint64_t client_timeout_ms{30000};
+    uint64_t identify_timeout_ms{30000};
     uint64_t rate_capacity{100};
     uint64_t rate_refill_per_s{20};
 public:
@@ -72,6 +73,7 @@ public:
          * recv thread already stopped. */
     };
     void setClientTimeoutMs(uint64_t ms) { this->client_timeout_ms = ms; }
+    void setClientIdentifyTimeoutMs(uint64_t ms) { this->identify_timeout_ms = ms; }
     void setClientRateLimits(uint64_t capacity, uint64_t refill_per_s)
     {
         this->rate_capacity = capacity;
@@ -84,6 +86,7 @@ public:
          * let a message reach the client (touching msg_rate) while the rate
          * limiter is still being reconfigured. */
         client->setTimeoutMs(this->client_timeout_ms);
+        client->setIdentifyTimeoutMs(this->identify_timeout_ms);
         client->setRateLimits(this->rate_capacity, this->rate_refill_per_s);
         auto *raw = client.get();
         {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -147,6 +147,11 @@ auto main(int argc, char *argv[]) -> int
         config.isMember("client_timeout") ? config["client_timeout"].asUInt64() : default_client_timeout_sec;
     clients->setClientTimeoutMs(client_timeout_sec * msec_per_sec);
 
+    constexpr int default_identify_timeout_sec = 30;
+    uint64_t identify_timeout_sec =
+        config.isMember("identify_timeout") ? config["identify_timeout"].asUInt64() : default_identify_timeout_sec;
+    clients->setClientIdentifyTimeoutMs(identify_timeout_sec * msec_per_sec);
+
     constexpr uint64_t default_rate_capacity = 100;
     constexpr uint64_t default_rate_refill_per_s = 20;
     uint64_t rate_capacity =

--- a/tests/timeout_test.cpp
+++ b/tests/timeout_test.cpp
@@ -67,7 +67,7 @@ public:
 
 } // namespace
 
-TEST_CASE("timeout: isTimedOut false before identification")
+TEST_CASE("timeout: isTimedOut false for unidentified client within identify deadline")
 {
     fss_test::MockDatabase mock;
     auto conn = std::make_shared<FakeConnection>();
@@ -76,8 +76,50 @@ TEST_CASE("timeout: isTimedOut false before identification")
     auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
     auto clock = std::make_shared<FakeClock>();
     session->setClock(clock);
+    session->setIdentifyTimeoutMs(30000);
+    session->activate();
 
-    clock->advance(100000);
+    clock->advance(29999);
+    REQUIRE_FALSE(session->isTimedOut());
+}
+
+TEST_CASE("timeout: isTimedOut true for unidentified client past identify deadline")
+{
+    fss_test::MockDatabase mock;
+    auto conn = std::make_shared<FakeConnection>();
+    NullClientHandler handler;
+    auto writer = make_null_writer();
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    auto clock = std::make_shared<FakeClock>();
+    session->setClock(clock);
+    session->setIdentifyTimeoutMs(30000);
+    session->activate();
+
+    clock->advance(30001);
+    REQUIRE(session->isTimedOut());
+}
+
+TEST_CASE("timeout: identified client not pruned by identify deadline")
+{
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+    auto writer = make_null_writer();
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    auto clock = std::make_shared<FakeClock>();
+    session->setClock(clock);
+    /* Use a very short identify deadline so advancing past it is easy. */
+    session->setIdentifyTimeoutMs(5000);
+    session->activate();
+
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    /* Advance past the identify deadline but stay within the liveness window.
+     * Identification resets last_rtt_response_time, so the liveness clock
+     * starts here; the session must NOT be pruned by the identify deadline. */
+    clock->advance(10000);
     REQUIRE_FALSE(session->isTimedOut());
 }
 


### PR DESCRIPTION
## Description

A peer that completes the mutual-TLS handshake but never sends an identity message was never reaped: isTimedOut() returns false while liveness is inactive, and liveness only activates after identification. Such a connection held a thread and fd indefinitely (and a half-sent header could stall its recv thread).

Add a hard deadline from activation to identification (not reset by partial activity or the version handshake), default 30s, configurable via the 'identify_timeout' config key and plumbed through server_clients like the existing client_timeout. isTimedOut() now reports an unidentified client as timed out once the deadline passes (logged distinctly), so checkTimeouts prunes it; teardown's shutdown() unblocks any stalled recv(). Once identified the existing liveness logic applies unchanged. Add fake-clock tests for within-deadline, past-deadline, and identified-not-pruned cases.

## Summary by Sourcery

Enforce and configure a hard identification deadline for server clients and ensure unidentified connections are pruned after that deadline while preserving existing liveness-based timeouts for identified clients.

New Features:
- Add a configurable identify timeout for clients that must elapse between connection activation and successful identification, defaulting to 30 seconds.
- Expose an identify_timeout configuration option wired through server_clients to each fss_client instance.

Bug Fixes:
- Ensure clients that complete TLS but never identify are now treated as timed out and pruned instead of persisting indefinitely.

Enhancements:
- Log a warning when a client is pruned for failing to identify within the configured deadline.
- Track client activation time to distinguish between pre-activation and post-activation timeout checks.

Tests:
- Add fake-clock tests covering unidentified clients within the identify deadline, unidentified clients past the identify deadline, and identified clients that must not be pruned by the identify deadline.