### PR TITLE
Update version to 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2026-06-09
+
+### Fixed
+- `fss_message_cb::conn` is now guarded by a mutex, eliminating a data race
+  between the reconnect path (writer) and send/query paths (readers).
+- `disconnect()` no longer nulls `conn` before joining the recv thread,
+  preventing a null-pointer dereference in `processMessage()` during teardown.
+
 ## [1.0.1] - 2026-06-08
 
 ### Fixed

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([flight-safety-system], [1.0.1], [sjp@canterburyairpatrol.org])
+AC_INIT([flight-safety-system], [1.0.2], [sjp@canterburyairpatrol.org])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign -Wno-portability])
 
 m4_include([m4/ax_cxx_compile_stdcxx.m4])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+flight-safety-system (1.0.2) stable; urgency=medium
+
+  * Fix data race on fss_message_cb::conn between reconnect and send paths.
+  * Fix null-pointer dereference in disconnect() during connection teardown.
+
+ -- Scott Parlane <sjp@canterburyairpatrol.org>  Mon, 9 Jun 2026 00:00:00 +0000
+
 flight-safety-system (1.0.1) stable; urgency=medium
   * Correctly install the new header files
 


### PR DESCRIPTION
## Summary by Sourcery

Bump the project to version 1.0.2 and record the associated concurrency-related bug fixes.

Bug Fixes:
- Guard fss_message_cb::conn with a mutex to remove a data race between reconnect and send/query paths.
- Ensure disconnect() waits for the receive thread before nulling conn to avoid a teardown-time null-pointer dereference.

Build:
- Update Autotools package version from 1.0.1 to 1.0.2 in configure.ac.

Documentation:
- Add a 1.0.2 section to the changelog documenting recent concurrency fixes.