### PR TITLE
feat(transport): add fss_message_command_ack wire format (todo/17.1)

### DIFF
--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -571,6 +571,11 @@ void flight_safety_system::client_ssl::fss_server::processMessage(
                 }
             }
             break;
+            case flight_safety_system::transport::message_type_command_ack:
+                /* Command acks flow FMU -> server (todo/17 item 1). The bundled
+                 * client is the command sender, not a recipient, so it never
+                 * needs to consume one. */
+                break;
         }
     }
 }

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -785,6 +785,15 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                 }
             }
             break;
+            /* message_type_command_ack (todo/17 item 1): an aircraft client
+             * acking a command we sent. The message type and wire format exist,
+             * but routing to operators and storage against the asset land in a
+             * follow-up commit (the storage shape is still being agreed). Until
+             * then FSS_FEATURE_COMMAND_ACK is deliberately NOT in
+             * FSS_SUPPORTED_FEATURES, so a conforming client never negotiates the
+             * capability and never sends this; dropping a stray ack is safe and
+             * groups with the other message types the server does not act on. */
+            case fss::transport::message_type_command_ack:
             case fss::transport::message_type_command:
             case fss::transport::message_type_server_list:
             case fss::transport::message_type_smm_settings: break;

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -100,6 +100,28 @@ using fss_message_type = enum fss_message_type_e {
     /* Protocol version handshake. Sent first by both peers after the TLS
      * handshake; the negotiated version is min(peer max, our max). */
     message_type_version,
+
+    /* Acknowledgement of a server command, sent by an aircraft client (FMU)
+     * back to the server. Optional capability gated by FSS_FEATURE_COMMAND_ACK;
+     * appended last so existing type numbering is unchanged for legacy peers.
+     * See todo/17 item 1. */
+    message_type_command_ack,
+};
+
+/* Outcome carried by a command ack. A command may produce up to two acks with
+ * the same acked-command id: an early command_ack_received on receipt, then a
+ * terminal outcome once the FMU resolves it. The terminal ack is authoritative.
+ * - received:   frame decoded; not yet actioned.
+ * - actioned:   the FMU state machine transitioned in response to the command.
+ * - superseded: received but deliberately not actioned because a higher-priority
+ *               latched state is engaged (the FMU prioritises terminate >
+ *               low-battery > comms > command); superseding_state names it.
+ * - rejected:   unactionable command (unknown/malformed/invalid). */
+using fss_command_ack_outcome = enum fss_command_ack_outcome_e {
+    command_ack_received = 0,
+    command_ack_actioned = 1,
+    command_ack_superseded = 2,
+    command_ack_rejected = 3,
 };
 
 using fss_asset_command = enum fss_asset_command_e {
@@ -549,6 +571,39 @@ public:
     auto getProtocolVersion() const -> uint16_t { return this->protocol_version; }
     auto getMinSupportedVersion() const -> uint16_t { return this->min_supported_version; }
     auto getFeatureFlags() const -> uint32_t { return this->feature_flags; }
+};
+
+class fss_message_command_ack : public fss_message {
+private:
+    /* The header id of the asset_command being acked, echoed back so the server
+     * can match the ack to the specific command it sent rather than "last
+     * command seen" (commands carry a per-connection monotonic header id). */
+    uint64_t acked_command_id{0};
+    /* The fss_asset_command value being acked. Redundant with the command the
+     * server already holds under acked_command_id, but cheap and useful for
+     * cross-checking and human-readable storage. */
+    uint8_t command{asset_command_unknown};
+    uint8_t outcome{command_ack_received};
+    /* The fss_asset_command-domain value of the higher-priority state that
+     * blocked actioning; asset_command_unknown (0) unless outcome is
+     * command_ack_superseded. */
+    uint8_t superseding_state{asset_command_unknown};
+    /* The responder's wall-clock reading (ms since epoch) when it built the ack. */
+    uint64_t timestamp{0};
+protected:
+    void unpackData(const std::shared_ptr<buf_len> &bl);
+    void packData(std::shared_ptr<buf_len> bl) override;
+public:
+    fss_message_command_ack(uint64_t t_acked_command_id, fss_asset_command t_command, fss_command_ack_outcome t_outcome,
+                            uint64_t t_timestamp);
+    fss_message_command_ack(uint64_t t_acked_command_id, fss_asset_command t_command, fss_command_ack_outcome t_outcome,
+                            fss_asset_command t_superseding_state, uint64_t t_timestamp);
+    fss_message_command_ack(uint64_t t_id, const std::shared_ptr<buf_len> &bl);
+    virtual auto getAckedCommandId() -> uint64_t;
+    virtual auto getCommand() -> fss_asset_command;
+    virtual auto getOutcome() -> fss_command_ack_outcome;
+    virtual auto getSupersedingState() -> fss_asset_command;
+    auto getTimeStamp() -> uint64_t override;
 };
 } // namespace transport
 } // namespace flight_safety_system

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -76,6 +76,21 @@ static auto decode_asset_command(uint8_t cmd) -> flight_safety_system::transport
     }
 }
 
+static auto decode_command_ack_outcome(uint8_t outcome) -> flight_safety_system::transport::fss_command_ack_outcome
+{
+    using namespace flight_safety_system::transport;
+    switch (outcome)
+    {
+        case static_cast<uint8_t>(command_ack_received): return command_ack_received;
+        case static_cast<uint8_t>(command_ack_actioned): return command_ack_actioned;
+        case static_cast<uint8_t>(command_ack_superseded): return command_ack_superseded;
+        case static_cast<uint8_t>(command_ack_rejected): return command_ack_rejected;
+        /* An unrecognised outcome from a newer peer degrades to "received": we
+         * know the command reached the asset but cannot interpret the result. */
+        default: return command_ack_received;
+    }
+}
+
 static void packStringRaw(const std::shared_ptr<flight_safety_system::transport::buf_len> &bl, const char *data,
                           size_t str_len)
 {
@@ -983,6 +998,87 @@ auto flight_safety_system::transport::fss_message_asset_command::getTimeStamp() 
     return this->timestamp;
 }
 
+// NOLINTBEGIN(bugprone-easily-swappable-parameters)
+flight_safety_system::transport::fss_message_command_ack::fss_message_command_ack(uint64_t t_acked_command_id,
+                                                                                  fss_asset_command t_command,
+                                                                                  fss_command_ack_outcome t_outcome,
+                                                                                  uint64_t t_timestamp)
+    : fss_message(message_type_command_ack), acked_command_id(t_acked_command_id),
+      command(static_cast<uint8_t>(t_command)), outcome(static_cast<uint8_t>(t_outcome)),
+      superseding_state(static_cast<uint8_t>(asset_command_unknown)), timestamp(t_timestamp)
+{
+}
+
+flight_safety_system::transport::fss_message_command_ack::fss_message_command_ack(uint64_t t_acked_command_id,
+                                                                                  fss_asset_command t_command,
+                                                                                  fss_command_ack_outcome t_outcome,
+                                                                                  fss_asset_command t_superseding_state,
+                                                                                  uint64_t t_timestamp)
+    : fss_message(message_type_command_ack), acked_command_id(t_acked_command_id),
+      command(static_cast<uint8_t>(t_command)), outcome(static_cast<uint8_t>(t_outcome)),
+      superseding_state(static_cast<uint8_t>(t_superseding_state)), timestamp(t_timestamp)
+{
+}
+// NOLINTEND(bugprone-easily-swappable-parameters)
+
+flight_safety_system::transport::fss_message_command_ack::fss_message_command_ack(uint64_t t_id,
+                                                                                  const std::shared_ptr<buf_len> &bl)
+    : fss_message(t_id, message_type_command_ack)
+{
+    this->unpackData(bl);
+}
+
+void flight_safety_system::transport::fss_message_command_ack::packData(std::shared_ptr<buf_len> bl)
+{
+    uint64_t acked = fss_htobe64(this->acked_command_id);
+    uint64_t ts = fss_htobe64(this->timestamp);
+    bl->addData(&acked, sizeof(uint64_t));
+    bl->addData(&this->command, sizeof(uint8_t));
+    bl->addData(&this->outcome, sizeof(uint8_t));
+    bl->addData(&this->superseding_state, sizeof(uint8_t));
+    bl->addData(&ts, sizeof(uint64_t));
+}
+
+void flight_safety_system::transport::fss_message_command_ack::unpackData(const std::shared_ptr<buf_len> &bl)
+{
+    BufferReader reader(bl->getData(), bl->getLength(), this->headerLength());
+    this->acked_command_id = 0;
+    this->command = static_cast<uint8_t>(asset_command_unknown);
+    this->outcome = static_cast<uint8_t>(command_ack_received);
+    this->superseding_state = static_cast<uint8_t>(asset_command_unknown);
+    this->timestamp = 0;
+    reader.readUint64(this->acked_command_id);
+    reader.readUint8(this->command);
+    reader.readUint8(this->outcome);
+    reader.readUint8(this->superseding_state);
+    reader.readUint64(this->timestamp);
+}
+
+auto flight_safety_system::transport::fss_message_command_ack::getAckedCommandId() -> uint64_t
+{
+    return this->acked_command_id;
+}
+
+auto flight_safety_system::transport::fss_message_command_ack::getCommand() -> fss_asset_command
+{
+    return decode_asset_command(this->command);
+}
+
+auto flight_safety_system::transport::fss_message_command_ack::getOutcome() -> fss_command_ack_outcome
+{
+    return decode_command_ack_outcome(this->outcome);
+}
+
+auto flight_safety_system::transport::fss_message_command_ack::getSupersedingState() -> fss_asset_command
+{
+    return decode_asset_command(this->superseding_state);
+}
+
+auto flight_safety_system::transport::fss_message_command_ack::getTimeStamp() -> uint64_t
+{
+    return this->timestamp;
+}
+
 void flight_safety_system::transport::fss_message_smm_settings::packData(std::shared_ptr<buf_len> bl)
 {
     packString(bl, this->getServerURL());
@@ -1221,6 +1317,7 @@ auto flight_safety_system::transport::fss_message::decode(const std::shared_ptr<
             break;
         case message_type_identity_required: msg = std::make_shared<fss_message_identity_required>(msg_id, bl); break;
         case message_type_version: msg = std::make_shared<fss_message_version>(msg_id, bl); break;
+        case message_type_command_ack: msg = std::make_shared<fss_message_command_ack>(msg_id, bl); break;
     }
 
     if (msg != nullptr && msg->getType() != type)

--- a/tests/messages.cpp
+++ b/tests/messages.cpp
@@ -459,6 +459,73 @@ TEST_CASE("Asset Command Message Check - Altitude")
     REQUIRE(decoded_generic->getAltitude() == altitude);
 }
 
+TEST_CASE("Command Ack Message Check - Actioned")
+{
+    auto msg_id = static_cast<uint64_t>(random());
+    auto acked_command_id = static_cast<uint64_t>(random());
+    auto timestamp = static_cast<uint64_t>(random());
+
+    /* An ack for a command the FMU actioned. No higher-priority state was
+     * engaged, so the superseding state is unknown (the not-applicable value). */
+    auto msg = std::make_shared<flight_safety_system::transport::fss_message_command_ack>(
+        acked_command_id, flight_safety_system::transport::asset_command_rtl,
+        flight_safety_system::transport::command_ack_actioned, timestamp);
+    REQUIRE(msg->getType() == flight_safety_system::transport::message_type_command_ack);
+    REQUIRE(msg->getAckedCommandId() == acked_command_id);
+    REQUIRE(msg->getCommand() == flight_safety_system::transport::asset_command_rtl);
+    REQUIRE(msg->getOutcome() == flight_safety_system::transport::command_ack_actioned);
+    REQUIRE(msg->getSupersedingState() == flight_safety_system::transport::asset_command_unknown);
+    REQUIRE(msg->getTimeStamp() == timestamp);
+    /* Convert to bl and back */
+    msg->setId(msg_id);
+    auto bl = msg->getPacked();
+    REQUIRE(bl != nullptr);
+    auto decoded = std::make_shared<flight_safety_system::transport::fss_message_command_ack>(msg_id, bl);
+    REQUIRE(decoded->getType() == flight_safety_system::transport::message_type_command_ack);
+    REQUIRE(decoded->getId() == msg_id);
+    REQUIRE(decoded->getAckedCommandId() == acked_command_id);
+    REQUIRE(decoded->getCommand() == flight_safety_system::transport::asset_command_rtl);
+    REQUIRE(decoded->getOutcome() == flight_safety_system::transport::command_ack_actioned);
+    REQUIRE(decoded->getSupersedingState() == flight_safety_system::transport::asset_command_unknown);
+    REQUIRE(decoded->getTimeStamp() == timestamp);
+    auto decoded_generic = flight_safety_system::transport::fss_message::decode(bl);
+    REQUIRE(decoded_generic->getType() == flight_safety_system::transport::message_type_command_ack);
+    REQUIRE(decoded_generic->getId() == msg_id);
+    auto decoded_generic_ack =
+        std::dynamic_pointer_cast<flight_safety_system::transport::fss_message_command_ack>(decoded_generic);
+    REQUIRE(decoded_generic_ack != nullptr);
+    REQUIRE(decoded_generic_ack->getAckedCommandId() == acked_command_id);
+    REQUIRE(decoded_generic_ack->getOutcome() == flight_safety_system::transport::command_ack_actioned);
+    REQUIRE(decoded_generic_ack->getTimeStamp() == timestamp);
+}
+
+TEST_CASE("Command Ack Message Check - Superseded carries the higher-priority state")
+{
+    auto msg_id = static_cast<uint64_t>(random());
+    auto acked_command_id = static_cast<uint64_t>(random());
+    auto timestamp = static_cast<uint64_t>(random());
+
+    /* A manual command was received but not actioned because a low-battery RTL
+     * latch is engaged; the ack names that higher-priority state. */
+    auto msg = std::make_shared<flight_safety_system::transport::fss_message_command_ack>(
+        acked_command_id, flight_safety_system::transport::asset_command_manual,
+        flight_safety_system::transport::command_ack_superseded, flight_safety_system::transport::asset_command_rtl,
+        timestamp);
+    REQUIRE(msg->getCommand() == flight_safety_system::transport::asset_command_manual);
+    REQUIRE(msg->getOutcome() == flight_safety_system::transport::command_ack_superseded);
+    REQUIRE(msg->getSupersedingState() == flight_safety_system::transport::asset_command_rtl);
+
+    msg->setId(msg_id);
+    auto bl = msg->getPacked();
+    REQUIRE(bl != nullptr);
+    auto decoded = std::make_shared<flight_safety_system::transport::fss_message_command_ack>(msg_id, bl);
+    REQUIRE(decoded->getAckedCommandId() == acked_command_id);
+    REQUIRE(decoded->getCommand() == flight_safety_system::transport::asset_command_manual);
+    REQUIRE(decoded->getOutcome() == flight_safety_system::transport::command_ack_superseded);
+    REQUIRE(decoded->getSupersedingState() == flight_safety_system::transport::asset_command_rtl);
+    REQUIRE(decoded->getTimeStamp() == timestamp);
+}
+
 TEST_CASE("SMM Settings Message Check")
 {
     auto msg_id = static_cast<uint64_t>(random());
@@ -852,6 +919,27 @@ TEST_CASE("messages: truncated asset_command decodes coordinates as NaN")
     REQUIRE(decoded != nullptr);
     REQUIRE(std::isnan(decoded->getLatitude()));
     REQUIRE(std::isnan(decoded->getLongitude()));
+}
+
+TEST_CASE("messages: truncated command_ack decodes to safe defaults")
+{
+    using flight_safety_system::transport::message_type_command_ack;
+    /* Only the acked-command id (uint64) is present; the command, outcome and
+     * superseding-state bytes plus the timestamp are absent, so the reader must
+     * stop short rather than over-read and leave those fields at their safe
+     * defaults. */
+    constexpr size_t payload = sizeof(uint64_t);
+    constexpr size_t total = framed_header_len + payload;
+    auto bl = fss_test::make_framed_buffer(static_cast<uint16_t>(message_type_command_ack), 1,
+                                           std::string(payload, '\0'), total);
+    auto decoded = std::dynamic_pointer_cast<flight_safety_system::transport::fss_message_command_ack>(
+        flight_safety_system::transport::fss_message::decode(bl));
+    REQUIRE(decoded != nullptr);
+    REQUIRE(decoded->getAckedCommandId() == 0);
+    REQUIRE(decoded->getCommand() == flight_safety_system::transport::asset_command_unknown);
+    REQUIRE(decoded->getOutcome() == flight_safety_system::transport::command_ack_received);
+    REQUIRE(decoded->getSupersedingState() == flight_safety_system::transport::asset_command_unknown);
+    REQUIRE(decoded->getTimeStamp() == 0);
 }
 
 /* readUint32 failure (line 129): version message truncated after the two


### PR DESCRIPTION
## Description

Define the FMU -> FSS command-acknowledgement message so an operator can confirm a command (RTL, Goto, Hold, etc.) reached and was actioned by the asset, rather than inferring it from telemetry.

The ack matches a SPECIFIC command via the command's existing per-connection header id (echoed as acked_command_id), so it is unambiguous when commands arrive close together. Outcome distinguishes received / actioned / superseded (received but not actioned because a higher-priority latched state is engaged, which the ack names) / rejected, matching the FMU's debounce-and-prioritise model. The wire field set is fixed-width and decodes truncated payloads to safe defaults.

Capability is gated by FSS_FEATURE_COMMAND_ACK, but the bit is deliberately NOT yet in FSS_SUPPORTED_FEATURES: the message type and codec exist and are tested, while server-side routing/storage land in a follow-up. Until the capability is advertised end-to-end no conforming client sends an ack, so the server's accept-and-drop case is safe. No protocol-version bump; legacy peers are unaffected.

## Summary by Sourcery

Introduce a new wire-format message for acknowledging asset commands and integrate it into the transport layer.

New Features:
- Add fss_message_command_ack message type and associated outcome enum to report the result of asset commands over the transport protocol.

Enhancements:
- Extend message decoding to handle the new command-ack message type and map raw outcome bytes to semantic enums.
- Ensure truncated command-ack payloads decode to safe default values without overruns.

Tests:
- Add unit tests covering packing/unpacking, generic decoding, superseded-state handling, and truncated-payload behaviour for command-ack messages.