### PR TITLE
fix(server): refuse commands built from NULL position or altitude rows

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -56,8 +56,10 @@ auto fss::server::fss_server_details::getPort() -> uint16_t
 
 // NOLINTBEGIN(bugprone-easily-swappable-parameters)
 fss::server::asset_command::asset_command(uint64_t t_dbid, uint64_t t_timestamp, const std::string &t_cmd,
-                                          double t_latitude, double t_longitude, uint32_t t_altitude)
-    : dbid(t_dbid), timestamp(t_timestamp), latitude(t_latitude), longitude(t_longitude), altitude(t_altitude)
+                                          double t_latitude, double t_longitude, uint32_t t_altitude,
+                                          bool t_altitude_valid)
+    : dbid(t_dbid), timestamp(t_timestamp), latitude(t_latitude), longitude(t_longitude), altitude(t_altitude),
+      altitude_valid(t_altitude_valid)
 // NOLINTEND(bugprone-easily-swappable-parameters)
 {
     if (t_cmd == "RTL")
@@ -121,6 +123,10 @@ auto fss::server::asset_command::getLongitude() -> double
 auto fss::server::asset_command::getAltitude() -> uint32_t
 {
     return this->altitude;
+}
+auto fss::server::asset_command::isAltitudeValid() -> bool
+{
+    return this->altitude_valid;
 }
 
 // NOLINTBEGIN(bugprone-easily-swappable-parameters)
@@ -207,6 +213,14 @@ void fss::server::fss_client::sendCommand()
             FSS_LOG_ERROR("server", "Refusing to dispatch GOTO command with invalid coordinates to "
                                         << this->name << " (dbid=" << ac->getDBId() << ", lat=" << ac->getLatitude()
                                         << ", lon=" << ac->getLongitude() << ")");
+            return;
+        }
+        if (command == fss::transport::asset_command_altitude && !ac->isAltitudeValid())
+        {
+            /* A NULL altitude must not dispatch as 0 — that is a
+             * descend-to-ground instruction. */
+            FSS_LOG_ERROR("server", "Refusing to dispatch ALT command with NULL altitude to "
+                                        << this->name << " (dbid=" << ac->getDBId() << ")");
             return;
         }
         std::shared_ptr<fss::transport::fss_message_asset_command> msg = nullptr;

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -136,7 +136,8 @@ auto flight_safety_system::server::db_connection::getCommand(uint64_t asset_id) 
         if (command)
         {
             res = std::make_shared<asset_command>(command->dbid, command->timestamp, std::string(command->command),
-                                                  command->latitude, command->longitude, command->altitude);
+                                                  command->latitude, command->longitude, command->altitude,
+                                                  command->altitude_null == 0);
             free(command->command);
             free(command);
         }

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -47,15 +47,20 @@ private:
     double latitude;
     double longitude;
     uint32_t altitude;
+    /* False when the DB row's altitude was NULL: altitude is unsigned, so
+     * unlike a NULL position (NaN) it has no in-band sentinel. sendCommand
+     * refuses to dispatch an ALT command without a valid altitude. */
+    bool altitude_valid;
 public:
     asset_command(uint64_t t_dbid, uint64_t t_timestamp, const std::string &t_cmd, double t_latitude,
-                  double t_longitude, uint32_t t_altitude);
+                  double t_longitude, uint32_t t_altitude, bool t_altitude_valid = true);
     auto getDBId() -> uint64_t;
     auto getTimeStamp() -> uint64_t;
     auto getCommand() -> transport::fss_asset_command;
     auto getLatitude() -> double;
     auto getLongitude() -> double;
     auto getAltitude() -> uint32_t;
+    auto isAltitudeValid() -> bool;
 };
 
 /* Pure-virtual database seam: lets ClientSession be unit-tested against

--- a/src/server-db.h
+++ b/src/server-db.h
@@ -20,9 +20,14 @@ struct asset_command_s {
     char *command;
     unsigned long long timestamp;
     unsigned long long dbid;
+    /* NaN when the row's position is NULL — the dispatch layer's coordinate
+     * validation then refuses to send a GOTO built from this row. */
     double latitude;
     double longitude;
     uint32_t altitude;
+    /* Non-zero when the row's altitude is NULL; altitude is unsigned so it
+     * has no NaN-style sentinel of its own. */
+    int altitude_null;
 };
 
 struct asset_command_s *db_asset_command_get(const char *conn, unsigned long long asset_id_arg);

--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -1,5 +1,6 @@
 #include "server-db.h"
 
+#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -162,9 +163,14 @@ db_asset_command_get(const char *conn_arg, unsigned long long asset_id_arg)
             }
             res->dbid = id;
             res->timestamp = ts;
-            res->latitude = lat;
-            res->longitude = lng;
+            /* A NULL position must not decode as (0,0) -- Null Island is a
+             * legal coordinate, so a GOTO built from it would dispatch.  Map
+             * NULL to NaN, which the dispatch layer's coordinate validation
+             * refuses.  Altitude has no NaN, so carry an explicit flag. */
+            res->latitude = (lat_ind < 0) ? NAN : lat;
+            res->longitude = (lng_ind < 0) ? NAN : lng;
             res->altitude = alt;
+            res->altitude_null = (alt_ind < 0);
         }
     }
     return res;
@@ -217,7 +223,7 @@ db_asset_smm_settings_get(const char *conn_arg, unsigned long long asset_id_arg)
     int success = 0;
     EXEC SQL END DECLARE SECTION;
 
-    EXEC SQL AT :conn SELECT 1, SMM.address, SMM.port, SMM.https, A.smm_login, A.smm_password A INTO :success, :server_address, :server_port, :server_https, :smm_login, :smm_password FROM config_assetconfig AS A, config_smmconfig AS SMM WHERE A.asset_id = :asset_id AND A.smm_id = SMM.id;
+    EXEC SQL AT :conn SELECT 1, SMM.address, SMM.port, SMM.https, A.smm_login, A.smm_password INTO :success, :server_address, :server_port, :server_https, :smm_login, :smm_password FROM config_assetconfig AS A, config_smmconfig AS SMM WHERE A.asset_id = :asset_id AND A.smm_id = SMM.id;
 
 
     struct smm_settings_s *settings = NULL;

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -10,6 +10,7 @@
 #error No catch header
 #endif
 
+#include <cmath>
 #include <limits>
 #include <list>
 #include <memory>
@@ -835,6 +836,65 @@ TEST_CASE("session: sendCommand skips unknown command type")
     session->sendCommand();
 
     REQUIRE(find_sent<fss::transport::fss_message_asset_command>(conn->sent) == nullptr);
+}
+
+TEST_CASE("session: sendCommand refuses GOTO built from a NULL position")
+{
+    /* A command row with a NULL position maps to NaN coordinates in the DB
+     * layer (db_asset_command_get); the dispatch guard must refuse it rather
+     * than send the aircraft to whatever the host vars happened to hold. */
+    fss_test::MockDatabase mock;
+    constexpr uint64_t asset_id = 21;
+    mock.asset_ids["craft"] = asset_id;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+    conn->sent.clear();
+
+    auto null_pos_goto = std::make_shared<fss::server::asset_command>(100, 2000, "GOTO", NAN, NAN, 0);
+    session->setPendingCommand(null_pos_goto);
+    session->sendCommand();
+
+    REQUIRE(find_sent<fss::transport::fss_message_asset_command>(conn->sent) == nullptr);
+}
+
+TEST_CASE("session: sendCommand refuses ALT built from a NULL altitude")
+{
+    /* A command row with a NULL altitude must not dispatch as altitude 0 -
+     * that is a descend-to-ground instruction. The DB layer flags the NULL
+     * via altitude_valid=false. */
+    fss_test::MockDatabase mock;
+    constexpr uint64_t asset_id = 22;
+    mock.asset_ids["craft"] = asset_id;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+    conn->sent.clear();
+
+    auto null_alt =
+        std::make_shared<fss::server::asset_command>(101, 2000, "ALT", 0.0, 0.0, 0, /*altitude_valid*/ false);
+    session->setPendingCommand(null_alt);
+    session->sendCommand();
+    REQUIRE(find_sent<fss::transport::fss_message_asset_command>(conn->sent) == nullptr);
+
+    /* The same command with a real altitude dispatches normally. */
+    auto valid_alt = std::make_shared<fss::server::asset_command>(102, 2001, "ALT", 0.0, 0.0, 250);
+    session->setPendingCommand(valid_alt);
+    session->sendCommand();
+    auto cmd_msg = find_sent<fss::transport::fss_message_asset_command>(conn->sent);
+    REQUIRE(cmd_msg != nullptr);
+    REQUIRE(cmd_msg->getCommand() == fss::transport::asset_command_altitude);
+    REQUIRE(cmd_msg->getAltitude() == 250);
 }
 
 TEST_CASE("session: sendSMMSettings sends smm_settings message when db returns settings")


### PR DESCRIPTION
## Description

db_asset_command_get bound NULL indicators for position and altitude but never read them: a command row with a NULL position decoded as lat=0.0/lng=0.0, and Null Island is a legal coordinate, so a GOTO built from such a row would pass validation and dispatch an aircraft toward (0,0). A NULL altitude likewise decoded as 0 - a descend-to-ground instruction for an ALT command.

Map NULL lat/lng to NaN in the DB layer, which the existing is_valid_coordinate dispatch guard already refuses. Altitude is unsigned with no in-band sentinel, so carry an explicit altitude_valid flag through asset_command and refuse to dispatch ALT without it, mirroring the GOTO guard. The web frontend should never create such rows; this layer emits flight commands and must not trust row shape.

Also drop a stray column alias in db_asset_smm_settings_get ("A.smm_password A" aliased the column as "A").

## Summary by Sourcery

Prevent server from dispatching flight commands built from database rows with NULL position or altitude fields.

Bug Fixes:
- Ensure GOTO commands derived from rows with NULL position are rejected instead of using bogus (NaN-backed) coordinates.
- Ensure ALT commands derived from rows with NULL altitude are rejected rather than defaulting to altitude 0, while allowing valid ALT commands to dispatch.

Tests:
- Add session tests verifying that GOTO commands with NaN coordinates and ALT commands with invalid altitude are not sent, and that valid ALT commands still dispatch correctly.