### PR TITLE
fix(transport-ssl): verify client certificates chain to the trusted CA

### DIFF
--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -328,6 +328,17 @@ auto flight_safety_system::transport_ssl::fss_connection_server::setupSSL() -> b
 
     serverSession->set_certificate_request(GNUTLS_CERT_REQUIRE);
 
+    /* GNUTLS_CERT_REQUIRE only forces the client to PRESENT a certificate;
+     * on its own it does not check that the certificate chains to our
+     * trusted CA. Without this, a self-signed cert carrying a known asset
+     * CN would pass the handshake and then satisfy the CN-based identity
+     * check — an authentication bypass. Enable inline verification so the
+     * handshake itself fails for any client cert that does not validate
+     * against the trust file (the client side already does the equivalent
+     * via set_verify_cert). NULL hostname: a client certificate's identity
+     * is its CN, matched at the application layer, not a hostname. */
+    gnutls_session_set_verify_cert(this->session->ptr(), nullptr, 0);
+
     int ret = -1;
     try
     {

--- a/tests/ssl_failure_test.cpp
+++ b/tests/ssl_failure_test.cpp
@@ -146,6 +146,38 @@ TEST_CASE("ssl: server surfaces wrong-CN-but-CA-signed cert via getClientNames",
     accepted = nullptr;
 }
 
+TEST_CASE("ssl: server rejects a client cert signed by an untrusted CA", "[ssl_foreign_client_cert]")
+{
+    /* Authentication bypass regression: GNUTLS_CERT_REQUIRE forces the
+     * client to present a cert but does not by itself verify it chains to
+     * the trusted CA. The server must reject a cert signed by a foreign CA
+     * during the handshake, so it never reaches the CN-based identity check
+     * — otherwise a self-signed cert carrying a known asset CN would
+     * authenticate. The client trusts the main CA (so it accepts the
+     * server); it presents an alt-CA client cert the server does not trust.
+     * A correctly verifying server must surface NO client name. */
+    accepted = nullptr;
+    const uint16_t port = fss_test::pick_port();
+    REQUIRE(port != 0);
+    auto listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(
+        port, accept_cb, CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
+    REQUIRE(listen != nullptr);
+
+    auto client = std::make_shared<flight_safety_system::transport_ssl::fss_connection_client>(
+        CA_PUBLIC_FILE, ALT_CLIENT_PRIVATE_FILE, ALT_CLIENT_PUBLIC_FILE);
+    /* The client's own verification of the (trusted) server may briefly
+     * succeed before the server aborts; we don't assert on connectTo's
+     * result, only that the server never accepts the foreign identity. */
+    client->connectTo("localhost", port);
+
+    /* The SSL listener runs the handshake synchronously before invoking the
+     * accept callback, so once accepted is set the server has finished (and
+     * rejected) verification; a correctly verifying server surfaces no CN. */
+    REQUIRE(fss_test::wait_for([]() { return accepted != nullptr; }));
+    REQUIRE(accepted->getClientNames().empty());
+    accepted = nullptr;
+}
+
 TEST_CASE("ssl: misconfigured cert paths fail without throwing")
 {
     /* Regression: set_x509_trust_file / set_x509_key_file throw


### PR DESCRIPTION
## Description

GNUTLS_CERT_REQUIRE forces a client to present a certificate but does not, on its own, verify that the certificate chains to the configured CA. The server never ran that verification, so a self-signed certificate carrying a known asset CN passed the handshake and then satisfied the CN-based identity check - authenticating as that aircraft. Confirmed empirically: a client cert signed by a foreign CA connected and the server extracted its CN.

Enable inline verification with gnutls_session_set_verify_cert before the server handshake (NULL hostname: a client certificate's identity is its CN, matched at the application layer, not a hostname). The handshake now fails for any client cert that does not validate against the trust file - which also covers expiry and the configured CRL. The client side already verified the server; this restores the symmetry.

Regression test: a client cert signed by an untrusted CA yields no server-side client name (it did pre-fix).

## Summary by Sourcery

Enforce verification of client TLS certificates against the configured CA on the server side and add a regression test to ensure untrusted CA-signed client certificates are rejected and yield no client identity.

Bug Fixes:
- Prevent authentication bypass by rejecting client certificates that do not chain to the trusted CA during the TLS handshake.

Tests:
- Add regression test ensuring client certificates signed by an untrusted CA are rejected and no client common name is surfaced.