### PR TITLE
fix(transport): retry EINTR in recvMsg instead of dropping the peer

### DIFF
--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -158,6 +158,10 @@ protected:
     auto recvMsg() -> std::shared_ptr<fss_message>;
     auto getMessageId() -> uint64_t;
     virtual auto sendMsg(const std::shared_ptr<flight_safety_system::transport::buf_len> &bl) -> bool;
+    /* Contract: never reports an interrupted call — implementations retry
+     * EINTR (plain TCP) / GNUTLS_E_INTERRUPTED (TLS) internally.  Returns
+     * -2 when the transport is already closed/unusable, 0 on orderly peer
+     * close, and a negative value on hard errors. */
     virtual auto recvBytes(void *bytes, size_t max_bytes) -> ssize_t;
     auto getFd() -> int;
     void setFd(int new_fd);

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -373,12 +373,29 @@ void flight_safety_system::transport::fss_connection::setHandler(fss_message_cb 
 
 auto flight_safety_system::transport::fss_connection::recvBytes(void *t_bytes, size_t t_max_bytes) -> ssize_t
 {
-    int current_fd = this->fd.load();
-    if (current_fd < 0)
+    for (;;)
     {
-        return -2;
+        int current_fd = this->fd.load();
+        if (current_fd < 0)
+        {
+            return -2;
+        }
+        ssize_t received = recv(current_fd, t_bytes, t_max_bytes, 0);
+        if (received == -1 && errno == EINTR)
+        {
+            /* A signal interrupted recv() before any data arrived; that is
+             * not a connection failure, so retry rather than reporting an
+             * error to the caller (same rationale as the EINTR retry in
+             * sendMsg).  The fd is re-loaded every iteration so a concurrent
+             * disconnect() (fd.exchange(-1) then close) still terminates the
+             * loop via the -2 path.  This keeps the contract aligned with
+             * the transport_ssl override, which likewise retries
+             * GNUTLS_E_INTERRUPTED internally: recvBytes never reports an
+             * interrupted call to recvMsg. */
+            continue;
+        }
+        return received;
     }
-    return recv(current_fd, t_bytes, t_max_bytes, 0);
 }
 
 auto flight_safety_system::transport::fss_connection::getFd() -> int
@@ -408,17 +425,8 @@ auto flight_safety_system::transport::fss_connection::recvMsg()
         ssize_t this_time = this->recvBytes(&header[received], sizeof(uint16_t) - received);
         if ((this_time == -2) || (this_time < 0 && errno == EBADF) || this_time == 0)
         {
-            /* Connection was closed. The EBADF check must stay ahead of the
-             * EINTR retry: disconnect() closes the fd under us to wake this
-             * recv, and that must terminate the loop, not retry. */
+            /* Connection was closed */
             return std::make_shared<flight_safety_system::transport::fss_message_closed>();
-        }
-        if (this_time == -1 && errno == EINTR)
-        {
-            /* A signal interrupted recv() before any bytes arrived; that is
-             * not a connection failure, so retry rather than dropping the
-             * peer (same rationale as the EINTR retry in sendMsg). */
-            continue;
         }
         if (this_time < 0)
         {
@@ -453,12 +461,6 @@ auto flight_safety_system::transport::fss_connection::recvMsg()
     while (received != total_length)
     {
         ssize_t this_time = this->recvBytes(&data[received], total_length - received);
-        if (this_time == -1 && errno == EINTR)
-        {
-            /* Interrupted by a signal mid-message; retry. -2 (transport
-             * already closed) must not retry and is handled below. */
-            continue;
-        }
         if (this_time < 0)
         {
             FSS_PERROR("transport", "Error receiving data");

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -408,8 +408,17 @@ auto flight_safety_system::transport::fss_connection::recvMsg()
         ssize_t this_time = this->recvBytes(&header[received], sizeof(uint16_t) - received);
         if ((this_time == -2) || (this_time < 0 && errno == EBADF) || this_time == 0)
         {
-            /* Connection was closed */
+            /* Connection was closed. The EBADF check must stay ahead of the
+             * EINTR retry: disconnect() closes the fd under us to wake this
+             * recv, and that must terminate the loop, not retry. */
             return std::make_shared<flight_safety_system::transport::fss_message_closed>();
+        }
+        if (this_time == -1 && errno == EINTR)
+        {
+            /* A signal interrupted recv() before any bytes arrived; that is
+             * not a connection failure, so retry rather than dropping the
+             * peer (same rationale as the EINTR retry in sendMsg). */
+            continue;
         }
         if (this_time < 0)
         {
@@ -444,6 +453,12 @@ auto flight_safety_system::transport::fss_connection::recvMsg()
     while (received != total_length)
     {
         ssize_t this_time = this->recvBytes(&data[received], total_length - received);
+        if (this_time == -1 && errno == EINTR)
+        {
+            /* Interrupted by a signal mid-message; retry. -2 (transport
+             * already closed) must not retry and is handled below. */
+            continue;
+        }
         if (this_time < 0)
         {
             FSS_PERROR("transport", "Error receiving data");

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -12,6 +12,12 @@
 #error No catch header
 #endif
 
+#include <atomic>
+#include <csignal>
+#include <thread>
+
+#include <pthread.h>
+#include <sys/socket.h>
 #include <unistd.h>
 
 #include "fss-transport.hpp"
@@ -138,6 +144,82 @@ TEST_CASE("Queue overflow drops oldest messages")
 
     conn = nullptr;
     client_conn = nullptr;
+}
+
+namespace {
+
+/* Expose the protected fd-constructor and recvMsg so a test can drive the
+ * receive path synchronously on its own thread (no recv thread started). */
+class raw_recv_connection : public flight_safety_system::transport::fss_connection {
+public:
+    explicit raw_recv_connection(int t_fd) : fss_connection(t_fd) {}
+    using fss_connection::recvMsg;
+};
+
+void noop_signal_handler(int /*signum*/) {}
+
+} // namespace
+
+TEST_CASE("recvMsg survives EINTR mid-message")
+{
+    /* Regression: a signal interrupting recv() (no SA_RESTART) used to be
+     * treated as a connection failure, synthesising message_closed and
+     * dropping a healthy peer.  Block in recvMsg with a partial header,
+     * signal the receiving thread several times, then complete the message
+     * and require it to arrive intact. */
+    int fds[2];
+    REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+
+    struct sigaction sa = {};
+    sa.sa_handler = noop_signal_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0; /* deliberately no SA_RESTART so recv() returns EINTR */
+    struct sigaction old_sa = {};
+    REQUIRE(sigaction(SIGUSR1, &sa, &old_sa) == 0);
+
+    raw_recv_connection conn(fds[0]);
+
+    auto send_msg = std::make_shared<flight_safety_system::transport::fss_message_identity>("eintrClient");
+    auto bl = send_msg->getPacked();
+    const char *data = bl->getData();
+    size_t len = bl->getLength();
+    REQUIRE(len > 1);
+
+    /* First byte only: recvMsg blocks waiting for the rest of the header. */
+    REQUIRE(::write(fds[1], data, 1) == 1);
+
+    /* Catch2 assertions are not thread-safe: collect the worker's result in
+     * an atomic and assert after join(), as the concurrency tests do. */
+    std::atomic<ssize_t> rest_written{-1};
+    pthread_t recv_thread_id = pthread_self();
+    std::thread signaller([&]() -> void {
+        /* Best-effort pause so the main thread reaches recv() before the
+         * signals; correctness does not depend on it (an early signal is
+         * swallowed by the no-op handler and the final write still
+         * completes the message). */
+        constexpr int signal_count = 5;
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        for (int i = 0; i < signal_count; i++)
+        {
+            pthread_kill(recv_thread_id, SIGUSR1);
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        rest_written.store(::write(fds[1], data + 1, len - 1));
+    });
+
+    auto msg = conn.recvMsg();
+    signaller.join();
+
+    REQUIRE(rest_written.load() == static_cast<ssize_t>(len - 1));
+    REQUIRE(msg != nullptr);
+    REQUIRE(msg->getType() == flight_safety_system::transport::message_type_identity);
+    auto identity = std::dynamic_pointer_cast<flight_safety_system::transport::fss_message_identity>(msg);
+    REQUIRE(identity != nullptr);
+    REQUIRE(identity->getName() == "eintrClient");
+
+    REQUIRE(sigaction(SIGUSR1, &old_sa, nullptr) == 0);
+    ::close(fds[1]);
+    /* fds[0] is owned and closed by conn's destructor. */
 }
 
 TEST_CASE("fss_connection: base isPeerCertRevoked always returns false")

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -158,35 +158,29 @@ public:
 
 void noop_signal_handler(int /*signum*/) {}
 
-} // namespace
-
-TEST_CASE("recvMsg survives EINTR mid-message")
+/* Regression driver: a signal interrupting recv() (no SA_RESTART) used to be
+ * treated as a connection failure, synthesising message_closed and dropping a
+ * healthy peer.  Send the first prefix_len bytes of a framed identity message
+ * so recvMsg blocks at the desired stage (1 byte = mid-header; the full
+ * 2-byte length prefix and more = mid-body), signal the receiving thread
+ * several times, then complete the message and require it to arrive intact. */
+void run_eintr_recv_test(size_t prefix_len, const std::string &client_name)
 {
-    /* Regression: a signal interrupting recv() (no SA_RESTART) used to be
-     * treated as a connection failure, synthesising message_closed and
-     * dropping a healthy peer.  Block in recvMsg with a partial header,
-     * signal the receiving thread several times, then complete the message
-     * and require it to arrive intact. */
     int fds[2];
     REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    fss_test::scoped_fd peer(fds[1]);
+    raw_recv_connection conn(fds[0]); /* owns and closes fds[0] */
 
-    struct sigaction sa = {};
-    sa.sa_handler = noop_signal_handler;
-    sigemptyset(&sa.sa_mask);
-    sa.sa_flags = 0; /* deliberately no SA_RESTART so recv() returns EINTR */
-    struct sigaction old_sa = {};
-    REQUIRE(sigaction(SIGUSR1, &sa, &old_sa) == 0);
+    fss_test::scoped_signal_handler sig_guard(SIGUSR1, noop_signal_handler);
+    REQUIRE(sig_guard.ok());
 
-    raw_recv_connection conn(fds[0]);
-
-    auto send_msg = std::make_shared<flight_safety_system::transport::fss_message_identity>("eintrClient");
+    auto send_msg = std::make_shared<flight_safety_system::transport::fss_message_identity>(client_name);
     auto bl = send_msg->getPacked();
     const char *data = bl->getData();
     size_t len = bl->getLength();
-    REQUIRE(len > 1);
+    REQUIRE(len > prefix_len);
 
-    /* First byte only: recvMsg blocks waiting for the rest of the header. */
-    REQUIRE(::write(fds[1], data, 1) == 1);
+    REQUIRE(::write(peer.get(), data, prefix_len) == static_cast<ssize_t>(prefix_len));
 
     /* Catch2 assertions are not thread-safe: collect the worker's result in
      * an atomic and assert after join(), as the concurrency tests do. */
@@ -204,22 +198,33 @@ TEST_CASE("recvMsg survives EINTR mid-message")
             pthread_kill(recv_thread_id, SIGUSR1);
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
-        rest_written.store(::write(fds[1], data + 1, len - 1));
+        rest_written.store(::write(peer.get(), data + prefix_len, len - prefix_len));
     });
 
     auto msg = conn.recvMsg();
     signaller.join();
 
-    REQUIRE(rest_written.load() == static_cast<ssize_t>(len - 1));
+    REQUIRE(rest_written.load() == static_cast<ssize_t>(len - prefix_len));
     REQUIRE(msg != nullptr);
     REQUIRE(msg->getType() == flight_safety_system::transport::message_type_identity);
     auto identity = std::dynamic_pointer_cast<flight_safety_system::transport::fss_message_identity>(msg);
     REQUIRE(identity != nullptr);
-    REQUIRE(identity->getName() == "eintrClient");
+    REQUIRE(identity->getName() == client_name);
+}
 
-    REQUIRE(sigaction(SIGUSR1, &old_sa, nullptr) == 0);
-    ::close(fds[1]);
-    /* fds[0] is owned and closed by conn's destructor. */
+} // namespace
+
+TEST_CASE("recvMsg survives EINTR mid-header")
+{
+    /* One byte: recvMsg blocks reading the 2-byte length prefix. */
+    run_eintr_recv_test(1, "eintrClient");
+}
+
+TEST_CASE("recvMsg survives EINTR mid-body")
+{
+    /* Full length prefix plus one byte: the header read completes and
+     * recvMsg blocks in the body read loop. */
+    run_eintr_recv_test(sizeof(uint16_t) + 1, "eintrBodyClient");
 }
 
 TEST_CASE("fss_connection: base isPeerCertRevoked always returns false")

--- a/tests/test_helpers.hpp
+++ b/tests/test_helpers.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <csignal>
 #include <cstdint>
 #include <cstring>
 #include <functional>
@@ -104,6 +105,66 @@ public:
     auto operator=(const scoped_log_level &) -> scoped_log_level & = delete;
     auto operator=(scoped_log_level &&) -> scoped_log_level & = delete;
     ~scoped_log_level() { flight_safety_system::log::detail::current_level().store(saved); }
+};
+
+/* RAII signal-handler override.  Installs the handler deliberately without
+ * SA_RESTART (so blocking syscalls return EINTR) and restores the previous
+ * disposition on destruction — including when a Catch2 assertion unwinds the
+ * test early, so the override cannot leak into later tests. */
+class scoped_signal_handler {
+private:
+    int signum;
+    struct sigaction old_sa = {};
+    bool installed{false};
+public:
+    scoped_signal_handler(int t_signum, void (*t_handler)(int)) : signum(t_signum)
+    {
+        struct sigaction sa = {};
+        sa.sa_handler = t_handler;
+        sigemptyset(&sa.sa_mask);
+        sa.sa_flags = 0;
+        this->installed = (sigaction(this->signum, &sa, &this->old_sa) == 0);
+    }
+    scoped_signal_handler(const scoped_signal_handler &) = delete;
+    scoped_signal_handler(scoped_signal_handler &&) = delete;
+    auto operator=(const scoped_signal_handler &) -> scoped_signal_handler & = delete;
+    auto operator=(scoped_signal_handler &&) -> scoped_signal_handler & = delete;
+    ~scoped_signal_handler()
+    {
+        if (this->installed)
+        {
+            sigaction(this->signum, &this->old_sa, nullptr);
+        }
+    }
+    [[nodiscard]] auto ok() const -> bool { return this->installed; }
+};
+
+/* RAII owner for a test-created file descriptor: closed on destruction even
+ * when an assertion unwinds the test early.  release() transfers ownership
+ * (e.g. to an fss_connection, which closes its fd itself). */
+class scoped_fd {
+private:
+    int fd_;
+public:
+    explicit scoped_fd(int t_fd) : fd_(t_fd) {}
+    scoped_fd(const scoped_fd &) = delete;
+    scoped_fd(scoped_fd &&) = delete;
+    auto operator=(const scoped_fd &) -> scoped_fd & = delete;
+    auto operator=(scoped_fd &&) -> scoped_fd & = delete;
+    ~scoped_fd()
+    {
+        if (this->fd_ >= 0)
+        {
+            ::close(this->fd_);
+        }
+    }
+    [[nodiscard]] auto get() const -> int { return this->fd_; }
+    auto release() -> int
+    {
+        int f = this->fd_;
+        this->fd_ = -1;
+        return f;
+    }
 };
 
 /* Build a buf_len with a valid header (length/type/id) but a caller-specified


### PR DESCRIPTION
## Description

A signal interrupting a blocking recv() (handlers installed without SA_RESTART) returned -1/EINTR, which both receive loops in recvMsg treated as fatal: the header loop synthesised message_closed and the body loop abandoned the message. Either way a healthy connection was torn down.

Retry on EINTR in both loops, mirroring the existing EINTR handling in sendMsg and safe_close_fd/safe_shutdown_fd. The closed-detection ordering is preserved: disconnect() still wakes the recv thread via EBADF/-2 and terminates the loop, never retries. The SSL recvBytes override can return -1 with stale errno after a gnutls failure; that costs at most one extra iteration before its unusable check returns -2.

Add a regression test that blocks recvMsg on a partial header, signals the receiving thread repeatedly, then completes the message and requires intact delivery.

## Summary by Sourcery

Handle interrupted recv calls in the transport receive path without dropping healthy connections.

Bug Fixes:
- Retry recvMsg on EINTR during header and body reads instead of treating it as a connection failure and closing the peer.

Tests:
- Add a regression test that simulates signals interrupting a partial recvMsg and verifies the full message is still delivered intact.