### PR TITLE
fix(transport): make fss_message_cb::conn thread-safe with a mutex

### DIFF
--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <queue>
 #include <sys/types.h>
 #include <thread>
@@ -121,6 +122,7 @@ public:
 class fss_message_cb {
 private:
     std::shared_ptr<fss_connection> conn;
+    mutable std::mutex conn_lock{};
 protected:
     void setConnection(std::shared_ptr<fss_connection> t_conn);
     void clearConnection();

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -285,15 +285,21 @@ flight_safety_system::transport::fss_message_cb::fss_message_cb(std::shared_ptr<
 {
 }
 
-flight_safety_system::transport::fss_message_cb::fss_message_cb(const fss_message_cb &from) = default;
+flight_safety_system::transport::fss_message_cb::fss_message_cb(const fss_message_cb &from) : conn(nullptr)
+{
+    const std::scoped_lock lock(from.conn_lock);
+    this->conn = from.conn;
+}
 
 void flight_safety_system::transport::fss_message_cb::setConnection(std::shared_ptr<fss_connection> t_conn)
 {
+    const std::scoped_lock lock(this->conn_lock);
     this->conn = std::move(t_conn);
 }
 
 void flight_safety_system::transport::fss_message_cb::clearConnection()
 {
+    const std::scoped_lock lock(this->conn_lock);
     this->conn = nullptr;
 }
 
@@ -302,6 +308,7 @@ auto flight_safety_system::transport::fss_message_cb::operator=(
 {
     if (this != &other)
     {
+        const std::scoped_lock lock(this->conn_lock, other.conn_lock);
         this->conn = other.conn;
     }
     return *this;
@@ -309,29 +316,37 @@ auto flight_safety_system::transport::fss_message_cb::operator=(
 
 auto flight_safety_system::transport::fss_message_cb::getConnection() -> std::shared_ptr<fss_connection>
 {
+    const std::scoped_lock lock(this->conn_lock);
     return this->conn;
 }
+
 auto flight_safety_system::transport::fss_message_cb::connected() -> bool
 {
+    const std::scoped_lock lock(this->conn_lock);
     return this->conn != nullptr;
 }
 
 void flight_safety_system::transport::fss_message_cb::disconnect()
 {
-    if (this->conn != nullptr)
+    std::shared_ptr<fss_connection> c;
     {
-        this->conn->disconnect();
-        this->conn = nullptr;
+        const std::scoped_lock lock(this->conn_lock);
+        c = std::move(this->conn);
+    }
+    if (c)
+    {
+        c->disconnect();
     }
 }
 
 auto flight_safety_system::transport::fss_message_cb::sendMsg(const std::shared_ptr<fss_message> &msg) -> bool
 {
-    if (this->conn != nullptr)
+    std::shared_ptr<fss_connection> c;
     {
-        return this->conn->sendMsg(msg);
+        const std::scoped_lock lock(this->conn_lock);
+        c = this->conn;
     }
-    return false;
+    return c ? c->sendMsg(msg) : false;
 }
 
 flight_safety_system::transport::fss_message::fss_message(fss_message_type t_type) : id(0), type(t_type) {}

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -331,11 +331,16 @@ void flight_safety_system::transport::fss_message_cb::disconnect()
     std::shared_ptr<fss_connection> c;
     {
         const std::scoped_lock lock(this->conn_lock);
-        c = std::move(this->conn);
+        c = this->conn; // copy — conn must stay non-null while the recv thread runs
     }
     if (c)
     {
-        c->disconnect();
+        c->disconnect(); // joins recv thread; processMessage may call getConnection() during this
+        const std::scoped_lock lock(this->conn_lock);
+        if (this->conn == c)
+        {
+            this->conn = nullptr;
+        }
     }
 }
 

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -590,6 +590,8 @@ auto flight_safety_system::transport::fss_listen::startListening() -> bool
 
 flight_safety_system::transport::fss_message_cb::~fss_message_cb()
 {
+    // No lock: destructor runs only when no other thread holds a reference to
+    // this object, so conn cannot be concurrently read or written here.
     if (this->conn != nullptr)
     {
         this->conn->setHandler(nullptr);


### PR DESCRIPTION
## Description

Add a mutable std::mutex conn_lock to fss_message_cb to guard every access to conn.  All mutating accessors (setConnection, clearConnection, copy-assign) lock before touching conn.  sendMsg and disconnect copy the shared_ptr out under the lock and perform blocking network I/O outside it, so a slow or hung server cannot stall a concurrent reconnect.  The copy constructor locks the source before reading conn; the two-mutex scoped_lock in operator= uses deadlock-avoidance.  The destructor is left unlocked by design — it runs only when no other thread holds a reference, and locking a mutex in a destructor would be incorrect here.

## Summary by Sourcery

Guard fss_message_cb connection state with a mutex to make connection management thread-safe and avoid blocking on network I/O while holding locks.

Bug Fixes:
- Prevent data races on fss_message_cb::conn by synchronizing all reads and writes with a mutex.
- Avoid potential deadlocks and stalls by copying the connection pointer under lock and performing disconnect/send operations outside the critical section.

Enhancements:
- Implement custom copy constructor and assignment operator for fss_message_cb to safely copy the guarded connection.
- Document the rationale for not locking in the fss_message_cb destructor to clarify thread-safety assumptions.