### PR TITLE
fix(tests): mark generated server-db.c as nodist source

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -45,6 +45,11 @@ pkgconfig_DATA += fss-client-ssl.pc
 .pgc.c:
 	ecpg -o $@ $< $(ECPGFLAGS)
 
+# server-db.c is generated from server-db.pgc, by either the server build or
+# the tests (when the server is disabled). Clean it unconditionally so it is
+# never left behind after distclean, which `make distcheck` rejects.
+CLEANFILES = server-db.c
+
 if SERVER
 sbin_PROGRAMS += fss-server
 
@@ -56,6 +61,5 @@ fss_server_LDADD += libfss-transport-ssl.la
 else
 if ENABLE_TESTS
 BUILT_SOURCES = server-db.c
-CLEANFILES = server-db.c
 endif
 endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -29,8 +29,11 @@ all_test_SOURCES = main.cpp messages.cpp connection.cpp client.cpp \
 	exception_isolation_test.cpp \
 	../src/client_session.cpp \
 	../src/db-write-queue.cpp \
-	../src/db.cpp \
-	../src/server-db.c
+	../src/db.cpp
+# server-db.c is generated from server-db.pgc by ecpg (see src/Makefile.am).
+# It must be nodist_ so `make dist` distributes the .pgc source, not the
+# generated .c, and doesn't demand a build rule that only exists in src/.
+nodist_all_test_SOURCES = ../src/server-db.c
 # Header search path belongs at the preprocessor layer so it applies to both
 # the C (server-db.c) and C++ sources, independent of CFLAGS/CXXFLAGS.
 all_test_CPPFLAGS = -I$(top_srcdir)/src


### PR DESCRIPTION
## Description

server-db.c is generated from server-db.pgc by ecpg, with the .pgc.c rule living only in src/Makefile.am. Listing it in all_test_SOURCES made automake try to copy it into the distdir, but make dist failed because the file does not exist in a clean tree and tests/ has no rule to generate it:

    No rule to make target '../src/server-db.c', needed by 'distdir-am'.

Move it to nodist_all_test_SOURCES so make dist ships server-db.pgc (the real source) instead of the generated .c, and no longer demands a build rule that only exists in src/.

## Summary by Sourcery

Tests:
- Adjust test build sources to treat server-db.c as a nodist input rather than a distributed source file.