### PR TITLE
fix(transport-ssl): contain gnutls exceptions in TLS setup

### DIFF
--- a/src/fss-transport-ssl.hpp
+++ b/src/fss-transport-ssl.hpp
@@ -107,6 +107,12 @@ protected:
 public:
     fss_listen(uint16_t t_port, flight_safety_system::transport::fss_connect_cb t_cb, std::string t_ca,
                std::string t_private_key, std::string t_public_key, std::string t_crl = {});
+    /* Copy/move are already deleted via the base class. */
+    /* Joins the accept thread before this class's members are destroyed:
+     * that thread reads the cert/key path strings above in newConnection(),
+     * and the base destructor's join runs only after derived members are
+     * already gone — a use-after-free window without this. */
+    ~fss_listen() override;
 };
 } // namespace transport_ssl
 } // namespace flight_safety_system

--- a/src/fss-transport-ssl.hpp
+++ b/src/fss-transport-ssl.hpp
@@ -11,6 +11,13 @@ class session;
 
 namespace flight_safety_system {
 namespace transport_ssl {
+/* Exception contract: no gnutls::exception escapes this library's public
+ * entry points. Misconfiguration (missing/unreadable CA, key, cert, or CRL
+ * files) and TLS setup failures surface as fss_connection_client::create()
+ * returning nullptr, connectTo() returning false, or — on the server accept
+ * path — a connection delivered to the connect callback in an unusable
+ * state (recv thread never started, getMsg() stays null). The cause is
+ * logged. Callers must not need a try/catch around connection setup. */
 class fss_connection : public flight_safety_system::transport::fss_connection {
 private:
     std::unique_ptr<gnutls::certificate_credentials> credentials;

--- a/src/fss-transport-ssl.hpp
+++ b/src/fss-transport-ssl.hpp
@@ -25,6 +25,13 @@ private:
     std::string private_key_file;
     std::string public_key_file;
     std::string crl_file;
+    /* Each contains the gnutlsxx exception for one credential-loading step,
+     * logging the offending file and returning false (see the exception
+     * contract above). */
+    auto loadTrustFile() -> bool;
+    auto loadKeyPair() -> bool;
+    auto loadCrl() -> bool;
+    auto attachCredentials() -> bool;
 protected:
     /* session and possible_names (in fss_connection_server) are written only
      * during setupSSL(), which completes before startRecvThread() — so they

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -191,12 +191,19 @@ public:
 class fss_listen : public fss_connection {
 private:
     uint16_t port;
-    auto startListening() -> bool;
     fss_connect_cb cb;
     static constexpr int default_max_pending_conns = 10;
     int max_pending_connections{default_max_pending_conns};
 protected:
     virtual auto newConnection(int fd) -> std::shared_ptr<flight_safety_system::transport::fss_connection>;
+    /* Binds, listens, and starts the accept thread. The public constructor
+     * calls this; derived classes use the defer_start_t constructor and call
+     * it at the END of their own constructor instead, so the accept thread
+     * (which virtual-dispatches processMessages/newConnection and reads
+     * derived members) can never observe a partially constructed object. */
+    auto startListening() -> bool;
+    struct defer_start_t {};
+    fss_listen(uint16_t t_port, fss_connect_cb t_cb, defer_start_t);
 public:
     fss_listen(uint16_t t_port, fss_connect_cb t_cb);
     fss_listen(fss_listen &) = delete;

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -450,9 +450,23 @@ flight_safety_system::transport_ssl::fss_listen::fss_listen(uint16_t t_port,
                                                             flight_safety_system::transport::fss_connect_cb t_cb,
                                                             std::string t_ca, std::string t_private_key,
                                                             std::string t_public_key, std::string t_crl)
-    : flight_safety_system::transport::fss_listen(t_port, std::move(t_cb)), ca_file(std::move(t_ca)),
+    : flight_safety_system::transport::fss_listen(t_port, std::move(t_cb), defer_start_t{}), ca_file(std::move(t_ca)),
       private_key_file(std::move(t_private_key)), public_key_file(std::move(t_public_key)), crl_file(std::move(t_crl))
 {
+    /* Start the accept thread only now that this object is fully
+     * constructed: the thread virtual-dispatches into newConnection(),
+     * which reads the path strings initialised above. Starting it from the
+     * base constructor (the default behaviour) would race that. */
+    this->startListening();
+}
+
+flight_safety_system::transport_ssl::fss_listen::~fss_listen()
+{
+    /* Join the accept thread while the cert/key path strings it reads in
+     * newConnection() are still alive; the base destructor's disconnect()
+     * would run only after they are destroyed. disconnect() is idempotent,
+     * so the base's call becomes a no-op. */
+    this->disconnect();
 }
 
 auto flight_safety_system::transport_ssl::fss_connection_server::getClientNames() -> std::list<std::string>

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -20,6 +20,27 @@
 extern const char *inet_ntop_stor(struct sockaddr_storage *src, char *dst, size_t dstlen, uint16_t *port);
 #endif
 
+namespace {
+
+/* gnutls_init (via the gnutls::session constructors) can throw; contain it
+ * so session construction follows the same no-throw contract as the
+ * credential loaders. Returns the derived type so callers can use the
+ * session-specific API without a downcast. */
+template<typename SessionT> auto make_session_or_log(const char *what) -> std::unique_ptr<SessionT>
+{
+    try
+    {
+        return std::make_unique<SessionT>();
+    }
+    catch (const gnutls::exception &e)
+    {
+        FSS_LOG_ERROR("ssl", "Failed to initialise " << what << ": " << e.what());
+        return nullptr;
+    }
+}
+
+} // anonymous namespace
+
 flight_safety_system::transport_ssl::fss_connection::fss_connection(std::string t_ca, std::string t_private_key,
                                                                     std::string t_public_key, std::string t_crl)
     : flight_safety_system::transport::fss_connection(), credentials(new gnutls::certificate_credentials()),
@@ -155,6 +176,73 @@ auto flight_safety_system::transport_ssl::fss_connection_client::create(std::str
     return conn;
 }
 
+/* The gnutlsxx wrappers throw on failure (missing file, unreadable key,
+ * malformed PEM). Each loader below contains the exception for one step so
+ * misconfiguration surfaces as setupSession() returning false — never as a
+ * gnutls::exception escaping the library API (see the contract note in the
+ * header). */
+auto flight_safety_system::transport_ssl::fss_connection::loadTrustFile() -> bool
+{
+    try
+    {
+        this->credentials->set_x509_trust_file(this->ca_file.c_str(), GNUTLS_X509_FMT_PEM);
+        return true;
+    }
+    catch (const gnutls::exception &e)
+    {
+        FSS_LOG_ERROR("ssl", "Failed to load CA trust file '" << this->ca_file << "': " << e.what());
+        return false;
+    }
+}
+
+auto flight_safety_system::transport_ssl::fss_connection::loadKeyPair() -> bool
+{
+    try
+    {
+        this->credentials->set_x509_key_file(this->public_key_file.c_str(), this->private_key_file.c_str(),
+                                             GNUTLS_X509_FMT_PEM);
+        return true;
+    }
+    catch (const gnutls::exception &e)
+    {
+        FSS_LOG_ERROR("ssl", "Failed to load key pair (cert '" << this->public_key_file << "', key '"
+                                                               << this->private_key_file << "'): " << e.what());
+        return false;
+    }
+}
+
+auto flight_safety_system::transport_ssl::fss_connection::loadCrl() -> bool
+{
+    if (this->crl_file.empty())
+    {
+        return true;
+    }
+    try
+    {
+        this->credentials->set_x509_crl_file(this->crl_file.c_str(), GNUTLS_X509_FMT_PEM);
+        return true;
+    }
+    catch (const gnutls::exception &e)
+    {
+        FSS_LOG_ERROR("ssl", "Failed to load CRL file '" << this->crl_file << "': " << e.what());
+        return false;
+    }
+}
+
+auto flight_safety_system::transport_ssl::fss_connection::attachCredentials() -> bool
+{
+    try
+    {
+        this->session->set_credentials(*this->credentials);
+        return true;
+    }
+    catch (const gnutls::exception &e)
+    {
+        FSS_LOG_ERROR("ssl", "Failed to attach credentials to TLS session: " << e.what());
+        return false;
+    }
+}
+
 auto flight_safety_system::transport_ssl::fss_connection::setupSession() -> bool
 {
     const char *err_pos = nullptr;
@@ -162,7 +250,7 @@ auto flight_safety_system::transport_ssl::fss_connection::setupSession() -> bool
     {
         this->session->set_priority("SECURE256:+SECURE128:-VERS-TLS1.0:-VERS-TLS1.1:%SERVER_PRECEDENCE", &err_pos);
     }
-    catch (gnutls::exception &ex)
+    catch (const gnutls::exception &ex)
     {
         FSS_LOG_ERROR("ssl",
                       "Failed to set TLS priority: " << ex.what() << (err_pos ? std::string(" near: ") + err_pos : ""));
@@ -170,49 +258,8 @@ auto flight_safety_system::transport_ssl::fss_connection::setupSession() -> bool
         return false;
     }
 
-    /* The gnutlsxx wrappers throw on failure (missing file, unreadable key,
-     * malformed PEM). Contain every load here so misconfiguration surfaces
-     * as setupSession() returning false — never as a gnutls::exception
-     * escaping the library API (see the contract note in the header). */
-    try
+    if (!this->loadTrustFile() || !this->loadKeyPair() || !this->loadCrl() || !this->attachCredentials())
     {
-        this->credentials->set_x509_trust_file(this->ca_file.c_str(), GNUTLS_X509_FMT_PEM);
-    }
-    catch (gnutls::exception &e)
-    {
-        FSS_LOG_ERROR("ssl", "Failed to load CA trust file '" << this->ca_file << "': " << e.what());
-        return false;
-    }
-    try
-    {
-        this->credentials->set_x509_key_file(this->public_key_file.c_str(), this->private_key_file.c_str(),
-                                             GNUTLS_X509_FMT_PEM);
-    }
-    catch (gnutls::exception &e)
-    {
-        FSS_LOG_ERROR("ssl", "Failed to load key pair (cert '" << this->public_key_file << "', key '"
-                                                               << this->private_key_file << "'): " << e.what());
-        return false;
-    }
-    if (!this->crl_file.empty())
-    {
-        try
-        {
-            this->credentials->set_x509_crl_file(this->crl_file.c_str(), GNUTLS_X509_FMT_PEM);
-        }
-        catch (gnutls::exception &e)
-        {
-            FSS_LOG_ERROR("ssl", "Failed to load CRL file '" << this->crl_file << "': " << e.what());
-            return false;
-        }
-    }
-    try
-    {
-        this->session->set_credentials(*this->credentials);
-    }
-    catch (gnutls::exception &e)
-    {
-        FSS_LOG_ERROR("ssl", "Failed to attach credentials to TLS session: " << e.what());
         return false;
     }
 
@@ -222,18 +269,13 @@ auto flight_safety_system::transport_ssl::fss_connection::setupSession() -> bool
 
 auto flight_safety_system::transport_ssl::fss_connection_client::setupSSL() -> bool
 {
-    gnutls::client_session *clientSession = nullptr;
-    try
+    auto new_session = make_session_or_log<gnutls::client_session>("TLS client session");
+    if (new_session == nullptr)
     {
-        clientSession = new gnutls::client_session();
-    }
-    catch (gnutls::exception &e)
-    {
-        FSS_LOG_ERROR("ssl", "Failed to initialise TLS client session: " << e.what());
         return false;
     }
-
-    this->session = std::unique_ptr<gnutls::session>(clientSession);
+    auto *clientSession = new_session.get();
+    this->session = std::move(new_session);
 
     if (!this->setupSession())
     {
@@ -262,18 +304,13 @@ auto flight_safety_system::transport_ssl::fss_connection_client::setupSSL() -> b
 
 auto flight_safety_system::transport_ssl::fss_connection_server::setupSSL() -> bool
 {
-    gnutls::server_session *serverSession = nullptr;
-    try
+    auto new_session = make_session_or_log<gnutls::server_session>("TLS server session");
+    if (new_session == nullptr)
     {
-        serverSession = new gnutls::server_session();
-    }
-    catch (gnutls::exception &e)
-    {
-        FSS_LOG_ERROR("ssl", "Failed to initialise TLS server session: " << e.what());
         return false;
     }
-
-    this->session = std::unique_ptr<gnutls::session>(serverSession);
+    auto *serverSession = new_session.get();
+    this->session = std::move(new_session);
 
     if (!this->setupSession())
     {

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -170,9 +170,30 @@ auto flight_safety_system::transport_ssl::fss_connection::setupSession() -> bool
         return false;
     }
 
-    this->credentials->set_x509_trust_file(this->ca_file.c_str(), GNUTLS_X509_FMT_PEM);
-    this->credentials->set_x509_key_file(this->public_key_file.c_str(), this->private_key_file.c_str(),
-                                         GNUTLS_X509_FMT_PEM);
+    /* The gnutlsxx wrappers throw on failure (missing file, unreadable key,
+     * malformed PEM). Contain every load here so misconfiguration surfaces
+     * as setupSession() returning false — never as a gnutls::exception
+     * escaping the library API (see the contract note in the header). */
+    try
+    {
+        this->credentials->set_x509_trust_file(this->ca_file.c_str(), GNUTLS_X509_FMT_PEM);
+    }
+    catch (gnutls::exception &e)
+    {
+        FSS_LOG_ERROR("ssl", "Failed to load CA trust file '" << this->ca_file << "': " << e.what());
+        return false;
+    }
+    try
+    {
+        this->credentials->set_x509_key_file(this->public_key_file.c_str(), this->private_key_file.c_str(),
+                                             GNUTLS_X509_FMT_PEM);
+    }
+    catch (gnutls::exception &e)
+    {
+        FSS_LOG_ERROR("ssl", "Failed to load key pair (cert '" << this->public_key_file << "', key '"
+                                                               << this->private_key_file << "'): " << e.what());
+        return false;
+    }
     if (!this->crl_file.empty())
     {
         try
@@ -185,7 +206,15 @@ auto flight_safety_system::transport_ssl::fss_connection::setupSession() -> bool
             return false;
         }
     }
-    this->session->set_credentials(*this->credentials);
+    try
+    {
+        this->session->set_credentials(*this->credentials);
+    }
+    catch (gnutls::exception &e)
+    {
+        FSS_LOG_ERROR("ssl", "Failed to attach credentials to TLS session: " << e.what());
+        return false;
+    }
 
     gnutls_transport_set_int(this->session->ptr(), this->getFd());
     return true;
@@ -193,7 +222,16 @@ auto flight_safety_system::transport_ssl::fss_connection::setupSession() -> bool
 
 auto flight_safety_system::transport_ssl::fss_connection_client::setupSSL() -> bool
 {
-    auto clientSession = new gnutls::client_session();
+    gnutls::client_session *clientSession = nullptr;
+    try
+    {
+        clientSession = new gnutls::client_session();
+    }
+    catch (gnutls::exception &e)
+    {
+        FSS_LOG_ERROR("ssl", "Failed to initialise TLS client session: " << e.what());
+        return false;
+    }
 
     this->session = std::unique_ptr<gnutls::session>(clientSession);
 
@@ -224,7 +262,16 @@ auto flight_safety_system::transport_ssl::fss_connection_client::setupSSL() -> b
 
 auto flight_safety_system::transport_ssl::fss_connection_server::setupSSL() -> bool
 {
-    auto serverSession = new gnutls::server_session();
+    gnutls::server_session *serverSession = nullptr;
+    try
+    {
+        serverSession = new gnutls::server_session();
+    }
+    catch (gnutls::exception &e)
+    {
+        FSS_LOG_ERROR("ssl", "Failed to initialise TLS server session: " << e.what());
+        return false;
+    }
 
     this->session = std::unique_ptr<gnutls::session>(serverSession);
 

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -501,6 +501,12 @@ flight_safety_system::transport::fss_listen::fss_listen(uint16_t t_port, fss_con
     this->startListening();
 }
 
+flight_safety_system::transport::fss_listen::fss_listen(uint16_t t_port, fss_connect_cb t_cb, defer_start_t /*tag*/)
+    : fss_connection(), port(t_port), cb(std::move(t_cb))
+{
+    /* Derived constructor calls startListening() when it is done. */
+}
+
 flight_safety_system::transport::fss_listen::~fss_listen()
 {
     this->disconnect();

--- a/tests/ssl_failure_test.cpp
+++ b/tests/ssl_failure_test.cpp
@@ -146,6 +146,51 @@ TEST_CASE("ssl: server surfaces wrong-CN-but-CA-signed cert via getClientNames",
     accepted = nullptr;
 }
 
+TEST_CASE("ssl: misconfigured cert paths fail without throwing")
+{
+    /* Regression: set_x509_trust_file / set_x509_key_file throw
+     * gnutls::exception on a missing or unreadable file, and those calls
+     * were outside any try block — a misconfigured client crashed instead
+     * of logging and returning failure.  The library contract is that no
+     * gnutls exception escapes: connectTo() returns false and create()
+     * returns nullptr.  A live listener is required so the TCP connect
+     * succeeds and the failure happens in TLS setup, not before it. */
+    accepted = nullptr;
+    const uint16_t port = fss_test::pick_port();
+    REQUIRE(port != 0);
+    auto listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(
+        port, accept_cb, CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
+    REQUIRE(listen != nullptr);
+
+    SECTION("nonexistent CA file")
+    {
+        auto client = std::make_shared<flight_safety_system::transport_ssl::fss_connection_client>(
+            "certs/no-such-ca.pem", CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+        bool connected = true;
+        REQUIRE_NOTHROW(connected = client->connectTo("localhost", port));
+        REQUIRE_FALSE(connected);
+    }
+
+    SECTION("nonexistent client key")
+    {
+        auto client = std::make_shared<flight_safety_system::transport_ssl::fss_connection_client>(
+            CA_PUBLIC_FILE, "certs/no-such-key.pem", CLIENT_PUBLIC_FILE);
+        bool connected = true;
+        REQUIRE_NOTHROW(connected = client->connectTo("localhost", port));
+        REQUIRE_FALSE(connected);
+    }
+
+    SECTION("create() with nonexistent key returns nullptr")
+    {
+        std::shared_ptr<flight_safety_system::transport_ssl::fss_connection_client> client;
+        REQUIRE_NOTHROW(client = flight_safety_system::transport_ssl::fss_connection_client::create(
+                            CA_PUBLIC_FILE, "certs/no-such-key.pem", CLIENT_PUBLIC_FILE, "localhost", port));
+        REQUIRE(client == nullptr);
+    }
+
+    accepted = nullptr;
+}
+
 TEST_CASE("ssl: getSessionDesc on unconnected client returns empty string")
 {
     auto conn = std::make_shared<flight_safety_system::transport_ssl::fss_connection_client>(

--- a/tests/ssl_failure_test.cpp
+++ b/tests/ssl_failure_test.cpp
@@ -188,6 +188,9 @@ TEST_CASE("ssl: misconfigured cert paths fail without throwing")
         REQUIRE(client == nullptr);
     }
 
+    /* Join the accept thread (which assigns the `accepted` global from its
+     * callback) before clearing the global, so the two writes can't race. */
+    listen = nullptr;
     accepted = nullptr;
 }
 


### PR DESCRIPTION
## Description

The gnutlsxx wrappers for set_x509_trust_file, set_x509_key_file, and set_credentials throw gnutls::exception on failure (missing, unreadable, or malformed files), and those calls were outside any try block. On the server accept path the exception_guard absorbed this; on the client path a raw gnutls::exception escaped fss_connection_client::create() into consumer code, crashing a misconfigured client instead of logging and retrying.

Wrap each credential-loading call in its own try/catch that logs the offending path and returns false, mirroring the pre-existing CRL-load pattern, and likewise contain the gnutls session construction (gnutls_init can throw) in both setupSSL methods. Document the resulting no-throw contract in the header. set_verify_cert and set_certificate_request wrap void C functions and cannot throw.

Add regression tests: connectTo()/create() with nonexistent CA or key paths must fail without throwing (a live listener ensures the failure happens in TLS setup, not the TCP connect).

## Summary by Sourcery

Contain TLS setup gnutls exceptions in the SSL transport layer so misconfiguration surfaces as clean connection failures instead of uncaught exceptions.

Bug Fixes:
- Ensure client and server TLS credential loading and session initialization failures are handled by logging and returning failure instead of propagating gnutls::exception to callers.

Documentation:
- Document the no-throw exception contract for the SSL transport public API in the header comments.

Tests:
- Add regression tests verifying misconfigured certificate or key paths cause connectTo() and create() to fail without throwing exceptions.