### PR TITLE
fix(examples): always distribute fss-server.service.in

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -4,7 +4,10 @@ AM_CXXFLAGS = -pthread -fPIC -std=c++17 -I. -Werror -Wall -Wshadow -Wunused -Wnu
 
 bin_PROGRAMS =
 
-EXTRA_DIST=client.json server.json
+# fss-server.service.in is distributed unconditionally: a source template must
+# ship in every tarball regardless of whether the host that ran `make dist`
+# detected systemd, so the tarball can be rebuilt in a systemd-enabled config.
+EXTRA_DIST=client.json server.json fss-server.service.in
 
 if FAKE_CLIENT
 bin_PROGRAMS += fss-fake-client
@@ -17,10 +20,9 @@ endif
 if HAVE_SYSTEMD
 if SERVER
 # fss-server.service is generated from the .in template: install it but do not
-# distribute it (nodist_). The template itself ships in the tarball via
-# EXTRA_DIST and must never be installed into the unit directory.
+# distribute it (nodist_). The template itself ships via EXTRA_DIST above and
+# must never be installed into the unit directory.
 nodist_systemdsystemunit_DATA = fss-server.service
-EXTRA_DIST += fss-server.service.in
 CLEANFILES = fss-server.service
 
 SERVICE_SUBS = \


### PR DESCRIPTION
## Description

EXTRA_DIST += fss-server.service.in lived inside the HAVE_SYSTEMD/SERVER conditional, so whether the systemd unit template shipped in the tarball depended on the configuration of the host that ran `make dist`. When that host did not detect systemd (e.g. the arm64 dist runner), the template was omitted; building the tarball later in a systemd-enabled container then fired the generation rule with no source:

    No rule to make target 'fss-server.service.in', needed by 'fss-server.service'.

A source template must ship unconditionally so the tarball is rebuildable in any configuration. Move it to the unconditional EXTRA_DIST; the generation rule and nodist_ install stay gated on HAVE_SYSTEMD && SERVER.

Verified: a tarball built with --with-systemdsystemunitdir=no now contains the template, and a debuild of it in a systemd-enabled container generates, installs and packages fss-server.service successfully.

## Summary by Sourcery

Ensure the fss-server systemd unit template is always included in example tarball distributions so builds are reproducible regardless of systemd detection on the dist host.

Bug Fixes:
- Fix missing fss-server.service.in in tarballs built on non-systemd hosts that caused rebuild failures in systemd-enabled environments.

Enhancements:
- Clarify Makefile comments around distribution vs installation of the fss-server systemd unit and its template.