### PR TITLE
fix: detach thread after a failed join in destructor paths

### DIFF
--- a/src/db-write-queue.cpp
+++ b/src/db-write-queue.cpp
@@ -3,6 +3,8 @@
 
 #include <algorithm>
 #include <exception>
+#include <system_error>
+#include <thread>
 #include <utility>
 
 namespace flight_safety_system::server {
@@ -67,9 +69,14 @@ void db_write_queue::stop()
         {
             this->worker.join();
         }
-        catch (const std::exception &e)
+        catch (const std::system_error &e)
         {
-            FSS_LOG_ERROR("db-writer", "worker.join() failed: " << e.what());
+            /* join() failed, so the thread is still joinable; leaving it would
+             * make ~std::thread call std::terminate. Detach to avoid that
+             * (leaking the thread) — we cannot recover the worker here. */
+            FSS_LOG_ERROR("db-writer", "worker.join() failed, detaching: " << e.what());
+            this->worker.detach();
+            this->worker = std::thread();
         }
     }
 }

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <string>
 #include <cstring>
+#include <system_error>
 #include <thread>
 #include <vector>
 #include "fss-transport.hpp"
@@ -132,9 +133,15 @@ void flight_safety_system::transport::fss_connection::disconnect()
             {
                 this->recv_thread.join();
             }
-            catch (const std::exception &e)
+            catch (const std::system_error &e)
             {
-                FSS_LOG_ERROR("transport", "recv_thread.join() failed: " << e.what());
+                /* join() failed, so the thread is still joinable; leaving it
+                 * would make ~std::thread call std::terminate. Detach to avoid
+                 * that (leaking the thread) — we are already in a degenerate
+                 * state where the thread could not be joined. */
+                FSS_LOG_ERROR("transport", "recv_thread.join() failed, detaching: " << e.what());
+                this->recv_thread.detach();
+                this->recv_thread = std::thread();
             }
         }
     }


### PR DESCRIPTION
## Description

Address Sourcery review on #177: a try/catch around join() that merely logged left the thread joinable, so ~std::thread would still call std::terminate -- the catch only moved the failure. Narrow the catch to std::system_error (the only type join() throws, so genuinely unexpected exceptions still surface) and detach the thread on failure so the std::thread member's destructor is a no-op. Applies to fss_connection::disconnect() and db_write_queue::stop().

## Summary by Sourcery

Handle thread join failures more safely in database write queue and transport connection shutdown paths to avoid unexpected termination.

Bug Fixes:
- Prevent std::terminate by detaching worker thread when db_write_queue::stop() fails to join it.
- Prevent std::terminate by detaching recv_thread when fss_connection::disconnect() fails to join it.
- Restrict join() exception handling to std::system_error so unexpected exceptions still propagate.