### PR TITLE
test(transport): derive coord clamp bounds from the scale constant

### DIFF
--- a/tests/coordinate_precision_test.cpp
+++ b/tests/coordinate_precision_test.cpp
@@ -25,6 +25,7 @@ using flight_safety_system::transport::fss_message_position_report;
 using flight_safety_system::transport::fss_message_system_status;
 using flight_safety_system::transport::asset_command_hold;
 using flight_safety_system::transport::asset_command_rtl;
+using flight_safety_system::transport::FSS_COORD_SCALE;
 using flight_safety_system::transport::FSS_VOLTAGE_SCALE;
 
 /* Regression for todo/11-coordinate-constant.md
@@ -221,8 +222,8 @@ TEST_CASE("coord: out-of-range latitude clamps rather than wrapping")
     std::tie(lat, lng) = round_trip(large, 0.0);
     /* Must be finite and bounded by the valid coordinate space. */
     REQUIRE(std::isfinite(lat));
-    /* Clamped to INT32_MAX * FSS_COORD_SCALE ≈ 214.748 degrees. */
-    REQUIRE(lat <= 215.0);
+    /* Clamped to INT32_MAX * FSS_COORD_SCALE rather than wrapping. */
+    REQUIRE(lat <= static_cast<double>(std::numeric_limits<int32_t>::max()) * FSS_COORD_SCALE);
     REQUIRE(lat > 0.0);
 }
 
@@ -232,7 +233,7 @@ TEST_CASE("coord: large negative out-of-range latitude clamps rather than wrappi
     double lat = 0.0, lng = 0.0;
     std::tie(lat, lng) = round_trip(neg_large, 0.0);
     REQUIRE(std::isfinite(lat));
-    REQUIRE(lat >= -215.0);
+    REQUIRE(lat >= static_cast<double>(std::numeric_limits<int32_t>::min()) * FSS_COORD_SCALE);
     REQUIRE(lat < 0.0);
 }
 


### PR DESCRIPTION
## Description

Address Sourcery review on #174: the out-of-range coordinate tests hard-coded 215.0. Derive the bounds from INT32_MAX/INT32_MIN * FSS_COORD_SCALE so the tests stay correct if the scale or integer width ever changes.

## Summary by Sourcery

Tests:
- Adjust out-of-range latitude clamp assertions to compute bounds from INT32 min/max and FSS_COORD_SCALE, avoiding hard-coded constants.