### PR TITLE
perf(server): move shared_ptr when draining the disconnected queue

### DIFF
--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -8,6 +8,7 @@
 #include <list>
 #include <mutex>
 #include <queue>
+#include <utility>
 #include <vector>
 
 class server_clients : public flight_safety_system::server::fss_client_handler {
@@ -60,7 +61,7 @@ public:
             std::scoped_lock guard(this->lock);
             while (!this->disconnected.empty())
             {
-                removable.push_back(this->disconnected.front());
+                removable.push_back(std::move(this->disconnected.front()));
                 this->disconnected.pop();
                 total_clients--;
             }


### PR DESCRIPTION
## Description

Address Sourcery review on #182: cleanupRemovableClients copied each shared_ptr out of the disconnected queue before popping it. Move it instead to avoid the extra refcount churn (add <utility> for std::move).

## Summary by Sourcery

Enhancements:
- Reduce overhead when draining the disconnected client queue by moving shared_ptr instances instead of copying them.