### PR TITLE
docs(transport): document the multi-send id-stamp invariant

### DIFF
--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -161,6 +161,10 @@ class fss_client_handler {
 public:
     virtual ~fss_client_handler() = default;
     virtual void clientDisconnected(fss_client *client) = 0;
+    /* Sends msg to every client (bar `except`). Implementations must iterate
+     * the connections sequentially: fss_connection::sendMsg stamps a
+     * per-connection id into msg, so fanning one instance out concurrently
+     * would race that write (todo/12 C8). */
     virtual void broadcastMsg(const std::shared_ptr<transport::fss_message> &msg, fss_client *except = nullptr) = 0;
 };
 

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -223,6 +223,16 @@ public:
     void setNegotiatedVersion(uint16_t v) { this->negotiated_version.store(v); }
     auto getNegotiatedFeatureFlags() -> uint32_t { return this->negotiated_feature_flags.load(); }
     void setNegotiatedFeatureFlags(uint32_t f) { this->negotiated_feature_flags.store(f); }
+    /* Sends one message on this connection. NOTE: this mutates the message —
+     * it stamps the per-connection sequence id into msg (setId) before packing.
+     * Invariant (todo/12 C8): a single fss_message instance must not be sent
+     * concurrently on multiple connections; the id stamp would race. The one
+     * path that fans a shared instance out — broadcastMsg (one msg to every
+     * client) — iterates the connections sequentially on a single thread.
+     * sendRTTRequest sends a single message and then reads its assigned id back
+     * immediately after this returns, so it too relies on the stamp being
+     * synchronous and unraced. (sendSMMSettings builds a fresh message per
+     * client, so it never shares an instance.) */
     auto sendMsg(const std::shared_ptr<fss_message> &msg) -> bool;
     auto getMsg() -> std::shared_ptr<fss_message>;
     virtual void processMessages();
@@ -231,6 +241,12 @@ public:
     virtual auto isPeerCertRevoked(const std::string &) const -> bool { return false; }
 };
 
+/* NOTE (todo/12 C7): a listen socket is-a fss_connection only to reuse the fd +
+ * recv-thread lifecycle; it inherits sendMsg/getMsg/message-queue members that
+ * are meaningless for it. The clean shape is a small fd_owner base shared by
+ * sibling fss_listen / fss_connection. Deferred deliberately: it is an ABI break
+ * (a -version-info bump — all four libs export this header) not worth doing on
+ * its own; fold it into the next transport rework. */
 class fss_listen : public fss_connection {
 private:
     uint16_t port;


### PR DESCRIPTION
## Description

C8: fss_connection::sendMsg stamps a per-connection sequence id into the message before packing, so fanning one fss_message instance out to N connections rewrites its id N times. The "no concurrent multi-send of one message" invariant was relied on (broadcastMsg / sendRTTRequest / sendSMMSettings all iterate sequentially on one thread, and sendRTTRequest reads the id back) but undocumented — note it on fss_connection::sendMsg and fss_client_handler::broadcastMsg.

C7: record why fss_listen inherits fss_connection (fd + recv-thread lifecycle reuse) and that splitting out an fd_owner base is deferred as an ABI break to fold into the next transport rework.

Docs only; no behaviour or wire change.

## Summary by Sourcery

Document transport-layer invariants and design rationale around connection message ID stamping and listen socket inheritance.

Documentation:
- Clarify that fss_connection::sendMsg mutates messages by stamping a per-connection sequence ID and describe the non-concurrent multi-send invariant relied on by callers.
- Explain that fss_listen inherits from fss_connection solely to reuse file descriptor and receive-thread lifecycle handling, and note plans to refactor this into a shared fd_owner base class in a future transport rework.
- Document that fss_client_handler::broadcastMsg implementations must iterate connections sequentially to avoid races on per-connection ID stamping when reusing a single message instance.