### PR TITLE
fix(server): make the position staleness check skew-aware and configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   degrades safely (a new sender's no-fix sentinel is rejected as out-of-range
   by an old receiver, and an old sender's no-fix still arrives as (0,0) until
   the fleet upgrades).
+- The position-report staleness check is now symmetric and skew-aware. It
+  previously compared the client-stamped time one-sidedly against the server
+  clock, so a client whose clock lagged >30 s had *every* position silently
+  discarded (a healthy-looking link with a frozen track) while a client whose
+  clock ran *ahead* bypassed the check entirely. The window now rejects
+  future-dated reports too, escalates from a single WARN to an ERROR naming the
+  suspected skew once a client trips it repeatedly (instead of a per-message
+  WARN drip), and is configurable via `position_staleness_ms` (default 30000,
+  0 disables). The gate carries a per-client clock-offset correction that is
+  currently 0 — a later change will measure it so a skewed-but-healthy client's
+  positions are accepted rather than dropped.
 
 ## [1.0.3] - 2026-06-13
 

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -20,6 +20,11 @@ static auto is_valid_coordinate(double latitude, double longitude) -> bool
 
 constexpr uint64_t sec_to_msec = 1000;
 constexpr uint64_t rtt_retry_interval = 10 * sec_to_msec;
+/* Staleness-discard escalation: first discard logs WARN; the Nth consecutive
+ * (and every Mth after) logs an ERROR naming the suspected clock skew, so a
+ * persistently skewed client is unmistakable without a per-message WARN drip. */
+constexpr uint64_t staleness_escalation_threshold = 10;
+constexpr uint64_t staleness_escalation_interval = 100;
 
 fss::server::smm_settings::smm_settings(std::string t_address, fss::secure_string t_username,
                                         fss::secure_string t_password)
@@ -262,6 +267,12 @@ void fss::server::fss_client::setIdentifyTimeoutMs(uint64_t ms)
 {
     std::scoped_lock guard(this->client_lock);
     this->identify_timeout_ms = ms;
+}
+
+void fss::server::fss_client::setStalenessMs(uint64_t ms)
+{
+    std::scoped_lock guard(this->client_lock);
+    this->position_staleness_ms = ms;
 }
 
 void fss::server::fss_client::setRateLimits(uint64_t capacity, uint64_t refill_per_s)
@@ -625,16 +636,38 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
             }
             break;
             case fss::transport::message_type_position_report: {
-                constexpr uint64_t staleness_limit_ms = 30000;
                 uint64_t report_ts = msg->getTimeStamp();
-                if (report_ts > 0)
+                if (this->position_staleness_ms != 0 && report_ts > 0)
                 {
                     uint64_t now = fss::fss_current_timestamp();
-                    if (now > report_ts + staleness_limit_ms)
+                    /* Compare the client-stamped time against the server clock,
+                     * offset-corrected (client_clock_offset_ms is 0 until the
+                     * RTT clock-offset feature measures it). The window is
+                     * symmetric: a clock ahead of the server is as wrong as one
+                     * behind, so future-dated reports are rejected too. */
+                    int64_t skew = static_cast<int64_t>(now) - static_cast<int64_t>(report_ts) +
+                                   this->client_clock_offset_ms;
+                    int64_t magnitude = skew < 0 ? -skew : skew;
+                    if (magnitude > static_cast<int64_t>(this->position_staleness_ms))
                     {
-                        FSS_LOG_WARN("server", "Stale position report (age=" << (now - report_ts) << "ms), discarding");
+                        uint64_t discards = ++this->staleness_discards;
+                        if (discards == 1)
+                        {
+                            FSS_LOG_WARN("server", "Stale position report from " << this->name << " (skew=" << skew
+                                                                                 << "ms), discarding");
+                        }
+                        else if (discards == staleness_escalation_threshold ||
+                                 discards % staleness_escalation_interval == 0)
+                        {
+                            FSS_LOG_ERROR("server", "Client " << this->name << " clock skew suspected (skew=" << skew
+                                                              << "ms, " << discards
+                                                              << " consecutive), discarding all positions");
+                        }
                         return;
                     }
+                    /* In-window: the clock is fine, so clear the skew streak
+                     * even if the coordinate below is later rejected. */
+                    this->staleness_discards = 0;
                 }
                 if (std::isnan(msg->getLatitude()) || std::isnan(msg->getLongitude()))
                 {

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -644,9 +644,14 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                      * offset-corrected (client_clock_offset_ms is 0 until the
                      * RTT clock-offset feature measures it). The window is
                      * symmetric: a clock ahead of the server is as wrong as one
-                     * behind, so future-dated reports are rejected too. */
-                    int64_t skew = static_cast<int64_t>(now) - static_cast<int64_t>(report_ts) +
-                                   this->client_clock_offset_ms;
+                     * behind, so future-dated reports are rejected too.
+                     *
+                     * Take the signed difference from the unsigned subtraction so
+                     * the two epoch-ms values are never narrowed to int64 (the
+                     * difference itself is small and always fits). */
+                    int64_t diff = now >= report_ts ? static_cast<int64_t>(now - report_ts)
+                                                    : -static_cast<int64_t>(report_ts - now);
+                    int64_t skew = diff + this->client_clock_offset_ms;
                     int64_t magnitude = skew < 0 ? -skew : skew;
                     if (magnitude > static_cast<int64_t>(this->position_staleness_ms))
                     {

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -186,6 +186,19 @@ private:
      * coordinates) this session; touched only on the recv thread
      * (processMessage), used to throttle the warning. */
     uint64_t no_fix_reports{0};
+    /* Position staleness window in ms (0 disables the check). A report whose
+     * timestamp is further than this from the (offset-corrected) server clock
+     * is discarded. Configurable via server.json position_staleness_ms. */
+    uint64_t position_staleness_ms{30000};
+    /* Estimate of (client clock - server clock) in ms: positive if the client
+     * runs ahead. Used only to offset-correct the staleness gate, never to
+     * rewrite stored timestamps. Stays 0 until measured (todo/17 item 3, the
+     * RTT clock-offset feature); 0 makes the gate a plain symmetric window. */
+    int64_t client_clock_offset_ms{0};
+    /* Consecutive staleness discards; reset by the first in-window report.
+     * Drives WARN->ERROR escalation so a skewed client is unmistakable without
+     * a per-message WARN drip. Recv thread only. */
+    uint64_t staleness_discards{0};
     /* Cumulative duplicate protocol-version messages seen this session
      * (never reset); touched only on the recv thread (processMessage), used
      * to throttle the warning. */
@@ -215,6 +228,7 @@ public:
     void setClock(std::shared_ptr<IClock> t_clock);
     void setTimeoutMs(uint64_t ms);
     void setIdentifyTimeoutMs(uint64_t ms);
+    void setStalenessMs(uint64_t ms);
     void setRateLimits(uint64_t capacity, uint64_t refill_per_s); // must be called before any messages are processed
     auto isTimedOut() -> bool;
 };

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -17,6 +17,10 @@ namespace server {
 
 constexpr int command_poll_ms = 100;
 
+/* Default position-staleness window (ms). Shared so the fss_client member,
+ * server_clients, and server.cpp config default cannot drift apart. */
+constexpr uint64_t default_position_staleness_ms = 30000;
+
 class smm_settings {
 private:
     std::string address;
@@ -189,7 +193,7 @@ private:
     /* Position staleness window in ms (0 disables the check). A report whose
      * timestamp is further than this from the (offset-corrected) server clock
      * is discarded. Configurable via server.json position_staleness_ms. */
-    uint64_t position_staleness_ms{30000};
+    uint64_t position_staleness_ms{default_position_staleness_ms};
     /* Estimate of (client clock - server clock) in ms: positive if the client
      * runs ahead. Used only to offset-correct the staleness gate, never to
      * rewrite stored timestamps. Stays 0 until measured (todo/17 item 3, the

--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -20,6 +20,7 @@ private:
     std::atomic<bool> shutting_down{false};
     uint64_t client_timeout_ms{30000};
     uint64_t identify_timeout_ms{30000};
+    uint64_t position_staleness_ms{30000};
     uint64_t rate_capacity{100};
     uint64_t rate_refill_per_s{20};
     /* Guarded by lock. Built by the command poller thread (the only place
@@ -107,6 +108,7 @@ public:
     };
     void setClientTimeoutMs(uint64_t ms) { this->client_timeout_ms = ms; }
     void setClientIdentifyTimeoutMs(uint64_t ms) { this->identify_timeout_ms = ms; }
+    void setClientStalenessMs(uint64_t ms) { this->position_staleness_ms = ms; }
     void setClientRateLimits(uint64_t capacity, uint64_t refill_per_s)
     {
         this->rate_capacity = capacity;
@@ -120,6 +122,7 @@ public:
          * limiter is still being reconfigured. */
         client->setTimeoutMs(this->client_timeout_ms);
         client->setIdentifyTimeoutMs(this->identify_timeout_ms);
+        client->setStalenessMs(this->position_staleness_ms);
         client->setRateLimits(this->rate_capacity, this->rate_refill_per_s);
         auto *raw = client.get();
         {

--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -20,7 +20,7 @@ private:
     std::atomic<bool> shutting_down{false};
     uint64_t client_timeout_ms{30000};
     uint64_t identify_timeout_ms{30000};
-    uint64_t position_staleness_ms{30000};
+    uint64_t position_staleness_ms{flight_safety_system::server::default_position_staleness_ms};
     uint64_t rate_capacity{100};
     uint64_t rate_refill_per_s{20};
     /* Guarded by lock. Built by the command poller thread (the only place

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -81,6 +81,7 @@ auto main(int argc, char *argv[]) -> int
     constexpr std::size_t default_db_queue_depth = 10000;
     constexpr int default_client_timeout_sec = 30;
     constexpr int default_identify_timeout_sec = 30;
+    constexpr uint64_t default_position_staleness_ms = 30000;
     constexpr uint64_t default_rate_capacity = 100;
     constexpr uint64_t default_rate_refill_per_s = 20;
     constexpr unsigned int default_tls_handshake_timeout_ms =
@@ -95,6 +96,7 @@ auto main(int argc, char *argv[]) -> int
     std::size_t db_queue_depth = default_db_queue_depth;
     uint64_t client_timeout_sec = default_client_timeout_sec;
     uint64_t identify_timeout_sec = default_identify_timeout_sec;
+    uint64_t position_staleness_ms = default_position_staleness_ms;
     uint64_t rate_capacity = default_rate_capacity;
     uint64_t rate_refill = default_rate_refill_per_s;
     unsigned int tls_handshake_timeout_ms = default_tls_handshake_timeout_ms;
@@ -159,6 +161,10 @@ auto main(int argc, char *argv[]) -> int
         if (config.isMember("identify_timeout"))
         {
             identify_timeout_sec = config["identify_timeout"].asUInt64();
+        }
+        if (config.isMember("position_staleness_ms"))
+        {
+            position_staleness_ms = config["position_staleness_ms"].asUInt64();
         }
         if (config.isMember("message_rate_capacity"))
         {
@@ -237,6 +243,7 @@ auto main(int argc, char *argv[]) -> int
     constexpr int msec_per_sec = 1000;
     clients->setClientTimeoutMs(client_timeout_sec * msec_per_sec);
     clients->setClientIdentifyTimeoutMs(identify_timeout_sec * msec_per_sec);
+    clients->setClientStalenessMs(position_staleness_ms);
     clients->setClientRateLimits(rate_capacity, rate_refill);
 
     std::shared_ptr<flight_safety_system::transport::fss_listen> listen;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -81,7 +81,7 @@ auto main(int argc, char *argv[]) -> int
     constexpr std::size_t default_db_queue_depth = 10000;
     constexpr int default_client_timeout_sec = 30;
     constexpr int default_identify_timeout_sec = 30;
-    constexpr uint64_t default_position_staleness_ms = 30000;
+    constexpr uint64_t default_position_staleness_ms = flight_safety_system::server::default_position_staleness_ms;
     constexpr uint64_t default_rate_capacity = 100;
     constexpr uint64_t default_rate_refill_per_s = 20;
     constexpr unsigned int default_tls_handshake_timeout_ms =

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -868,6 +868,93 @@ TEST_CASE("session: no-fix (NaN) position report is discarded, not stored or bro
     REQUIRE(handler.broadcasts.size() == 1);
 }
 
+TEST_CASE("session: future-dated position report is discarded (symmetric window)")
+{
+    /* Phase 08: the staleness window is symmetric — a client clock ahead of the
+     * server is as wrong as one behind. Previously a future timestamp passed
+     * the one-sided check unconditionally. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+    REQUIRE(handler.disconnects == 0);
+
+    constexpr uint64_t sixty_seconds_ms = 60000;
+    auto future = make_position_msg(fss::fss_current_timestamp() + sixty_seconds_ms);
+    session->processMessage(future);
+    REQUIRE(handler.broadcasts.empty());
+
+    /* An in-window report is still accepted. */
+    auto fresh = make_position_msg(fss::fss_current_timestamp());
+    session->processMessage(fresh);
+    REQUIRE(handler.broadcasts.size() == 1);
+}
+
+TEST_CASE("session: position_staleness_ms = 0 disables the staleness gate")
+{
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->setStalenessMs(0); // escape hatch for fleets with undisciplined clocks
+
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+    REQUIRE(handler.disconnects == 0);
+
+    constexpr uint64_t sixty_seconds_ms = 60000;
+    auto old = make_position_msg(fss::fss_current_timestamp() - sixty_seconds_ms);
+    session->processMessage(old);
+    REQUIRE(handler.broadcasts.size() == 1); // accepted despite being well outside the window
+}
+
+TEST_CASE("session: repeated clock skew escalates WARN -> ERROR and resets on recovery")
+{
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+    REQUIRE(handler.disconnects == 0);
+
+    constexpr uint64_t sixty_seconds_ms = 60000;
+    fss_test::capture_cerr cap;
+    /* Ten consecutive stale reports — the escalation fires an ERROR. */
+    for (int i = 0; i < 10; ++i)
+    {
+        session->processMessage(make_position_msg(fss::fss_current_timestamp() - sixty_seconds_ms));
+    }
+    REQUIRE(handler.broadcasts.empty());
+    REQUIRE(cap.str().find("clock skew suspected") != std::string::npos);
+
+    /* An in-window report resets the streak. */
+    session->processMessage(make_position_msg(fss::fss_current_timestamp()));
+    REQUIRE(handler.broadcasts.size() == 1);
+
+    /* A single subsequent stale report logs only WARN, not another ERROR. */
+    cap.clear();
+    session->processMessage(make_position_msg(fss::fss_current_timestamp() - sixty_seconds_ms));
+    REQUIRE(cap.str().find("Stale position report") != std::string::npos);
+    REQUIRE(cap.str().find("clock skew suspected") == std::string::npos);
+}
+
 TEST_CASE("smm_settings: ctor and accessors")
 {
     fss::server::smm_settings s("https://smm.example", fss::secure_string{"user"}, fss::secure_string{"pass"});


### PR DESCRIPTION
## Description

The staleness gate compared the client-stamped timestamp one-sidedly against the server wall clock (now > report_ts + 30s). Two failures:
- A client whose clock lagged >30s had every position silently discarded — the link looked healthy but the track was frozen.
- A client whose clock ran ahead bypassed the check entirely (future-dated reports were always accepted).

Make the window symmetric and skew-aware:
- Reject when |now - report_ts + client_clock_offset_ms| > limit, computed signed. With the offset at 0 this is a plain symmetric window that also rejects future-dated reports.
- client_clock_offset_ms (client - server) is a pluggable per-client correction, currently always 0; the RTT clock-offset feature (todo/17.3) will measure it so a skewed-but-healthy client's positions are accepted instead of dropped. It only ever gates acceptance, never rewrites stored timestamps (DB uses server NOW()).
- Escalate: first discard logs WARN; the 10th consecutive (and every 100th after) logs an ERROR naming the suspected skew, instead of a per-message WARN drip. The streak resets on the first in-window report.
- Promote the hardcoded 30s to a per-client position_staleness_ms, threaded like client_timeout (server.json key, default 30000, 0 disables).

Tests: future-dated discarded, staleness=0 disables the gate, and the WARN->ERROR escalation fires after 10 consecutive discards then resets on a healthy report. Closes the server-only half of todo/08.

## Summary by Sourcery

Make position report staleness validation symmetric, skew-aware, and configurable per client, with clearer logging and test coverage.

New Features:
- Add configurable per-client position staleness window controlled via server.json `position_staleness_ms`, with support for disabling the gate.
- Introduce per-client clock-offset correction and consecutive-discard tracking to drive skew-aware staleness gating and log escalation.

Enhancements:
- Treat future-dated position reports as invalid using a symmetric staleness window around the server clock.
- Escalate repeated stale position discards from a single WARN to periodic ERROR logs that call out suspected client clock skew.
- Thread staleness configuration through server and client-session setup alongside existing timeouts and rate limits.

Documentation:
- Document the new skew-aware, symmetric staleness behavior and `position_staleness_ms` configuration in the changelog.

Tests:
- Add tests covering rejection of future-dated position reports, disabling the staleness gate via `position_staleness_ms = 0`, and WARN→ERROR log escalation with reset on recovery.