### PR TITLE
fix: use a monotonic clock for liveness and timeout timing

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -187,7 +187,7 @@ void fss::server::fss_client::sendCommand()
     {
         return;
     }
-    uint64_t ts = fss_current_timestamp();
+    uint64_t ts = this->clock->now_ms();
     auto ac = this->pending_command;
     constexpr int timeout_time = 10 * sec_to_msec;
     if (ac != nullptr && (ac->getDBId() != this->last_command_dbid || ts > (this->last_command_send_ts + timeout_time)))
@@ -542,7 +542,7 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
             break;
             case fss::transport::message_type_rtt_response: {
                 std::shared_ptr<fss_client_rtt> rtt_req = nullptr;
-                uint64_t current_ts = fss_current_timestamp();
+                uint64_t current_ts = this->clock->now_ms();
                 auto rtt_resp_msg = std::dynamic_pointer_cast<fss::transport::fss_message_rtt_response>(msg);
                 if (rtt_resp_msg != nullptr)
                 {
@@ -575,7 +575,7 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                 uint64_t report_ts = msg->getTimeStamp();
                 if (report_ts > 0)
                 {
-                    uint64_t now = this->clock->now_ms();
+                    uint64_t now = fss::fss_current_timestamp();
                     if (now > report_ts + staleness_limit_ms)
                     {
                         FSS_LOG_WARN("server", "Stale position report (age=" << (now - report_ts) << "ms), discarding");

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -75,7 +75,7 @@ private:
     uint64_t retry_delay{retry_delay_start};
     uint64_t effective_delay{retry_delay_start};
     std::mt19937 rng{std::random_device{}()};
-    std::shared_ptr<flight_safety_system::IClock> clock{std::make_shared<flight_safety_system::WallClock>()};
+    std::shared_ptr<flight_safety_system::IClock> clock{std::make_shared<flight_safety_system::MonotonicClock>()};
     std::atomic<bool> liveness_active{false};
     std::atomic<uint64_t> last_message_received_time{0};
     uint64_t server_timeout_ms{30000};

--- a/src/fss-main.cpp
+++ b/src/fss-main.cpp
@@ -1,5 +1,6 @@
 #include "fss.hpp"
 
+#include <ctime>
 #include <sys/time.h>
 
 auto flight_safety_system::fss_current_timestamp() -> uint64_t
@@ -14,4 +15,13 @@ auto flight_safety_system::fss_current_timestamp() -> uint64_t
 auto flight_safety_system::WallClock::now_ms() const -> uint64_t
 {
     return flight_safety_system::fss_current_timestamp();
+}
+
+auto flight_safety_system::MonotonicClock::now_ms() const -> uint64_t
+{
+    struct timespec ts = {};
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    constexpr uint64_t sec_to_msec = 1000;
+    constexpr uint64_t nsec_to_msec = 1000000;
+    return static_cast<uint64_t>(ts.tv_sec) * sec_to_msec + static_cast<uint64_t>(ts.tv_nsec) / nsec_to_msec;
 }

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -169,7 +169,7 @@ private:
     IDatabase *dbc;
     std::shared_ptr<db_write_queue> writer;
     fss_client_handler *client_handler;
-    std::shared_ptr<IClock> clock{std::make_shared<WallClock>()};
+    std::shared_ptr<IClock> clock{std::make_shared<MonotonicClock>()};
     rate_limiter msg_rate{100, 20};
     uint64_t rate_limit_rejects{0};
     uint64_t last_rate_limit_log_ms{0};

--- a/src/fss.hpp
+++ b/src/fss.hpp
@@ -18,16 +18,26 @@ auto fss_current_timestamp() -> uint64_t;
 class IClock {
 public:
     IClock() = default;
-    IClock(const IClock&) = delete;
-    IClock(IClock&&) = delete;
-    auto operator=(const IClock&) -> IClock& = delete;
-    auto operator=(IClock&&) -> IClock& = delete;
+    IClock(const IClock &) = delete;
+    IClock(IClock &&) = delete;
+    auto operator=(const IClock &) -> IClock & = delete;
+    auto operator=(IClock &&) -> IClock & = delete;
     virtual ~IClock() = default;
     virtual auto now_ms() const -> uint64_t = 0;
 };
 
 class WallClock : public IClock {
 public:
+    auto now_ms() const -> uint64_t override;
+};
+
+class MonotonicClock : public IClock {
+public:
+    MonotonicClock() = default;
+    MonotonicClock(const MonotonicClock &) = delete;
+    MonotonicClock(MonotonicClock &&) = delete;
+    auto operator=(const MonotonicClock &) -> MonotonicClock & = delete;
+    auto operator=(MonotonicClock &&) -> MonotonicClock & = delete;
     auto now_ms() const -> uint64_t override;
 };
 } // namespace flight_safety_system

--- a/src/fss.hpp
+++ b/src/fss.hpp
@@ -33,11 +33,6 @@ public:
 
 class MonotonicClock : public IClock {
 public:
-    MonotonicClock() = default;
-    MonotonicClock(const MonotonicClock &) = delete;
-    MonotonicClock(MonotonicClock &&) = delete;
-    auto operator=(const MonotonicClock &) -> MonotonicClock & = delete;
-    auto operator=(MonotonicClock &&) -> MonotonicClock & = delete;
     auto now_ms() const -> uint64_t override;
 };
 } // namespace flight_safety_system

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -711,7 +711,8 @@ TEST_CASE("session: v1 client skips seq checking")
 TEST_CASE("session: stale position report is discarded")
 {
     /* m7.1 phase 3: position reports with a timestamp older than 30 s must
-     * be discarded. The test uses a controllable clock so no real time passes. */
+     * be discarded. Staleness compares against real wall-clock time
+     * (fss_current_timestamp), so timestamps are built from wall time here. */
     fss_test::MockDatabase mock;
     mock.asset_ids["craft"] = 1;
 
@@ -720,7 +721,7 @@ TEST_CASE("session: stale position report is discarded")
     NullClientHandler handler;
 
     auto clock = std::make_shared<FakeClock>();
-    clock->t = 100000; // arbitrary "now" in ms
+    clock->t = 100000; // arbitrary "now" in ms — still injected (harmless)
 
     auto writer = make_mock_writer(mock);
     auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
@@ -732,12 +733,12 @@ TEST_CASE("session: stale position report is discarded")
 
     /* Position with a timestamp 60 s in the past — stale. */
     constexpr uint64_t sixty_seconds_ms = 60000;
-    auto stale = make_position_msg(clock->t - sixty_seconds_ms);
+    auto stale = make_position_msg(fss::fss_current_timestamp() - sixty_seconds_ms);
     session->processMessage(stale);
     REQUIRE(handler.broadcasts.empty());
 
     /* Position with a current timestamp — fresh. */
-    auto fresh = make_position_msg(clock->t);
+    auto fresh = make_position_msg(fss::fss_current_timestamp());
     session->processMessage(fresh);
     REQUIRE(handler.broadcasts.size() == 1);
 }
@@ -853,6 +854,16 @@ TEST_CASE("session: sendSMMSettings sends smm_settings message when db returns s
     session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
 
     REQUIRE(find_sent<fss::transport::fss_message_smm_settings>(conn->sent) != nullptr);
+}
+
+TEST_CASE("MonotonicClock: now_ms is non-decreasing")
+{
+    /* Sanity check: two back-to-back calls must return a non-decreasing
+     * value — CLOCK_MONOTONIC never goes backward. */
+    fss::MonotonicClock mc;
+    uint64_t t1 = mc.now_ms();
+    uint64_t t2 = mc.now_ms();
+    REQUIRE(t2 >= t1);
 }
 
 TEST_CASE("session: system_status message is forwarded to db writer")


### PR DESCRIPTION
## Description

Liveness, identify-deadline, RTT, rate-limit and command-dedup timing all ran off the wall clock (gettimeofday) with unsigned now-last arithmetic. A backward wall-clock step (NTP correction, admin date change, VM resume) underflows to a huge value, so every connected aircraft simultaneously exceeds client_timeout_ms and is disconnected.

Add a MonotonicClock (CLOCK_MONOTONIC) and make it the default IClock for both the server-side fss_client and the client-side fss_server, so all duration timing is immune to wall-clock steps. The RTT round-trip delta and command-dedup timestamp now read from the same monotonic clock for consistency. Position-report staleness still uses wall-clock time (fss_current_timestamp), since it compares against the aircraft's wall-clock wire timestamp; its test now builds timestamps from wall time. Add a MonotonicClock sanity test.

## Summary by Sourcery

Use a monotonic clock implementation for internal timing to make client/server time-based logic robust against wall-clock adjustments.

Bug Fixes:
- Prevent spurious client disconnects and command/RTT timing issues caused by wall-clock time moving backwards.

Enhancements:
- Introduce a MonotonicClock implementation of IClock and make it the default clock for server and client timing-sensitive logic while retaining wall-clock usage where protocol timestamps require it.

Tests:
- Adjust stale position report tests to build timestamps from wall-clock time and add a sanity test ensuring MonotonicClock is non-decreasing.