### PR TITLE
test(transport): defer-start the queue test listeners (todo/13.1)

### DIFF
--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -104,8 +104,12 @@ class small_queue_listen : public flight_safety_system::transport::fss_listen {
 public:
     static constexpr size_t queue_limit = 5;
     small_queue_listen(uint16_t t_port, flight_safety_system::transport::fss_connect_cb t_cb)
-        : fss_listen(t_port, std::move(t_cb))
+        : fss_listen(t_port, std::move(t_cb), defer_start_t{})
     {
+        /* Start the accept thread only once this derived object is fully
+         * constructed; the auto-starting base constructor would let the thread
+         * virtual-dispatch into newConnection() before the vptr settles. */
+        this->startListening();
     }
 protected:
     auto newConnection(int t_fd) -> std::shared_ptr<flight_safety_system::transport::fss_connection> override

--- a/tests/queue_test.cpp
+++ b/tests/queue_test.cpp
@@ -40,8 +40,12 @@ auto accept_cb(std::shared_ptr<fss_connection> new_conn) -> bool
 class large_queue_listen : public fss_listen {
 public:
     large_queue_listen(uint16_t t_port, flight_safety_system::transport::fss_connect_cb t_cb)
-        : fss_listen(t_port, std::move(t_cb))
+        : fss_listen(t_port, std::move(t_cb), defer_start_t{})
     {
+        /* Start the accept thread only once this derived object is fully
+         * constructed; the auto-starting base constructor would let the thread
+         * virtual-dispatch into newConnection() before the vptr settles. */
+        this->startListening();
     }
 protected:
     auto newConnection(int t_fd) -> std::shared_ptr<fss_connection> override


### PR DESCRIPTION
## Description

small_queue_listen (tests/connection.cpp) and large_queue_listen (tests/queue_test.cpp) subclassed fss_listen with the auto-starting constructor, so the accept thread could virtual-dispatch into the derived newConnection() before the vptr settled — the same construction race the SSL listener already fixed. Both now use the defer_start_t constructor and call startListening() at the end of their own constructor. Test-only; no shipped behaviour changes.

## Summary by Sourcery

Tests:
- Update small_queue_listen and large_queue_listen test listeners to use the defer-start constructor and explicitly start listening after construction to prevent construction-time races.