### PR TITLE
fix(server): ignore duplicate protocol version messages

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -394,8 +394,18 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                  * re-negotiate the protocol version mid-session and re-anchor
                  * the sequence check; instead advance the sequence (the
                  * duplicate still consumed a message id on the sender) and
-                 * drop the message. */
-                FSS_LOG_WARN("server", "Ignoring duplicate protocol version message");
+                 * drop the message. This path runs before the rate limiter,
+                 * so throttle the warning (first, then every 100th, with the
+                 * running count) so a peer spamming version messages cannot
+                 * flood the log. */
+                ++this->duplicate_version_count;
+                constexpr uint64_t log_every = 100;
+                if (this->duplicate_version_count == 1 || (this->duplicate_version_count % log_every) == 0)
+                {
+                    FSS_LOG_WARN("server", "Ignoring duplicate protocol version message from "
+                                               << this->getName() << " (seq=" << msg->getSeq()
+                                               << ", count=" << this->duplicate_version_count << ")");
+                }
                 uint64_t wanted = this->expected_seq.load();
                 if (wanted != 0 && msg->getSeq() == wanted)
                 {

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -388,6 +388,21 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
         auto version_msg = std::dynamic_pointer_cast<fss::transport::fss_message_version>(msg);
         if (version_msg != nullptr)
         {
+            if (this->version_received)
+            {
+                /* Duplicate handshake from a buggy peer. Honouring it would
+                 * re-negotiate the protocol version mid-session and re-anchor
+                 * the sequence check; instead advance the sequence (the
+                 * duplicate still consumed a message id on the sender) and
+                 * drop the message. */
+                FSS_LOG_WARN("server", "Ignoring duplicate protocol version message");
+                uint64_t wanted = this->expected_seq.load();
+                if (wanted != 0 && msg->getSeq() == wanted)
+                {
+                    this->expected_seq.fetch_add(1);
+                }
+                return;
+            }
             uint16_t peer_version = version_msg->getProtocolVersion();
             uint16_t peer_min = version_msg->getMinSupportedVersion();
             if (peer_version < fss::transport::FSS_PROTOCOL_MIN_VERSION ||

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -182,6 +182,10 @@ private:
     rate_limiter msg_rate{100, 20};
     uint64_t rate_limit_rejects{0};
     uint64_t last_rate_limit_log_ms{0};
+    /* Cumulative duplicate protocol-version messages seen this session
+     * (never reset); touched only on the recv thread (processMessage), used
+     * to throttle the warning. */
+    uint64_t duplicate_version_count{0};
 public:
     fss_client(std::shared_ptr<transport::fss_connection> conn, IDatabase *t_dbc,
                std::shared_ptr<db_write_queue> t_writer, fss_client_handler *t_handler);

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -703,6 +703,45 @@ TEST_CASE("session: duplicate version message is ignored without derailing the s
     REQUIRE(handler.disconnects == 0);
 }
 
+TEST_CASE("session: duplicate version warnings are throttled")
+{
+    /* The duplicate-version branch runs before the rate limiter, so a peer
+     * spamming version messages must not flood the log: warn on the first
+     * and every 100th only. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+
+    uint64_t next_id = 1;
+    establish_v2_session(session, next_id);
+
+    fss_test::capture_cerr capture;
+    fss_test::scoped_log_level level("warn");
+    constexpr int duplicates = 250; /* warns at 1, 100, 200 → 3 lines */
+    for (int i = 0; i < duplicates; i++)
+    {
+        auto dup = std::make_shared<fss::transport::fss_message_version>(1U, 1U, 0U);
+        dup->setId(next_id++);
+        session->processMessage(dup);
+    }
+    REQUIRE(handler.disconnects == 0);
+
+    const std::string logged = capture.str();
+    std::size_t occurrences = 0;
+    for (std::size_t pos = logged.find("duplicate protocol version"); pos != std::string::npos;
+         pos = logged.find("duplicate protocol version", pos + 1))
+    {
+        occurrences++;
+    }
+    REQUIRE(occurrences == 3);
+}
+
 TEST_CASE("session: v2 replayed identity disconnects")
 {
     /* m7.1 phase 2: a replayed (or out-of-order) identity message must

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -653,6 +653,56 @@ TEST_CASE("session: v2 replayed data message is dropped")
     REQUIRE(handler.disconnects == 0);       // connection stays up
 }
 
+TEST_CASE("session: duplicate version message is ignored without derailing the session")
+{
+    /* A buggy peer re-sending the version handshake mid-session must not
+     * re-negotiate the protocol version (downgrade) nor re-anchor the
+     * sequence check (which, for an out-of-order duplicate, would silently
+     * drop all subsequent telemetry while the session looks alive). */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+
+    uint64_t next_id = 1;
+    establish_v2_session(session, next_id);
+
+    auto pos = make_position_msg(fss::fss_current_timestamp());
+    pos->setId(next_id++);
+    session->processMessage(pos);
+    REQUIRE(handler.broadcasts.size() == 1);
+
+    /* In-sequence duplicate offering a lower version: must not downgrade. */
+    auto dup = std::make_shared<fss::transport::fss_message_version>(1U, 1U, 0U);
+    dup->setId(next_id++);
+    session->processMessage(dup);
+    REQUIRE(conn->getNegotiatedVersion() == fss::transport::FSS_PROTOCOL_VERSION);
+    REQUIRE(handler.disconnects == 0);
+
+    /* The duplicate consumed a sequence id; the stream must continue. */
+    auto pos2 = make_position_msg(fss::fss_current_timestamp());
+    pos2->setId(next_id++);
+    session->processMessage(pos2);
+    REQUIRE(handler.broadcasts.size() == 2);
+
+    /* Out-of-sequence duplicate: ignored entirely, must not re-anchor the
+     * sequence check to its id. */
+    auto stray = std::make_shared<fss::transport::fss_message_version>(1U, 1U, 0U);
+    stray->setId(99);
+    session->processMessage(stray);
+
+    auto pos3 = make_position_msg(fss::fss_current_timestamp());
+    pos3->setId(next_id++);
+    session->processMessage(pos3);
+    REQUIRE(handler.broadcasts.size() == 3);
+    REQUIRE(handler.disconnects == 0);
+}
+
 TEST_CASE("session: v2 replayed identity disconnects")
 {
     /* m7.1 phase 2: a replayed (or out-of-order) identity message must


### PR DESCRIPTION
## Description

A peer re-sending the version handshake after negotiation could downgrade the protocol version mid-session, and an out-of-order duplicate re-anchored the sequence check to its id - silently dropping all subsequent telemetry while the session looked alive.

Drop duplicates with a WARN instead: advance the sequence only when the duplicate is exactly in-sequence (it consumed a sender id), never re-negotiate, never re-anchor. A client that committed to the legacy path is likewise refused a mid-stream handshake.

The test pins both failure modes: no downgrade on an in-sequence duplicate (stream continues) and no re-anchor on an out-of-sequence one (verified to fail against the previous code).

## Summary by Sourcery

Handle duplicate protocol version handshakes without renegotiating or disrupting active server sessions.

Bug Fixes:
- Prevent mid-session protocol version downgrades caused by peers re-sending version handshake messages.
- Ensure out-of-order duplicate version messages do not re-anchor the sequence check and drop subsequent telemetry while the session appears alive.

Tests:
- Add server session test coverage to verify duplicate version messages are ignored, avoid downgrades, and do not derail the sequence numbering.