### PR TITLE
feat(transport): rtt_response can carry the responder's clock reading

### DIFF
--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -345,13 +345,29 @@ public:
 class fss_message_rtt_response : public fss_message {
 private:
     uint64_t request_id;
+    /* The responder's wall-clock reading (ms since epoch) at the moment it
+     * built this response. 0 means "not reported" — a legacy peer, or one that
+     * has not negotiated the RTT clock-offset capability. Carried as an
+     * optional trailing wire field (see todo/17 item 3); the server uses it to
+     * estimate the client↔server clock offset that feeds the position
+     * staleness gate.
+     *
+     * The 0 sentinel is lossy: it cannot distinguish "not reported" from a
+     * responder whose clock genuinely reads Unix epoch midnight (an unsynced
+     * RTC or a simulator stub). That collision degrades safely — the consumer
+     * treats epoch-0 as "no measurement", so the offset stays 0 and the
+     * staleness gate falls back to a symmetric window; an aircraft with a
+     * frozen 1970 clock has no usable offset to feed it anyway. */
+    uint64_t client_timestamp{0};
 protected:
     void unpackData(const std::shared_ptr<buf_len> &bl);
     void packData(std::shared_ptr<buf_len> bl) override;
 public:
     explicit fss_message_rtt_response(uint64_t t_request_id);
+    fss_message_rtt_response(uint64_t t_request_id, uint64_t t_client_timestamp);
     fss_message_rtt_response(uint64_t t_id, const std::shared_ptr<buf_len> &bl);
     virtual auto getRequestId() -> uint64_t;
+    virtual auto getClientTimestamp() -> uint64_t;
 };
 
 class fss_message_position_report : public fss_message {

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -587,6 +587,14 @@ flight_safety_system::transport::fss_message_rtt_response::fss_message_rtt_respo
 {
 }
 
+// NOLINTBEGIN(bugprone-easily-swappable-parameters)
+flight_safety_system::transport::fss_message_rtt_response::fss_message_rtt_response(uint64_t t_request_id,
+                                                                                    uint64_t t_client_timestamp)
+    : fss_message(message_type_rtt_response), request_id(t_request_id), client_timestamp(t_client_timestamp)
+// NOLINTEND(bugprone-easily-swappable-parameters)
+{
+}
+
 flight_safety_system::transport::fss_message_rtt_response::fss_message_rtt_response(uint64_t t_id,
                                                                                     const std::shared_ptr<buf_len> &bl)
     : fss_message(t_id, message_type_rtt_response), request_id(0)
@@ -598,6 +606,14 @@ void flight_safety_system::transport::fss_message_rtt_response::packData(std::sh
 {
     uint64_t data = fss_htobe64(this->request_id);
     bl->addData(&data, sizeof(uint64_t));
+    /* The client timestamp is an optional trailing field: omitting it when 0
+     * keeps the wire bytes identical to a legacy response, so a peer that never
+     * reports its clock is unaffected. */
+    if (this->client_timestamp != 0)
+    {
+        uint64_t ts = fss_htobe64(this->client_timestamp);
+        bl->addData(&ts, sizeof(uint64_t));
+    }
 }
 
 void flight_safety_system::transport::fss_message_rtt_response::unpackData(const std::shared_ptr<buf_len> &bl)
@@ -607,11 +623,21 @@ void flight_safety_system::transport::fss_message_rtt_response::unpackData(const
     {
         this->request_id = 0;
     }
+    /* Optional trailing field; left at 0 when absent (legacy response). */
+    if (!reader.readUint64(this->client_timestamp))
+    {
+        this->client_timestamp = 0;
+    }
 }
 
 auto flight_safety_system::transport::fss_message_rtt_response::getRequestId() -> uint64_t
 {
     return this->request_id;
+}
+
+auto flight_safety_system::transport::fss_message_rtt_response::getClientTimestamp() -> uint64_t
+{
+    return this->client_timestamp;
 }
 
 // NOLINTBEGIN(bugprone-easily-swappable-parameters)

--- a/tests/messages.cpp
+++ b/tests/messages.cpp
@@ -124,6 +124,56 @@ TEST_CASE("RTT Response Message Check")
     auto decoded_generic_rtt_resp =
         std::dynamic_pointer_cast<flight_safety_system::transport::fss_message_rtt_response>(decoded_generic);
     REQUIRE((decoded_generic_rtt_resp)->getRequestId() == request_id);
+    /* No client timestamp supplied: defaults to "not reported". */
+    REQUIRE(msg->getClientTimestamp() == 0);
+    REQUIRE(decoded->getClientTimestamp() == 0);
+}
+
+TEST_CASE("RTT Response carries an optional client timestamp")
+{
+    auto msg_id = static_cast<uint64_t>(random());
+    auto request_id = static_cast<uint64_t>(random());
+    constexpr uint64_t client_ts = 0x1122334455667788ULL;
+
+    auto msg = std::make_shared<flight_safety_system::transport::fss_message_rtt_response>(request_id, client_ts);
+    REQUIRE(msg->getRequestId() == request_id);
+    REQUIRE(msg->getClientTimestamp() == client_ts);
+
+    msg->setId(msg_id);
+    auto bl = msg->getPacked();
+    REQUIRE(bl != nullptr);
+
+    auto decoded = std::make_shared<flight_safety_system::transport::fss_message_rtt_response>(msg_id, bl);
+    REQUIRE(decoded->getRequestId() == request_id);
+    REQUIRE(decoded->getClientTimestamp() == client_ts);
+
+    auto decoded_generic = std::dynamic_pointer_cast<flight_safety_system::transport::fss_message_rtt_response>(
+        flight_safety_system::transport::fss_message::decode(bl));
+    REQUIRE(decoded_generic != nullptr);
+    REQUIRE(decoded_generic->getClientTimestamp() == client_ts);
+}
+
+TEST_CASE("RTT Response without a timestamp is byte-identical to a legacy response")
+{
+    /* Backward compatibility: a response whose client timestamp is 0 (not
+     * reported) must pack to exactly the same bytes as before the optional
+     * field existed — request_id only, no trailing 8 bytes. */
+    constexpr uint64_t request_id = 0x0102030405060708ULL;
+    auto without = std::make_shared<flight_safety_system::transport::fss_message_rtt_response>(request_id);
+    auto with_zero = std::make_shared<flight_safety_system::transport::fss_message_rtt_response>(request_id, 0ULL);
+    without->setId(7);
+    with_zero->setId(7);
+    auto bl_without = without->getPacked();
+    auto bl_with_zero = with_zero->getPacked();
+    REQUIRE(bl_without->getLength() == bl_with_zero->getLength());
+    REQUIRE(std::string(bl_without->getData(), bl_without->getLength()) ==
+            std::string(bl_with_zero->getData(), bl_with_zero->getLength()));
+
+    /* And a response that does report a timestamp is exactly 8 bytes longer. */
+    auto with_ts = std::make_shared<flight_safety_system::transport::fss_message_rtt_response>(request_id, 42ULL);
+    with_ts->setId(7);
+    auto bl_with_ts = with_ts->getPacked();
+    REQUIRE(bl_with_ts->getLength() == bl_without->getLength() + sizeof(uint64_t));
 }
 
 TEST_CASE("Position Report Message Check")


### PR DESCRIPTION
## Description

Add an optional client_timestamp field to fss_message_rtt_response: the responder's wall-clock reading (ms since epoch) when it built the response. The server will use it to estimate the client↔server clock offset that feeds the position-staleness gate (todo/17 item 3).

The field is an optional trailing wire element. When 0 ("not reported") it is omitted entirely, so a response packs byte-for-byte identically to the legacy format; the decoder reads it only if present and otherwise leaves it 0. This keeps existing peers wire-compatible. No behaviour is wired to it yet and no feature bit is enabled — this commit is the carrier only.

## Summary by Sourcery

Add an optional client timestamp field to RTT response messages while preserving wire compatibility with legacy peers.

New Features:
- Allow RTT response messages to carry the responder's wall-clock timestamp as an optional field.

Enhancements:
- Expose accessor for the RTT response client timestamp and support constructing messages with or without it.
- Ensure encoded RTT responses omit the timestamp when unset so legacy and zero-timestamp messages remain byte-identical, and include it only when provided.

Tests:
- Extend RTT response tests to cover default timestamp behavior, propagation through encode/decode, and wire-format compatibility with legacy responses.