### PR TITLE
fix(debian): package the fss-log.hpp and secure-string.hpp headers

### DIFF
--- a/debian/libfss-transport.install
+++ b/debian/libfss-transport.install
@@ -1,3 +1,4 @@
 usr/lib/*/libfss-transport.*
 usr/lib/*/pkgconfig/fss-transport.pc
 usr/include/fss-transport.hpp
+usr/include/secure-string.hpp

--- a/debian/libfss.install
+++ b/debian/libfss.install
@@ -1,3 +1,4 @@
 usr/lib/*/libfss.*
 usr/lib/*/pkgconfig/fss.pc
 usr/include/fss.hpp
+usr/include/fss-log.hpp


### PR DESCRIPTION
## Description

Both are installed by make install via include_HEADERS but no debian/*.install file claimed them, so they landed in debian/tmp and were dropped from every package. This left the shipped libfss-transport broken for downstream users: its public fss-transport.hpp does #include "secure-string.hpp", which was in no package. fss-log.hpp had the same gap.

Add each to the .install file matching its src/Makefile.am grouping: secure-string.hpp -> libfss-transport (alongside fss-transport.hpp), fss-log.hpp -> libfss (alongside fss.hpp).

Verified via a bookworm debuild that both headers now ship in their respective .deb packages.

## Summary by Sourcery

Ensure Debian packages include missing public headers for libfss and libfss-transport.

Bug Fixes:
- Include secure-string.hpp in the libfss-transport Debian package to fix missing dependency for downstream users.
- Include fss-log.hpp in the libfss Debian package to restore access to its public logging header.

Build:
- Update Debian .install manifests to ship newly claimed headers in their respective -dev packages.