### PR TITLE
feat(client): report wall clock in rtt_response when rtt-offset negotiated

### DIFF
--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -509,9 +509,20 @@ void flight_safety_system::client_ssl::fss_server::processMessage(
             }
             break;
             case flight_safety_system::transport::message_type_rtt_request: {
-                /* Send a response */
+                /* Send a response. When the RTT clock-offset capability was
+                 * negotiated, stamp our wall clock so the server can estimate
+                 * our clock offset (todo/17 item 3); otherwise reply in the
+                 * legacy form (no timestamp). getConnection() may be null (e.g.
+                 * mid-teardown), so guard it the same way sendMsg does. */
+                auto active_conn = this->getConnection();
+                bool report_clock =
+                    active_conn != nullptr && (active_conn->getNegotiatedFeatureFlags() &
+                                               flight_safety_system::transport::FSS_FEATURE_RTT_OFFSET) != 0;
                 auto reply_msg =
-                    std::make_shared<flight_safety_system::transport::fss_message_rtt_response>(msg->getId());
+                    report_clock
+                        ? std::make_shared<flight_safety_system::transport::fss_message_rtt_response>(
+                              msg->getId(), flight_safety_system::fss_current_timestamp())
+                        : std::make_shared<flight_safety_system::transport::fss_message_rtt_response>(msg->getId());
                 this->sendMsg(reply_msg);
             }
             break;

--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -161,6 +161,40 @@ TEST_CASE("client: processMessage rtt_request sends reply (no-op with null conne
     server->processMessage(msg); // sendMsg returns false (conn is null); must not crash
 }
 
+TEST_CASE("client: rtt_request reply carries our clock when rtt-offset negotiated")
+{
+    TrackingClient client;
+    auto server = std::make_shared<ConnInjectableServer>(&client, "localhost", uint16_t{0}, CA_PUBLIC_FILE,
+                                                         CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+    auto conn = std::make_shared<CapturingConnection>();
+    conn->setNegotiatedFeatureFlags(fss::transport::FSS_FEATURE_RTT_OFFSET);
+    server->setConnection(conn);
+
+    server->processMessage(std::make_shared<fss::transport::fss_message_rtt_request>());
+
+    REQUIRE(conn->sent.size() == 1);
+    auto resp = std::dynamic_pointer_cast<fss::transport::fss_message_rtt_response>(conn->sent.front());
+    REQUIRE(resp != nullptr);
+    REQUIRE(resp->getClientTimestamp() != 0); // our wall clock was stamped
+}
+
+TEST_CASE("client: rtt_request reply omits our clock without the negotiated capability")
+{
+    TrackingClient client;
+    auto server = std::make_shared<ConnInjectableServer>(&client, "localhost", uint16_t{0}, CA_PUBLIC_FILE,
+                                                         CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+    auto conn = std::make_shared<CapturingConnection>();
+    /* No capability negotiated (negotiated feature flags left at 0). */
+    server->setConnection(conn);
+
+    server->processMessage(std::make_shared<fss::transport::fss_message_rtt_request>());
+
+    REQUIRE(conn->sent.size() == 1);
+    auto resp = std::dynamic_pointer_cast<fss::transport::fss_message_rtt_response>(conn->sent.front());
+    REQUIRE(resp != nullptr);
+    REQUIRE(resp->getClientTimestamp() == 0); // legacy reply, no timestamp
+}
+
 TEST_CASE("client: processMessage version incompatibility triggers serverRequiresReconnect")
 {
     TrackingClient client;


### PR DESCRIPTION
## Description

Complete the RTT clock-offset round trip (todo/17 item 3) on the bundled client library. When the connection negotiated FSS_FEATURE_RTT_OFFSET, the client now stamps its wall clock into the rtt_response it sends in reply to a server rtt_request, so the server can measure the client↔server offset. When the capability was not negotiated it replies in the legacy form (no timestamp).

getConnection() is null-checked before reading the negotiated flags, matching how sendMsg already guards a torn-down connection.

## Summary by Sourcery

Tests:
- Add tests verifying RTT responses include a client timestamp when RTT offset is negotiated and omit it otherwise.