### PR TITLE
fix(transport): throttle the undecodable-frame warning

### DIFF
--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -153,6 +153,12 @@ class fss_connection {
     std::mutex msg_lock{};
     size_t max_queue_size{default_max_queue_size};
     std::atomic<uint64_t> dropped_messages{0};
+    /* Consecutive undecodable frames from the peer; reset by the next
+     * successfully decoded message. Drives log throttling in
+     * processMessages() — atomic so tests/monitoring can read it from
+     * another thread. */
+    std::atomic<uint64_t> consecutive_null_msgs{0};
+    static constexpr uint64_t null_msg_log_interval = 100;
     std::atomic<uint16_t> negotiated_version{FSS_PROTOCOL_VERSION_LEGACY};
 protected:
     auto recvMsg() -> std::shared_ptr<fss_message>;
@@ -171,6 +177,7 @@ public:
     fss_connection();
     static auto create(int fd, size_t t_max_queue_size = default_max_queue_size) -> std::shared_ptr<fss_connection>;
     auto getDroppedMessages() -> uint64_t;
+    auto getNullMsgCount() -> uint64_t;
     fss_connection(fss_connection &) = delete;
     fss_connection(fss_connection &&) = delete;
     auto operator=(fss_connection &) -> fss_connection & = delete;

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -108,6 +108,11 @@ auto flight_safety_system::transport::fss_connection::getDroppedMessages() -> ui
     return this->dropped_messages.load();
 }
 
+auto flight_safety_system::transport::fss_connection::getNullMsgCount() -> uint64_t
+{
+    return this->consecutive_null_msgs.load();
+}
+
 void flight_safety_system::transport::fss_connection::disconnect()
 {
     this->run.store(false);
@@ -171,9 +176,19 @@ void flight_safety_system::transport::fss_connection::processMessages()
         auto msg = this->recvMsg();
         if (msg == nullptr)
         {
-            FSS_LOG_WARN("transport", "Got a null msg");
+            /* Undecodable frame (zero/short declared length, unknown type,
+             * or decode mismatch). A peer streaming garbage drives this
+             * loop at line rate, so throttle the log to the first frame and
+             * every null_msg_log_interval-th after — otherwise a single bad
+             * peer floods the log unboundedly. */
+            uint64_t nulls = ++this->consecutive_null_msgs;
+            if (nulls == 1 || (nulls % null_msg_log_interval) == 0)
+            {
+                FSS_LOG_WARN("transport", "Got a null msg (" << nulls << " consecutive undecodable frames)");
+            }
             continue;
         }
+        this->consecutive_null_msgs.store(0);
         if (msg->getType() == message_type_closed)
         {
             FSS_LOG_INFO("transport", "Remote closed the connection");

--- a/tests/malformed_message_test.cpp
+++ b/tests/malformed_message_test.cpp
@@ -13,6 +13,9 @@
 #include <memory>
 #include <string>
 
+#include <sys/socket.h>
+#include <unistd.h>
+
 #include "fss-transport.hpp"
 #include "test_helpers.hpp"
 
@@ -43,6 +46,56 @@ using flight_safety_system::transport::message_type_server_list;
 using flight_safety_system::transport::message_type_smm_settings;
 using flight_safety_system::transport::message_type_system_status;
 using flight_safety_system::transport::message_type_unknown;
+
+TEST_CASE("malformed: undecodable frame stream is log-throttled and survivable")
+{
+    /* A connected peer streaming garbage frames used to emit one WARN per
+     * frame — unbounded log growth at line rate.  The log is now throttled
+     * to the first frame and every 100th after, the connection stays up,
+     * and a subsequent valid message resets the counter and is delivered. */
+    fss_test::capture_cerr capture; /* installed before the recv thread starts */
+    int fds[2];
+    REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    fss_test::scoped_fd peer(fds[1]);
+    auto conn = flight_safety_system::transport::fss_connection::create(fds[0]);
+
+    /* Unknown-type frame, declared length 16 (8-byte aligned so recvMsg
+     * consumes exactly what is written): header (12) + 4 padding bytes. */
+    constexpr uint64_t frames = 250;
+    auto garbage = fss_test::make_framed_buffer(0x00FFU, 1, std::string(4, '\0'), 16);
+    for (uint64_t i = 0; i < frames; i++)
+    {
+        REQUIRE(::write(peer.get(), garbage->getData(), garbage->getLength()) ==
+                static_cast<ssize_t>(garbage->getLength()));
+    }
+    REQUIRE(fss_test::wait_for([&]() { return conn->getNullMsgCount() >= frames; }));
+    REQUIRE(conn->getNullMsgCount() == frames);
+
+    /* A valid message is still delivered and resets the counter. */
+    auto ident = std::make_shared<fss_message_identity>("recovers");
+    ident->setId(2);
+    auto good = ident->getPacked();
+    REQUIRE(::write(peer.get(), good->getData(), good->getLength()) == static_cast<ssize_t>(good->getLength()));
+    std::shared_ptr<fss_message> msg;
+    REQUIRE(fss_test::wait_for([&]() {
+        msg = conn->getMsg();
+        return msg != nullptr;
+    }));
+    REQUIRE(msg->getType() == message_type_identity);
+    REQUIRE(conn->getNullMsgCount() == 0);
+
+    conn->disconnect();
+
+    /* 250 garbage frames log at 1, 100, and 200 — three lines, not 250. */
+    const std::string logged = capture.str();
+    std::size_t occurrences = 0;
+    for (std::size_t pos = logged.find("Got a null msg"); pos != std::string::npos;
+         pos = logged.find("Got a null msg", pos + 1))
+    {
+        occurrences++;
+    }
+    REQUIRE(occurrences == 3);
+}
 
 TEST_CASE("malformed: decode returns nullptr for buffer shorter than header")
 {


### PR DESCRIPTION
## Description

Every undecodable frame from a connected peer (zero/short declared length, unknown message type, decode mismatch) logged one WARN, so a peer streaming garbage produced unbounded log output at line rate - a disk-fill hazard from a single compromised or version-skewed fleet member.

Count consecutive undecodable frames and log only the first and every 100th, mirroring the existing queue-drop throttle; the counter resets on the next successfully decoded message, so an honest peer interleaving unknown message types with valid traffic is unaffected. Expose getNullMsgCount() alongside getDroppedMessages() for tests and monitoring.

Disconnecting a peer after a garbage threshold is a connection-policy change deferred to a minor release (todo/11).

## Summary by Sourcery

Throttle logging of undecodable transport frames and expose their count for monitoring to prevent log flooding from misbehaving peers.

New Features:
- Expose a getNullMsgCount() API on fss_connection to retrieve the count of consecutive undecodable frames.

Bug Fixes:
- Prevent unbounded WARN log spam when a connected peer streams undecodable frames by throttling the associated log messages.

Enhancements:
- Reset the undecodable-frame counter on the next valid message so that intermittent malformed frames do not affect normal peers.

Tests:
- Add an integration-style test that streams many malformed frames to verify log throttling behavior, connection stability, and counter reset after a valid message.