### PR TITLE
test(db): cover the mid-cursor active-server-list discard path

### DIFF
--- a/tests/mock_database.hpp
+++ b/tests/mock_database.hpp
@@ -20,6 +20,10 @@ public:
     std::map<uint64_t, std::shared_ptr<flight_safety_system::server::smm_settings>> smm{};
     std::map<uint64_t, std::vector<std::shared_ptr<flight_safety_system::server::asset_command>>> commands{};
     std::vector<flight_safety_system::server::fss_server_details> active_servers{};
+    /* When set, getActiveServers throws database_error, simulating a
+     * mid-cursor read failure so tests can exercise the partial-result
+     * discard path. */
+    bool active_servers_fail{false};
 
     struct recorded_rtt {
         uint64_t asset_id;
@@ -99,6 +103,10 @@ public:
 
     auto getActiveServers() -> std::vector<flight_safety_system::server::fss_server_details> override
     {
+        if (active_servers_fail)
+        {
+            throw flight_safety_system::server::database_error("mock mid-cursor failure");
+        }
         return active_servers;
     }
 

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -351,6 +351,30 @@ TEST_CASE("session: server list sent on identify contains seeded servers")
     CHECK(servers[1].second == 9090);
 }
 
+TEST_CASE("session: identify surfaces a mid-cursor server-list failure instead of a partial list")
+{
+    /* getActiveServers throws when the cursor is cut short by a mid-iteration
+     * error. The throw must propagate out of processMessage (where production
+     * wraps it in an exception_guard) rather than a truncated server list
+     * reaching the wire. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+    mock.active_servers.emplace_back("10.0.0.1", uint16_t{8080});
+    mock.active_servers_fail = true;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    REQUIRE_THROWS_AS(session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft")),
+                      fss::server::database_error);
+
+    /* No server list was sent: the partial result was discarded, not shipped. */
+    REQUIRE(find_sent<fss::transport::fss_message_server_list>(conn->sent) == nullptr);
+}
+
 TEST_CASE("session: rapid sendCommand does not duplicate a single pending command")
 {
     /* sendCommand is called every 100ms to minimise command delivery


### PR DESCRIPTION
## Description

Add an active_servers_fail switch to MockDatabase so getActiveServers can simulate the database_error raised on a truncated cursor read, and a session test asserting that an identify drives the exception out of processMessage (where production's exception_guard catches it) rather than sending a partial server list on the wire.

## Summary by Sourcery

Add test coverage and mocking support to verify that mid-iteration failures when fetching active servers result in errors rather than partial server lists being sent.

Enhancements:
- Extend MockDatabase with a configurable failure mode for getActiveServers to simulate mid-cursor read errors in tests.

Tests:
- Add a session test ensuring identify propagates a database error from a mid-cursor active-server lookup and does not emit a partial server list.