### PR TITLE
fix(server): keep all synchronous DB reads off the main loop

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -311,7 +311,7 @@ void fss::server::fss_client::sendRTTRequest(const std::shared_ptr<fss::transpor
     }
 }
 
-void fss::server::fss_client::sendSMMSettings()
+void fss::server::fss_client::refreshSmmSettings()
 {
     uint64_t asset_id = this->cached_asset_id.load();
     if (asset_id == 0)
@@ -319,6 +319,17 @@ void fss::server::fss_client::sendSMMSettings()
         return;
     }
     auto smm = this->dbc->getSmmSettings(asset_id);
+    std::scoped_lock guard(this->client_lock);
+    this->cached_smm_settings = std::move(smm);
+}
+
+void fss::server::fss_client::sendSMMSettings()
+{
+    std::shared_ptr<smm_settings> smm;
+    {
+        std::scoped_lock guard(this->client_lock);
+        smm = this->cached_smm_settings;
+    }
     if (smm != nullptr)
     {
         auto settings_msg = std::make_shared<fss::transport::fss_message_smm_settings>(
@@ -464,6 +475,10 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                 this->identified = true;
                 FSS_LOG_INFO("server", "Aircraft client identified: " << this->getName());
                 this->sendCommand();
+                /* Identify runs on the recv thread, where a synchronous DB
+                 * read is allowed — prime the cache so the settings go out
+                 * now rather than after the poller's next refresh. */
+                this->refreshSmmSettings();
                 this->sendSMMSettings();
                 this->getConnection()->sendMsg(getServersListMsg(this->dbc));
             }

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -153,6 +153,10 @@ private:
     std::atomic<uint64_t> expected_seq{0};
     std::atomic<uint64_t> cached_asset_id{0};
     std::shared_ptr<asset_command> pending_command{nullptr};
+    /* Guarded by client_lock. Refreshed by refreshSmmSettings() (poller
+     * thread, plus once at identify time); read by sendSMMSettings() so the
+     * main loop never performs a synchronous DB read. */
+    std::shared_ptr<smm_settings> cached_smm_settings{nullptr};
     std::string name{};
     std::mutex client_lock{};
     std::list<std::shared_ptr<fss_client_rtt>> outstanding_rtt_requests{};
@@ -186,6 +190,10 @@ public:
     void activate();
     void processMessage(std::shared_ptr<transport::fss_message> message) override;
     void sendRTTRequest(const std::shared_ptr<transport::fss_message_rtt_request> &rtt_req);
+    /* Synchronous DB read; called from the command poller thread (and once
+     * from the recv thread at identify time) — never from the main loop. */
+    void refreshSmmSettings();
+    /* Sends the cached settings only; no DB access. */
     void sendSMMSettings();
     void sendCommand();
     auto isAircraft() -> bool;

--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -22,6 +22,10 @@ private:
     uint64_t identify_timeout_ms{30000};
     uint64_t rate_capacity{100};
     uint64_t rate_refill_per_s{20};
+    /* Guarded by lock. Built by the command poller thread (the only place
+     * allowed to read the DB for it); broadcast by the main loop, which must
+     * never perform a synchronous DB read. */
+    std::shared_ptr<flight_safety_system::transport::fss_message_server_list> cached_server_list{};
 public:
     server_clients() = default;
     ~server_clients() override
@@ -169,7 +173,8 @@ public:
     };
     void sendSMMSettings()
     {
-        /* Snapshot, then act outside the lock — see broadcastMsg(). */
+        /* Snapshot, then act outside the lock — see broadcastMsg().
+         * Sends cached settings only; the poller refreshes the caches. */
         std::vector<std::shared_ptr<flight_safety_system::server::fss_client>> snapshot;
         {
             std::scoped_lock guard(this->lock);
@@ -179,6 +184,30 @@ public:
         {
             client->sendSMMSettings();
         }
+    };
+    /* Synchronous DB reads; poller thread only — see the main-loop DB
+     * contract in server.cpp. */
+    void refreshSmmSettings()
+    {
+        std::vector<std::shared_ptr<flight_safety_system::server::fss_client>> snapshot;
+        {
+            std::scoped_lock guard(this->lock);
+            std::copy(this->clients.begin(), this->clients.end(), std::back_inserter(snapshot));
+        }
+        for (const auto &client : snapshot)
+        {
+            client->refreshSmmSettings();
+        }
+    };
+    void setCachedServerList(std::shared_ptr<flight_safety_system::transport::fss_message_server_list> msg)
+    {
+        std::scoped_lock guard(this->lock);
+        this->cached_server_list = std::move(msg);
+    };
+    auto getCachedServerList() -> std::shared_ptr<flight_safety_system::transport::fss_message_server_list>
+    {
+        std::scoped_lock guard(this->lock);
+        return this->cached_server_list;
     };
     void sendRTTRequest(const std::shared_ptr<flight_safety_system::transport::fss_message_rtt_request> &rtt_req)
     {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -184,10 +184,12 @@ auto main(int argc, char *argv[]) -> int
 
     /* Main-loop DB contract: the loop below must make NO synchronous DB
      * reads. Reads are handled exclusively by the command_poller thread
-     * below, which caches results on each fss_client. The loop only calls
-     * sendCommand() (reads the cache), write-queue enqueues (async), and
-     * in-memory bookkeeping. A DB stall therefore cannot block heartbeats
-     * or timeout monitoring.
+     * below, which caches results: pending commands and SMM settings on
+     * each fss_client, and the active-server-list message on
+     * server_clients. The loop only calls sendCommand()/sendSMMSettings()/
+     * broadcastMsg() (all read caches), write-queue enqueues (async), and
+     * in-memory bookkeeping. A DB stall therefore cannot block heartbeats,
+     * timeout monitoring, or command dispatch.
      *
      * Split tick: sendCommand runs every command_poll_ms so safety-critical
      * commands (TERM, DISARM) reach aircraft in <=100ms instead of <=1s.
@@ -203,9 +205,21 @@ auto main(int argc, char *argv[]) -> int
     std::atomic<bool> poll_running{true};
     std::thread command_poller([&clients, &dbc, &poll_running, command_poll_ms]() -> void {
         flight_safety_system::exception_guard poll_guard("server", "pollCommands");
+        uint64_t poll_counter = 0;
         while (poll_running.load())
         {
-            poll_guard.run([&]() -> void { clients->pollCommands(dbc.get()); });
+            poll_guard.run([&]() -> void {
+                clients->pollCommands(dbc.get());
+                /* Config reads share the poller so the main loop never
+                 * touches the DB. First refresh happens immediately
+                 * (counter 0) so the caches are primed at startup. */
+                if ((poll_counter % send_config_period_ticks) == 0)
+                {
+                    clients->setCachedServerList(flight_safety_system::server::build_server_list_msg(dbc.get()));
+                    clients->refreshSmmSettings();
+                }
+            });
+            poll_counter++;
             std::this_thread::sleep_for(std::chrono::milliseconds(command_poll_ms));
         }
     });
@@ -254,7 +268,15 @@ auto main(int argc, char *argv[]) -> int
             }
             if ((tick_counter % send_config_period_ticks) == 0)
             {
-                clients->broadcastMsg(flight_safety_system::server::build_server_list_msg(dbc.get()));
+                /* Cache-only: the poller builds the server list and refreshes
+                 * the per-client SMM settings. Empty cache (startup race with
+                 * the poller's first pass) just skips one broadcast; clients
+                 * also receive the list directly at identify time. */
+                auto server_list = clients->getCachedServerList();
+                if (server_list != nullptr)
+                {
+                    clients->broadcastMsg(server_list);
+                }
                 clients->sendSMMSettings();
             }
         });

--- a/tests/mock_database.hpp
+++ b/tests/mock_database.hpp
@@ -104,9 +104,14 @@ public:
 
     auto getSmmSettings(uint64_t asset_id) -> std::shared_ptr<flight_safety_system::server::smm_settings> override
     {
+        smm_reads++;
         auto it = smm.find(asset_id);
         return it == smm.end() ? nullptr : it->second;
     }
+
+    /* Number of getSmmSettings calls — lets tests assert that send paths
+     * use the cache rather than re-reading the database. */
+    int smm_reads{0};
 
     auto isConnected() const -> bool override { return true; }
     void tryReconnectIfNeeded() override {}

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -1180,8 +1180,8 @@ TEST_CASE("session: rtt_request from identified client receives rtt_response")
 
 TEST_CASE("session: sendSMMSettings returns early when asset_id is zero")
 {
-    /* sendSMMSettings() guards against asset_id==0 (unidentified client)
-     * and must return without calling getSmmSettings on the database. */
+    /* An unidentified client (asset_id==0) has an empty settings cache and
+     * must neither send a message nor touch the database. */
     fss_test::MockDatabase mock;
     /* Do NOT add an asset_id entry — the client will remain unidentified
      * so cached_asset_id stays 0 after any processMessage call. */
@@ -1192,9 +1192,48 @@ TEST_CASE("session: sendSMMSettings returns early when asset_id is zero")
     auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
 
     const std::size_t before = conn->sent.size();
-    session->sendSMMSettings(); /* asset_id == 0 → early return */
-    /* No smm_settings message should have been sent. */
+    session->sendSMMSettings();    /* empty cache → nothing sent */
+    session->refreshSmmSettings(); /* asset_id == 0 → early return, no DB read */
     REQUIRE(conn->sent.size() == before);
+    REQUIRE(mock.smm_reads == 0);
+}
+
+TEST_CASE("session: sendSMMSettings sends from cache without re-reading the database")
+{
+    /* The main loop calls sendSMMSettings() every 15 s; it must serve the
+     * cache primed at identify time (and refreshed by the poller thread),
+     * never performing a synchronous DB read itself. */
+    fss_test::MockDatabase mock;
+    constexpr uint64_t asset_id = 14;
+    mock.asset_ids["craft"] = asset_id;
+    mock.smm[asset_id] = std::make_shared<fss::server::smm_settings>("https://smm.test", fss::secure_string{"u"},
+                                                                     fss::secure_string{"p"});
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    const int reads_after_identify = mock.smm_reads;
+    REQUIRE(reads_after_identify >= 1); /* identify primes the cache */
+
+    /* Drop the DB entry: a cache-respecting send still delivers the cached
+     * settings and performs no new read. */
+    mock.smm.clear();
+    conn->sent.clear();
+    session->sendSMMSettings();
+    REQUIRE(find_sent<fss::transport::fss_message_smm_settings>(conn->sent) != nullptr);
+    REQUIRE(mock.smm_reads == reads_after_identify);
+
+    /* refreshSmmSettings (poller path) re-reads: the entry is gone, so the
+     * cache empties and nothing further is sent. */
+    session->refreshSmmSettings();
+    REQUIRE(mock.smm_reads == reads_after_identify + 1);
+    conn->sent.clear();
+    session->sendSMMSettings();
+    REQUIRE(find_sent<fss::transport::fss_message_smm_settings>(conn->sent) == nullptr);
 }
 
 TEST_CASE("session: sendRTTRequest skips second request within retry interval")


### PR DESCRIPTION
## Description

The main loop documents that it must make no synchronous DB reads, so a DB stall cannot block heartbeats, timeouts, or command dispatch - but the 15 s tick violated that twice: building the server-list broadcast (getActiveServers) and sendSMMSettings (a getSmmSettings read per client, formerly under the global client lock). A stalled DB could block the same tick that runs sendCommand, delaying TERM/DISARM far beyond the 100 ms target.

Move both reads onto the existing command poller thread: every 15 s worth of polls it rebuilds the server-list message into a cache on server_clients and refreshes a per-client SMM settings cache. The main loop now only broadcasts the cached list (skipping one round if the startup race leaves the cache empty - identify-time sends cover new clients) and sends cached settings. The identify path still primes the cache synchronously on the recv thread, where DB reads are allowed, so newly identified aircraft get their settings immediately.

Add a MockDatabase read counter and tests pinning the contract: sends are cache-served with no DB read, refresh re-reads, and an unidentified client never touches the DB.

## Summary by Sourcery

Move synchronous DB reads for server list broadcasts and SMM settings off the main loop onto the command poller, relying on per-client and global caches so the main loop only reads cached data.

Bug Fixes:
- Ensure periodic SMM settings sends are served from a cache, preventing synchronous DB reads from blocking the main loop.
- Prevent unidentified clients from triggering SMM settings DB reads or messages.
- Ensure server list broadcasts use a cached message built by the poller, avoiding main-loop DB access.

Enhancements:
- Add per-client cached SMM settings and a cached server list on the server client manager, refreshed by the command poller at a fixed tick interval.
- Prime SMM settings cache on client identification so newly identified aircraft receive settings immediately without extra DB hits.

Tests:
- Extend server session tests to verify SMM settings are served from cache, refreshed by the poller, and never read from the DB for unidentified clients.
- Augment MockDatabase with an SMM settings read counter to assert correct caching and DB access patterns.