### PR TITLE
fix(db): discard a truncated active-server list on mid-cursor failure

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -195,9 +195,10 @@ auto flight_safety_system::server::db_connection::getActiveServers() -> std::vec
 {
     std::vector<fss_server_details> res;
     struct fss_server_s **servers = nullptr;
+    int fetch_error = 0;
     {
         std::scoped_lock guard(this->read_lock);
-        servers = db_active_fss_servers_get(read_conn_name);
+        servers = db_active_fss_servers_get(read_conn_name, &fetch_error);
     }
     if (servers)
     {
@@ -208,6 +209,14 @@ auto flight_safety_system::server::db_connection::getActiveServers() -> std::vec
             free(servers[i]);
         }
         db_free_fss_servers(servers);
+    }
+    /* A mid-cursor failure leaves res holding only the rows read before the
+     * error. Discard it: shipping a truncated list to aircraft would drop
+     * servers that are actually active. The caller's exception_guard retains
+     * the previous good cache. */
+    if (fetch_error != 0)
+    {
+        throw database_error("active FSS server list read failed mid-cursor; partial result discarded");
     }
     return res;
 }

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -7,6 +7,7 @@
 
 #include <atomic>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <list>
 #include <mutex>
@@ -65,6 +66,15 @@ public:
     auto getLongitude() -> double;
     auto getAltitude() -> uint32_t;
     auto isAltitudeValid() -> bool;
+};
+
+/* Thrown by a database read that could only return a partial, misleading
+ * result. getActiveServers raises it when the cursor is cut short by a
+ * mid-iteration error so the caller discards the truncated list rather than
+ * mistaking it for the complete set of active servers. */
+class database_error : public std::runtime_error {
+public:
+    explicit database_error(const std::string &what) : std::runtime_error(what) {}
 };
 
 /* Pure-virtual database seam: lets ClientSession be unit-tested against

--- a/src/server-db.h
+++ b/src/server-db.h
@@ -45,6 +45,9 @@ struct fss_server_s {
     int port;
 };
 
-struct fss_server_s **db_active_fss_servers_get(const char *conn);
+/* On return *error_out is non-zero if the cursor was cut short by a
+ * mid-iteration error (the returned list is then partial and must not be
+ * treated as complete); zero on a clean read. error_out may be NULL. */
+struct fss_server_s **db_active_fss_servers_get(const char *conn, int *error_out);
 
 void db_free_fss_servers(struct fss_server_s **servers);

--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -279,9 +279,13 @@ db_asset_smm_settings_get(const char *conn_arg, unsigned long long asset_id_arg)
 }
 
 struct fss_server_s **
-db_active_fss_servers_get(const char *conn_arg)
+db_active_fss_servers_get(const char *conn_arg, int *error_out)
 {
     size_t len = 0;
+    if (error_out != NULL)
+    {
+        *error_out = 0;
+    }
     struct fss_server_s **res = (struct fss_server_s **)malloc(sizeof(struct fss_server_s *) * (len + 1));
     if (res != NULL)
     {
@@ -341,6 +345,15 @@ db_active_fss_servers_get(const char *conn_arg)
     EXEC SQL WHENEVER NOT FOUND CONTINUE;
     EXEC SQL WHENEVER SQLERROR CONTINUE;
     EXEC SQL WHENEVER SQLWARNING CONTINUE;
+
+    /* sqlca still reflects the FETCH that ended the loop. A negative sqlcode
+     * means a mid-cursor error (e.g. the read connection dropped) rather than
+     * the normal NOT FOUND (100) end of cursor: the list accumulated so far is
+     * partial. Capture it before CLOSE / SET AUTOCOMMIT overwrite sqlca. */
+    if (error_out != NULL && sqlca.sqlcode < 0)
+    {
+        *error_out = 1;
+    }
 
     EXEC SQL AT :conn CLOSE cur1;
     EXEC SQL AT :conn SET AUTOCOMMIT TO ON;


### PR DESCRIPTION
## Description

db_active_fss_servers_get drove the FETCH loop with WHENEVER SQLERROR DO BREAK, the same action as the NOT FOUND that ends the cursor normally. A read connection dropping mid-iteration therefore looked identical to a clean end: the rows gathered so far were returned as if complete. The poller cached that partial list and shipped it to aircraft, which could then drop servers that are actually active.

Report the distinction through a new error out-param: after the loop, sqlca.sqlcode < 0 means a mid-cursor error rather than NOT FOUND (100), captured before CLOSE / SET AUTOCOMMIT overwrite sqlca. getActiveServers frees the partial list and throws database_error, which the existing exception_guard around both call sites (the config poller and the identify path) catches -- so the previous good cache is retained instead of being overwritten with a truncated one.

todo/14 item 1.

## Summary by Sourcery

Protect active-server cache from being overwritten with a truncated list when the database cursor fails mid-iteration.

Bug Fixes:
- Ensure mid-cursor database read failures are reported and cause the active-server list to be discarded instead of treating a partial result as complete.

Enhancements:
- Introduce a database_error exception type to signal misleading partial-read results from database queries.
- Extend db_active_fss_servers_get to report mid-iteration cursor errors via an out-parameter so callers can distinguish clean completion from failures.