### PR TITLE
refactor(client): erase matched server by iterator, not list::remove

### DIFF
--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -263,12 +263,12 @@ void flight_safety_system::client_ssl::fss_client::serverRequiresReconnect(
     size_t count = 0;
     {
         std::scoped_lock lock(this->servers_lock);
-        for (auto s : this->servers)
+        for (auto it = this->servers.begin(); it != this->servers.end(); ++it)
         {
-            if (s.get() == server)
+            if (it->get() == server)
             {
-                this->servers.remove(s);
-                this->reconnect_servers.push_back(std::move(s));
+                this->reconnect_servers.push_back(std::move(*it));
+                this->servers.erase(it);
                 break;
             }
         }


### PR DESCRIPTION
## Description

Address Sourcery review on #183: serverRequiresReconnect iterated by value (copying each shared_ptr) and called list::remove, which rescans the whole list and would remove every element equal to the match. Iterate with an iterator and erase the single matched element directly.

## Summary by Sourcery

Bug Fixes:
- Prevent potential removal of multiple matching server entries and redundant list rescans when marking a server for reconnection.