### PR TITLE
ci: glob all test logs in the sanitizers failure step

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -277,5 +277,4 @@ jobs:
     - name: show test logs on failure
       if: failure()
       run: |
-        cat tests/test-suite.log 2>/dev/null || true
-        cat tests/all_test.log 2>/dev/null || true
+        cat tests/*.log 2>/dev/null || true


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Collect all test log files in the sanitizer failure step by globbing tests/*.log instead of listing specific files.