### PR TITLE
fix(server): avoid shutdown deadlock in ~server_clients

### DIFF
--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -26,9 +26,26 @@ public:
     server_clients() = default;
     ~server_clients() override
     {
+        /* Same hazard as cleanupRemovableClients() (see the comment there):
+         * disconnect() joins the connection's recv thread, and that thread may
+         * itself be blocked acquiring this->lock in clientDisconnected() or
+         * broadcastMsg().  Joining while holding the lock would deadlock, so
+         * drain both lists under the lock and disconnect outside it.
+         * shutting_down is set first so a recv thread that wins the race to
+         * clientDisconnected() no-ops instead of re-queueing into a dying
+         * object. */
         this->shutting_down = true;
-        std::scoped_lock guard(this->lock);
-        for (const auto &c : this->clients)
+        std::list<std::shared_ptr<flight_safety_system::server::fss_client>> doomed;
+        {
+            std::scoped_lock guard(this->lock);
+            doomed.splice(doomed.end(), this->clients);
+            while (!this->disconnected.empty())
+            {
+                doomed.push_back(std::move(this->disconnected.front()));
+                this->disconnected.pop();
+            }
+        }
+        for (const auto &c : doomed)
         {
             c->disconnect();
         }

--- a/tests/server_clients_test.cpp
+++ b/tests/server_clients_test.cpp
@@ -13,6 +13,10 @@
 #include <list>
 #include <memory>
 #include <string>
+#include <vector>
+
+#include <sys/socket.h>
+#include <unistd.h>
 
 #include "fss-transport.hpp"
 #include "fss-server.hpp"
@@ -261,6 +265,38 @@ TEST_CASE("server_clients: disconnectRevokedClients drops revoked connections")
 
     sc.disconnectRevokedClients("any.crl");
     sc.cleanupRemovableClients();
+}
+
+TEST_CASE("server_clients: destruction races recv-thread disconnect callbacks")
+{
+    /* Regression: ~server_clients used to join each connection's recv thread
+     * while holding the list lock.  A recv thread delivering message_closed
+     * calls clientDisconnected(), which needs that same lock — deadlock.
+     * Build clients on real socketpair-backed connections (live recv
+     * threads), close every peer so the closed messages race the destructor,
+     * and require the destructor to complete.  Pre-fix this case hangs. */
+    constexpr int n_clients = 8;
+    fss_test::MockDatabase mock;
+    std::vector<int> peer_fds;
+    {
+        auto sc = std::make_unique<server_clients>();
+        for (int i = 0; i < n_clients; i++)
+        {
+            int fds[2];
+            REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+            auto conn = fss::transport::fss_connection::create(fds[0]);
+            auto writer = make_null_writer();
+            auto client = std::make_shared<fss::server::fss_client>(conn, &mock, writer, sc.get());
+            sc->clientConnected(client);
+            peer_fds.push_back(fds[1]);
+        }
+        for (int fd : peer_fds)
+        {
+            ::close(fd);
+        }
+        sc.reset();
+    }
+    SUCCEED("destructor completed without deadlock");
 }
 
 TEST_CASE("server_clients: disconnectRevokedClients leaves non-revoked clients")


### PR DESCRIPTION
## Description

The destructor held the client-list lock while calling disconnect() on each client. disconnect() joins the connection's recv thread, and that thread can concurrently be blocked acquiring the same lock inside clientDisconnected() or broadcastMsg(), deadlocking shutdown.

Drain both the active list and the pending-disconnect queue into a local list under the lock, then disconnect outside it - the same pattern cleanupRemovableClients() already uses for the same reason.

Add a regression test using socketpair-backed connections with live recv threads; it hangs before this fix and passes reliably after.

## Summary by Sourcery

Prevent server client shutdown from deadlocking when disconnecting active connections during destruction.

Bug Fixes:
- Avoid a shutdown deadlock in server_clients destruction by disconnecting clients outside the internal list lock.

Tests:
- Add a regression test that creates live socketpair-backed client connections and verifies server_clients destruction completes without hanging.