### PR TITLE
feat(server): measure client clock offset from RTT and feed the staleness gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- The position-staleness gate now corrects for a measured client↔server clock
+  offset, so a client whose clock is skewed but whose link is healthy no longer
+  has all its positions dropped. The offset is estimated from RTT responses: a
+  peer that negotiates the new `rtt-offset` capability stamps its wall clock
+  into each `rtt_response`, and the server folds `client - server` (bounded by
+  half the round trip, smoothed across samples) into the gate. The stored
+  timestamp is never rewritten — only the accept/reject window shifts. A peer
+  that does not negotiate the capability is unaffected and the gate stays a
+  plain symmetric window.
 - Optional-capability negotiation in the protocol version handshake. The
   handshake's `feature_flags` field is now a bitmask of capabilities each peer
   supports; the negotiated set is the intersection of the two, recorded on the

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -25,6 +25,13 @@ constexpr uint64_t rtt_retry_interval = 10 * sec_to_msec;
  * persistently skewed client is unmistakable without a per-message WARN drip. */
 constexpr uint64_t staleness_escalation_threshold = 10;
 constexpr uint64_t staleness_escalation_interval = 100;
+/* RTT clock-offset smoothing (todo/17 item 3). A sample's error is bounded by
+ * half the round trip, so a link slower than this yields an estimate too coarse
+ * to trust for the staleness window — drop it rather than poison the average. */
+constexpr uint64_t max_rtt_for_clock_offset_ms = 5000;
+/* EWMA weight: each new sample moves the smoothed offset by 1/N of the gap, so
+ * jitter is damped while genuine drift is still tracked. */
+constexpr int64_t clock_offset_smoothing_divisor = 4;
 
 fss::server::smm_settings::smm_settings(std::string t_address, fss::secure_string t_username,
                                         fss::secure_string t_password)
@@ -336,6 +343,43 @@ void fss::server::fss_client::sendRTTRequest(const std::shared_ptr<fss::transpor
     }
 }
 
+// NOLINTBEGIN(bugprone-easily-swappable-parameters)
+void fss::server::fss_client::updateClockOffset(uint64_t client_timestamp, uint64_t rtt_ms, uint64_t recv_wall)
+// NOLINTEND(bugprone-easily-swappable-parameters)
+{
+    /* 0 means the peer did not report its clock (or its clock genuinely reads
+     * the epoch, which we deliberately treat the same — see the field comment
+     * in fss-transport.hpp); either way there is nothing usable to fold in. */
+    if (client_timestamp == 0)
+    {
+        return;
+    }
+    if (rtt_ms > max_rtt_for_clock_offset_ms)
+    {
+        return;
+    }
+    /* The request's midpoint in server wall-clock terms is half a round trip
+     * before we received the response. rtt_ms is a duration, so subtracting it
+     * from recv_wall is sound even though the RTT itself is timed on the
+     * monotonic clock; the caller captures recv_wall adjacent to that monotonic
+     * receive time so the two refer to the same instant. */
+    int64_t midpoint = static_cast<int64_t>(recv_wall) - static_cast<int64_t>(rtt_ms / 2);
+    int64_t sample = static_cast<int64_t>(client_timestamp) - midpoint;
+    if (!this->clock_offset_measured)
+    {
+        this->client_clock_offset_ms = sample;
+        this->clock_offset_measured = true;
+    }
+    else
+    {
+        /* EWMA in integer ms: once the estimate is within
+         * clock_offset_smoothing_divisor-1 ms of a sample the delta truncates to
+         * 0 and the value rests, which is far finer than any sane staleness
+         * window — genuine drift larger than that floor is still tracked. */
+        this->client_clock_offset_ms += (sample - this->client_clock_offset_ms) / clock_offset_smoothing_divisor;
+    }
+}
+
 void fss::server::fss_client::refreshSmmSettings()
 {
     uint64_t asset_id = this->cached_asset_id.load();
@@ -610,6 +654,10 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
             case fss::transport::message_type_rtt_response: {
                 std::shared_ptr<fss_client_rtt> rtt_req = nullptr;
                 uint64_t current_ts = this->clock->now_ms();
+                /* Captured adjacent to the monotonic receive time above so the
+                 * wall and monotonic readings refer to the same instant (see
+                 * updateClockOffset). */
+                uint64_t recv_wall = fss::fss_current_timestamp();
                 auto rtt_resp_msg = std::dynamic_pointer_cast<fss::transport::fss_message_rtt_response>(msg);
                 if (rtt_resp_msg != nullptr)
                 {
@@ -627,13 +675,24 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                         this->last_rtt_response_time = this->clock->now_ms();
                     }
                 }
-                if (rtt_req != nullptr && asset_id != 0)
+                if (rtt_req != nullptr)
                 {
+                    uint64_t rtt_ms = current_ts - rtt_req->getTimeStamp();
+                    if (asset_id != 0)
+                    {
 #ifdef DEBUG
-                    std::cout << "RTT for " << this->getName() << " is " << (current_ts - rtt_req->getTimeStamp())
-                              << std::endl;
+                        std::cout << "RTT for " << this->getName() << " is " << rtt_ms << std::endl;
 #endif
-                    this->writer->enqueue(rtt_write{asset_id, current_ts - rtt_req->getTimeStamp()});
+                        this->writer->enqueue(rtt_write{asset_id, rtt_ms});
+                    }
+                    /* RTT clock-offset (todo/17 item 3): only when the peer
+                     * negotiated the capability — otherwise any trailing
+                     * timestamp is not part of the agreed dialect and is ignored. */
+                    if ((this->getConnection()->getNegotiatedFeatureFlags() & fss::transport::FSS_FEATURE_RTT_OFFSET) !=
+                        0)
+                    {
+                        this->updateClockOffset(rtt_resp_msg->getClientTimestamp(), rtt_ms, recv_wall);
+                    }
                 }
             }
             break;
@@ -643,10 +702,11 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                 {
                     uint64_t now = fss::fss_current_timestamp();
                     /* Compare the client-stamped time against the server clock,
-                     * offset-corrected (client_clock_offset_ms is 0 until the
-                     * RTT clock-offset feature measures it). The window is
-                     * symmetric: a clock ahead of the server is as wrong as one
-                     * behind, so future-dated reports are rejected too.
+                     * offset-corrected (client_clock_offset_ms is measured from
+                     * RTT responses that carry the client's clock, else 0). The
+                     * window is symmetric: a clock ahead of the server is as
+                     * wrong as one behind, so future-dated reports are rejected
+                     * too.
                      *
                      * Take the signed difference from the unsigned subtraction so
                      * the two epoch-ms values are never narrowed to int64 (the

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -180,6 +180,16 @@ private:
     std::mutex client_lock{};
     std::list<std::shared_ptr<fss_client_rtt>> outstanding_rtt_requests{};
     auto getName() -> std::string;
+    /* Fold one RTT round trip into the smoothed client↔server clock offset that
+     * feeds the staleness gate (todo/17 item 3). client_timestamp is the peer's
+     * wall clock from the response (0 = not reported); rtt_ms is the measured
+     * round-trip duration, which bounds the estimate's error; recv_wall is the
+     * server wall clock captured at receive, adjacent to the monotonic receive
+     * time rtt_ms is derived from, so the two refer to the same instant and an
+     * NTP step cannot land between them. The client timestamp is trusted data
+     * from an authenticated peer — this is a healthy-link correction, not an
+     * adversarial defence (see todo/17). Recv thread only. */
+    void updateClockOffset(uint64_t client_timestamp, uint64_t rtt_ms, uint64_t recv_wall);
     uint64_t last_command_send_ts{0};
     uint64_t last_command_dbid{0};
     bool liveness_active{false};
@@ -206,9 +216,16 @@ private:
     uint64_t position_staleness_ms{default_position_staleness_ms};
     /* Estimate of (client clock - server clock) in ms: positive if the client
      * runs ahead. Used only to offset-correct the staleness gate, never to
-     * rewrite stored timestamps. Stays 0 until measured (todo/17 item 3, the
-     * RTT clock-offset feature); 0 makes the gate a plain symmetric window. */
+     * rewrite stored timestamps. Measured from RTT responses that carry the
+     * client's clock (todo/17 item 3, via updateClockOffset); stays 0 — making
+     * the gate a plain symmetric window — until a peer that negotiated the
+     * capability reports its clock. */
     int64_t client_clock_offset_ms{0};
+    /* False until the first usable RTT clock-offset sample arrives; gates
+     * whether client_clock_offset_ms is a measurement or the unmeasured-0
+     * default, so the first sample seeds the smoother directly instead of being
+     * averaged against a meaningless 0. Recv thread only. */
+    bool clock_offset_measured{false};
     /* Consecutive staleness discards; reset by the first in-window report.
      * Drives WARN->ERROR escalation so a skewed client is unmistakable without
      * a per-message WARN drip. Recv thread only. */
@@ -238,6 +255,9 @@ public:
     void sendCommand();
     auto isAircraft() -> bool;
     auto getCachedAssetId() -> uint64_t { return this->cached_asset_id.load(); }
+    /* The smoothed client↔server clock offset (ms; positive = client ahead)
+     * currently feeding the staleness gate. 0 until measured. Exposed for tests. */
+    auto getClockOffsetMs() -> int64_t { return this->client_clock_offset_ms; }
     void setPendingCommand(std::shared_ptr<asset_command> cmd);
     void setClock(std::shared_ptr<IClock> t_clock);
     void setTimeoutMs(uint64_t ms);

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -47,7 +47,7 @@ static constexpr uint16_t FSS_PROTOCOL_MIN_VERSION = 1;
 static constexpr uint32_t FSS_FEATURE_RTT_OFFSET = 0x1U;    /* todo/17 item 3 */
 static constexpr uint32_t FSS_FEATURE_COMMAND_ACK = 0x2U;   /* todo/17 item 1 */
 static constexpr uint32_t FSS_FEATURE_SYSTEM_HEALTH = 0x4U; /* todo/17 item 2 */
-static constexpr uint32_t FSS_SUPPORTED_FEATURES = 0U;
+static constexpr uint32_t FSS_SUPPORTED_FEATURES = FSS_FEATURE_RTT_OFFSET;
 
 /* The capability set to adopt for a peer that advertised peer_flags: the
  * intersection with what this build implements, so a peer can never enable a

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -997,6 +997,161 @@ TEST_CASE("session: position_staleness_ms = 0 disables the staleness gate")
     REQUIRE(handler.broadcasts.size() == 1); // accepted despite being well outside the window
 }
 
+TEST_CASE("session: RTT clock-offset measurement shifts the staleness gate")
+{
+    /* Phase 17.3: a client whose clock is skewed but whose link is healthy must
+     * not have its positions dropped. An RTT response carrying the client's
+     * clock lets the server measure the offset and shift the gate by it. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+
+    /* The peer negotiated the RTT clock-offset capability. */
+    conn->setNegotiatedFeatureFlags(fss::transport::FSS_FEATURE_RTT_OFFSET);
+    session->setStalenessMs(5000);
+
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+    REQUIRE(handler.disconnects == 0);
+
+    /* The client's clock runs 60 s ahead of the server — well outside the 5 s
+     * window, so absent any correction every report it sends is discarded. */
+    constexpr int64_t client_ahead_ms = 60000;
+
+    /* Drive one RTT round trip whose response carries the client's skewed clock.
+     * sendMsg assigns the request its id; the response echoes it back. */
+    auto rtt_req = std::make_shared<fss::transport::fss_message_rtt_request>();
+    session->sendRTTRequest(rtt_req);
+    uint64_t client_now = fss::fss_current_timestamp() + static_cast<uint64_t>(client_ahead_ms);
+    auto rtt_resp = std::make_shared<fss::transport::fss_message_rtt_response>(rtt_req->getId(), client_now);
+    session->processMessage(rtt_resp);
+
+    /* Offset measured at ~ +60 s (generous slop for test wall-clock drift and
+     * half-RTT rounding; the round trip here is sub-millisecond). */
+    constexpr int64_t slop_ms = 2000;
+    REQUIRE(session->getClockOffsetMs() > client_ahead_ms - slop_ms);
+    REQUIRE(session->getClockOffsetMs() < client_ahead_ms + slop_ms);
+
+    /* A report stamped with the client's skewed-but-fresh clock is now accepted
+     * rather than discarded as stale. */
+    auto skewed = make_position_msg(fss::fss_current_timestamp() + static_cast<uint64_t>(client_ahead_ms));
+    session->processMessage(skewed);
+    REQUIRE(handler.broadcasts.size() == 1);
+}
+
+TEST_CASE("session: RTT clock-offset is ignored without the negotiated capability")
+{
+    /* The offset must only be trusted when the peer negotiated the capability:
+     * a stray client timestamp on the wire from a peer that did not negotiate
+     * it must leave the gate a plain symmetric window. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+
+    /* No capability negotiated (negotiated feature flags left at 0). */
+    session->setStalenessMs(5000);
+
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+    REQUIRE(handler.disconnects == 0);
+
+    constexpr int64_t client_ahead_ms = 60000;
+    auto rtt_req = std::make_shared<fss::transport::fss_message_rtt_request>();
+    session->sendRTTRequest(rtt_req);
+    uint64_t client_now = fss::fss_current_timestamp() + static_cast<uint64_t>(client_ahead_ms);
+    auto rtt_resp = std::make_shared<fss::transport::fss_message_rtt_response>(rtt_req->getId(), client_now);
+    session->processMessage(rtt_resp);
+
+    REQUIRE(session->getClockOffsetMs() == 0); // never measured
+
+    /* So the skewed report is still discarded as stale. */
+    auto skewed = make_position_msg(fss::fss_current_timestamp() + static_cast<uint64_t>(client_ahead_ms));
+    session->processMessage(skewed);
+    REQUIRE(handler.broadcasts.empty());
+}
+
+TEST_CASE("session: RTT clock-offset ignores samples from a slow link")
+{
+    /* A sample's error is bounded by half the round trip, so a response that
+     * took longer than max_rtt_for_clock_offset_ms (5 s) is too coarse to trust
+     * and must not move the offset. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+
+    auto clock = std::make_shared<FakeClock>(); // drives the monotonic RTT timing
+    session->setClock(clock);
+    conn->setNegotiatedFeatureFlags(fss::transport::FSS_FEATURE_RTT_OFFSET);
+
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    auto rtt_req = std::make_shared<fss::transport::fss_message_rtt_request>();
+    session->sendRTTRequest(rtt_req); // recorded at monotonic t=0
+    clock->advance(6000);             // a 6 s round trip — beyond the 5 s cap
+    auto rtt_resp = std::make_shared<fss::transport::fss_message_rtt_response>(rtt_req->getId(),
+                                                                               fss::fss_current_timestamp() + 60000);
+    session->processMessage(rtt_resp);
+
+    REQUIRE(session->getClockOffsetMs() == 0); // sample dropped, offset untouched
+}
+
+TEST_CASE("session: RTT clock-offset smooths across samples")
+{
+    /* The first sample seeds the offset directly; subsequent samples move it by
+     * 1/divisor of the gap (EWMA), so a later sample at a different offset pulls
+     * the estimate partway rather than replacing it. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+
+    auto clock = std::make_shared<FakeClock>(); // keep every round trip at 0 ms
+    session->setClock(clock);
+    conn->setNegotiatedFeatureFlags(fss::transport::FSS_FEATURE_RTT_OFFSET);
+
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    /* Sample 1: client 60 s ahead → seeds the offset at ~ +60 s. */
+    auto req1 = std::make_shared<fss::transport::fss_message_rtt_request>();
+    session->sendRTTRequest(req1);
+    auto resp1 =
+        std::make_shared<fss::transport::fss_message_rtt_response>(req1->getId(), fss::fss_current_timestamp() + 60000);
+    session->processMessage(resp1);
+
+    /* Sample 2: client now matches the server (offset 0). With divisor 4 the
+     * estimate moves to 60000 + (0 - 60000)/4 = 45000, not all the way to 0. */
+    auto req2 = std::make_shared<fss::transport::fss_message_rtt_request>();
+    session->sendRTTRequest(req2);
+    auto resp2 =
+        std::make_shared<fss::transport::fss_message_rtt_response>(req2->getId(), fss::fss_current_timestamp());
+    session->processMessage(resp2);
+
+    constexpr int64_t slop_ms = 2000;
+    REQUIRE(session->getClockOffsetMs() > 45000 - slop_ms);
+    REQUIRE(session->getClockOffsetMs() < 45000 + slop_ms);
+}
+
 TEST_CASE("session: repeated clock skew escalates WARN -> ERROR and resets on recovery")
 {
     fss_test::MockDatabase mock;


### PR DESCRIPTION
## Description

Enable the rtt-offset capability (todo/17 item 3) and consume it server-side. When a peer negotiates FSS_FEATURE_RTT_OFFSET and stamps its wall clock into an rtt_response, the server estimates the client↔server offset from that response:

  offset ≈ t_client - (t_recv_wall - rtt/2)   (= client - server)

The estimate's error is bounded by half the round trip, so samples from a link slower than max_rtt_for_clock_offset_ms (5 s) are dropped rather than allowed to poison the average; surviving samples feed an EWMA (alpha 1/4). The smoothed offset is fed into the existing position-staleness gate (08) as client_clock_offset_ms, so a skewed-but-healthy client's positions are accepted instead of all dropped. The stored timestamp is never rewritten — only the accept/reject window shifts.

The offset is only trusted when the capability was negotiated; a stray timestamp from a peer that did not negotiate it is ignored and the gate stays a plain symmetric window. FSS_SUPPORTED_FEATURES now advertises rtt-offset.

## Summary by Sourcery

Measure client↔server clock offset from RTT responses and feed it into the server-side position staleness gate when the RTT offset capability is negotiated.

New Features:
- Estimate and smooth client↔server clock offset from RTT responses that carry client timestamps, and use it to shift the position staleness window without mutating stored timestamps.
- Advertise support for the new RTT offset capability in the transport feature flags so peers can negotiate clock-offset reporting.

Enhancements:
- Ignore RTT samples from excessively slow links when computing clock offset, and seed versus smooth subsequent offset samples using an EWMA to balance drift tracking and jitter.
- Expose the measured clock offset to tests and wire it into staleness gate evaluation only when the capability is negotiated.

Documentation:
- Document the new RTT-based clock-offset correction in the changelog, including its negotiation, smoothing, and impact on the staleness gate.

Tests:
- Add server session tests covering staleness gate behavior with and without negotiated RTT offset, slow-link sample rejection, and multi-sample smoothing of the measured clock offset.