### PR TITLE
test(tsan): add concurrency regression test for fss_message_cb::conn

### DIFF
--- a/tests/concurrency_connection_test.cpp
+++ b/tests/concurrency_connection_test.cpp
@@ -127,8 +127,9 @@ TEST_CASE("tsan: concurrent setConnection/clearConnection and sendMsg/getConnect
     std::atomic<bool> start{false};
 
     std::thread writer([&]() {
-        while (!start.load())
+        while (!start.load(std::memory_order_acquire))
         {
+            std::this_thread::yield();
         }
         for (int i = 0; i < iterations; ++i)
         {
@@ -138,8 +139,9 @@ TEST_CASE("tsan: concurrent setConnection/clearConnection and sendMsg/getConnect
     });
 
     std::thread reader([&]() {
-        while (!start.load())
+        while (!start.load(std::memory_order_acquire))
         {
+            std::this_thread::yield();
         }
         for (int i = 0; i < iterations; ++i)
         {
@@ -149,7 +151,7 @@ TEST_CASE("tsan: concurrent setConnection/clearConnection and sendMsg/getConnect
         }
     });
 
-    start.store(true);
+    start.store(true, std::memory_order_release);
     writer.join();
     reader.join();
 }

--- a/tests/concurrency_connection_test.cpp
+++ b/tests/concurrency_connection_test.cpp
@@ -22,9 +22,19 @@
 #include "fss-transport.hpp"
 
 using flight_safety_system::transport::fss_connection;
+using flight_safety_system::transport::fss_message_cb;
 using flight_safety_system::transport::fss_message_identity;
 
 namespace {
+
+/* Minimal fss_message_cb subclass for concurrency tests.  Exposes the
+ * protected writer methods so the test threads can exercise them directly. */
+struct MinimalCb : fss_message_cb {
+    explicit MinimalCb(std::shared_ptr<fss_connection> t_conn = nullptr) : fss_message_cb(std::move(t_conn)) {}
+    void processMessage(std::shared_ptr<flight_safety_system::transport::fss_message>) override {}
+    void testSetConnection(std::shared_ptr<fss_connection> c) { setConnection(std::move(c)); }
+    void testClearConnection() { clearConnection(); }
+};
 
 /* Build a Unix socketpair and return both fds; close the second so the
  * first observes EOF and the recv thread exits naturally. */
@@ -102,4 +112,44 @@ TEST_CASE("tsan: concurrent sendMsg + disconnect on a connected pair")
     REQUIRE(send_successes.load() <= send_attempts.load());
 
     ::close(fds[1]);
+}
+
+/* Regression for the thread-safety fix on fss_message_cb::conn: one thread
+ * repeatedly writes conn via setConnection/clearConnection while another reads
+ * it via sendMsg, getConnection, and connected.  TSan must not report a race. */
+TEST_CASE("tsan: concurrent setConnection/clearConnection and sendMsg/getConnection")
+{
+    auto conn = std::make_shared<fss_connection>();
+    MinimalCb cb{conn};
+    auto msg = std::make_shared<fss_message_identity>("tsan-cb-racer");
+
+    constexpr int iterations = 5000;
+    std::atomic<bool> start{false};
+
+    std::thread writer([&]() {
+        while (!start.load())
+        {
+        }
+        for (int i = 0; i < iterations; ++i)
+        {
+            cb.testSetConnection(conn);
+            cb.testClearConnection();
+        }
+    });
+
+    std::thread reader([&]() {
+        while (!start.load())
+        {
+        }
+        for (int i = 0; i < iterations; ++i)
+        {
+            cb.sendMsg(msg);
+            cb.getConnection();
+            cb.connected();
+        }
+    });
+
+    start.store(true);
+    writer.join();
+    reader.join();
 }


### PR DESCRIPTION
## Description

Add a TSan test that races setConnection/clearConnection (writer thread) against sendMsg/getConnection/connected (reader thread) on a single fss_message_cb instance.  Without the mutex fix this would produce a data race on conn; with it TSan must be clean.

## Summary by Sourcery

Add a ThreadSanitizer regression test to verify concurrent access to fss_message_cb::conn is race-free.

Tests:
- Introduce a MinimalCb test subclass of fss_message_cb to expose connection mutation methods for concurrency testing.
- Add a TSan concurrency test that races setConnection/clearConnection against sendMsg/getConnection/connected on a single callback instance.