### PR TITLE
fix(transport): prevent out-of-bounds read on overshooting string padding

### DIFF
--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -119,11 +119,19 @@ static auto unpackString(const char *data, size_t length, size_t &offset, String
     }
     result.assign(data + offset, len);
     offset += len;
-    /* Align to 8-byte boundary */
+    /* Align to 8-byte boundary. This can push offset past length when the
+     * string ends near the buffer end; that is fine for the string itself
+     * (already fully read), and every subsequent reader guards against
+     * offset > length, but clamp so the overshoot can never be mistaken for
+     * available bytes. */
     size_t unpack_remainder = offset % sizeof(uint64_t);
     if (unpack_remainder != 0)
     {
         offset += sizeof(uint64_t) - unpack_remainder;
+    }
+    if (offset > length)
+    {
+        offset = length;
     }
     return true;
 }
@@ -137,7 +145,10 @@ class BufferReader {
     bool m_ok;
     auto ensureAvailable(size_t n) -> bool
     {
-        if (!m_ok || m_length - m_offset < n)
+        /* m_offset > m_length is possible after unpackString aligns the
+         * offset up past the end of the buffer; guard before subtracting so
+         * the size_t arithmetic cannot wrap and admit an out-of-bounds read. */
+        if (!m_ok || m_offset > m_length || m_length - m_offset < n)
         {
             m_ok = false;
             return false;

--- a/tests/malformed_message_test.cpp
+++ b/tests/malformed_message_test.cpp
@@ -278,6 +278,44 @@ TEST_CASE("decode type consistency: identity_non_aircraft")
     REQUIRE(std::dynamic_pointer_cast<fss_message_identity_non_aircraft>(decoded) != nullptr);
 }
 
+TEST_CASE("malformed: string alignment overshoot does not read past the buffer")
+{
+    /* Regression for a heap over-read: unpackString rounds the offset up to
+     * an 8-byte boundary, which can push it past the declared buffer length;
+     * BufferReader::ensureAvailable then subtracted (length - offset) as
+     * size_t and wrapped, admitting an out-of-bounds read on the following
+     * field. Craft a server_list whose single address ends so the alignment
+     * overshoots, then the loop attempts to read the next port (the
+     * underflow site). Pre-fix this aborts under ASan; post-fix the loop
+     * ends cleanly with exactly the one decoded server.
+     *
+     * Layout after the 12-byte header: port(2) + len(2) + 6 addr bytes = 22
+     * total. offset reaches 22, aligns up to 24 (> 22). */
+    std::string payload;
+    const uint16_t port_n = htons(1);
+    const uint16_t len_n = htons(6);
+    payload.append(reinterpret_cast<const char *>(&port_n), sizeof(port_n));
+    payload.append(reinterpret_cast<const char *>(&len_n), sizeof(len_n));
+    payload.append("abcdef", 6);
+    REQUIRE(payload.size() == 10);
+
+    auto framed = fss_test::make_framed_buffer(static_cast<uint16_t>(message_type_server_list), 1, payload,
+                                               static_cast<uint16_t>(12 + payload.size()));
+    /* Re-wrap at EXACT size, as recvMsg does: make_framed_buffer grows its
+     * string via append() and leaves spare capacity that would absorb the
+     * over-read, whereas the real receive path builds the buffer from the
+     * wire at precisely its length. */
+    auto bl = std::make_shared<buf_len>(framed->getData(), static_cast<uint16_t>(framed->getLength()));
+    auto decoded = fss_message::decode(bl);
+    REQUIRE(decoded != nullptr);
+    auto sl = std::dynamic_pointer_cast<fss_message_server_list>(decoded);
+    REQUIRE(sl != nullptr);
+    auto servers = sl->getServers();
+    REQUIRE(servers.size() == 1);
+    REQUIRE(servers[0].first == "abcdef");
+    REQUIRE(servers[0].second == 1);
+}
+
 TEST_CASE("decode type consistency: position_report")
 {
     auto orig =


### PR DESCRIPTION
## Description

unpackString rounds the buffer offset up to an 8-byte boundary, which can push it past the declared message length when a length-prefixed string ends near the buffer end. BufferReader::ensureAvailable then computed (m_length - m_offset) as size_t, wrapping on underflow so the bounds check passed, and the next field read ran past the buffer. The real receive path builds the buffer at exactly the declared length, so this is a wire-reachable heap over-read (confirmed: ASan heap-buffer-overflow in readUint16 on a crafted server_list).

Guard m_offset > m_length before the subtraction, and clamp the offset to the length after alignment so the overshoot can never be mistaken for available bytes. Full-length round-trips are unaffected: when a string is followed by more fields the padding is physically present, so the clamp is a no-op.

## Summary by Sourcery

Prevent out-of-bounds reads when unpacking aligned strings in transport message decoding and add a regression test for the malformed message case.

Bug Fixes:
- Guard buffer length checks in the transport BufferReader to avoid size_t underflow and out-of-bounds reads after string alignment padding.
- Clamp the string unpacking offset to the buffer length after 8-byte alignment so overshoot is not treated as available data.

Tests:
- Add a malformed server_list message test to verify aligned string unpacking does not read past the buffer and decodes a single server correctly.