### PR TITLE
fix(transport): harden message decode and capability edge cases

### DIFF
--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -464,6 +464,10 @@ flight_safety_system::transport::fss_message_identity::fss_message_identity(std:
 
 void flight_safety_system::transport::fss_message_identity::packData(std::shared_ptr<buf_len> bl)
 {
+    /* Deliberately NOT packString format: the name is raw bytes with no
+     * length prefix, and the decoder derives its length from the message
+     * header (see unpackData). Converting this to packString would break
+     * wire compatibility with every deployed peer. */
     bl->addData(this->name.c_str(), this->name.length());
 }
 
@@ -638,8 +642,19 @@ void flight_safety_system::transport::fss_message_position_report::unpackData(co
     reader.readUint8(this->altitude_type);
     reader.readUint8(this->emitter_type);
     reader.readUint8(this->tslc);
-    this->latitude = static_cast<double>(lat) * FSS_COORD_SCALE;
-    this->longitude = static_cast<double>(lng) * FSS_COORD_SCALE;
+    /* A truncated frame must not yield (0,0) — Null Island is a legal
+     * coordinate that passes validation. NaN is the honest "unknown" and
+     * is rejected by the coordinate checks downstream. */
+    if (reader.ok())
+    {
+        this->latitude = static_cast<double>(lat) * FSS_COORD_SCALE;
+        this->longitude = static_cast<double>(lng) * FSS_COORD_SCALE;
+    }
+    else
+    {
+        this->latitude = NAN;
+        this->longitude = NAN;
+    }
 }
 
 auto flight_safety_system::transport::fss_message_position_report::getLatitude() -> double
@@ -874,8 +889,18 @@ void flight_safety_system::transport::fss_message_asset_command::unpackData(cons
     {
         this->command = decode_asset_command(cmd);
     }
-    this->latitude = lat * FSS_COORD_SCALE;
-    this->longitude = lng * FSS_COORD_SCALE;
+    /* Same rationale as fss_message_position_report::unpackData: a truncated
+     * frame decodes to NaN, never to Null Island. */
+    if (reader.ok())
+    {
+        this->latitude = lat * FSS_COORD_SCALE;
+        this->longitude = lng * FSS_COORD_SCALE;
+    }
+    else
+    {
+        this->latitude = NAN;
+        this->longitude = NAN;
+    }
 }
 
 auto flight_safety_system::transport::fss_message_asset_command::getCommand() -> fss_asset_command
@@ -1026,11 +1051,21 @@ flight_safety_system::transport::fss_message_identity_non_aircraft::fss_message_
 
 void flight_safety_system::transport::fss_message_identity_non_aircraft::addCapability(uint8_t cap_id)
 {
+    /* Shifting by >= the type width is undefined behaviour; the bitmap holds
+     * capability ids 0..63 only. */
+    if (cap_id >= std::numeric_limits<uint64_t>::digits)
+    {
+        return;
+    }
     this->capabilities |= (static_cast<uint64_t>(1) << cap_id);
 }
 
 auto flight_safety_system::transport::fss_message_identity_non_aircraft::getCapability(uint8_t cap_id) -> bool
 {
+    if (cap_id >= std::numeric_limits<uint64_t>::digits)
+    {
+        return false;
+    }
     return !!(this->capabilities & (static_cast<uint64_t>(1) << cap_id));
 }
 

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -219,6 +219,25 @@ public:
     }
 };
 
+/* Apply decoded fixed-point lat/lng to a message, but only if the buffer was
+ * fully read: a truncated frame must decode to NaN, never to (0,0) — Null
+ * Island is a legal coordinate that passes validation. Shared by the
+ * position-report and asset-command decoders so the policy stays in one place. */
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+void assign_coordinates(const BufferReader &reader, int32_t lat, int32_t lng, double &out_lat, double &out_lng)
+{
+    if (reader.ok())
+    {
+        out_lat = static_cast<double>(lat) * FSS_COORD_SCALE;
+        out_lng = static_cast<double>(lng) * FSS_COORD_SCALE;
+    }
+    else
+    {
+        out_lat = NAN;
+        out_lng = NAN;
+    }
+}
+
 } // namespace
 
 flight_safety_system::transport::buf_len::buf_len(const buf_len &bl) = default;
@@ -642,19 +661,7 @@ void flight_safety_system::transport::fss_message_position_report::unpackData(co
     reader.readUint8(this->altitude_type);
     reader.readUint8(this->emitter_type);
     reader.readUint8(this->tslc);
-    /* A truncated frame must not yield (0,0) — Null Island is a legal
-     * coordinate that passes validation. NaN is the honest "unknown" and
-     * is rejected by the coordinate checks downstream. */
-    if (reader.ok())
-    {
-        this->latitude = static_cast<double>(lat) * FSS_COORD_SCALE;
-        this->longitude = static_cast<double>(lng) * FSS_COORD_SCALE;
-    }
-    else
-    {
-        this->latitude = NAN;
-        this->longitude = NAN;
-    }
+    assign_coordinates(reader, lat, lng, this->latitude, this->longitude);
 }
 
 auto flight_safety_system::transport::fss_message_position_report::getLatitude() -> double
@@ -889,18 +896,7 @@ void flight_safety_system::transport::fss_message_asset_command::unpackData(cons
     {
         this->command = decode_asset_command(cmd);
     }
-    /* Same rationale as fss_message_position_report::unpackData: a truncated
-     * frame decodes to NaN, never to Null Island. */
-    if (reader.ok())
-    {
-        this->latitude = lat * FSS_COORD_SCALE;
-        this->longitude = lng * FSS_COORD_SCALE;
-    }
-    else
-    {
-        this->latitude = NAN;
-        this->longitude = NAN;
-    }
+    assign_coordinates(reader, lat, lng, this->latitude, this->longitude);
 }
 
 auto flight_safety_system::transport::fss_message_asset_command::getCommand() -> fss_asset_command
@@ -1052,9 +1048,11 @@ flight_safety_system::transport::fss_message_identity_non_aircraft::fss_message_
 void flight_safety_system::transport::fss_message_identity_non_aircraft::addCapability(uint8_t cap_id)
 {
     /* Shifting by >= the type width is undefined behaviour; the bitmap holds
-     * capability ids 0..63 only. */
+     * capability ids 0..63 only. An out-of-range id is a caller error, so
+     * surface it (at debug, to avoid log noise) rather than silently no-op. */
     if (cap_id >= std::numeric_limits<uint64_t>::digits)
     {
+        FSS_LOG_DEBUG("transport", "Ignoring out-of-range capability id " << static_cast<unsigned>(cap_id));
         return;
     }
     this->capabilities |= (static_cast<uint64_t>(1) << cap_id);
@@ -1064,6 +1062,7 @@ auto flight_safety_system::transport::fss_message_identity_non_aircraft::getCapa
 {
     if (cap_id >= std::numeric_limits<uint64_t>::digits)
     {
+        FSS_LOG_DEBUG("transport", "Querying out-of-range capability id " << static_cast<unsigned>(cap_id));
         return false;
     }
     return !!(this->capabilities & (static_cast<uint64_t>(1) << cap_id));

--- a/tests/messages.cpp
+++ b/tests/messages.cpp
@@ -758,6 +758,11 @@ TEST_CASE("messages: BufferReader readInt32 short-read returns false")
                                            std::string(payload, '\0'), total);
     auto decoded = flight_safety_system::transport::fss_message::decode(bl);
     REQUIRE(decoded != nullptr);
+    /* The latitude/longitude reads failed, so the coordinates must decode to
+     * NaN, never to (0,0) — Null Island is a legal coordinate that would pass
+     * validation. */
+    REQUIRE(std::isnan(decoded->getLatitude()));
+    REQUIRE(std::isnan(decoded->getLongitude()));
 }
 
 /* readInt16 failure (line 99): position_report truncated just before the
@@ -774,6 +779,27 @@ TEST_CASE("messages: BufferReader readInt16 short-read returns false")
                                            std::string(payload, '\0'), total);
     auto decoded = flight_safety_system::transport::fss_message::decode(bl);
     REQUIRE(decoded != nullptr);
+    /* Truncation in a trailing field still NaNs the coordinates, even though
+     * latitude/longitude themselves were read — the buffer is incomplete. */
+    REQUIRE(std::isnan(decoded->getLatitude()));
+    REQUIRE(std::isnan(decoded->getLongitude()));
+}
+
+/* asset_command truncated before the trailing command byte: the coordinates
+ * must likewise decode to NaN rather than (0,0). */
+TEST_CASE("messages: truncated asset_command decodes coordinates as NaN")
+{
+    using flight_safety_system::transport::message_type_command;
+    /* timestamp(uint64) + latitude(int32) + longitude(int32); altitude and
+     * the command byte are absent, so reader.ok() is false at the end. */
+    constexpr size_t payload = sizeof(uint64_t) + sizeof(int32_t) * 2;
+    constexpr size_t total = framed_header_len + payload;
+    auto bl =
+        fss_test::make_framed_buffer(static_cast<uint16_t>(message_type_command), 1, std::string(payload, '\0'), total);
+    auto decoded = flight_safety_system::transport::fss_message::decode(bl);
+    REQUIRE(decoded != nullptr);
+    REQUIRE(std::isnan(decoded->getLatitude()));
+    REQUIRE(std::isnan(decoded->getLongitude()));
 }
 
 /* readUint32 failure (line 129): version message truncated after the two


### PR DESCRIPTION
## Description

- addCapability/getCapability: shifting by >= 64 bits is undefined behaviour; ids outside the 0..63 bitmap are now dropped/false.
- Truncated position_report and asset_command frames decode their coordinates to NaN instead of (0,0) - Null Island is a legal coordinate that passes validation, NaN is the honest unknown and is rejected downstream. Only reachable via direct decode() of a crafted buffer; the recv path already enforces the declared length.
- Document that fss_message_identity::packData deliberately does not use the packString wire format, so nobody 'fixes' it into a wire-compatibility break.

## Summary by Sourcery

Harden transport message decoding and capability handling to avoid undefined behavior and ensure truncated frames are treated as invalid coordinates.

Bug Fixes:
- Prevent capability bit shifts with IDs outside the 0–63 range to avoid undefined behavior and treat them as absent.
- Decode truncated position_report frames to NaN coordinates instead of (0,0) so downstream validation correctly rejects them.
- Decode truncated asset_command frames to NaN coordinates instead of (0,0) to avoid treating unknown positions as valid.

Documentation:
- Clarify that fss_message_identity::packData intentionally does not use the packString wire format to preserve wire compatibility.