### PR TITLE
fix(transport): bound unacked sends with TCP_USER_TIMEOUT

### DIFF
--- a/src/transport-helpers.cpp
+++ b/src/transport-helpers.cpp
@@ -89,4 +89,18 @@ void set_tcp_keepalive(int fd)
     {
         FSS_PERROR("transport", "setsockopt TCP_KEEPCNT failed");
     }
+#ifdef TCP_USER_TIMEOUT
+    /* Keepalive probes only fire on an idle connection; once unacked data is
+     * in flight the kernel falls back to the retransmission timeout
+     * (~15 minutes), so a blocking send() into a black-holed peer can stall
+     * a sender thread for that long. TCP_USER_TIMEOUT bounds how long
+     * transmitted data may stay unacknowledged before the kernel errors the
+     * connection out, matching the 30 s liveness timeout the server already
+     * applies at the application layer (default client_timeout). */
+    unsigned int user_timeout_ms = 30000;
+    if (setsockopt(fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &user_timeout_ms, sizeof(user_timeout_ms)) < 0)
+    {
+        FSS_PERROR("transport", "setsockopt TCP_USER_TIMEOUT failed");
+    }
+#endif
 }

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -16,12 +16,14 @@
 #include <csignal>
 #include <thread>
 
+#include <netinet/tcp.h>
 #include <pthread.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
 #include "fss-transport.hpp"
 #include "test_helpers.hpp"
+#include "transport.hpp"
 
 TEST_CASE("Connection Create (failure)")
 {
@@ -225,6 +227,23 @@ TEST_CASE("recvMsg survives EINTR mid-body")
     /* Full length prefix plus one byte: the header read completes and
      * recvMsg blocks in the body read loop. */
     run_eintr_recv_test(sizeof(uint16_t) + 1, "eintrBodyClient");
+}
+
+TEST_CASE("set_tcp_keepalive bounds unacked data with TCP_USER_TIMEOUT")
+{
+#ifdef TCP_USER_TIMEOUT
+    /* Keepalives only cover idle connections; TCP_USER_TIMEOUT is what
+     * bounds a blocking send() into a black-holed peer.  Regression-pin
+     * that set_tcp_keepalive applies it. */
+    int sock = ::socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
+    REQUIRE(sock >= 0);
+    fss_test::scoped_fd guard(sock);
+    set_tcp_keepalive(sock);
+    unsigned int val = 0;
+    socklen_t len = sizeof(val);
+    REQUIRE(::getsockopt(sock, IPPROTO_TCP, TCP_USER_TIMEOUT, &val, &len) == 0);
+    REQUIRE(val == 30000);
+#endif
 }
 
 TEST_CASE("fss_connection: base isPeerCertRevoked always returns false")


### PR DESCRIPTION
## Description

Keepalive probes only fire on an idle connection; once unacked data is in flight the kernel falls back to the retransmission timeout (~15 minutes), so a blocking send() into a black-holed peer - a radio dropout, the normal failure mode for an RPAS link - could stall a sender thread for that long.

Set TCP_USER_TIMEOUT to 30 s in set_tcp_keepalive, matching both the existing keepalive death detection (idle 15 s + 5 s x 3 probes) and the server's default application-level client_timeout. Applies to client connect and server accepted fds alike; the listen socket never passes through this helper. Guarded by #ifdef for non-Linux builds.

## Summary by Sourcery

Bound TCP connections’ unacknowledged send duration using TCP_USER_TIMEOUT to align kernel behavior with existing liveness timeouts.

Bug Fixes:
- Prevent sender threads from blocking for extended periods on black-holed peers by configuring TCP_USER_TIMEOUT alongside keepalive settings.

Tests:
- Add a regression test ensuring set_tcp_keepalive applies TCP_USER_TIMEOUT with a 30s timeout when supported by the platform.