### PR TITLE
refactor(db): use fixed-width uint32_t for asset_command altitude

### DIFF
--- a/src/server-db.h
+++ b/src/server-db.h
@@ -1,3 +1,5 @@
+#include <stdint.h>
+
 /* Every entry point takes the name of the ECPG connection to run on, so the
  * caller can keep telemetry writes and command/config reads on separate
  * connections (see db.cpp). */
@@ -20,7 +22,7 @@ struct asset_command_s {
     unsigned long long dbid;
     double latitude;
     double longitude;
-    unsigned int altitude;
+    uint32_t altitude;
 };
 
 struct asset_command_s *db_asset_command_get(const char *conn, unsigned long long asset_id_arg);


### PR DESCRIPTION
## Description

Address Sourcery review on #175: the C asset_command_s.altitude used plain unsigned int while the C++ asset_command uses uint32_t. Use the fixed-width type so both sides match explicitly.

## Summary by Sourcery

Enhancements:
- Replace the asset_command_s altitude field type with uint32_t and include the appropriate fixed-width integer header for consistency across C and C++ code.