### PR TITLE
fix(client-ssl): make the close-triggered backoff reset thread-safe

### DIFF
--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -373,6 +373,18 @@ void flight_safety_system::client_ssl::fss_server::setClock(std::shared_ptr<flig
 
 auto flight_safety_system::client_ssl::fss_server::reconnect() -> bool
 {
+    /* Consume a reset requested by the recv thread (connection closed):
+     * retry immediately and restart the backoff progression. All backoff
+     * fields are only ever touched on this thread (see the header), so the
+     * atomic flag is the only cross-thread hand-off. */
+    if (this->backoff_reset_requested.exchange(false))
+    {
+        this->last_tried = 0;
+        this->retry_count = 0;
+        this->retry_delay = retry_delay_start;
+        this->effective_delay = retry_delay_start;
+    }
+
     uint64_t ts = this->clock->now_ms();
     uint64_t elapsed_time = ts - this->last_tried;
 
@@ -438,10 +450,12 @@ void flight_safety_system::client_ssl::fss_server::processMessage(
 #endif
     if (msg->getType() == flight_safety_system::transport::message_type_closed)
     {
-        /* Connection has been closed, schedule reconnection */
+        /* Connection has been closed, schedule reconnection. This runs on
+         * the recv thread, which must not touch the backoff fields directly
+         * (they belong to the reconnect-driving thread — see the header);
+         * request the reset via the atomic flag instead. */
+        this->backoff_reset_requested.store(true);
         this->getClient()->serverRequiresReconnect(this);
-        this->last_tried = 0;
-        this->retry_count = 0;
         return;
     }
     else

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -68,6 +68,12 @@ private:
     std::string ca_file{""};
     std::string private_key_file{""};
     std::string public_key_file{""};
+    /* Backoff bookkeeping (last_tried, retry_count, retry_delay,
+     * effective_delay, rng) is touched only from the application thread that
+     * drives reconnection — the caller of attemptReconnect() / reconnect()
+     * and connectTo(..., true). The recv thread must NOT write these
+     * directly: when a connection closes it requests a reset via the atomic
+     * backoff_reset_requested flag, which reconnect() consumes. */
     uint64_t last_tried{0};
     uint64_t retry_count{0};
     static constexpr uint64_t retry_delay_start = 1000;
@@ -75,6 +81,7 @@ private:
     uint64_t retry_delay{retry_delay_start};
     uint64_t effective_delay{retry_delay_start};
     std::mt19937 rng{std::random_device{}()};
+    std::atomic<bool> backoff_reset_requested{false};
     std::shared_ptr<flight_safety_system::IClock> clock{std::make_shared<flight_safety_system::MonotonicClock>()};
     std::atomic<bool> liveness_active{false};
     std::atomic<uint64_t> last_message_received_time{0};

--- a/tests/reconnect_test.cpp
+++ b/tests/reconnect_test.cpp
@@ -171,6 +171,36 @@ TEST_CASE("reconnect: fake clock throttles attempts within retry window")
     REQUIRE(server->attempts == 1);
 }
 
+TEST_CASE("reconnect: connection close resets backoff for an immediate retry")
+{
+    /* A closed connection requests a backoff reset via the atomic
+     * backoff_reset_requested hand-off (the recv thread must not touch the
+     * backoff fields directly); the next reconnect() consumes it and
+     * attempts immediately, even mid-retry-window. */
+    auto client = std::make_shared<flight_safety_system::client_ssl::fss_client>(CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE,
+                                                                                 CLIENT_PUBLIC_FILE);
+    auto server = std::make_shared<CountingServer>(client.get(), "127.0.0.1", static_cast<uint16_t>(20598),
+                                                   CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+    auto fake = std::make_shared<FakeClock>();
+    server->setClock(fake);
+
+    /* Arm the throttle with one (failed) attempt past the initial window. */
+    fake->advance(1001);
+    server->reconnect();
+    REQUIRE(server->attempts == 1);
+
+    /* Inside the grown retry window: throttled. */
+    fake->advance(1);
+    server->reconnect();
+    REQUIRE(server->attempts == 1);
+
+    /* Deliver closed as the recv thread would; the reset must take effect
+     * on the next reconnect() call. */
+    server->processMessage(std::make_shared<flight_safety_system::transport::fss_message_closed>());
+    server->reconnect();
+    REQUIRE(server->attempts == 2);
+}
+
 TEST_CASE("reconnect: fake clock exposes exponential backoff growth")
 {
     auto client = std::make_shared<flight_safety_system::client_ssl::fss_client>(CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE,


### PR DESCRIPTION
## Description

processMessage (recv thread) wrote last_tried/retry_count directly on message_type_closed while the application thread driving reconnect() reads and writes the same non-atomic backoff fields - a data race, the same family as the fss_message_cb::conn race fixed in 1.0.2.

Replace the direct writes with an atomic backoff_reset_requested flag: the recv thread requests the reset, reconnect() consumes it and resets the backoff before computing the throttle. All backoff fields (and the jitter rng) are now touched by exactly one thread; the ownership rule is documented on the members.

Resetting retry_delay/effective_delay in the consume block is a no-op in practice (every close is preceded by a successful connect, which already reset them) but makes the reset self-contained.

Add a deterministic regression test: a close mid-retry-window must produce an immediate retry on the next reconnect().

## Summary by Sourcery

Make client SSL reconnect backoff resets thread-safe by handing off reset requests from the receive thread to the reconnect-driving thread via an atomic flag.

Bug Fixes:
- Prevent data races on reconnect backoff state when handling connection-closed messages by removing cross-thread writes to backoff fields.

Enhancements:
- Document thread ownership of backoff bookkeeping fields and introduce an atomic flag to coordinate backoff resets between threads.

Tests:
- Add a deterministic reconnect test verifying that a connection close mid-retry window resets backoff and triggers an immediate retry on the next reconnect().