### PR TITLE
fix(transport): wire sentinel for "no position fix" (NaN, not Null Island)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - A position report from an aircraft with no GPS fix is no longer recorded and
-  broadcast as a real position at (0,0) — Null Island. The "no fix" condition
+  broadcast as a real position at (0,0) — Null Island. The "no-fix" condition
   (a NaN coordinate) now travels the wire as an `INT32_MIN` sentinel that
   decodes back to NaN, so the server discards it (with a distinct, throttled
   "no GPS fix" warning) instead of storing a bogus 0°N 0°E telemetry point.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   be used to exhaust threads/memory. The client side also bounds its handshake
   so a stalled server cannot hang `connectTo()`.
 
+### Fixed
+- A position report from an aircraft with no GPS fix is no longer recorded and
+  broadcast as a real position at (0,0) — Null Island. The "no fix" condition
+  (a NaN coordinate) now travels the wire as an `INT32_MIN` sentinel that
+  decodes back to NaN, so the server discards it (with a distinct, throttled
+  "no GPS fix" warning) instead of storing a bogus 0°N 0°E telemetry point.
+  Framing is unchanged, so no protocol-version bump is required; interop
+  degrades safely (a new sender's no-fix sentinel is rejected as out-of-range
+  by an old receiver, and an old sender's no-fix still arrives as (0,0) until
+  the fleet upgrades).
+
 ## [1.0.3] - 2026-06-13
 
 ### Security

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -636,6 +636,21 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                         return;
                     }
                 }
+                if (std::isnan(msg->getLatitude()) || std::isnan(msg->getLongitude()))
+                {
+                    /* NaN coordinates are the wire sentinel for "no GPS fix"
+                     * (see pack_scaled_coord). This is operationally distinct
+                     * from a malformed coordinate, so log it as such — but a
+                     * persistent no-fix arrives every report, so throttle to
+                     * first + every 100th to avoid flooding the log. */
+                    uint64_t no_fix = ++this->no_fix_reports;
+                    if (no_fix == 1 || (no_fix % 100) == 0)
+                    {
+                        FSS_LOG_WARN("server", "Position report with no GPS fix from "
+                                                   << this->name << " (count=" << no_fix << "), discarding");
+                    }
+                    return;
+                }
                 if (!is_valid_coordinate(msg->getLatitude(), msg->getLongitude()))
                 {
                     FSS_LOG_WARN("server", "Invalid position report coordinates (lat=" << msg->getLatitude()

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -182,6 +182,10 @@ private:
     rate_limiter msg_rate{100, 20};
     uint64_t rate_limit_rejects{0};
     uint64_t last_rate_limit_log_ms{0};
+    /* Cumulative position reports discarded for having no GPS fix (NaN
+     * coordinates) this session; touched only on the recv thread
+     * (processMessage), used to throttle the warning. */
+    uint64_t no_fix_reports{0};
     /* Cumulative duplicate protocol-version messages seen this session
      * (never reset); touched only on the recv thread (processMessage), used
      * to throttle the warning. */

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -16,19 +16,23 @@ using flight_safety_system::transport::FSS_COORD_SCALE;
 using flight_safety_system::transport::FSS_VOLTAGE_SCALE;
 
 /* Guard a double->int32_t conversion against NaN, Inf, and out-of-range values.
- * NaN maps to 0 (the defined sentinel — decodes back to 0.0 degrees/volts).
- * Finite values outside [INT32_MIN, INT32_MAX] are clamped rather than
- * allowing undefined behaviour in the cast. */
+ * Non-finite input (NaN/Inf) maps to INT32_MIN, the on-wire "no fix" sentinel:
+ * it lies outside the encodable coordinate range (±180° -> ±1.8e9, INT32_MIN
+ * ~= -2.147e9) so it can never alias a real position. The receiver decodes
+ * INT32_MIN back to NaN (see assign_coordinates), keeping "we don't know where
+ * the aircraft is" distinct from (0,0) — Null Island, a legal coordinate.
+ * Finite values are clamped into [INT32_MIN + 1, INT32_MAX] (the low side stops
+ * one above the sentinel) so a clamped real value can never collide with it. */
 static auto pack_scaled_coord(double value, double scale) -> int32_t
 {
     if (!std::isfinite(value))
     {
-        return 0;
+        return std::numeric_limits<int32_t>::min();
     }
     const double scaled = value / scale;
-    if (scaled <= static_cast<double>(std::numeric_limits<int32_t>::min()))
+    if (scaled <= static_cast<double>(std::numeric_limits<int32_t>::min() + 1))
     {
-        return std::numeric_limits<int32_t>::min();
+        return std::numeric_limits<int32_t>::min() + 1;
     }
     if (scaled >= static_cast<double>(std::numeric_limits<int32_t>::max()))
     {
@@ -38,7 +42,9 @@ static auto pack_scaled_coord(double value, double scale) -> int32_t
 }
 
 /* Like pack_scaled_coord but clamps the low side at 0, for non-negative
- * quantities such as battery voltage so a stray negative never wraps. */
+ * quantities such as battery voltage so a stray negative never wraps. This also
+ * deliberately collapses the no-fix sentinel (INT32_MIN, which is < 0) to 0:
+ * voltage uses 0 as its own "unknown" convention and has no NaN sentinel. */
 static auto pack_scaled_nonneg(double value, double scale) -> int32_t
 {
     const int32_t packed = pack_scaled_coord(value, scale);
@@ -234,17 +240,29 @@ public:
     }
 };
 
+/* Decode one fixed-point coordinate, mapping the INT32_MIN "no fix" sentinel
+ * (see pack_scaled_coord) back to NaN so it is never read as a real position. */
+static auto decode_coord(int32_t raw) -> double
+{
+    if (raw == std::numeric_limits<int32_t>::min())
+    {
+        return NAN;
+    }
+    return static_cast<double>(raw) * FSS_COORD_SCALE;
+}
+
 /* Apply decoded fixed-point lat/lng to a message, but only if the buffer was
  * fully read: a truncated frame must decode to NaN, never to (0,0) — Null
- * Island is a legal coordinate that passes validation. Shared by the
- * position-report and asset-command decoders so the policy stays in one place. */
+ * Island is a legal coordinate that passes validation. The INT32_MIN no-fix
+ * sentinel likewise decodes to NaN. Shared by the position-report and
+ * asset-command decoders so the policy stays in one place. */
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void assign_coordinates(const BufferReader &reader, int32_t lat, int32_t lng, double &out_lat, double &out_lng)
 {
     if (reader.ok())
     {
-        out_lat = static_cast<double>(lat) * FSS_COORD_SCALE;
-        out_lng = static_cast<double>(lng) * FSS_COORD_SCALE;
+        out_lat = decode_coord(lat);
+        out_lng = decode_coord(lng);
     }
     else
     {

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -15,24 +15,28 @@ using flight_safety_system::fss_be64toh;
 using flight_safety_system::transport::FSS_COORD_SCALE;
 using flight_safety_system::transport::FSS_VOLTAGE_SCALE;
 
+/* On-wire "no fix" sentinel for a scaled coordinate. INT32_MIN lies outside the
+ * encodable coordinate range (±180° -> ±1.8e9, INT32_MIN ~= -2.147e9) so it can
+ * never alias a real position; the receiver decodes it back to NaN (see
+ * decode_coord), keeping "we don't know where the aircraft is" distinct from
+ * (0,0) — Null Island, a legal coordinate. Finite values are clamped into
+ * [coord_min_encodable, INT32_MAX], the low side stopping one above the
+ * sentinel so a clamped real value can never collide with it. */
+static constexpr int32_t coord_no_fix_sentinel = std::numeric_limits<int32_t>::min();
+static constexpr int32_t coord_min_encodable = coord_no_fix_sentinel + 1;
+
 /* Guard a double->int32_t conversion against NaN, Inf, and out-of-range values.
- * Non-finite input (NaN/Inf) maps to INT32_MIN, the on-wire "no fix" sentinel:
- * it lies outside the encodable coordinate range (±180° -> ±1.8e9, INT32_MIN
- * ~= -2.147e9) so it can never alias a real position. The receiver decodes
- * INT32_MIN back to NaN (see assign_coordinates), keeping "we don't know where
- * the aircraft is" distinct from (0,0) — Null Island, a legal coordinate.
- * Finite values are clamped into [INT32_MIN + 1, INT32_MAX] (the low side stops
- * one above the sentinel) so a clamped real value can never collide with it. */
+ * Non-finite input maps to the no-fix sentinel; finite values are clamped. */
 static auto pack_scaled_coord(double value, double scale) -> int32_t
 {
     if (!std::isfinite(value))
     {
-        return std::numeric_limits<int32_t>::min();
+        return coord_no_fix_sentinel;
     }
     const double scaled = value / scale;
-    if (scaled <= static_cast<double>(std::numeric_limits<int32_t>::min() + 1))
+    if (scaled <= static_cast<double>(coord_min_encodable))
     {
-        return std::numeric_limits<int32_t>::min() + 1;
+        return coord_min_encodable;
     }
     if (scaled >= static_cast<double>(std::numeric_limits<int32_t>::max()))
     {
@@ -244,7 +248,7 @@ public:
  * (see pack_scaled_coord) back to NaN so it is never read as a real position. */
 static auto decode_coord(int32_t raw) -> double
 {
-    if (raw == std::numeric_limits<int32_t>::min())
+    if (raw == coord_no_fix_sentinel)
     {
         return NAN;
     }

--- a/tests/coordinate_precision_test.cpp
+++ b/tests/coordinate_precision_test.cpp
@@ -138,46 +138,44 @@ TEST_CASE("coord: 7-decimal-place precision preserved")
 
 /* Regression for pack_scaled_coord NaN/Inf/out-of-range guard.
  *
- * Before the fix, passing NaN or Inf lat/long to pack_scaled_coord triggered
- * undefined behaviour in the double->int32_t cast.  After the fix NaN/Inf map
- * to 0 on the wire (decoding to 0.0), and finite out-of-range values are
- * clamped to INT32_MIN / INT32_MAX rather than wrapping.
+ * Originally, passing NaN or Inf lat/long to pack_scaled_coord triggered
+ * undefined behaviour in the double->int32_t cast; the first fix mapped them to
+ * 0 (decoding to 0.0). As of the no-fix-sentinel change, non-finite input maps
+ * to INT32_MIN on the wire and decodes back to NaN — "no GPS fix" must stay
+ * distinct from (0,0), a legal coordinate (Null Island). Finite out-of-range
+ * values are clamped into [INT32_MIN + 1, INT32_MAX] (the low side stops one
+ * above the sentinel) so a clamped real value can never alias it.
  */
 
-TEST_CASE("coord: asset_command RTL (NaN lat/lng) packs and decodes to defined value")
+TEST_CASE("coord: asset_command RTL (NaN lat/lng) round-trips to NaN, not Null Island")
 {
     /* RTL constructed with (command, timestamp) leaves latitude and longitude
-     * as NaN.  Before the fix this was UB; after the fix 0 is placed on the
-     * wire and the decoded coordinates must be exactly 0.0. */
+     * as NaN (it carries no position). That must decode back to NaN, not to
+     * (0,0) which would look like a real coordinate. */
     auto orig = std::make_shared<fss_message_asset_command>(asset_command_rtl, /*timestamp*/ 0ULL);
     orig->setId(1);
     auto bl = orig->getPacked();
     auto decoded = std::dynamic_pointer_cast<fss_message_asset_command>(fss_message::decode(bl));
     REQUIRE(decoded != nullptr);
-    /* Round-tripped coordinates must be a defined, finite value. */
-    REQUIRE(std::isfinite(decoded->getLatitude()));
-    REQUIRE(std::isfinite(decoded->getLongitude()));
-    /* The sentinel value for NaN input is 0.0. */
-    REQUIRE(decoded->getLatitude() == 0.0);
-    REQUIRE(decoded->getLongitude() == 0.0);
+    REQUIRE(std::isnan(decoded->getLatitude()));
+    REQUIRE(std::isnan(decoded->getLongitude()));
 }
 
-TEST_CASE("coord: asset_command HOLD (NaN lat/lng) packs and decodes to defined value")
+TEST_CASE("coord: asset_command HOLD (NaN lat/lng) round-trips to NaN, not Null Island")
 {
     auto orig = std::make_shared<fss_message_asset_command>(asset_command_hold, /*timestamp*/ 12345ULL);
     orig->setId(2);
     auto bl = orig->getPacked();
     auto decoded = std::dynamic_pointer_cast<fss_message_asset_command>(fss_message::decode(bl));
     REQUIRE(decoded != nullptr);
-    REQUIRE(std::isfinite(decoded->getLatitude()));
-    REQUIRE(std::isfinite(decoded->getLongitude()));
-    REQUIRE(decoded->getLatitude() == 0.0);
-    REQUIRE(decoded->getLongitude() == 0.0);
+    REQUIRE(std::isnan(decoded->getLatitude()));
+    REQUIRE(std::isnan(decoded->getLongitude()));
 }
 
-TEST_CASE("coord: position_report NaN lat/lng packs and decodes to defined value")
+TEST_CASE("coord: position_report NaN lat/lng round-trips to NaN, not Null Island")
 {
-    /* NAN passed as latitude and longitude must not trigger UB on pack. */
+    /* A client with no GPS fix sends the default-NaN position. It must not be
+     * indistinguishable from a real report at 0N 0E. */
     auto orig = std::make_shared<fss_message_position_report>(
         std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(),
         /*altitude*/ 0U, /*heading*/ 0U, /*hor_vel*/ 0U, /*ver_vel*/ 0,
@@ -188,15 +186,13 @@ TEST_CASE("coord: position_report NaN lat/lng packs and decodes to defined value
     auto bl = orig->getPacked();
     auto decoded = std::dynamic_pointer_cast<fss_message_position_report>(fss_message::decode(bl));
     REQUIRE(decoded != nullptr);
-    REQUIRE(std::isfinite(decoded->getLatitude()));
-    REQUIRE(std::isfinite(decoded->getLongitude()));
-    REQUIRE(decoded->getLatitude() == 0.0);
-    REQUIRE(decoded->getLongitude() == 0.0);
+    REQUIRE(std::isnan(decoded->getLatitude()));
+    REQUIRE(std::isnan(decoded->getLongitude()));
 }
 
-TEST_CASE("coord: position_report Inf lat/lng packs and decodes to defined value")
+TEST_CASE("coord: position_report Inf lat/lng round-trips to NaN, not Null Island")
 {
-    /* Positive infinity must also map to a defined (finite) wire value. */
+    /* Infinity is also non-finite and maps to the no-fix sentinel. */
     auto orig = std::make_shared<fss_message_position_report>(
         std::numeric_limits<double>::infinity(), -std::numeric_limits<double>::infinity(),
         /*altitude*/ 0U, /*heading*/ 0U, /*hor_vel*/ 0U, /*ver_vel*/ 0,
@@ -207,10 +203,8 @@ TEST_CASE("coord: position_report Inf lat/lng packs and decodes to defined value
     auto bl = orig->getPacked();
     auto decoded = std::dynamic_pointer_cast<fss_message_position_report>(fss_message::decode(bl));
     REQUIRE(decoded != nullptr);
-    REQUIRE(std::isfinite(decoded->getLatitude()));
-    REQUIRE(std::isfinite(decoded->getLongitude()));
-    REQUIRE(decoded->getLatitude() == 0.0);
-    REQUIRE(decoded->getLongitude() == 0.0);
+    REQUIRE(std::isnan(decoded->getLatitude()));
+    REQUIRE(std::isnan(decoded->getLongitude()));
 }
 
 TEST_CASE("coord: out-of-range latitude clamps rather than wrapping")
@@ -232,8 +226,11 @@ TEST_CASE("coord: large negative out-of-range latitude clamps rather than wrappi
     double neg_large = -1e12;
     double lat = 0.0, lng = 0.0;
     std::tie(lat, lng) = round_trip(neg_large, 0.0);
+    /* Clamps to INT32_MIN + 1, one above the no-fix sentinel, so the result
+     * stays finite (isfinite) and must NOT alias the sentinel and decode to
+     * NaN. This is what keeps a clamped real value distinct from "no fix". */
     REQUIRE(std::isfinite(lat));
-    REQUIRE(lat >= static_cast<double>(std::numeric_limits<int32_t>::min()) * FSS_COORD_SCALE);
+    REQUIRE(lat >= static_cast<double>(std::numeric_limits<int32_t>::min() + 1) * FSS_COORD_SCALE);
     REQUIRE(lat < 0.0);
 }
 

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -833,6 +833,41 @@ TEST_CASE("session: stale position report is discarded")
     REQUIRE(handler.broadcasts.size() == 1);
 }
 
+TEST_CASE("session: no-fix (NaN) position report is discarded, not stored or broadcast")
+{
+    /* Phase 07: a client with no GPS fix sends a NaN position. It decodes to
+     * NaN (the wire sentinel), and must be discarded distinctly from a
+     * malformed coordinate — never stored or broadcast as a real position. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+    REQUIRE(handler.disconnects == 0);
+
+    fss_test::capture_cerr cap;
+    auto no_fix = std::make_shared<fss::transport::fss_message_position_report>(
+        std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(), 0U, 0U, 0U, int16_t{0}, 0U,
+        std::string{}, 0U, uint8_t{0}, 0U, uint8_t{0}, uint8_t{0}, fss::fss_current_timestamp());
+    session->processMessage(no_fix);
+
+    REQUIRE(mock.positions.empty());     // not stored
+    REQUIRE(handler.broadcasts.empty()); // not broadcast
+    /* Logged distinctly as a no-fix, not the generic invalid-coordinate path. */
+    REQUIRE(cap.str().find("no GPS fix") != std::string::npos);
+
+    /* A subsequent real fix is still accepted, proving the session is healthy. */
+    auto fresh = make_position_msg(fss::fss_current_timestamp());
+    session->processMessage(fresh);
+    REQUIRE(handler.broadcasts.size() == 1);
+}
+
 TEST_CASE("smm_settings: ctor and accessors")
 {
     fss::server::smm_settings s("https://smm.example", fss::secure_string{"user"}, fss::secure_string{"pass"});


### PR DESCRIPTION
## Description

pack_scaled_coord mapped NaN/Inf to 0 on the wire, so a client with no GPS fix (default-NaN position report) arrived as lat=0/lng=0. (0,0) is a legal coordinate (Null Island) that is_valid_coordinate accepts, so the bogus position was stored and broadcast as real telemetry — "we don't know where the aircraft is" was indistinguishable from "the aircraft is at 0N 0E".

Use INT32_MIN as the on-wire no-fix sentinel: it is outside the encodable coordinate range (±180 -> ±1.8e9; INT32_MIN ~= -2.147e9) so it can never alias a real position.

- pack_scaled_coord: non-finite -> INT32_MIN; finite values clamp into [INT32_MIN + 1, INT32_MAX] so a clamped real value can't alias the sentinel. Voltage (pack_scaled_nonneg) is unchanged: it floors <0 to 0, collapsing the sentinel to voltage's own 0 "unknown".
- assign_coordinates (shared position-report/asset-command decoder): a coordinate of INT32_MIN decodes back to NaN, alongside the existing truncation -> NaN.
- Server: a NaN position report is discarded with a distinct, throttled "no GPS fix" warning (per-client counter, first + every 100th) instead of the generic invalid-coordinate path. is_valid_coordinate already rejected NaN, so once the server sees NaN it is neither stored nor broadcast.

Framing is unchanged, so no FSS_PROTOCOL_VERSION bump. Interop degrades safely: new sender -> old receiver decodes INT32_MIN as ~-214.7deg and the old is_valid_coordinate rejects it (better than today's silent (0,0)); old sender -> new receiver still sends (0,0) until the fleet upgrades.

Tests invert the four coordinate cases that asserted the old NaN->0.0 contract (now NaN->NaN) and add a server-session case proving a no-fix report is not stored or broadcast and is logged distinctly. Closes todo/07.

## Summary by Sourcery

Ensure NaN coordinates represent "no GPS fix" using an INT32_MIN on-wire sentinel, so missing position data is not stored or broadcast as a real position.

Bug Fixes:
- Prevent NaN/Inf coordinates from being serialized as (0,0) by introducing an INT32_MIN sentinel that round-trips back to NaN and is rejected server-side.
- Treat no-fix position reports distinctly from malformed coordinates on the server, discarding them with a throttled "no GPS fix" warning instead of persisting bogus telemetry.

Enhancements:
- Centralize coordinate decoding via a helper that consistently maps the no-fix sentinel to NaN and keeps clamped out-of-range values distinct from the sentinel.

Documentation:
- Document the no-fix coordinate handling and interoperability behavior in the changelog.

Tests:
- Update coordinate serialization tests to assert NaN round-trips for no-fix inputs and add a server-session test verifying that no-fix reports are neither stored nor broadcast and are logged distinctly.