### PR TITLE
fix(server): never append a NULL entry to the active-server list

### DIFF
--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -318,21 +318,24 @@ db_active_fss_servers_get(const char *conn_arg)
                 s->port = server_port;
             }
         }
-        struct fss_server_s **old = res;
-        res = (struct fss_server_s **)realloc(res, sizeof(struct fss_server_s *) * (len + 2));
-        if (res)
+        /* Only append a real entry: writing a NULL s into the middle of the
+         * array would act as a premature terminator for the caller, silently
+         * truncating the list and leaking everything appended after it. */
+        if (s != NULL)
         {
-            res[len] = s;
-            len++;
-            res[len] = NULL;
-        } else {
-            res = old;
-            if (s != NULL)
+            struct fss_server_s **old = res;
+            res = (struct fss_server_s **)realloc(res, sizeof(struct fss_server_s *) * (len + 2));
+            if (res)
             {
+                res[len] = s;
+                len++;
+                res[len] = NULL;
+            } else {
+                res = old;
                 free (s->address);
                 free (s);
+                s = NULL;
             }
-            s = NULL;
         }
     }
     EXEC SQL WHENEVER NOT FOUND CONTINUE;


### PR DESCRIPTION
## Description

In db_active_fss_servers_get a malloc/strdup failure mid-cursor still wrote the NULL entry into the result array, where it acted as a premature terminator: the caller stopped iterating there, silently truncating the active-server list and leaking every entry appended after it. Skip the append instead; the array stays NULL-terminated.

## Summary by Sourcery

Bug Fixes:
- Ensure the active-server list remains correctly populated and NULL-terminated by skipping appends when allocation fails in db_active_fss_servers_get.