### PR TITLE
release: prepare 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.3] - 2026-06-13
 
 ### Security
 - The server now verifies that a client certificate chains to the configured
@@ -49,6 +49,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The per-frame "Got a null msg" warning is throttled (first frame and
   every 100th), so a peer streaming undecodable frames cannot flood the
   log at line rate.
+- A peer re-sending the wire-protocol version handshake after negotiation
+  could downgrade the protocol version mid-session, and an out-of-sequence
+  duplicate re-anchored the sequence check to its id — silently dropping all
+  subsequent telemetry while the session still looked alive. Duplicates are
+  now dropped with a throttled warning: the sequence advances only for an
+  exactly in-sequence duplicate, the version is never re-negotiated, and the
+  check is never re-anchored.
+- `db_active_fss_servers_get` no longer appends a NULL entry to the
+  active-server list when an allocation fails mid-cursor; the NULL acted as a
+  premature terminator that truncated the list and leaked every entry after
+  it. The append is skipped instead, keeping the array NULL-terminated.
+- A malformed or wrong-typed configuration value (e.g. a string where a
+  number is expected) no longer aborts the server through an uncaught
+  `jsoncpp` exception or throws out of the client library constructor. The
+  server now reads every value inside one guarded block and reports the
+  offending file; the client contains the exception and behaves as it does
+  for a missing config file.
+- Hardened message decoding: capability ids outside the 0..63 bitmap no
+  longer trigger shift undefined behaviour (they are dropped / read as
+  false), and truncated `position_report`/`asset_command` frames decode their
+  coordinates to NaN — rejected downstream as the honest "unknown" — instead
+  of (0,0), which is Null Island, a legal coordinate that passes validation.
+  Only reachable via a crafted direct `decode()`; the recv path already
+  enforces the declared frame length.
 - Failure-path cleanups: `setenv` in `db_connect` runs only before
   threads exist, DB read errors during identification are logged
   distinctly from "unknown asset", truncated SMM credentials are

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([flight-safety-system], [1.0.2], [sjp@canterburyairpatrol.org])
+AC_INIT([flight-safety-system], [1.0.3], [sjp@canterburyairpatrol.org])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign -Wno-portability])
 
 m4_include([m4/ax_cxx_compile_stdcxx.m4])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,28 @@
+flight-safety-system (1.0.3) stable; urgency=medium
+
+  * Verify client certificates chain to the configured CA during the TLS
+    handshake (closes a self-signed-certificate authentication bypass).
+  * Fix an out-of-bounds read decoding a string field whose alignment padding
+    overshoots the declared buffer length.
+  * Bound unacked sends with TCP_USER_TIMEOUT and stop holding the global
+    client lock across blocking sends, so a black-holed client can no longer
+    stall command dispatch.
+  * Keep all synchronous DB reads off the main loop; fix the ~server_clients
+    shutdown deadlock.
+  * Refuse commands built from NULL position/altitude rows instead of
+    dispatching Null Island / descend-to-ground.
+  * Make transport_ssl's usable flag atomic and the client reconnect backoff
+    thread-safe; retry EINTR on recv instead of dropping the peer.
+  * Contain gnutls and jsoncpp exceptions from bad config/credentials; never
+    append a NULL entry to the active-server list.
+  * Ignore duplicate protocol-version messages (no mid-session downgrade or
+    sequence re-anchor); throttle the undecodable-frame and duplicate-version
+    warnings.
+  * Harden message decode: guard capability-id shift UB; decode truncated
+    coordinate frames to NaN rather than (0,0).
+
+ -- Scott Parlane <sjp@canterburyairpatrol.org>  Sat, 13 Jun 2026 00:00:00 +0000
+
 flight-safety-system (1.0.2) stable; urgency=medium
 
   * Fix data race on fss_message_cb::conn between reconnect and send paths.


### PR DESCRIPTION
## Description

Bump AC_INIT to 1.0.3, promote the CHANGELOG [Unreleased] section to [1.0.3] - 2026-06-13, and add the matching debian/changelog stanza.

The CHANGELOG section was missing four fixes that landed after it was last written; add them under Fixed:
- duplicate/out-of-sequence protocol-version handling (no mid-session downgrade or sequence re-anchor)
- NULL entry no longer appended to the active-server list
- jsoncpp config-parse exception containment
- message-decode hardening (capability-id shift UB, NaN-on-truncation)

Library -version-info intentionally left at 1:0:0, consistent with the 1.0.1/1.0.2 patch releases.

## Summary by Sourcery

Prepare the 1.0.3 patch release by finalizing release notes and aligning project and packaging metadata with the new version.

Bug Fixes:
- Document additional fixes around protocol version handshake handling, active-server list construction, configuration parsing robustness, and message decoding hardening in the changelog.

Build:
- Bump the project version to 1.0.3 in the Autotools configuration and add the corresponding Debian changelog entry for the new release.

Documentation:
- Promote the unreleased changelog section to 1.0.3 with date and include the missing fixed items for this patch release.