### PR TITLE
build(tests): move src include path to CPPFLAGS

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -30,7 +30,10 @@ all_test_SOURCES = main.cpp messages.cpp connection.cpp client.cpp \
 	../src/db-write-queue.cpp \
 	../src/db.cpp \
 	../src/server-db.c
-all_test_CFLAGS = $(ECPG_CFLAGS) -I$(top_srcdir)/src
+# Header search path belongs at the preprocessor layer so it applies to both
+# the C (server-db.c) and C++ sources, independent of CFLAGS/CXXFLAGS.
+all_test_CPPFLAGS = -I$(top_srcdir)/src
+all_test_CFLAGS = $(ECPG_CFLAGS)
 all_test_LDADD = ../src/libfss-transport.la ../src/libfss-client-ssl.la ../src/libfss.la $(JSONCPP_LIBS) $(ECPG_LIBS)
 
 all_test_SOURCES += connection-ssl.cpp


### PR DESCRIPTION
## Description

Address Sourcery review on #180: the -I$(top_srcdir)/src header search path was in all_test_CFLAGS, tying it to C-compiler flags. Move it to all_test_CPPFLAGS so it applies at the preprocessor layer for both the C (server-db.c) and C++ sources.

## Summary by Sourcery

Build:
- Set all_test_CPPFLAGS to include the src directory header search path instead of placing it in all_test_CFLAGS.