### PR TITLE
feat(transport): command-ack v2 — dedicated supersede reason + noop outcome

### DIFF
--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -115,13 +115,36 @@ using fss_message_type = enum fss_message_type_e {
  * - actioned:   the FMU state machine transitioned in response to the command.
  * - superseded: received but deliberately not actioned because a higher-priority
  *               latched state is engaged (the FMU prioritises terminate >
- *               low-battery > comms > command); superseding_state names it.
+ *               low-battery > comms > command); the ack's reason names which.
+ * - noop:       the command resolved to the state already current, so nothing
+ *               changed. Operationally distinct from actioned ("already in RTL"
+ *               vs "transitioned to RTL") so the operator is not misled into
+ *               thinking a fresh transition occurred.
  * - rejected:   unactionable command (unknown/malformed/invalid). */
 using fss_command_ack_outcome = enum fss_command_ack_outcome_e {
     command_ack_received = 0,
     command_ack_actioned = 1,
     command_ack_superseded = 2,
     command_ack_rejected = 3,
+    command_ack_noop = 4,
+};
+
+/* Why a command was superseded. The superseding *state* cannot be expressed as
+ * an fss_asset_command value: the FMU's low-battery latch and its comms-failsafe
+ * latch BOTH resolve to RTL, so a command-domain value collapses the very
+ * distinction the operator UI needs ("superseded by LOW-BATTERY RTL" vs comms).
+ * This dedicated enum keeps them apart. supersede_none (0) is the
+ * not-applicable value carried whenever the outcome is not command_ack_superseded. */
+using fss_command_ack_reason = enum fss_command_ack_reason_e {
+    supersede_none = 0,
+    /* Flight-termination latch (highest FMU priority). */
+    supersede_terminate = 1,
+    /* Low-battery return-to-launch latch. */
+    supersede_low_battery = 2,
+    /* Comms-loss failsafe latch (also an RTL, distinct from low-battery). */
+    supersede_comms_loss = 3,
+    /* A manual-override / pilot-in-command state blocking the command. */
+    supersede_manual_override = 4,
 };
 
 using fss_asset_command = enum fss_asset_command_e {
@@ -584,10 +607,11 @@ private:
      * cross-checking and human-readable storage. */
     uint8_t command{asset_command_unknown};
     uint8_t outcome{command_ack_received};
-    /* The fss_asset_command-domain value of the higher-priority state that
-     * blocked actioning; asset_command_unknown (0) unless outcome is
+    /* Why the command was superseded, as a dedicated fss_command_ack_reason
+     * (NOT a command value: low-battery and comms-loss both resolve to RTL and
+     * must stay distinguishable). supersede_none (0) unless outcome is
      * command_ack_superseded. */
-    uint8_t superseding_state{asset_command_unknown};
+    uint8_t reason{supersede_none};
     /* The responder's wall-clock reading (ms since epoch) when it built the ack. */
     uint64_t timestamp{0};
 protected:
@@ -597,12 +621,12 @@ public:
     fss_message_command_ack(uint64_t t_acked_command_id, fss_asset_command t_command, fss_command_ack_outcome t_outcome,
                             uint64_t t_timestamp);
     fss_message_command_ack(uint64_t t_acked_command_id, fss_asset_command t_command, fss_command_ack_outcome t_outcome,
-                            fss_asset_command t_superseding_state, uint64_t t_timestamp);
+                            fss_command_ack_reason t_reason, uint64_t t_timestamp);
     fss_message_command_ack(uint64_t t_id, const std::shared_ptr<buf_len> &bl);
     virtual auto getAckedCommandId() -> uint64_t;
     virtual auto getCommand() -> fss_asset_command;
     virtual auto getOutcome() -> fss_command_ack_outcome;
-    virtual auto getSupersedingState() -> fss_asset_command;
+    virtual auto getReason() -> fss_command_ack_reason;
     auto getTimeStamp() -> uint64_t override;
 };
 } // namespace transport

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -85,9 +85,26 @@ static auto decode_command_ack_outcome(uint8_t outcome) -> flight_safety_system:
         case static_cast<uint8_t>(command_ack_actioned): return command_ack_actioned;
         case static_cast<uint8_t>(command_ack_superseded): return command_ack_superseded;
         case static_cast<uint8_t>(command_ack_rejected): return command_ack_rejected;
+        case static_cast<uint8_t>(command_ack_noop): return command_ack_noop;
         /* An unrecognised outcome from a newer peer degrades to "received": we
          * know the command reached the asset but cannot interpret the result. */
         default: return command_ack_received;
+    }
+}
+
+static auto decode_command_ack_reason(uint8_t reason) -> flight_safety_system::transport::fss_command_ack_reason
+{
+    using namespace flight_safety_system::transport;
+    switch (reason)
+    {
+        case static_cast<uint8_t>(supersede_none): return supersede_none;
+        case static_cast<uint8_t>(supersede_terminate): return supersede_terminate;
+        case static_cast<uint8_t>(supersede_low_battery): return supersede_low_battery;
+        case static_cast<uint8_t>(supersede_comms_loss): return supersede_comms_loss;
+        case static_cast<uint8_t>(supersede_manual_override): return supersede_manual_override;
+        /* An unrecognised reason from a newer peer degrades to "none" rather
+         * than inventing a cause the operator might act on. */
+        default: return supersede_none;
     }
 }
 
@@ -1005,18 +1022,18 @@ flight_safety_system::transport::fss_message_command_ack::fss_message_command_ac
                                                                                   uint64_t t_timestamp)
     : fss_message(message_type_command_ack), acked_command_id(t_acked_command_id),
       command(static_cast<uint8_t>(t_command)), outcome(static_cast<uint8_t>(t_outcome)),
-      superseding_state(static_cast<uint8_t>(asset_command_unknown)), timestamp(t_timestamp)
+      reason(static_cast<uint8_t>(supersede_none)), timestamp(t_timestamp)
 {
 }
 
 flight_safety_system::transport::fss_message_command_ack::fss_message_command_ack(uint64_t t_acked_command_id,
                                                                                   fss_asset_command t_command,
                                                                                   fss_command_ack_outcome t_outcome,
-                                                                                  fss_asset_command t_superseding_state,
+                                                                                  fss_command_ack_reason t_reason,
                                                                                   uint64_t t_timestamp)
     : fss_message(message_type_command_ack), acked_command_id(t_acked_command_id),
       command(static_cast<uint8_t>(t_command)), outcome(static_cast<uint8_t>(t_outcome)),
-      superseding_state(static_cast<uint8_t>(t_superseding_state)), timestamp(t_timestamp)
+      reason(static_cast<uint8_t>(t_reason)), timestamp(t_timestamp)
 {
 }
 // NOLINTEND(bugprone-easily-swappable-parameters)
@@ -1035,7 +1052,7 @@ void flight_safety_system::transport::fss_message_command_ack::packData(std::sha
     bl->addData(&acked, sizeof(uint64_t));
     bl->addData(&this->command, sizeof(uint8_t));
     bl->addData(&this->outcome, sizeof(uint8_t));
-    bl->addData(&this->superseding_state, sizeof(uint8_t));
+    bl->addData(&this->reason, sizeof(uint8_t));
     bl->addData(&ts, sizeof(uint64_t));
 }
 
@@ -1045,12 +1062,12 @@ void flight_safety_system::transport::fss_message_command_ack::unpackData(const 
     this->acked_command_id = 0;
     this->command = static_cast<uint8_t>(asset_command_unknown);
     this->outcome = static_cast<uint8_t>(command_ack_received);
-    this->superseding_state = static_cast<uint8_t>(asset_command_unknown);
+    this->reason = static_cast<uint8_t>(supersede_none);
     this->timestamp = 0;
     reader.readUint64(this->acked_command_id);
     reader.readUint8(this->command);
     reader.readUint8(this->outcome);
-    reader.readUint8(this->superseding_state);
+    reader.readUint8(this->reason);
     reader.readUint64(this->timestamp);
 }
 
@@ -1069,9 +1086,9 @@ auto flight_safety_system::transport::fss_message_command_ack::getOutcome() -> f
     return decode_command_ack_outcome(this->outcome);
 }
 
-auto flight_safety_system::transport::fss_message_command_ack::getSupersedingState() -> fss_asset_command
+auto flight_safety_system::transport::fss_message_command_ack::getReason() -> fss_command_ack_reason
 {
-    return decode_asset_command(this->superseding_state);
+    return decode_command_ack_reason(this->reason);
 }
 
 auto flight_safety_system::transport::fss_message_command_ack::getTimeStamp() -> uint64_t

--- a/tests/messages.cpp
+++ b/tests/messages.cpp
@@ -466,7 +466,7 @@ TEST_CASE("Command Ack Message Check - Actioned")
     auto timestamp = static_cast<uint64_t>(random());
 
     /* An ack for a command the FMU actioned. No higher-priority state was
-     * engaged, so the superseding state is unknown (the not-applicable value). */
+     * engaged, so the supersede reason is none (the not-applicable value). */
     auto msg = std::make_shared<flight_safety_system::transport::fss_message_command_ack>(
         acked_command_id, flight_safety_system::transport::asset_command_rtl,
         flight_safety_system::transport::command_ack_actioned, timestamp);
@@ -474,7 +474,7 @@ TEST_CASE("Command Ack Message Check - Actioned")
     REQUIRE(msg->getAckedCommandId() == acked_command_id);
     REQUIRE(msg->getCommand() == flight_safety_system::transport::asset_command_rtl);
     REQUIRE(msg->getOutcome() == flight_safety_system::transport::command_ack_actioned);
-    REQUIRE(msg->getSupersedingState() == flight_safety_system::transport::asset_command_unknown);
+    REQUIRE(msg->getReason() == flight_safety_system::transport::supersede_none);
     REQUIRE(msg->getTimeStamp() == timestamp);
     /* Convert to bl and back */
     msg->setId(msg_id);
@@ -486,7 +486,7 @@ TEST_CASE("Command Ack Message Check - Actioned")
     REQUIRE(decoded->getAckedCommandId() == acked_command_id);
     REQUIRE(decoded->getCommand() == flight_safety_system::transport::asset_command_rtl);
     REQUIRE(decoded->getOutcome() == flight_safety_system::transport::command_ack_actioned);
-    REQUIRE(decoded->getSupersedingState() == flight_safety_system::transport::asset_command_unknown);
+    REQUIRE(decoded->getReason() == flight_safety_system::transport::supersede_none);
     REQUIRE(decoded->getTimeStamp() == timestamp);
     auto decoded_generic = flight_safety_system::transport::fss_message::decode(bl);
     REQUIRE(decoded_generic->getType() == flight_safety_system::transport::message_type_command_ack);
@@ -499,21 +499,23 @@ TEST_CASE("Command Ack Message Check - Actioned")
     REQUIRE(decoded_generic_ack->getTimeStamp() == timestamp);
 }
 
-TEST_CASE("Command Ack Message Check - Superseded carries the higher-priority state")
+TEST_CASE("Command Ack Message Check - Superseded carries the reason")
 {
     auto msg_id = static_cast<uint64_t>(random());
     auto acked_command_id = static_cast<uint64_t>(random());
     auto timestamp = static_cast<uint64_t>(random());
 
     /* A manual command was received but not actioned because a low-battery RTL
-     * latch is engaged; the ack names that higher-priority state. */
+     * latch is engaged; the ack names that reason. The reason (not a command
+     * value) is what lets the operator UI tell low-battery RTL apart from a
+     * comms-loss RTL, which would otherwise both read as asset_command_rtl. */
     auto msg = std::make_shared<flight_safety_system::transport::fss_message_command_ack>(
         acked_command_id, flight_safety_system::transport::asset_command_manual,
-        flight_safety_system::transport::command_ack_superseded, flight_safety_system::transport::asset_command_rtl,
+        flight_safety_system::transport::command_ack_superseded, flight_safety_system::transport::supersede_low_battery,
         timestamp);
     REQUIRE(msg->getCommand() == flight_safety_system::transport::asset_command_manual);
     REQUIRE(msg->getOutcome() == flight_safety_system::transport::command_ack_superseded);
-    REQUIRE(msg->getSupersedingState() == flight_safety_system::transport::asset_command_rtl);
+    REQUIRE(msg->getReason() == flight_safety_system::transport::supersede_low_battery);
 
     msg->setId(msg_id);
     auto bl = msg->getPacked();
@@ -522,8 +524,30 @@ TEST_CASE("Command Ack Message Check - Superseded carries the higher-priority st
     REQUIRE(decoded->getAckedCommandId() == acked_command_id);
     REQUIRE(decoded->getCommand() == flight_safety_system::transport::asset_command_manual);
     REQUIRE(decoded->getOutcome() == flight_safety_system::transport::command_ack_superseded);
-    REQUIRE(decoded->getSupersedingState() == flight_safety_system::transport::asset_command_rtl);
+    REQUIRE(decoded->getReason() == flight_safety_system::transport::supersede_low_battery);
     REQUIRE(decoded->getTimeStamp() == timestamp);
+}
+
+TEST_CASE("Command Ack Message Check - No-op (already in the commanded state)")
+{
+    auto msg_id = static_cast<uint64_t>(random());
+    auto acked_command_id = static_cast<uint64_t>(random());
+    auto timestamp = static_cast<uint64_t>(random());
+
+    /* The command resolved to the state already current: nothing transitioned.
+     * Distinct from actioned so the operator is not shown a fresh transition. */
+    auto msg = std::make_shared<flight_safety_system::transport::fss_message_command_ack>(
+        acked_command_id, flight_safety_system::transport::asset_command_rtl,
+        flight_safety_system::transport::command_ack_noop, timestamp);
+    REQUIRE(msg->getOutcome() == flight_safety_system::transport::command_ack_noop);
+    REQUIRE(msg->getReason() == flight_safety_system::transport::supersede_none);
+
+    msg->setId(msg_id);
+    auto bl = msg->getPacked();
+    REQUIRE(bl != nullptr);
+    auto decoded = std::make_shared<flight_safety_system::transport::fss_message_command_ack>(msg_id, bl);
+    REQUIRE(decoded->getOutcome() == flight_safety_system::transport::command_ack_noop);
+    REQUIRE(decoded->getReason() == flight_safety_system::transport::supersede_none);
 }
 
 TEST_CASE("SMM Settings Message Check")
@@ -925,9 +949,8 @@ TEST_CASE("messages: truncated command_ack decodes to safe defaults")
 {
     using flight_safety_system::transport::message_type_command_ack;
     /* Only the acked-command id (uint64) is present; the command, outcome and
-     * superseding-state bytes plus the timestamp are absent, so the reader must
-     * stop short rather than over-read and leave those fields at their safe
-     * defaults. */
+     * reason bytes plus the timestamp are absent, so the reader must stop short
+     * rather than over-read and leave those fields at their safe defaults. */
     constexpr size_t payload = sizeof(uint64_t);
     constexpr size_t total = framed_header_len + payload;
     auto bl = fss_test::make_framed_buffer(static_cast<uint16_t>(message_type_command_ack), 1,
@@ -938,7 +961,7 @@ TEST_CASE("messages: truncated command_ack decodes to safe defaults")
     REQUIRE(decoded->getAckedCommandId() == 0);
     REQUIRE(decoded->getCommand() == flight_safety_system::transport::asset_command_unknown);
     REQUIRE(decoded->getOutcome() == flight_safety_system::transport::command_ack_received);
-    REQUIRE(decoded->getSupersedingState() == flight_safety_system::transport::asset_command_unknown);
+    REQUIRE(decoded->getReason() == flight_safety_system::transport::supersede_none);
     REQUIRE(decoded->getTimeStamp() == 0);
 }
 


### PR DESCRIPTION
## Description

Two semantic corrections to the command-ack wire format, surfaced by the FMU before any peer relies on it:

1. Replace the superseding-state field (an fss_asset_command) with a dedicated fss_command_ack_reason enum. The FMU's low-battery latch and its comms-failsafe latch BOTH resolve to RTL, so a command-domain value collapses exactly the distinction the operator UI must show ("superseded by LOW-BATTERY RTL" vs comms-loss). The reason enum keeps them apart: none/terminate/low_battery/comms_loss/manual_override.

2. Add command_ack_noop: a command that resolved to the state already current changed nothing, which is operationally distinct from a fresh transition ("already in RTL" vs "transitioned to RTL"). Distinguishing it keeps the operator from being shown a transition that did not happen.

Wire layout is unchanged in shape (the reason still occupies the single byte the superseding-state field did); only the field's meaning and value space change. The capability is still not advertised (FSS_FEATURE_COMMAND_ACK remains out of FSS_SUPPORTED_FEATURES), so this is a safe pre-rollout amendment. Tests updated and a noop round-trip added.

## Summary by Sourcery

Refine command acknowledgement semantics by introducing a dedicated supersede reason enum and a no-op outcome while preserving the existing wire layout.

New Features:
- Add a command_ack_noop outcome to distinguish no-op acknowledgements from actioned transitions.
- Introduce an fss_command_ack_reason enum to explicitly encode why a command was superseded.

Enhancements:
- Replace the superseding_state command field in command-ack messages with a reason field while keeping the payload shape unchanged.
- Default unknown or truncated command-ack reason and outcome values to safe, non-misleading interpretations during decode.

Tests:
- Update command-ack message tests to validate the new reason field semantics and add coverage for the no-op acknowledgement path.