### PR TITLE
Version bump 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-06-08
+
+### Fixed
+- debian packages installing the correct headers
+
 ## [1.0.0] - 2026-05-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.1] - 2026-06-08
 
 ### Fixed
-- debian packages installing the correct headers
+- Debian packages now install the correct headers
 
 ## [1.0.0] - 2026-05-16
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([flight-safety-system], [1.0.0], [sjp@canterburyairpatrol.org])
+AC_INIT([flight-safety-system], [1.0.1], [sjp@canterburyairpatrol.org])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign -Wno-portability])
 
 m4_include([m4/ax_cxx_compile_stdcxx.m4])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+flight-safety-system (1.0.1) stable; urgency=medium
+  * Correctly install the new header files
+
+ -- Scott Parlane <sjp@canterburyairpatrol.org>  Mon, 8 Jun 2026 00:00:00 +0000
+
 flight-safety-system (1.0.0) stable; urgency=medium
 
   * First stable release.


### PR DESCRIPTION
## Summary by Sourcery

Bump the project and Debian package versions to 1.0.1 and document the release.

Bug Fixes:
- Ensure Debian packages install the correct header files.

Build:
- Update autotools configuration and Debian packaging files for version 1.0.1.

Documentation:
- Add a 1.0.1 entry to the changelog describing the Debian header installation fix.