### PR TITLE
fix: isolate exceptions in worker threads and the main loop

### DIFF
--- a/src/fss-log.hpp
+++ b/src/fss-log.hpp
@@ -3,13 +3,16 @@
 #include <atomic>
 #include <cerrno>
 #include <chrono>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <exception>
 #include <iostream>
 #include <mutex>
 #include <sstream>
 #include <string>
+#include <utility>
 
 namespace flight_safety_system {
 namespace log {
@@ -136,3 +139,58 @@ inline void write(level lvl, const char *component, const std::string &msg)
         std::string _fss_perror_msg = (msg);                                                                           \
         FSS_LOG_ERROR((comp), _fss_perror_msg << ": " << std::strerror(_fss_saved_errno));                             \
     } while (false)
+
+namespace flight_safety_system {
+
+/* Runs a unit of work and isolates exceptions so a long-running loop is not
+ * torn down by one failure. Consecutive failures are logged with throttling
+ * (the first, then every log_interval-th) so a persistent fault does not flood
+ * the log, and a single recovery line is logged once work succeeds again. The
+ * loop is never stopped — the caller keeps running. */
+class exception_guard {
+    const char *category;
+    const char *label;
+    uint64_t consecutive_failures{0};
+    static constexpr uint64_t log_interval = 100;
+
+    void note_failure(const std::string &what)
+    {
+        this->consecutive_failures++;
+        if (this->consecutive_failures == 1 || (this->consecutive_failures % log_interval) == 0)
+        {
+            FSS_LOG_ERROR(this->category, "Exception in " << this->label << " (" << this->consecutive_failures
+                                                          << " consecutive): " << what);
+        }
+    }
+public:
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+    exception_guard(const char *t_category, const char *t_label) : category(t_category), label(t_label) {}
+    exception_guard(const exception_guard &) = delete;
+    exception_guard(exception_guard &&) = delete;
+    auto operator=(const exception_guard &) -> exception_guard & = delete;
+    auto operator=(exception_guard &&) -> exception_guard & = delete;
+
+    template<typename F> void run(F &&work)
+    {
+        try
+        {
+            std::forward<F>(work)();
+            if (this->consecutive_failures > 0)
+            {
+                FSS_LOG_INFO(this->category, this->label << " recovered after " << this->consecutive_failures
+                                                         << " consecutive failure(s)");
+                this->consecutive_failures = 0;
+            }
+        }
+        catch (const std::exception &e)
+        {
+            this->note_failure(e.what());
+        }
+        catch (...)
+        {
+            this->note_failure("unknown exception");
+        }
+    }
+};
+
+} // namespace flight_safety_system

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -204,7 +204,18 @@ auto main(int argc, char *argv[]) -> int
     std::thread command_poller([&clients, &dbc, &poll_running, command_poll_ms]() -> void {
         while (poll_running.load())
         {
-            clients->pollCommands(dbc.get());
+            try
+            {
+                clients->pollCommands(dbc.get());
+            }
+            catch (const std::exception &e)
+            {
+                FSS_LOG_ERROR("server", "Exception in pollCommands: " << e.what());
+            }
+            catch (...)
+            {
+                FSS_LOG_ERROR("server", "Unknown exception in pollCommands");
+            }
             std::this_thread::sleep_for(std::chrono::milliseconds(command_poll_ms));
         }
     });
@@ -225,26 +236,37 @@ auto main(int argc, char *argv[]) -> int
             }
         }
         usleep(command_poll_ms * usec_per_msec);
-        clients->sendCommand();
-        if ((tick_counter % ticks_per_sec) == 0)
+        try
         {
-            clients->cleanupRemovableClients();
-            clients->checkTimeouts();
-            auto rtt_req = std::make_shared<flight_safety_system::transport::fss_message_rtt_request>();
-            clients->sendRTTRequest(rtt_req);
-            static uint64_t last_failure_count = 0;
-            uint64_t current_failures = writer->write_failure_count();
-            if (current_failures != last_failure_count)
+            clients->sendCommand();
+            if ((tick_counter % ticks_per_sec) == 0)
             {
-                FSS_LOG_ERROR("server", "DB write failures since start: " << current_failures);
-                last_failure_count = current_failures;
+                clients->cleanupRemovableClients();
+                clients->checkTimeouts();
+                auto rtt_req = std::make_shared<flight_safety_system::transport::fss_message_rtt_request>();
+                clients->sendRTTRequest(rtt_req);
+                static uint64_t last_failure_count = 0;
+                uint64_t current_failures = writer->write_failure_count();
+                if (current_failures != last_failure_count)
+                {
+                    FSS_LOG_ERROR("server", "DB write failures since start: " << current_failures);
+                    last_failure_count = current_failures;
+                }
+                dbc->tryReconnectIfNeeded();
             }
-            dbc->tryReconnectIfNeeded();
+            if ((tick_counter % send_config_period_ticks) == 0)
+            {
+                clients->broadcastMsg(flight_safety_system::server::build_server_list_msg(dbc.get()));
+                clients->sendSMMSettings();
+            }
         }
-        if ((tick_counter % send_config_period_ticks) == 0)
+        catch (const std::exception &e)
         {
-            clients->broadcastMsg(flight_safety_system::server::build_server_list_msg(dbc.get()));
-            clients->sendSMMSettings();
+            FSS_LOG_ERROR("server", "Exception in main loop tick: " << e.what());
+        }
+        catch (...)
+        {
+            FSS_LOG_ERROR("server", "Unknown exception in main loop tick");
         }
         tick_counter++;
     }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -202,25 +202,16 @@ auto main(int argc, char *argv[]) -> int
     constexpr int send_config_period_ticks = 15 * ticks_per_sec;
     std::atomic<bool> poll_running{true};
     std::thread command_poller([&clients, &dbc, &poll_running, command_poll_ms]() -> void {
+        flight_safety_system::exception_guard poll_guard("server", "pollCommands");
         while (poll_running.load())
         {
-            try
-            {
-                clients->pollCommands(dbc.get());
-            }
-            catch (const std::exception &e)
-            {
-                FSS_LOG_ERROR("server", "Exception in pollCommands: " << e.what());
-            }
-            catch (...)
-            {
-                FSS_LOG_ERROR("server", "Unknown exception in pollCommands");
-            }
+            poll_guard.run([&]() -> void { clients->pollCommands(dbc.get()); });
             std::this_thread::sleep_for(std::chrono::milliseconds(command_poll_ms));
         }
     });
 
     uint64_t tick_counter = 0;
+    flight_safety_system::exception_guard tick_guard("server", "main loop tick");
     while (running == 1)
     {
         if (reload_crl == 1)
@@ -236,8 +227,7 @@ auto main(int argc, char *argv[]) -> int
             }
         }
         usleep(command_poll_ms * usec_per_msec);
-        try
-        {
+        tick_guard.run([&]() -> void {
             clients->sendCommand();
             if ((tick_counter % ticks_per_sec) == 0)
             {
@@ -259,15 +249,7 @@ auto main(int argc, char *argv[]) -> int
                 clients->broadcastMsg(flight_safety_system::server::build_server_list_msg(dbc.get()));
                 clients->sendSMMSettings();
             }
-        }
-        catch (const std::exception &e)
-        {
-            FSS_LOG_ERROR("server", "Exception in main loop tick: " << e.what());
-        }
-        catch (...)
-        {
-            FSS_LOG_ERROR("server", "Unknown exception in main loop tick");
-        }
+        });
         tick_counter++;
     }
 

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -165,6 +165,7 @@ auto flight_safety_system::transport::fss_connection::getMessageId() -> uint64_t
 void flight_safety_system::transport::fss_connection::processMessages()
 {
     this->run.store(true);
+    flight_safety_system::exception_guard handler_guard("transport", "processMessage");
     while (this->run.load())
     {
         auto msg = this->recvMsg();
@@ -181,18 +182,7 @@ void flight_safety_system::transport::fss_connection::processMessages()
                 std::scoped_lock lock_holder(this->msg_lock);
                 if (this->handler != nullptr)
                 {
-                    try
-                    {
-                        this->handler->processMessage(msg);
-                    }
-                    catch (const std::exception &e)
-                    {
-                        FSS_LOG_ERROR("transport", "Exception in processMessage (closed): " << e.what());
-                    }
-                    catch (...)
-                    {
-                        FSS_LOG_ERROR("transport", "Unknown exception in processMessage (closed)");
-                    }
+                    handler_guard.run([&]() -> void { this->handler->processMessage(msg); });
                 }
                 else
                 {
@@ -205,18 +195,7 @@ void flight_safety_system::transport::fss_connection::processMessages()
             std::scoped_lock lock_holder(this->msg_lock);
             if (this->handler != nullptr)
             {
-                try
-                {
-                    this->handler->processMessage(msg);
-                }
-                catch (const std::exception &e)
-                {
-                    FSS_LOG_ERROR("transport", "Exception in processMessage: " << e.what());
-                }
-                catch (...)
-                {
-                    FSS_LOG_ERROR("transport", "Unknown exception in processMessage");
-                }
+                handler_guard.run([&]() -> void { this->handler->processMessage(msg); });
             }
             else
             {
@@ -517,6 +496,7 @@ static void listen_thread(flight_safety_system::transport::fss_listen *listen)
 
 void flight_safety_system::transport::fss_listen::processMessages()
 {
+    flight_safety_system::exception_guard accept_guard("transport", "new connection");
     while (this->getFd() >= 0)
     {
         struct sockaddr_storage sa = {};
@@ -551,19 +531,10 @@ void flight_safety_system::transport::fss_listen::processMessages()
         set_tcp_keepalive(newfd);
         if (this->cb != nullptr)
         {
-            try
-            {
+            accept_guard.run([&]() -> void {
                 auto conn = this->newConnection(newfd);
                 this->cb(conn);
-            }
-            catch (const std::exception &e)
-            {
-                FSS_LOG_ERROR("transport", "Exception handling new connection: " << e.what());
-            }
-            catch (...)
-            {
-                FSS_LOG_ERROR("transport", "Unknown exception handling new connection");
-            }
+            });
         }
         else
         {

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -181,7 +181,18 @@ void flight_safety_system::transport::fss_connection::processMessages()
                 std::scoped_lock lock_holder(this->msg_lock);
                 if (this->handler != nullptr)
                 {
-                    this->handler->processMessage(msg);
+                    try
+                    {
+                        this->handler->processMessage(msg);
+                    }
+                    catch (const std::exception &e)
+                    {
+                        FSS_LOG_ERROR("transport", "Exception in processMessage (closed): " << e.what());
+                    }
+                    catch (...)
+                    {
+                        FSS_LOG_ERROR("transport", "Unknown exception in processMessage (closed)");
+                    }
                 }
                 else
                 {
@@ -194,7 +205,18 @@ void flight_safety_system::transport::fss_connection::processMessages()
             std::scoped_lock lock_holder(this->msg_lock);
             if (this->handler != nullptr)
             {
-                this->handler->processMessage(msg);
+                try
+                {
+                    this->handler->processMessage(msg);
+                }
+                catch (const std::exception &e)
+                {
+                    FSS_LOG_ERROR("transport", "Exception in processMessage: " << e.what());
+                }
+                catch (...)
+                {
+                    FSS_LOG_ERROR("transport", "Unknown exception in processMessage");
+                }
             }
             else
             {
@@ -529,8 +551,19 @@ void flight_safety_system::transport::fss_listen::processMessages()
         set_tcp_keepalive(newfd);
         if (this->cb != nullptr)
         {
-            auto conn = this->newConnection(newfd);
-            this->cb(conn);
+            try
+            {
+                auto conn = this->newConnection(newfd);
+                this->cb(conn);
+            }
+            catch (const std::exception &e)
+            {
+                FSS_LOG_ERROR("transport", "Exception handling new connection: " << e.what());
+            }
+            catch (...)
+            {
+                FSS_LOG_ERROR("transport", "Unknown exception handling new connection");
+            }
         }
         else
         {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -26,6 +26,7 @@ all_test_SOURCES = main.cpp messages.cpp connection.cpp client.cpp \
 	secure_string_test.cpp \
 	rate_limiter_test.cpp \
 	server_clients_test.cpp \
+	exception_isolation_test.cpp \
 	../src/client_session.cpp \
 	../src/db-write-queue.cpp \
 	../src/db.cpp \

--- a/tests/exception_isolation_test.cpp
+++ b/tests/exception_isolation_test.cpp
@@ -1,0 +1,95 @@
+#ifdef HAVE_CATCH2_CATCH_ALL_HPP
+#include <catch2/catch_all.hpp>
+#elif HAVE_CATCH2_CATCH_HPP
+#include <catch2/catch.hpp>
+#elif HAVE_CATCH_CATCH_HPP
+#include <catch/catch.hpp>
+#elif HAVE_CATCH_HPP
+#include <catch.hpp>
+#else
+#error No catch header
+#endif
+
+#include <atomic>
+#include <memory>
+#include <stdexcept>
+
+#include "fss-transport.hpp"
+#include "test_helpers.hpp"
+
+/* Verify that a handler whose processMessage() throws does NOT kill the
+ * recv thread: the loop should catch the exception, log it, and continue
+ * processing subsequent messages. */
+
+namespace {
+
+/* A handler that throws std::runtime_error on the first call, then records
+ * all subsequent messages so we can assert the loop survived. */
+class throwing_message_cb : public flight_safety_system::transport::fss_message_cb {
+public:
+    std::atomic<int> call_count{0};
+    std::atomic<int> after_throw_count{0};
+
+    explicit throwing_message_cb(std::shared_ptr<flight_safety_system::transport::fss_connection> t_conn)
+        : fss_message_cb(std::move(t_conn))
+    {
+    }
+    throwing_message_cb(const throwing_message_cb &) = delete;
+    throwing_message_cb(throwing_message_cb &&) = delete;
+    auto operator=(const throwing_message_cb &) -> throwing_message_cb & = delete;
+    auto operator=(throwing_message_cb &&) -> throwing_message_cb & = delete;
+    ~throwing_message_cb() override = default;
+
+    void processMessage(std::shared_ptr<flight_safety_system::transport::fss_message> /*message*/) override
+    {
+        int n = ++call_count;
+        if (n == 1)
+        {
+            throw std::runtime_error("deliberate test exception from processMessage");
+        }
+        ++after_throw_count;
+    }
+};
+
+static std::shared_ptr<flight_safety_system::transport::fss_connection> exception_test_conn;
+
+auto exception_test_accept_cb(std::shared_ptr<flight_safety_system::transport::fss_connection> new_conn) -> bool
+{
+    exception_test_conn = std::move(new_conn);
+    return true;
+}
+
+} // namespace
+
+TEST_CASE("processMessages: throwing handler does not kill recv loop")
+{
+    exception_test_conn = nullptr;
+    const auto port = fss_test::pick_port();
+    REQUIRE(port != 0);
+
+    auto listen = std::make_shared<flight_safety_system::transport::fss_listen>(port, exception_test_accept_cb);
+    REQUIRE(listen != nullptr);
+
+    auto sender = std::make_shared<flight_safety_system::transport::fss_connection>();
+    REQUIRE(sender != nullptr);
+    REQUIRE(sender->connectTo("localhost", port));
+
+    REQUIRE(fss_test::wait_for([]() { return exception_test_conn != nullptr; }));
+
+    auto cb = std::make_shared<throwing_message_cb>(exception_test_conn);
+    exception_test_conn->setHandler(cb.get());
+
+    /* First message — handler throws; loop must survive. */
+    sender->sendMsg(std::make_shared<flight_safety_system::transport::fss_message_rtt_request>());
+    REQUIRE(fss_test::wait_for([&]() { return cb->call_count.load() >= 1; }));
+
+    /* Second message — loop must still be running and dispatch it. */
+    sender->sendMsg(std::make_shared<flight_safety_system::transport::fss_message_rtt_request>());
+    REQUIRE(fss_test::wait_for([&]() { return cb->after_throw_count.load() >= 1; }));
+
+    REQUIRE(cb->call_count.load() >= 2);
+
+    cb->disconnect();
+    sender = nullptr;
+    exception_test_conn = nullptr;
+}


### PR DESCRIPTION
## Description

An unexpected exception (e.g. std::bad_alloc under memory pressure, or an unforeseen throw from a DB/parse path) propagating out of the recv thread, the accept thread, the command-poller thread, or the main loop would call std::terminate and take down the whole server.

Wrap the per-message handler dispatch in fss_connection::processMessages, the newConnection/callback step in the accept loop, the pollCommands call in the command-poller thread, and the main-loop tick work in try/catch that logs and continues, so one failure sheds at most a single message/connection instead of the entire process. Add a test that a throwing handler does not kill the recv loop.

## Summary by Sourcery

Isolate unexpected exceptions in long-running server and transport loops so individual failures no longer terminate the process.

New Features:
- Introduce an exception_guard helper that wraps units of work, catches and logs exceptions with throttling, and tracks recovery.

Bug Fixes:
- Prevent exceptions in message handlers, the command-poller thread, the accept loop, and the main loop tick from bringing down the entire server process.

Enhancements:
- Improve operational logging by throttling repeated exception messages and logging a single recovery message when work starts succeeding again.

Tests:
- Add an integration-style test that verifies a throwing message handler does not kill the recv loop and that subsequent messages are still processed.