### PR TITLE
refactor(client-ssl): extract resetBackoff (Sourcery, PR #215)

### DIFF
--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -371,6 +371,16 @@ void flight_safety_system::client_ssl::fss_server::setClock(std::shared_ptr<flig
     this->clock = std::move(t_clock);
 }
 
+/* Restore the backoff state to its cold-start values. Only ever called from
+ * the thread driving reconnection (see the ownership note in the header). */
+void flight_safety_system::client_ssl::fss_server::resetBackoff()
+{
+    this->last_tried = 0;
+    this->retry_count = 0;
+    this->retry_delay = retry_delay_start;
+    this->effective_delay = retry_delay_start;
+}
+
 auto flight_safety_system::client_ssl::fss_server::reconnect() -> bool
 {
     /* Consume a reset requested by the recv thread (connection closed):
@@ -379,10 +389,7 @@ auto flight_safety_system::client_ssl::fss_server::reconnect() -> bool
      * atomic flag is the only cross-thread hand-off. */
     if (this->backoff_reset_requested.exchange(false))
     {
-        this->last_tried = 0;
-        this->retry_count = 0;
-        this->retry_delay = retry_delay_start;
-        this->effective_delay = retry_delay_start;
+        this->resetBackoff();
     }
 
     uint64_t ts = this->clock->now_ms();
@@ -418,10 +425,7 @@ auto flight_safety_system::client_ssl::fss_server::reconnect() -> bool
              * exchanged after TLS connect, before identity. */
             this->sendVersion();
             this->sendIdentify();
-            this->retry_count = 0;
-            this->last_tried = 0;
-            this->retry_delay = retry_delay_start;
-            this->effective_delay = retry_delay_start;
+            this->resetBackoff();
             return true;
         }
     }

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -82,6 +82,7 @@ private:
     uint64_t effective_delay{retry_delay_start};
     std::mt19937 rng{std::random_device{}()};
     std::atomic<bool> backoff_reset_requested{false};
+    void resetBackoff();
     std::shared_ptr<flight_safety_system::IClock> clock{std::make_shared<flight_safety_system::MonotonicClock>()};
     std::atomic<bool> liveness_active{false};
     std::atomic<uint64_t> last_message_received_time{0};


### PR DESCRIPTION
## Description

The four-field backoff reset was duplicated between the close-triggered consume block and the success branch of reconnect(). Single helper, identical behaviour.

## Summary by Sourcery

Enhancements:
- Introduce a resetBackoff helper on the SSL client server to restore backoff state to its initial values and reuse it from reconnection paths.