### PR TITLE
fix: failure-path cleanups in the DB and socket layers

### DIFF
--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -1,6 +1,7 @@
 #include "server-db.h"
 
 #include <math.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -19,16 +20,23 @@
 int db_connect(const char *conn_arg, const char *host, int port, const char *user, const char *pass, const char *db)
 {
     /* Set connect_timeout and TCP keepalives via environment variables.
-     * overwrite=0 so this is a no-op on reconnects; the first call happens
-     * before any threads are started so the setenv is safe.
+     * setenv is not thread-safe, and reconnects call db_connect with other
+     * threads live, so guard it to run only on the first call - which
+     * happens in the db_connection constructor before any threads exist.
+     * overwrite=0 preserves operator overrides from the real environment.
      * keepalives_idle=10 / interval=5 / count=3 means the kernel declares
      * the connection dead after 10 + 5*3 = 25 s of silence, replacing the
      * OS default retransmit timeout of ~127 s. */
-    setenv("PGCONNECT_TIMEOUT",  "10", 0);
-    setenv("PGKEEPALIVES",       "1",  0);
-    setenv("PGKEEPALIVESIDLE",   "10", 0);
-    setenv("PGKEEPALIVEINTERVAL","5",  0);
-    setenv("PGKEEPALIVESCOUNT",  "3",  0);
+    static int env_configured = 0;
+    if (!env_configured)
+    {
+        env_configured = 1;
+        setenv("PGCONNECT_TIMEOUT",  "10", 0);
+        setenv("PGKEEPALIVES",       "1",  0);
+        setenv("PGKEEPALIVESIDLE",   "10", 0);
+        setenv("PGKEEPALIVEINTERVAL","5",  0);
+        setenv("PGKEEPALIVESCOUNT",  "3",  0);
+    }
 
     /* ECPG connection target: dbname@host:port */
     char *target = NULL;
@@ -74,6 +82,15 @@ unsigned long long db_get_asset_id(const char *conn_arg, const char *asset_name_
     EXEC SQL END DECLARE SECTION;
 
     EXEC SQL AT :conn SELECT id INTO :asset_id FROM assets_asset WHERE name = :asset_name;
+
+    if (sqlca.sqlcode < 0)
+    {
+        /* A query failure (connection down, etc.) returns 0 just like an
+         * unknown asset, and the caller rejects the client either way.
+         * Print the SQL error so the log tells the truth about why
+         * identification failed. */
+        sqlprint();
+    }
 
     return asset_id;
 }
@@ -225,6 +242,15 @@ db_asset_smm_settings_get(const char *conn_arg, unsigned long long asset_id_arg)
 
     EXEC SQL AT :conn SELECT 1, SMM.address, SMM.port, SMM.https, A.smm_login, A.smm_password INTO :success, :server_address, :server_port, :server_https, :smm_login, :smm_password FROM config_assetconfig AS A, config_smmconfig AS SMM WHERE A.asset_id = :asset_id AND A.smm_id = SMM.id;
 
+
+    if (success == 1 && sqlca.sqlwarn[1] == 'W')
+    {
+        /* A host variable was truncated (address/login/password longer than
+         * its buffer). Truncated credentials must not be shipped to an
+         * aircraft; treat the row as absent and say why. */
+        fprintf(stderr, "smm settings for asset %llu exceed buffer sizes; ignoring row\n", asset_id);
+        success = 0;
+    }
 
     struct smm_settings_s *settings = NULL;
     if (success == 1)

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -136,18 +136,27 @@ auto flight_safety_system::transport_ssl::fss_connection_client::connectTo(const
 
     if (this->getFd() == -1)
     {
-        this->setFd(socket(remote.ss_family == AF_INET ? PF_INET : PF_INET6, SOCK_STREAM, IPPROTO_TCP));
+        int new_fd = socket(remote.ss_family == AF_INET ? PF_INET : PF_INET6, SOCK_STREAM, IPPROTO_TCP);
+        if (new_fd < 0)
+        {
+            FSS_PERROR("ssl", "Failed to create socket");
+            return false;
+        }
+        this->setFd(new_fd);
     }
 
     // Limit the total number of SYN's that are sent
     int synRetries = 2;
-    setsockopt(this->getFd(), IPPROTO_TCP, TCP_SYNCNT, &synRetries, sizeof(synRetries));
+    if (setsockopt(this->getFd(), IPPROTO_TCP, TCP_SYNCNT, &synRetries, sizeof(synRetries)) < 0)
+    {
+        FSS_PERROR("ssl", "setsockopt TCP_SYNCNT failed, using kernel default");
+    }
 
     if (connect(this->getFd(), as_sockaddr(&remote),
                 remote.ss_family == AF_INET ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6)) < 0)
     {
         FSS_PERROR("ssl", "Failed to connect to " + address);
-        close(this->getFd());
+        safe_close_fd(this->getFd(), "ssl/connect");
         this->setFd(-1);
         return false;
     }

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -24,8 +24,6 @@
 
 #include "transport.hpp"
 
-namespace {
-
 auto safe_close_fd(int fd, const char *context) -> int
 {
     for (;;)
@@ -63,8 +61,6 @@ auto safe_shutdown_fd(int fd, const char *context) -> int
         return -1;
     }
 }
-
-} // anonymous namespace
 
 #ifdef DEBUG
 /* Run inet_ntop on a sockaddr_storage object */
@@ -267,7 +263,13 @@ auto flight_safety_system::transport::fss_connection::connectTo(const std::strin
 
     if (this->fd.load() == -1)
     {
-        this->fd.store(socket(remote.ss_family == AF_INET ? PF_INET : PF_INET6, SOCK_STREAM, IPPROTO_TCP));
+        int new_fd = socket(remote.ss_family == AF_INET ? PF_INET : PF_INET6, SOCK_STREAM, IPPROTO_TCP);
+        if (new_fd < 0)
+        {
+            FSS_PERROR("transport", "Failed to create socket");
+            return false;
+        }
+        this->fd.store(new_fd);
     }
 
     int current_fd = this->fd.load();

--- a/src/transport.hpp
+++ b/src/transport.hpp
@@ -5,6 +5,10 @@
 
 auto convert_str_to_sa(const std::string &addr, uint16_t port, struct sockaddr_storage *sa) -> bool;
 void set_tcp_keepalive(int fd);
+/* close()/shutdown() with EINTR retry and failure logging; context names the
+ * call site in the log. shutdown treats ENOTCONN as success. */
+auto safe_close_fd(int fd, const char *context) -> int;
+auto safe_shutdown_fd(int fd, const char *context) -> int;
 
 template<typename T> inline auto as_sockaddr(T *addr) -> struct sockaddr *
 {


### PR DESCRIPTION
## Description

DB layer (server-db.pgc):
- Guard the five setenv calls in db_connect to run only on the first call. setenv is not thread-safe and reconnects invoke db_connect with other threads live; the first call happens in the db_connection constructor before any threads exist. The old comment claimed the first call was the only one, which was untrue since reconnect support landed.
- db_get_asset_id: print the SQL error when the query fails. A failure returns 0 exactly like an unknown asset and the caller rejects the client either way; now the log distinguishes "DB down" from "unknown asset".
- db_asset_smm_settings_get: detect host-variable truncation (sqlca.sqlwarn[1]) and treat the row as absent instead of shipping silently truncated credentials to an aircraft.

Socket paths:
- Both connectTo implementations now check socket() failure instead of proceeding with fd -1 into setsockopt/connect.
- Promote safe_close_fd/safe_shutdown_fd from transport.cpp's anonymous namespace to the internal transport.hpp so the SSL client path uses them instead of a raw close(), and log TCP_SYNCNT setsockopt failure there, matching the plain-TCP path.

## Summary by Sourcery

Harden database and socket failure paths to avoid unsafe behavior and improve diagnostics.

Bug Fixes:
- Guard environment variable initialization in the DB connection setup so it only runs on the first connection and avoids thread-unsafe setenv calls on reconnect.
- Ensure both plain TCP and SSL client connection paths stop immediately when socket() creation fails instead of continuing with an invalid file descriptor.
- Handle host-variable truncation in db_asset_smm_settings_get by treating truncated rows as absent rather than returning partial credentials.

Enhancements:
- Log SQL errors when db_get_asset_id queries fail so operators can distinguish database outages from unknown assets in the logs.
- Promote shared safe_close_fd and safe_shutdown_fd helpers for consistent EINTR-safe socket closure and improved logging across plain TCP and SSL transports.
- Log TCP_SYNCNT setsockopt failures in the SSL client path, aligning diagnostics with the plain TCP implementation.