### PR TITLE
refactor(server): make getTotalClients() const

### DIFF
--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -12,7 +12,7 @@
 
 class server_clients : public flight_safety_system::server::fss_client_handler {
 private:
-    std::mutex lock{};
+    mutable std::mutex lock{};
     std::list<std::shared_ptr<flight_safety_system::server::fss_client>> clients{};
     std::queue<std::shared_ptr<flight_safety_system::server::fss_client>> disconnected{};
     uint32_t total_clients{0};
@@ -36,7 +36,7 @@ public:
     server_clients(server_clients &&) = delete;
     auto operator=(server_clients &) -> server_clients & = delete;
     auto operator=(server_clients &&) -> server_clients & = delete;
-    auto getTotalClients() -> uint32_t
+    auto getTotalClients() const -> uint32_t
     {
         std::scoped_lock guard(this->lock);
         return this->total_clients;


### PR DESCRIPTION
## Description

Address Sourcery review on #182: getTotalClients() only reads total_clients. Mark it const (and the lock mutable) to reflect its read-only intent and allow use on a const server_clients.

## Summary by Sourcery

Enhancements:
- Adjust server_clients to use a mutable mutex and a const-qualified getTotalClients() accessor for thread-safe read-only access to the total client count.