### PR TITLE
fix(rate-limiter): keep the refill clock accurate above 1000 tokens/s

### DIFF
--- a/src/rate-limiter.hpp
+++ b/src/rate-limiter.hpp
@@ -10,6 +10,12 @@ class rate_limiter {
     uint64_t max_tokens;
     uint64_t refill_per_s;
     uint64_t last_refill_ms{0};
+    // Sub-token carry: the numerator (elapsed_ms * refill_per_s) left over
+    // after granting whole tokens, always < 1000. Carrying it keeps the
+    // refill clock accurate for refill rates above 1000/s, where converting
+    // the granted tokens back to whole milliseconds would truncate to zero
+    // and stall the clock.
+    uint64_t refill_carry{0};
     bool initialized{false};
 public:
     rate_limiter(uint64_t capacity, uint64_t t_refill_per_s)
@@ -26,13 +32,29 @@ public:
         }
         if (now_ms > last_refill_ms)
         {
-            uint64_t elapsed = now_ms - last_refill_ms;
-            uint64_t new_tokens = (refill_per_s > 0) ? (elapsed * refill_per_s / 1000) : 0;
-            if (new_tokens > 0)
+            if (refill_per_s > 0)
             {
-                tokens = std::min(max_tokens, tokens + new_tokens);
-                last_refill_ms += new_tokens * 1000 / refill_per_s;
+                uint64_t elapsed = now_ms - last_refill_ms;
+                // Once enough time has passed to refill a full bucket, any
+                // extra only tops it off (tokens saturate at max_tokens). Cap
+                // elapsed at that point so elapsed * refill_per_s below stays
+                // bounded by ~max_tokens * 1000 and cannot overflow uint64_t
+                // after a very long idle gap or at a high refill rate.
+                uint64_t fill_ms = max_tokens * 1000 / refill_per_s + 1;
+                if (elapsed > fill_ms)
+                {
+                    elapsed = fill_ms;
+                    refill_carry = 0;
+                }
+                uint64_t numerator = elapsed * refill_per_s + refill_carry;
+                uint64_t new_tokens = numerator / 1000;
+                refill_carry = numerator % 1000;
+                if (new_tokens > 0)
+                {
+                    tokens = std::min(max_tokens, tokens + new_tokens);
+                }
             }
+            last_refill_ms = now_ms;
         }
         if (tokens < cost)
         {

--- a/tests/rate_limiter_test.cpp
+++ b/tests/rate_limiter_test.cpp
@@ -104,3 +104,43 @@ TEST_CASE("rate_limiter: cost greater than available tokens is rejected")
     // Bucket still has 3 tokens (none were consumed by the failed attempt)
     REQUIRE(rl.consume(0, 3));
 }
+
+TEST_CASE("rate_limiter: refill rate above 1000/s does not stall the clock")
+{
+    // For 1000 < refill_per_s < 2000 a single elapsed millisecond grants one
+    // token but less than a full millisecond's worth, so converting the grant
+    // back to whole milliseconds truncated to zero and stuck the refill clock,
+    // letting tokens accrue at the call rate instead of the configured rate.
+    fss::rate_limiter rl(2, 1500);
+    REQUIRE(rl.consume(0));
+    REQUIRE(rl.consume(0));
+    REQUIRE(!rl.consume(0)); // bucket drained
+    // 1ms later: 1.5 tokens accrue -> 1 whole token, 0.5 carried.
+    REQUIRE(rl.consume(1));
+    REQUIRE(!rl.consume(1)); // only one token was available, clock advanced
+    // 1ms more: 0.5 carried + 1.5 = 2 tokens (capped at capacity 2).
+    REQUIRE(rl.consume(2));
+    REQUIRE(rl.consume(2));
+    REQUIRE(!rl.consume(2));
+}
+
+TEST_CASE("rate_limiter: huge elapsed at a high refill rate does not overflow")
+{
+    // elapsed * refill_per_s is computed in uint64_t. With refill_per_s = 2^32
+    // and an elapsed of 2^32 ms the product is exactly 2^64, which wraps to 0
+    // -- so without clamping elapsed the drained bucket would never refill.
+    // The clamp caps elapsed at a full bucket's worth, keeping the product
+    // bounded and the refill correct.
+    const uint64_t two_pow_32 = 4294967296ULL;
+    fss::rate_limiter rl(3, two_pow_32);
+    REQUIRE(rl.consume(0));
+    REQUIRE(rl.consume(0));
+    REQUIRE(rl.consume(0));
+    REQUIRE(!rl.consume(0)); // bucket drained
+    // The clamped elapsed refills to capacity; an unclamped multiply would
+    // wrap to zero new tokens and leave the bucket wrongly empty.
+    REQUIRE(rl.consume(two_pow_32));
+    REQUIRE(rl.consume(two_pow_32));
+    REQUIRE(rl.consume(two_pow_32));
+    REQUIRE(!rl.consume(two_pow_32));
+}


### PR DESCRIPTION
## Description

For refill rates between 1001 and 1999 tokens/s a single elapsed millisecond grants one whole token but less than a full millisecond's worth of refill. Converting the granted tokens back to whole milliseconds (new_tokens * 1000 / refill_per_s) then truncated to zero, stalling last_refill_ms so tokens accrued at the call rate rather than the configured rate -- more permissive than intended.

Carry the sub-token remainder (the elapsed_ms * refill_per_s numerator left over after granting whole tokens) across calls and advance the clock straight to now_ms instead. Harmless at the default 20/s but correct for any rate. Adds a regression test at 1500/s.

## Summary by Sourcery

Fix rate limiter token refilling so high refill rates maintain an accurate refill clock and do not over-accumulate tokens.

Bug Fixes:
- Preserve sub-token refill remainder across calls to keep the refill clock accurate for refill rates above 1000 tokens per second and prevent tokens accruing at the call rate.

Tests:
- Add a regression test covering a 1500 tokens-per-second configuration to verify the refill clock does not stall at high refill rates.