### PR TITLE
fix(transport): run the TLS handshake off the accept thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+- The TLS handshake no longer runs inline on the accept thread. A peer that
+  completed the TCP connection but then stalled the handshake (sending no or
+  partial ClientHello) previously blocked the accept thread inside a blocking
+  handshake `recv` with no timeout, halting *all* new connections to the
+  server — a trivial unauthenticated denial of service. Connection setup now
+  runs on a bounded pool of worker threads, each handshake is bounded by
+  `gnutls_handshake_set_timeout` (configurable via `tls_handshake_timeout_ms`,
+  default 10 s), and concurrent in-progress handshakes are capped
+  (`max_concurrent_handshakes`, default 64) so the worker path cannot itself
+  be used to exhaust threads/memory. The client side also bounds its handshake
+  so a stalled server cannot hang `connectTo()`.
+
 ## [1.0.3] - 2026-06-13
 
 ### Security

--- a/src/fss-transport-ssl.hpp
+++ b/src/fss-transport-ssl.hpp
@@ -11,6 +11,12 @@ class session;
 
 namespace flight_safety_system {
 namespace transport_ssl {
+
+/* Default bound on a single TLS handshake. Passed to
+ * gnutls_handshake_set_timeout() so a peer that stalls mid-handshake is
+ * dropped rather than holding a setup worker indefinitely. */
+constexpr unsigned int default_handshake_timeout_ms = 10000;
+
 /* Exception contract: no gnutls::exception escapes this library's public
  * entry points. Misconfiguration (missing/unreadable CA, key, cert, or CRL
  * files) and TLS setup failures surface as fss_connection_client::create()
@@ -80,8 +86,9 @@ public:
 class fss_connection_server : public fss_connection {
 private:
     std::list<std::string> possible_names{};
+    unsigned int handshake_timeout_ms{default_handshake_timeout_ms};
     fss_connection_server(int t_fd, std::string t_ca, std::string t_private_key, std::string t_public_key,
-                          std::string t_crl = {});
+                          std::string t_crl, unsigned int t_handshake_timeout_ms);
 protected:
     auto setupSSL() -> bool;
 public:
@@ -90,8 +97,11 @@ public:
     auto operator=(fss_connection_server&) -> fss_connection_server& = delete;
     auto operator=(fss_connection_server&&) -> fss_connection_server& = delete;
     ~fss_connection_server() override;
+    /* Returns nullptr if the handshake fails or times out (the connection
+     * destructor closes the fd) so the caller never wires up a dead peer. */
     static auto create(int t_fd, std::string t_ca, std::string t_private_key, std::string t_public_key,
-                       std::string t_crl) -> std::shared_ptr<fss_connection_server>;
+                       std::string t_crl, unsigned int t_handshake_timeout_ms = default_handshake_timeout_ms)
+        -> std::shared_ptr<fss_connection_server>;
     auto getClientNames() -> std::list<std::string> override;
     auto isPeerCertRevoked(const std::string& t_crl_file) const -> bool override;
 };
@@ -102,11 +112,14 @@ private:
     std::string private_key_file;
     std::string public_key_file;
     std::string crl_file;
+    unsigned int handshake_timeout_ms;
 protected:
     auto newConnection(int fd) -> std::shared_ptr<flight_safety_system::transport::fss_connection> override;
 public:
     fss_listen(uint16_t t_port, flight_safety_system::transport::fss_connect_cb t_cb, std::string t_ca,
-               std::string t_private_key, std::string t_public_key, std::string t_crl = {});
+               std::string t_private_key, std::string t_public_key, std::string t_crl = {},
+               unsigned int t_handshake_timeout_ms = default_handshake_timeout_ms,
+               size_t t_max_concurrent_handshakes = 0);
     /* Copy/move are already deleted via the base class. */
     /* Joins the accept thread before this class's members are destroyed:
      * that thread reads the cert/key path strings above in newConnection(),

--- a/src/fss-transport-ssl.hpp
+++ b/src/fss-transport-ssl.hpp
@@ -68,10 +68,12 @@ public:
 class fss_connection_client : public fss_connection {
 private:
     std::string hostname{};
+    unsigned int handshake_timeout_ms{default_handshake_timeout_ms};
 protected:
     auto setupSSL() -> bool;
 public:
-    fss_connection_client(std::string t_ca, std::string t_private_key, std::string t_public_key);
+    fss_connection_client(std::string t_ca, std::string t_private_key, std::string t_public_key,
+                          unsigned int t_handshake_timeout_ms = default_handshake_timeout_ms);
     fss_connection_client(fss_connection_client&) = delete;
     fss_connection_client(fss_connection_client&&) = delete;
     auto operator=(fss_connection_client&) -> fss_connection& = delete;

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -215,6 +215,14 @@ private:
     bool accepting_setups{true};
     size_t max_concurrent_setups{default_max_concurrent_setups};
     std::atomic<uint64_t> rejected_setups{0};
+    /* Spawns the detached worker that runs newConnection()+cb for an admitted
+     * fd; the caller has already reserved the slot. May throw std::system_error
+     * if the thread cannot be created (caller rolls the reservation back). */
+    void startSetupWorker(int t_newfd);
+    /* Releases one reserved setup slot and wakes a draining disconnect(). The
+     * single place the active_setups decrement + notify lives, so the worker
+     * exit path and the thread-creation-failure path stay in lockstep. */
+    void releaseSetupSlot();
 protected:
     virtual auto newConnection(int fd) -> std::shared_ptr<flight_safety_system::transport::fss_connection>;
     /* Binds, listens, and starts the accept thread. The public constructor

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <condition_variable>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -201,6 +202,19 @@ private:
     fss_connect_cb cb;
     static constexpr int default_max_pending_conns = 10;
     int max_pending_connections{default_max_pending_conns};
+    /* Connection setup (newConnection + cb) runs on detached worker threads,
+     * not inline on the accept thread: for the TLS listener newConnection
+     * performs the blocking handshake, so running it inline let one silent
+     * peer block all new connections. setup_lock guards the bookkeeping
+     * below; the count is bounded so the worker path cannot itself become a
+     * thread/memory-exhaustion vector. */
+    static constexpr size_t default_max_concurrent_setups = 64;
+    std::mutex setup_lock{};
+    std::condition_variable setup_cv{};
+    size_t active_setups{0};
+    bool accepting_setups{true};
+    size_t max_concurrent_setups{default_max_concurrent_setups};
+    std::atomic<uint64_t> rejected_setups{0};
 protected:
     virtual auto newConnection(int fd) -> std::shared_ptr<flight_safety_system::transport::fss_connection>;
     /* Binds, listens, and starts the accept thread. The public constructor
@@ -209,6 +223,9 @@ protected:
      * (which virtual-dispatches processMessages/newConnection and reads
      * derived members) can never observe a partially constructed object. */
     auto startListening() -> bool;
+    /* Bound on concurrent in-progress connection setups. Derived classes set
+     * this before startListening() so the accept thread reads a settled value. */
+    void setMaxConcurrentSetups(size_t t_max);
     struct defer_start_t {};
     fss_listen(uint16_t t_port, fss_connect_cb t_cb, defer_start_t);
 public:
@@ -219,6 +236,11 @@ public:
     auto operator=(fss_listen &&) -> fss_listen & = delete;
     ~fss_listen() override;
     void processMessages() override;
+    /* Stops accepting new setups and drains in-flight setup workers before
+     * returning, so derived members the workers read stay alive until then. */
+    void disconnect() override;
+    auto getActiveSetupCount() -> size_t;
+    auto getRejectedSetupCount() -> uint64_t;
 };
 
 class fss_message {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -83,7 +83,8 @@ auto main(int argc, char *argv[]) -> int
     constexpr int default_identify_timeout_sec = 30;
     constexpr uint64_t default_rate_capacity = 100;
     constexpr uint64_t default_rate_refill_per_s = 20;
-    constexpr unsigned int default_tls_handshake_timeout_ms = flight_safety_system::transport_ssl::default_handshake_timeout_ms;
+    constexpr unsigned int default_tls_handshake_timeout_ms =
+        flight_safety_system::transport_ssl::default_handshake_timeout_ms;
     constexpr std::size_t default_max_concurrent_handshakes = 64;
     int listen_port = 0;
     int pg_port = default_pg_port;
@@ -171,9 +172,25 @@ auto main(int argc, char *argv[]) -> int
         {
             tls_handshake_timeout_ms = config["tls_handshake_timeout_ms"].asUInt();
         }
+        if (tls_handshake_timeout_ms == 0)
+        {
+            /* gnutls treats a 0 ms handshake timeout as "never time out", which
+             * re-opens the stalled-handshake DoS this setting exists to close. */
+            FSS_LOG_WARN("server",
+                         "tls_handshake_timeout_ms must be > 0 (0 disables the handshake timeout); using default "
+                             << default_tls_handshake_timeout_ms);
+            tls_handshake_timeout_ms = default_tls_handshake_timeout_ms;
+        }
         if (config.isMember("max_concurrent_handshakes"))
         {
             max_concurrent_handshakes = config["max_concurrent_handshakes"].asUInt();
+        }
+        if (max_concurrent_handshakes == 0)
+        {
+            /* A bound of 0 would refuse every incoming connection. */
+            FSS_LOG_WARN("server",
+                         "max_concurrent_handshakes must be > 0; using default " << default_max_concurrent_handshakes);
+            max_concurrent_handshakes = default_max_concurrent_handshakes;
         }
         ca_public_key = config["ssl"]["ca_public_key"].asString();
         server_private_key = config["ssl"]["server_private_key"].asString();

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -83,6 +83,8 @@ auto main(int argc, char *argv[]) -> int
     constexpr int default_identify_timeout_sec = 30;
     constexpr uint64_t default_rate_capacity = 100;
     constexpr uint64_t default_rate_refill_per_s = 20;
+    constexpr unsigned int default_tls_handshake_timeout_ms = flight_safety_system::transport_ssl::default_handshake_timeout_ms;
+    constexpr std::size_t default_max_concurrent_handshakes = 64;
     int listen_port = 0;
     int pg_port = default_pg_port;
     std::string pg_host;
@@ -94,6 +96,8 @@ auto main(int argc, char *argv[]) -> int
     uint64_t identify_timeout_sec = default_identify_timeout_sec;
     uint64_t rate_capacity = default_rate_capacity;
     uint64_t rate_refill = default_rate_refill_per_s;
+    unsigned int tls_handshake_timeout_ms = default_tls_handshake_timeout_ms;
+    std::size_t max_concurrent_handshakes = default_max_concurrent_handshakes;
     std::string ca_public_key;
     std::string server_private_key;
     std::string server_public_key;
@@ -163,6 +167,14 @@ auto main(int argc, char *argv[]) -> int
         {
             rate_refill = config["message_rate_refill"].asUInt64();
         }
+        if (config.isMember("tls_handshake_timeout_ms"))
+        {
+            tls_handshake_timeout_ms = config["tls_handshake_timeout_ms"].asUInt();
+        }
+        if (config.isMember("max_concurrent_handshakes"))
+        {
+            max_concurrent_handshakes = config["max_concurrent_handshakes"].asUInt();
+        }
         ca_public_key = config["ssl"]["ca_public_key"].asString();
         server_private_key = config["ssl"]["server_private_key"].asString();
         server_public_key = config["ssl"]["server_public_key"].asString();
@@ -226,7 +238,8 @@ auto main(int argc, char *argv[]) -> int
         return true;
     };
     listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(
-        listen_port, connect_cb, ca_public_key, server_private_key, server_public_key, crl_file);
+        listen_port, connect_cb, ca_public_key, server_private_key, server_public_key, crl_file,
+        tls_handshake_timeout_ms, max_concurrent_handshakes);
 
     /* Main-loop DB contract: the loop below must make NO synchronous DB
      * reads. Reads are handled exclusively by the command_poller thread

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -119,8 +119,10 @@ auto flight_safety_system::transport_ssl::fss_connection_server::create(int t_fd
 
 flight_safety_system::transport_ssl::fss_connection_client::fss_connection_client(std::string t_ca,
                                                                                   std::string t_private_key,
-                                                                                  std::string t_public_key)
-    : fss_connection(std::move(t_ca), std::move(t_private_key), std::move(t_public_key))
+                                                                                  std::string t_public_key,
+                                                                                  unsigned int t_handshake_timeout_ms)
+    : fss_connection(std::move(t_ca), std::move(t_private_key), std::move(t_public_key)),
+      handshake_timeout_ms(t_handshake_timeout_ms)
 {
 }
 
@@ -303,7 +305,7 @@ auto flight_safety_system::transport_ssl::fss_connection_client::setupSSL() -> b
 
     /* Bound the handshake so a server that accepts the TCP connection but
      * stalls the TLS handshake cannot hang connectTo() indefinitely. */
-    gnutls_handshake_set_timeout(this->session->ptr(), default_handshake_timeout_ms);
+    gnutls_handshake_set_timeout(this->session->ptr(), this->handshake_timeout_ms);
 
     int ret = -2;
     try

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -87,9 +87,11 @@ flight_safety_system::transport_ssl::fss_connection_server::~fss_connection_serv
 flight_safety_system::transport_ssl::fss_connection_server::fss_connection_server(int t_fd, std::string t_ca,
                                                                                   std::string t_private_key,
                                                                                   std::string t_public_key,
-                                                                                  std::string t_crl)
+                                                                                  std::string t_crl,
+                                                                                  unsigned int t_handshake_timeout_ms)
     : flight_safety_system::transport_ssl::fss_connection(std::move(t_ca), std::move(t_private_key),
-                                                          std::move(t_public_key), std::move(t_crl))
+                                                          std::move(t_public_key), std::move(t_crl)),
+      handshake_timeout_ms(t_handshake_timeout_ms)
 {
     this->setFd(t_fd);
     this->usable.store(this->setupSSL());
@@ -97,15 +99,21 @@ flight_safety_system::transport_ssl::fss_connection_server::fss_connection_serve
 
 auto flight_safety_system::transport_ssl::fss_connection_server::create(int t_fd, std::string t_ca,
                                                                         std::string t_private_key,
-                                                                        std::string t_public_key, std::string t_crl)
+                                                                        std::string t_public_key, std::string t_crl,
+                                                                        unsigned int t_handshake_timeout_ms)
     -> std::shared_ptr<fss_connection_server>
 {
-    auto conn = std::shared_ptr<fss_connection_server>(new fss_connection_server(
-        t_fd, std::move(t_ca), std::move(t_private_key), std::move(t_public_key), std::move(t_crl)));
-    if (conn->usable.load())
+    auto conn = std::shared_ptr<fss_connection_server>(
+        new fss_connection_server(t_fd, std::move(t_ca), std::move(t_private_key), std::move(t_public_key),
+                                  std::move(t_crl), t_handshake_timeout_ms));
+    if (!conn->usable.load())
     {
-        conn->startRecvThread(std::thread([conn]() -> void { conn->processMessages(); }));
+        /* Handshake failed or timed out: drop the dead connection (its
+         * destructor closes the fd) rather than handing a zombie peer to the
+         * accept callback. */
+        return nullptr;
     }
+    conn->startRecvThread(std::thread([conn]() -> void { conn->processMessages(); }));
     return conn;
 }
 
@@ -293,6 +301,10 @@ auto flight_safety_system::transport_ssl::fss_connection_client::setupSSL() -> b
 
     clientSession->set_verify_cert(this->hostname.c_str(), 0);
 
+    /* Bound the handshake so a server that accepts the TCP connection but
+     * stalls the TLS handshake cannot hang connectTo() indefinitely. */
+    gnutls_handshake_set_timeout(this->session->ptr(), default_handshake_timeout_ms);
+
     int ret = -2;
     try
     {
@@ -338,6 +350,13 @@ auto flight_safety_system::transport_ssl::fss_connection_server::setupSSL() -> b
      * via set_verify_cert). NULL hostname: a client certificate's identity
      * is its CN, matched at the application layer, not a hostname. */
     gnutls_session_set_verify_cert(this->session->ptr(), nullptr, 0);
+
+    /* Bound the handshake so a peer that completes the TCP connection but then
+     * stalls (sends no/partial ClientHello) cannot occupy this setup worker
+     * indefinitely. With the default int transport (gnutls_transport_set_int
+     * in setupSession), gnutls drives the handshake against its system
+     * pull-timeout function and returns GNUTLS_E_TIMEDOUT at the deadline. */
+    gnutls_handshake_set_timeout(this->session->ptr(), this->handshake_timeout_ms);
 
     int ret = -1;
     try
@@ -463,16 +482,26 @@ auto flight_safety_system::transport_ssl::fss_listen::newConnection(int t_newfd)
     -> std::shared_ptr<flight_safety_system::transport::fss_connection>
 {
     return flight_safety_system::transport_ssl::fss_connection_server::create(
-        t_newfd, this->ca_file, this->private_key_file, this->public_key_file, this->crl_file);
+        t_newfd, this->ca_file, this->private_key_file, this->public_key_file, this->crl_file,
+        this->handshake_timeout_ms);
 }
 
 flight_safety_system::transport_ssl::fss_listen::fss_listen(uint16_t t_port,
                                                             flight_safety_system::transport::fss_connect_cb t_cb,
                                                             std::string t_ca, std::string t_private_key,
-                                                            std::string t_public_key, std::string t_crl)
+                                                            std::string t_public_key, std::string t_crl,
+                                                            unsigned int t_handshake_timeout_ms,
+                                                            size_t t_max_concurrent_handshakes)
     : flight_safety_system::transport::fss_listen(t_port, std::move(t_cb), defer_start_t{}), ca_file(std::move(t_ca)),
-      private_key_file(std::move(t_private_key)), public_key_file(std::move(t_public_key)), crl_file(std::move(t_crl))
+      private_key_file(std::move(t_private_key)), public_key_file(std::move(t_public_key)), crl_file(std::move(t_crl)),
+      handshake_timeout_ms(t_handshake_timeout_ms)
 {
+    /* Apply the concurrency bound (0 = keep the base default) before
+     * startListening() so the accept thread reads a settled value. */
+    if (t_max_concurrent_handshakes > 0)
+    {
+        this->setMaxConcurrentSetups(t_max_concurrent_handshakes);
+    }
     /* Start the accept thread only now that this object is fully
      * constructed: the thread virtual-dispatches into newConnection(),
      * which reads the path strings initialised above. Starting it from the

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -488,6 +488,7 @@ auto flight_safety_system::transport_ssl::fss_listen::newConnection(int t_newfd)
         this->handshake_timeout_ms);
 }
 
+// NOLINTBEGIN(bugprone-easily-swappable-parameters)
 flight_safety_system::transport_ssl::fss_listen::fss_listen(uint16_t t_port,
                                                             flight_safety_system::transport::fss_connect_cb t_cb,
                                                             std::string t_ca, std::string t_private_key,
@@ -497,6 +498,7 @@ flight_safety_system::transport_ssl::fss_listen::fss_listen(uint16_t t_port,
     : flight_safety_system::transport::fss_listen(t_port, std::move(t_cb), defer_start_t{}), ca_file(std::move(t_ca)),
       private_key_file(std::move(t_private_key)), public_key_file(std::move(t_public_key)), crl_file(std::move(t_crl)),
       handshake_timeout_ms(t_handshake_timeout_ms)
+// NOLINTEND(bugprone-easily-swappable-parameters)
 {
     /* Apply the concurrency bound (0 = keep the base default) before
      * startListening() so the accept thread reads a settled value. */
@@ -513,11 +515,13 @@ flight_safety_system::transport_ssl::fss_listen::fss_listen(uint16_t t_port,
 
 flight_safety_system::transport_ssl::fss_listen::~fss_listen()
 {
-    /* Join the accept thread while the cert/key path strings it reads in
-     * newConnection() are still alive; the base destructor's disconnect()
-     * would run only after they are destroyed. disconnect() is idempotent,
-     * so the base's call becomes a no-op. */
-    this->disconnect();
+    /* Join the accept thread and drain setup workers while the cert/key path
+     * strings they read in newConnection() are still alive; the base
+     * destructor's disconnect() would run only after they are destroyed.
+     * Qualified (non-virtual) call: avoids a virtual dispatch from a
+     * destructor, and disconnect() is idempotent so the base's later call is a
+     * no-op. */
+    flight_safety_system::transport::fss_listen::disconnect();
 }
 
 auto flight_safety_system::transport_ssl::fss_connection_server::getClientNames() -> std::list<std::string>

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -593,49 +593,51 @@ void flight_safety_system::transport::fss_listen::processMessages()
             }
             ++this->active_setups;
         }
-        /* Run newConnection() (the blocking TLS handshake for the SSL listener)
-         * and the connect callback off the accept thread, so a slow or silent
-         * peer cannot block accept() for other clients. The worker is detached;
-         * disconnect() drains in-flight workers before this object dies, so the
-         * raw `this` capture stays valid for the worker's lifetime.
-         *
-         * The slot was reserved above; if the thread cannot be created the
-         * worker never runs to release it, so roll the reservation back here
-         * (and wake any waiting drain) — otherwise disconnect() would block
-         * forever waiting for active_setups to reach 0. */
+        /* The slot is reserved; hand the fd to a worker. If the worker thread
+         * cannot be created it never runs to release the slot, so roll the
+         * reservation back here (and wake any waiting drain) and drop the fd —
+         * otherwise disconnect() would block forever on active_setups != 0. */
         try
         {
-            std::thread([this, newfd]() -> void {
-                flight_safety_system::exception_guard setup_guard("transport", "new connection setup");
-                setup_guard.run([&]() -> void {
-                    auto conn = this->newConnection(newfd);
-                    if (conn != nullptr && this->cb != nullptr)
-                    {
-                        this->cb(conn);
-                    }
-                });
-                /* Final action: release the slot and wake the drain. notify_all()
-                 * runs while the lock is held so disconnect() cannot wake (re-lock),
-                 * see active_setups==0, and destroy setup_cv before this notify
-                 * completes. Touch no other `this` state afterwards. */
-                {
-                    std::scoped_lock setup_holder(this->setup_lock);
-                    --this->active_setups;
-                    this->setup_cv.notify_all();
-                }
-            }).detach();
+            this->startSetupWorker(newfd);
         }
         catch (const std::system_error &e)
         {
             FSS_LOG_ERROR("transport", "Failed to start connection setup worker: " << e.what());
-            {
-                std::scoped_lock setup_holder(this->setup_lock);
-                --this->active_setups;
-                this->setup_cv.notify_all();
-            }
+            this->releaseSetupSlot();
             safe_close_fd(newfd, "transport/accept");
         }
     }
+}
+
+void flight_safety_system::transport::fss_listen::startSetupWorker(int t_newfd)
+{
+    /* Run newConnection() (the blocking TLS handshake for the SSL listener) and
+     * the connect callback off the accept thread, so a slow or silent peer
+     * cannot block accept() for other clients. The worker is detached;
+     * disconnect() drains in-flight workers before this object dies, so the raw
+     * `this` capture stays valid for the worker's lifetime. */
+    std::thread([this, t_newfd]() -> void {
+        flight_safety_system::exception_guard setup_guard("transport", "new connection setup");
+        setup_guard.run([&]() -> void {
+            auto conn = this->newConnection(t_newfd);
+            if (conn != nullptr && this->cb != nullptr)
+            {
+                this->cb(conn);
+            }
+        });
+        this->releaseSetupSlot();
+    }).detach();
+}
+
+void flight_safety_system::transport::fss_listen::releaseSetupSlot()
+{
+    /* notify_all() runs while the lock is held so disconnect() cannot wake
+     * (re-lock), see active_setups==0, and destroy setup_cv before this notify
+     * completes. The worker must touch no other `this` state afterwards. */
+    std::scoped_lock setup_holder(this->setup_lock);
+    --this->active_setups;
+    this->setup_cv.notify_all();
 }
 
 void flight_safety_system::transport::fss_listen::disconnect()
@@ -652,6 +654,14 @@ void flight_safety_system::transport::fss_listen::disconnect()
 
 void flight_safety_system::transport::fss_listen::setMaxConcurrentSetups(size_t t_max)
 {
+    if (t_max == 0)
+    {
+        /* A bound of 0 would refuse every connection (active_setups >= 0 is
+         * always true). That is never intended, so ignore it and keep the
+         * current bound rather than silently bricking the listener. */
+        FSS_LOG_WARN("transport", "setMaxConcurrentSetups(0) ignored: a zero bound would refuse all connections");
+        return;
+    }
     std::scoped_lock setup_holder(this->setup_lock);
     this->max_concurrent_setups = t_max;
 }

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -536,7 +536,6 @@ static void listen_thread(flight_safety_system::transport::fss_listen *listen)
 
 void flight_safety_system::transport::fss_listen::processMessages()
 {
-    flight_safety_system::exception_guard accept_guard("transport", "new connection");
     while (this->getFd() >= 0)
     {
         struct sockaddr_storage sa = {};
@@ -569,19 +568,85 @@ void flight_safety_system::transport::fss_listen::processMessages()
         std::cout << "New client from " << addr_str << ":" << client_port << " as " << newfd << std::endl;
 #endif
         set_tcp_keepalive(newfd);
-        if (this->cb != nullptr)
-        {
-            accept_guard.run([&]() -> void {
-                auto conn = this->newConnection(newfd);
-                this->cb(conn);
-            });
-        }
-        else
+        if (this->cb == nullptr)
         {
             /* Thanks for your call, unfortunately we don't know how to deal with it */
             safe_close_fd(newfd, "transport/accept");
+            continue;
         }
+        /* Reserve a setup slot, or shed load if we are at the bound / shutting
+         * down. Closing the fd here lets the peer observe the rejection
+         * immediately rather than queueing unboundedly. */
+        {
+            std::scoped_lock setup_holder(this->setup_lock);
+            if (!this->accepting_setups || this->active_setups >= this->max_concurrent_setups)
+            {
+                uint64_t rejected = ++this->rejected_setups;
+                if (rejected == 1 || (rejected % 100) == 0)
+                {
+                    FSS_LOG_WARN("transport", "Connection setup slots exhausted ("
+                                                  << this->active_setups << "/" << this->max_concurrent_setups
+                                                  << "), dropping connection. Total dropped: " << rejected);
+                }
+                safe_close_fd(newfd, "transport/accept");
+                continue;
+            }
+            ++this->active_setups;
+        }
+        /* Run newConnection() (the blocking TLS handshake for the SSL listener)
+         * and the connect callback off the accept thread, so a slow or silent
+         * peer cannot block accept() for other clients. The worker is detached;
+         * disconnect() drains in-flight workers before this object dies, so the
+         * raw `this` capture stays valid for the worker's lifetime. */
+        std::thread([this, newfd]() -> void {
+            flight_safety_system::exception_guard setup_guard("transport", "new connection setup");
+            setup_guard.run([&]() -> void {
+                auto conn = this->newConnection(newfd);
+                if (conn != nullptr && this->cb != nullptr)
+                {
+                    this->cb(conn);
+                }
+            });
+            /* Final action: release the slot and wake the drain. notify_all()
+             * runs while the lock is held so disconnect() cannot wake (re-lock),
+             * see active_setups==0, and destroy setup_cv before this notify
+             * completes. Touch no other `this` state afterwards. */
+            {
+                std::scoped_lock setup_holder(this->setup_lock);
+                --this->active_setups;
+                this->setup_cv.notify_all();
+            }
+        }).detach();
     }
+}
+
+void flight_safety_system::transport::fss_listen::disconnect()
+{
+    /* Stop the accept loop and join the accept thread first, so no new setup
+     * workers can be spawned, then drain the ones already in flight. They read
+     * members of derived listeners (e.g. the SSL cert/key paths), so this must
+     * complete before those members are destroyed. */
+    flight_safety_system::transport::fss_connection::disconnect();
+    std::unique_lock setup_holder(this->setup_lock);
+    this->accepting_setups = false;
+    this->setup_cv.wait(setup_holder, [this]() -> bool { return this->active_setups == 0; });
+}
+
+void flight_safety_system::transport::fss_listen::setMaxConcurrentSetups(size_t t_max)
+{
+    std::scoped_lock setup_holder(this->setup_lock);
+    this->max_concurrent_setups = t_max;
+}
+
+auto flight_safety_system::transport::fss_listen::getActiveSetupCount() -> size_t
+{
+    std::scoped_lock setup_holder(this->setup_lock);
+    return this->active_setups;
+}
+
+auto flight_safety_system::transport::fss_listen::getRejectedSetupCount() -> uint64_t
+{
+    return this->rejected_setups.load();
 }
 
 auto flight_safety_system::transport::fss_listen::newConnection(int t_newfd)

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -597,26 +597,44 @@ void flight_safety_system::transport::fss_listen::processMessages()
          * and the connect callback off the accept thread, so a slow or silent
          * peer cannot block accept() for other clients. The worker is detached;
          * disconnect() drains in-flight workers before this object dies, so the
-         * raw `this` capture stays valid for the worker's lifetime. */
-        std::thread([this, newfd]() -> void {
-            flight_safety_system::exception_guard setup_guard("transport", "new connection setup");
-            setup_guard.run([&]() -> void {
-                auto conn = this->newConnection(newfd);
-                if (conn != nullptr && this->cb != nullptr)
+         * raw `this` capture stays valid for the worker's lifetime.
+         *
+         * The slot was reserved above; if the thread cannot be created the
+         * worker never runs to release it, so roll the reservation back here
+         * (and wake any waiting drain) — otherwise disconnect() would block
+         * forever waiting for active_setups to reach 0. */
+        try
+        {
+            std::thread([this, newfd]() -> void {
+                flight_safety_system::exception_guard setup_guard("transport", "new connection setup");
+                setup_guard.run([&]() -> void {
+                    auto conn = this->newConnection(newfd);
+                    if (conn != nullptr && this->cb != nullptr)
+                    {
+                        this->cb(conn);
+                    }
+                });
+                /* Final action: release the slot and wake the drain. notify_all()
+                 * runs while the lock is held so disconnect() cannot wake (re-lock),
+                 * see active_setups==0, and destroy setup_cv before this notify
+                 * completes. Touch no other `this` state afterwards. */
                 {
-                    this->cb(conn);
+                    std::scoped_lock setup_holder(this->setup_lock);
+                    --this->active_setups;
+                    this->setup_cv.notify_all();
                 }
-            });
-            /* Final action: release the slot and wake the drain. notify_all()
-             * runs while the lock is held so disconnect() cannot wake (re-lock),
-             * see active_setups==0, and destroy setup_cv before this notify
-             * completes. Touch no other `this` state afterwards. */
+            }).detach();
+        }
+        catch (const std::system_error &e)
+        {
+            FSS_LOG_ERROR("transport", "Failed to start connection setup worker: " << e.what());
             {
                 std::scoped_lock setup_holder(this->setup_lock);
                 --this->active_setups;
                 this->setup_cv.notify_all();
             }
-        }).detach();
+            safe_close_fd(newfd, "transport/accept");
+        }
     }
 }
 

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -526,7 +526,11 @@ flight_safety_system::transport::fss_listen::fss_listen(uint16_t t_port, fss_con
 
 flight_safety_system::transport::fss_listen::~fss_listen()
 {
-    this->disconnect();
+    /* Qualified (non-virtual) call: invoke this class's own disconnect during
+     * destruction. A plain this->disconnect() is a virtual call in a
+     * destructor — flagged by clang-analyzer and pointless here since the
+     * derived part is already gone. */
+    flight_safety_system::transport::fss_listen::disconnect();
 }
 
 static void listen_thread(flight_safety_system::transport::fss_listen *listen)

--- a/tests/ssl_failure_test.cpp
+++ b/tests/ssl_failure_test.cpp
@@ -368,3 +368,54 @@ TEST_CASE("ssl: concurrent handshakes are bounded and excess connections shed", 
     listen = nullptr;
     accepted = nullptr;
 }
+
+TEST_CASE("ssl: client handshake times out against a silent server", "[ssl_handshake_dos]")
+{
+    /* Client side of the same DoS: a server that completes the TCP connection
+     * but never performs the TLS handshake must not hang connectTo()
+     * indefinitely. fss_connection_client bounds its handshake via
+     * gnutls_handshake_set_timeout; a short injected timeout keeps this fast. */
+    const uint16_t port = fss_test::pick_port();
+    REQUIRE(port != 0);
+
+    /* A raw TCP server that accepts one connection and then stays silent. */
+    int listen_fd = ::socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
+    REQUIRE(listen_fd >= 0);
+    int reuse = 1;
+    (void)::setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+    struct sockaddr_in6 addr{};
+    addr.sin6_family = AF_INET6;
+    addr.sin6_port = htons(port);
+    addr.sin6_addr = in6addr_any;
+    REQUIRE(::bind(listen_fd, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)) == 0);
+    REQUIRE(::listen(listen_fd, 1) == 0);
+
+    std::atomic<bool> stop{false};
+    std::thread silent_server([&]() {
+        int peer = ::accept(listen_fd, nullptr, nullptr); // unblocked by closing listen_fd below
+        while (!stop.load())
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        if (peer >= 0)
+        {
+            ::close(peer);
+        }
+    });
+
+    constexpr unsigned int short_handshake_ms = 500;
+    auto client = std::make_shared<flight_safety_system::transport_ssl::fss_connection_client>(
+        CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE, short_handshake_ms);
+
+    auto start = std::chrono::steady_clock::now();
+    bool connected = client->connectTo("localhost", port);
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
+
+    REQUIRE_FALSE(connected);
+    /* Must give up near the timeout, not hang. Generous upper bound for CI. */
+    REQUIRE(elapsed < std::chrono::milliseconds(short_handshake_ms * 8));
+
+    stop.store(true);
+    ::close(listen_fd); // also unblocks accept() if the client never connected
+    silent_server.join();
+}

--- a/tests/ssl_failure_test.cpp
+++ b/tests/ssl_failure_test.cpp
@@ -16,6 +16,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <list>
@@ -56,6 +57,28 @@ auto accept_cb(std::shared_ptr<flight_safety_system::transport::fss_connection> 
 {
     accepted = std::move(new_conn);
     return true;
+}
+
+/* Open a raw TCP connection to the listener (IPv6 loopback) and send nothing
+ * — a "silent peer" that completes the TCP handshake but never starts the TLS
+ * handshake. Returns the fd (caller closes it) or -1 on failure. */
+auto connect_silent_peer(uint16_t port) -> int
+{
+    int sock = ::socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
+    if (sock < 0)
+    {
+        return -1;
+    }
+    struct sockaddr_in6 addr{};
+    addr.sin6_family = AF_INET6;
+    addr.sin6_port = htons(port);
+    addr.sin6_addr = in6addr_loopback;
+    if (::connect(sock, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)) < 0)
+    {
+        ::close(sock);
+        return -1;
+    }
+    return sock;
 }
 
 } // namespace
@@ -170,11 +193,14 @@ TEST_CASE("ssl: server rejects a client cert signed by an untrusted CA", "[ssl_f
      * result, only that the server never accepts the foreign identity. */
     client->connectTo("localhost", port);
 
-    /* The SSL listener runs the handshake synchronously before invoking the
-     * accept callback, so once accepted is set the server has finished (and
-     * rejected) verification; a correctly verifying server surfaces no CN. */
-    REQUIRE(fss_test::wait_for([]() { return accepted != nullptr; }));
-    REQUIRE(accepted->getClientNames().empty());
+    /* The server-side handshake must fail verification, so create() returns
+     * nullptr and the accept callback is never invoked — the untrusted cert
+     * yields no connection at all (a strictly stronger guarantee than the
+     * pre-1.1.0 behaviour, which surfaced a nameless connection). If the
+     * server regressed and accepted the foreign cert, the callback would fire
+     * and `accepted` would become non-null within the grace window. */
+    REQUIRE_FALSE(fss_test::wait_for([]() { return accepted != nullptr; }, std::chrono::milliseconds(500)));
+    listen = nullptr;
     accepted = nullptr;
 }
 
@@ -270,10 +296,75 @@ TEST_CASE("ssl: isPeerCertRevoked with non-existent CRL file returns false")
     server_conn = nullptr;
 }
 
-/* Deliberately omitted: a "silent raw-TCP peer blocks the accept thread"
- * regression test. The current server architecture performs the TLS
- * handshake inline on the accept thread, which means a single silent
- * peer wedges the listener indefinitely. Exercising that would deadlock
- * the test binary. Capturing this as a regression requires the
- * server-side refactor tracked in Phase 4 (move handshake off the
- * accept thread). */
+TEST_CASE("ssl: a silent peer does not block other clients' handshakes", "[ssl_handshake_dos]")
+{
+    /* Regression for the accept-thread DoS: a peer that completes the TCP
+     * connection but never sends a ClientHello must not block new
+     * connections. Before the off-accept-thread refactor the listener ran the
+     * TLS handshake inline, so this test would have wedged the accept thread
+     * and hung the suite. A short handshake timeout keeps teardown quick. */
+    accepted = nullptr;
+    const uint16_t port = fss_test::pick_port();
+    REQUIRE(port != 0);
+    constexpr unsigned int short_handshake_ms = 500;
+    auto listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(
+        port, accept_cb, CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE, std::string{}, short_handshake_ms);
+    REQUIRE(listen != nullptr);
+
+    int silent = connect_silent_peer(port);
+    REQUIRE(silent >= 0);
+    /* The silent peer should occupy a setup worker (mid-handshake). */
+    REQUIRE(fss_test::wait_for([&]() { return listen->getActiveSetupCount() >= 1; }));
+
+    /* A well-behaved client must still complete its handshake promptly while
+     * the silent peer is stuck — proving the accept thread is not blocked. */
+    auto client = std::make_shared<flight_safety_system::transport_ssl::fss_connection_client>(
+        CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+    REQUIRE(client->connectTo("localhost", port));
+    REQUIRE(fss_test::wait_for([]() { return accepted != nullptr; }));
+
+    ::close(silent);
+    listen = nullptr; // drains the (timed-out) silent worker before clearing globals
+    accepted = nullptr;
+}
+
+TEST_CASE("ssl: concurrent handshakes are bounded and excess connections shed", "[ssl_handshake_bound]")
+{
+    /* The setup-worker pool is bounded so the off-thread handshake path cannot
+     * itself be used to exhaust threads/memory: once the bound is reached,
+     * further accepted connections are closed immediately rather than queued. */
+    accepted = nullptr;
+    const uint16_t port = fss_test::pick_port();
+    REQUIRE(port != 0);
+    constexpr unsigned int short_handshake_ms = 1000;
+    constexpr size_t max_handshakes = 2;
+    auto listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(
+        port, accept_cb, CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE, std::string{}, short_handshake_ms,
+        max_handshakes);
+    REQUIRE(listen != nullptr);
+
+    /* Fill every setup slot with silent peers. */
+    std::array<int, max_handshakes> silent{};
+    for (auto &fd : silent)
+    {
+        fd = connect_silent_peer(port);
+        REQUIRE(fd >= 0);
+    }
+    REQUIRE(fss_test::wait_for([&]() { return listen->getActiveSetupCount() >= max_handshakes; }));
+
+    /* An additional connection is accepted at the TCP layer but must be shed:
+     * the rejected counter advances and the peer observes an immediate EOF. */
+    int extra = connect_silent_peer(port);
+    REQUIRE(extra >= 0);
+    REQUIRE(fss_test::wait_for([&]() { return listen->getRejectedSetupCount() >= 1; }));
+    char buf = 0;
+    REQUIRE(::recv(extra, &buf, 1, 0) == 0); // orderly close from the server side
+
+    ::close(extra);
+    for (auto fd : silent)
+    {
+        ::close(fd);
+    }
+    listen = nullptr;
+    accepted = nullptr;
+}


### PR DESCRIPTION
## Description

The accept loop ran newConnection() inline before returning to accept(). For the SSL listener that performs the full TLS handshake (a blocking recv) with no timeout, so a peer that completed the TCP connection but then sent no/partial ClientHello held the accept thread indefinitely — one unauthenticated peer blocked all new connections to the server, a trivial denial of service. TCP_USER_TIMEOUT (1.0.3) does not help: it bounds unacked sends, not a blocking handshake recv on an idle socket.

Fix it in two coordinated parts:

- Bound each handshake. setupSSL() now calls gnutls_handshake_set_timeout before handshake(); with the default int transport gnutls drives the handshake against its system pull-timeout and returns GNUTLS_E_TIMEDOUT at the deadline. Configurable via tls_handshake_timeout_ms (default 10 s). The client side bounds its handshake too, so a stalled server cannot hang connectTo().

- Run connection setup off the accept thread. fss_listen now hands each accepted fd to a detached worker that runs newConnection()+cb, so the accept thread returns to accept() immediately. Concurrent in-progress setups are capped (max_concurrent_handshakes, default 64) and excess connections are shed (closed) so the worker path cannot itself exhaust threads/memory. disconnect() drains in-flight workers before derived members (the SSL cert/key paths they read) are destroyed.

fss_connection_server::create() now returns nullptr when the handshake fails or times out, so the accept callback is never handed a dead peer (no zombie client per silent peer). The foreign-CA-client-cert test is updated to assert the stronger property: an untrusted cert yields no connection at all.

clientConnected() is already safe under concurrent invocation (list mutated under its lock; the config it reads is set once at startup), so moving the callback off the serial accept thread is safe.

Closes todo/15. Adds two regression tests (previously impossible — they would have wedged the accept thread): a silent peer must not block a good client, and the concurrency bound must shed excess connections.

## Summary by Sourcery

Bound TLS handshakes and moved connection setup off the accept thread to prevent a single stalled peer from blocking or exhausting the server, and made handshake limits configurable.

New Features:
- Add configurable TLS handshake timeout and maximum concurrent handshake settings for the SSL listener and client.

Bug Fixes:
- Prevent a silent or stalled TLS peer from blocking the accept thread and hanging other client connections.
- Ensure client connections time out if the server never completes the TLS handshake instead of hanging indefinitely.
- Avoid wiring up connections when the server-side TLS handshake fails or times out, eliminating zombie peers.

Enhancements:
- Run connection setup on bounded worker threads instead of inline on the accept thread, with tracking and draining of in-flight setups on shutdown.
- Expose counters for active and rejected connection setups for observability.
- Strengthen server-side client-cert rejection semantics so untrusted client certificates yield no connection object.

Documentation:
- Document the new TLS handshake timeout and concurrency limits in the changelog and server configuration options.

Tests:
- Add regression tests to verify silent peers do not block other clients, handshake concurrency is bounded and excess connections are dropped, and client-side handshakes time out against a silent server.