### PR TITLE
ci: print test logs when the sanitizers job fails

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -271,3 +271,11 @@ jobs:
         ASAN_OPTIONS: detect_leaks=0
         UBSAN_OPTIONS: print_stacktrace=1
       run: make check
+
+    # The automake test driver buries the sanitizer report in log files;
+    # without this step a failure here is undiagnosable from the job log.
+    - name: show test logs on failure
+      if: failure()
+      run: |
+        cat tests/test-suite.log 2>/dev/null || true
+        cat tests/all_test.log 2>/dev/null || true


### PR DESCRIPTION
## Description

The automake test driver redirects the test binary's output (including the ASan/UBSan report) into tests/*.log, so a sanitizers failure showed only "FAIL: all_test" in the job log - the PR #214 failure had to be diagnosed by local reproduction. Dump the logs on failure.

## Summary by Sourcery

CI:
- Add a failure-only CI step to dump automake test-suite and all_test logs in the sanitizers job.