### PR TITLE
feat(transport): negotiate optional capabilities via version feature_flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Optional-capability negotiation in the protocol version handshake. The
+  handshake's `feature_flags` field is now a bitmask of capabilities each peer
+  supports; the negotiated set is the intersection of the two, recorded on the
+  connection. This lets new optional features (see todo/17) be added without a
+  protocol-version bump — a peer that does not advertise a capability never has
+  it used, and a peer cannot enable one this build does not implement. No
+  capability bits are enabled yet, so this is wire-compatible with existing
+  peers (which advertise none).
+
 ### Security
 - The TLS handshake no longer runs inline on the accept thread. A peer that
   completed the TCP connection but then stalled the handshake (sending no or

--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -503,6 +503,8 @@ void flight_safety_system::client_ssl::fss_server::processMessage(
                     }
                     uint16_t negotiated = std::min(peer_version, flight_safety_system::transport::FSS_PROTOCOL_VERSION);
                     this->getConnection()->setNegotiatedVersion(negotiated);
+                    this->getConnection()->setNegotiatedFeatureFlags(
+                        flight_safety_system::transport::negotiateFeatureFlags(version_msg->getFeatureFlags()));
                 }
             }
             break;

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -438,6 +438,8 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
             }
             uint16_t negotiated = std::min(peer_version, fss::transport::FSS_PROTOCOL_VERSION);
             this->getConnection()->setNegotiatedVersion(negotiated);
+            this->getConnection()->setNegotiatedFeatureFlags(
+                fss::transport::negotiateFeatureFlags(version_msg->getFeatureFlags()));
             this->version_received = true;
             if (negotiated >= 2)
             {

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -36,6 +36,29 @@ static constexpr uint16_t FSS_PROTOCOL_VERSION_LEGACY = 0;
 static constexpr uint16_t FSS_PROTOCOL_VERSION = 2;
 static constexpr uint16_t FSS_PROTOCOL_MIN_VERSION = 1;
 
+/* Optional-capability negotiation. The version handshake's feature_flags is a
+ * bitmask of capabilities each peer supports; the negotiated set is the
+ * intersection (peer's flags & FSS_SUPPORTED_FEATURES), so a feature is only
+ * used when BOTH peers advertise it. This lets old peers interop unchanged
+ * (they advertise 0) without a protocol-version bump — see todo/17. A peer
+ * cannot force on a capability we do not implement: the AND with
+ * FSS_SUPPORTED_FEATURES masks any bit we have not enabled. Each bit is added
+ * to FSS_SUPPORTED_FEATURES only once this build actually implements it. */
+static constexpr uint32_t FSS_FEATURE_RTT_OFFSET = 0x1U;    /* todo/17 item 3 */
+static constexpr uint32_t FSS_FEATURE_COMMAND_ACK = 0x2U;   /* todo/17 item 1 */
+static constexpr uint32_t FSS_FEATURE_SYSTEM_HEALTH = 0x4U; /* todo/17 item 2 */
+static constexpr uint32_t FSS_SUPPORTED_FEATURES = 0U;
+
+/* The capability set to adopt for a peer that advertised peer_flags: the
+ * intersection with what this build implements, so a peer can never enable a
+ * feature we do not support. Both handshake paths (server: client_session.cpp,
+ * client: client-ssl.cpp) negotiate through this one function so the policy
+ * cannot drift between them. */
+inline auto negotiateFeatureFlags(uint32_t peer_flags) -> uint32_t
+{
+    return peer_flags & FSS_SUPPORTED_FEATURES;
+}
+
 /* Maximum payload length accepted from the wire. Anything larger is rejected
  * before allocation to prevent memory exhaustion attacks. Sized well above the
  * largest legitimate message (server_list with many entries) with headroom. */
@@ -167,6 +190,10 @@ class fss_connection {
      * the odd unknown message type is never disconnected. */
     static constexpr uint64_t null_msg_disconnect_threshold = 1000;
     std::atomic<uint16_t> negotiated_version{FSS_PROTOCOL_VERSION_LEGACY};
+    /* Capabilities both peers agreed on at handshake (intersection of the two
+     * advertised feature_flags, masked by FSS_SUPPORTED_FEATURES). 0 until the
+     * version handshake negotiates it; a legacy peer leaves it 0. */
+    std::atomic<uint32_t> negotiated_feature_flags{0};
 protected:
     auto recvMsg() -> std::shared_ptr<fss_message>;
     auto getMessageId() -> uint64_t;
@@ -194,6 +221,8 @@ public:
     virtual auto connectTo(const std::string &address, uint16_t port) -> bool;
     auto getNegotiatedVersion() -> uint16_t { return this->negotiated_version.load(); }
     void setNegotiatedVersion(uint16_t v) { this->negotiated_version.store(v); }
+    auto getNegotiatedFeatureFlags() -> uint32_t { return this->negotiated_feature_flags.load(); }
+    void setNegotiatedFeatureFlags(uint32_t f) { this->negotiated_feature_flags.store(f); }
     auto sendMsg(const std::shared_ptr<fss_message> &msg) -> bool;
     auto getMsg() -> std::shared_ptr<fss_message>;
     virtual void processMessages();
@@ -475,7 +504,9 @@ class fss_message_version : public fss_message {
 private:
     uint16_t protocol_version{FSS_PROTOCOL_VERSION};
     uint16_t min_supported_version{FSS_PROTOCOL_MIN_VERSION};
-    uint32_t feature_flags{0};
+    /* A default-constructed version message (the one each peer sends at
+     * handshake) advertises exactly the capabilities this build implements. */
+    uint32_t feature_flags{FSS_SUPPORTED_FEATURES};
 protected:
     void unpackData(const std::shared_ptr<buf_len> &bl);
     void packData(std::shared_ptr<buf_len> bl) override;

--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -44,6 +44,31 @@ public:
     }
 };
 
+/* A connection that records the messages the client tries to send, by decoding
+ * the framed buffer the base sendMsg(fss_message) hands to sendMsg(buf_len).
+ * Mirrors the FakeConnection used in the server-session tests. */
+class CapturingConnection : public fss::transport::fss_connection {
+public:
+    std::vector<std::shared_ptr<fss::transport::fss_message>> sent{};
+protected:
+    auto sendMsg(const std::shared_ptr<fss::transport::buf_len> &bl) -> bool override
+    {
+        if (auto decoded = fss::transport::fss_message::decode(bl))
+        {
+            sent.push_back(decoded);
+        }
+        return true;
+    }
+};
+
+/* fss_server with the protected setConnection exposed so a test can inject a
+ * CapturingConnection (and preset its negotiated capabilities). */
+class ConnInjectableServer : public fss::client_ssl::fss_server {
+public:
+    using fss::client_ssl::fss_server::fss_server;
+    using fss::transport::fss_message_cb::setConnection;
+};
+
 } // namespace
 
 constexpr const char *CA_PUBLIC_FILE = "certs/ca.public.pem";
@@ -144,6 +169,42 @@ TEST_CASE("client: processMessage version incompatibility triggers serverRequire
     constexpr uint16_t future_min = fss::transport::FSS_PROTOCOL_VERSION + 1;
     auto msg = std::make_shared<fss::transport::fss_message_version>(future_min, future_min, uint32_t{0});
     server->processMessage(msg); // serverRequiresReconnect called; no crash
+}
+
+TEST_CASE("client: version handshake negotiates feature flags as the intersection")
+{
+    /* Client-side mirror of the server-side test: on the client path the
+     * negotiated capability set is also (peer-advertised & FSS_SUPPORTED_FEATURES),
+     * recorded on the connection. */
+    TrackingClient client;
+    auto server = std::make_shared<ConnInjectableServer>(&client, "localhost", uint16_t{0}, CA_PUBLIC_FILE,
+                                                         CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+    auto conn = std::make_shared<CapturingConnection>();
+    server->setConnection(conn);
+
+    REQUIRE(conn->getNegotiatedFeatureFlags() == 0U); // nothing negotiated yet
+
+    constexpr uint32_t all_flags = 0xFFFFFFFFU; // server advertises every bit
+    auto version = std::make_shared<fss::transport::fss_message_version>(
+        fss::transport::FSS_PROTOCOL_VERSION, fss::transport::FSS_PROTOCOL_MIN_VERSION, all_flags);
+    server->processMessage(version);
+
+    REQUIRE(conn->getNegotiatedFeatureFlags() == (all_flags & fss::transport::FSS_SUPPORTED_FEATURES));
+}
+
+TEST_CASE("client: legacy server advertising no feature flags negotiates none")
+{
+    TrackingClient client;
+    auto server = std::make_shared<ConnInjectableServer>(&client, "localhost", uint16_t{0}, CA_PUBLIC_FILE,
+                                                         CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+    auto conn = std::make_shared<CapturingConnection>();
+    server->setConnection(conn);
+
+    auto version = std::make_shared<fss::transport::fss_message_version>(fss::transport::FSS_PROTOCOL_VERSION,
+                                                                         fss::transport::FSS_PROTOCOL_MIN_VERSION, 0U);
+    server->processMessage(version);
+
+    REQUIRE(conn->getNegotiatedFeatureFlags() == 0U);
 }
 
 TEST_CASE("client: JSON config with server entry parses name and creates reconnect entry")

--- a/tests/messages.cpp
+++ b/tests/messages.cpp
@@ -583,7 +583,9 @@ TEST_CASE("Version Message Defaults")
     REQUIRE(msg->getType() == flight_safety_system::transport::message_type_version);
     REQUIRE(msg->getProtocolVersion() == flight_safety_system::transport::FSS_PROTOCOL_VERSION);
     REQUIRE(msg->getMinSupportedVersion() == flight_safety_system::transport::FSS_PROTOCOL_MIN_VERSION);
-    REQUIRE(msg->getFeatureFlags() == 0);
+    /* A default-constructed version message advertises exactly the capabilities
+     * this build implements. */
+    REQUIRE(msg->getFeatureFlags() == flight_safety_system::transport::FSS_SUPPORTED_FEATURES);
 }
 
 TEST_CASE("messages: identity_required round-trip")

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -502,6 +502,55 @@ TEST_CASE("session: version handshake stores negotiated version and replies")
     REQUIRE(saw_version_response);
 }
 
+TEST_CASE("session: version handshake negotiates feature flags as the intersection")
+{
+    /* The negotiated capability set is (peer-advertised & FSS_SUPPORTED_FEATURES):
+     * a peer cannot enable a feature this build does not implement, and the
+     * value is recorded on the connection for the rest of the session. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+
+    /* No capabilities negotiated until the handshake. */
+    REQUIRE(conn->getNegotiatedFeatureFlags() == 0U);
+
+    /* Peer advertises every bit; we must mask down to what we support. */
+    constexpr uint32_t all_flags = 0xFFFFFFFFU;
+    auto version = std::make_shared<fss::transport::fss_message_version>(
+        fss::transport::FSS_PROTOCOL_VERSION, fss::transport::FSS_PROTOCOL_MIN_VERSION, all_flags);
+    session->processMessage(version);
+
+    REQUIRE(conn->getNegotiatedFeatureFlags() == (all_flags & fss::transport::FSS_SUPPORTED_FEATURES));
+    REQUIRE(handler.disconnects == 0);
+}
+
+TEST_CASE("session: legacy peer advertising no feature flags negotiates none")
+{
+    /* A peer advertising 0 (an old client, or one with no optional features)
+     * leaves the negotiated capability set empty regardless of what we support. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+
+    auto version = std::make_shared<fss::transport::fss_message_version>(fss::transport::FSS_PROTOCOL_VERSION,
+                                                                         fss::transport::FSS_PROTOCOL_MIN_VERSION, 0U);
+    session->processMessage(version);
+
+    REQUIRE(conn->getNegotiatedFeatureFlags() == 0U);
+}
+
 TEST_CASE("session: version handshake rejects incompatible peer")
 {
     /* When the client's max version is below our minimum, the server
@@ -633,7 +682,8 @@ auto make_position_msg(uint64_t ts) -> std::shared_ptr<fss::transport::fss_messa
 auto establish_v2_session(std::shared_ptr<fss::server::fss_client> &session, uint64_t &next_id) -> void
 {
     auto version = std::make_shared<fss::transport::fss_message_version>(fss::transport::FSS_PROTOCOL_VERSION,
-                                                                         fss::transport::FSS_PROTOCOL_MIN_VERSION, 0U);
+                                                                         fss::transport::FSS_PROTOCOL_MIN_VERSION,
+                                                                         fss::transport::FSS_SUPPORTED_FEATURES);
     version->setId(next_id++);
     session->processMessage(version);
 
@@ -695,17 +745,21 @@ TEST_CASE("session: duplicate version message is ignored without derailing the s
 
     uint64_t next_id = 1;
     establish_v2_session(session, next_id);
+    /* Capabilities negotiated at handshake; a duplicate must not disturb them. */
+    uint32_t negotiated_features = conn->getNegotiatedFeatureFlags();
 
     auto pos = make_position_msg(fss::fss_current_timestamp());
     pos->setId(next_id++);
     session->processMessage(pos);
     REQUIRE(handler.broadcasts.size() == 1);
 
-    /* In-sequence duplicate offering a lower version: must not downgrade. */
+    /* In-sequence duplicate offering a lower version and no capabilities: must
+     * neither downgrade the version nor clear the negotiated feature flags. */
     auto dup = std::make_shared<fss::transport::fss_message_version>(1U, 1U, 0U);
     dup->setId(next_id++);
     session->processMessage(dup);
     REQUIRE(conn->getNegotiatedVersion() == fss::transport::FSS_PROTOCOL_VERSION);
+    REQUIRE(conn->getNegotiatedFeatureFlags() == negotiated_features);
     REQUIRE(handler.disconnects == 0);
 
     /* The duplicate consumed a sequence id; the stream must continue. */


### PR DESCRIPTION
## Descriptio

Lay the foundation for the todo/17 protocol additions (command-ack, system-health, RTT clock-offset) without a protocol-version bump.

The version handshake's feature_flags field becomes a capability bitmask. Each peer advertises FSS_SUPPORTED_FEATURES (the set this build implements); the negotiated set is the intersection (peer flags & FSS_SUPPORTED_FEATURES), stored on the connection alongside the negotiated version. The AND means a peer cannot enable a capability we do not support, and a legacy peer advertising 0 negotiates none — so this is wire-compatible with existing peers.

No capability bits are enabled yet (FSS_SUPPORTED_FEATURES == 0); the three FSS_FEATURE_* constants are defined and each will be folded into the mask as its feature lands.

## Summary by Sourcery

Introduce negotiated optional capabilities in the transport version handshake while preserving wire compatibility with existing peers.

New Features:
- Add protocol-level optional capability flags and a supported-feature bitmask to negotiate capabilities during the version handshake.
- Expose negotiated feature flags on connections so session logic can access the agreed capability set.

Enhancements:
- Update version message defaults so peers automatically advertise the capabilities implemented by the current build.
- Ensure duplicate version messages do not alter the previously negotiated version or feature flags.

Documentation:
- Document capability negotiation behavior and compatibility guarantees in the changelog.

Tests:
- Add tests covering capability flag negotiation, legacy peers advertising no capabilities, and stability of negotiated capabilities on duplicate version messages.