### PR TITLE
fix(server): do not rebuild the listener on SIGHUP CRL reload

### DIFF
--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -187,13 +187,14 @@ public:
             client->sendCommand();
         }
     };
-    void disconnectRevokedClients(const std::string &crl_file)
+    auto disconnectRevokedClients(const std::string &crl_file) -> std::size_t
     {
         std::vector<std::shared_ptr<flight_safety_system::server::fss_client>> snapshot;
         {
             std::scoped_lock guard(this->lock);
             std::copy(this->clients.begin(), this->clients.end(), std::back_inserter(snapshot));
         }
+        std::size_t disconnected_count = 0;
         for (const auto &client : snapshot)
         {
             auto conn = client->getConnection();
@@ -202,7 +203,9 @@ public:
                 FSS_LOG_WARN("server", "Disconnecting client with revoked certificate after CRL reload");
                 client->disconnect();
                 this->clientDisconnected(client.get());
+                disconnected_count++;
             }
         }
+        return disconnected_count;
     };
 };

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -226,7 +226,12 @@ auto main(int argc, char *argv[]) -> int
              * already-established sessions whose certs are now revoked. */
             if (!crl_file.empty())
             {
-                clients->disconnectRevokedClients(crl_file);
+                auto disconnected = clients->disconnectRevokedClients(crl_file);
+                FSS_LOG_INFO("server", "CRL reload complete: disconnected " << disconnected << " revoked session(s)");
+            }
+            else
+            {
+                FSS_LOG_INFO("server", "CRL reload: no CRL file configured; nothing to do");
             }
         }
         usleep(command_poll_ms * usec_per_msec);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -217,10 +217,13 @@ auto main(int argc, char *argv[]) -> int
         if (reload_crl == 1)
         {
             reload_crl = 0;
-            FSS_LOG_INFO("server", "SIGHUP received — reloading CRL, rebuilding listener");
-            listen.reset();
-            listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(
-                config["port"].asInt(), connect_cb, ca_public_key, server_private_key, server_public_key, crl_file);
+            FSS_LOG_INFO("server", "SIGHUP received — reloading CRL");
+            /* The listener is not rebuilt: each new connection loads the CRL
+             * file fresh during its TLS handshake (see setupSession), so new
+             * connections already honour an updated CRL. Tearing down and
+             * rebinding the listener here only risks a window with no listener
+             * (or, on a failed rebind, a dead listener). We only need to drop
+             * already-established sessions whose certs are now revoked. */
             if (!crl_file.empty())
             {
                 clients->disconnectRevokedClients(crl_file);


### PR DESCRIPTION
## Description

The SIGHUP handler tore down and rebuilt the TLS listener to pick up an updated CRL. That was unnecessary -- each new connection loads the CRL file fresh during its TLS handshake (setupSession), so new connections already honour an updated CRL -- and harmful: it opened a window with no listener, and a failed rebind (returns fd=-1, no throw) would leave a dead listener silently accepting nothing until restart.

Drop the rebuild and keep only disconnectRevokedClients(), which terminates already-established sessions whose certificates are now revoked.

## Summary by Sourcery

Avoid rebuilding the TLS listener on SIGHUP CRL reload and improve logging around revoked-session disconnections.

Bug Fixes:
- Prevent the SIGHUP CRL reload handler from tearing down and rebinding the TLS listener, eliminating windows with no active listener and silent failures on rebind.

Enhancements:
- Return and log the number of client sessions disconnected after a CRL reload for better observability of revoked certificate enforcement.