### PR TITLE
feat(transport): trim supersede reasons to the agreed latch set

### DIFF
--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -134,17 +134,19 @@ using fss_command_ack_outcome = enum fss_command_ack_outcome_e {
  * latch BOTH resolve to RTL, so a command-domain value collapses the very
  * distinction the operator UI needs ("superseded by LOW-BATTERY RTL" vs comms).
  * This dedicated enum keeps them apart. supersede_none (0) is the
- * not-applicable value carried whenever the outcome is not command_ack_superseded. */
+ * not-applicable value carried whenever the outcome is not command_ack_superseded.
+ *
+ * Only the autonomous safety latches that can pre-empt an operator command are
+ * listed. Flight-termination is deliberately NOT a supersede source: it is an
+ * operator-issued command in its own right, not an automatic latch that quietly
+ * overrides another command — a terminate is acked on its own merits, not as the
+ * reason a different command was dropped. */
 using fss_command_ack_reason = enum fss_command_ack_reason_e {
     supersede_none = 0,
-    /* Flight-termination latch (highest FMU priority). */
-    supersede_terminate = 1,
     /* Low-battery return-to-launch latch. */
-    supersede_low_battery = 2,
+    supersede_low_battery = 1,
     /* Comms-loss failsafe latch (also an RTL, distinct from low-battery). */
-    supersede_comms_loss = 3,
-    /* A manual-override / pilot-in-command state blocking the command. */
-    supersede_manual_override = 4,
+    supersede_comms_loss = 2,
 };
 
 using fss_asset_command = enum fss_asset_command_e {

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -98,10 +98,8 @@ static auto decode_command_ack_reason(uint8_t reason) -> flight_safety_system::t
     switch (reason)
     {
         case static_cast<uint8_t>(supersede_none): return supersede_none;
-        case static_cast<uint8_t>(supersede_terminate): return supersede_terminate;
         case static_cast<uint8_t>(supersede_low_battery): return supersede_low_battery;
         case static_cast<uint8_t>(supersede_comms_loss): return supersede_comms_loss;
-        case static_cast<uint8_t>(supersede_manual_override): return supersede_manual_override;
         /* An unrecognised reason from a newer peer degrades to "none" rather
          * than inventing a cause the operator might act on. */
         default: return supersede_none;


### PR DESCRIPTION
## Description

Per the team's command-ack semantics decision, the supersede reason carries only the autonomous safety latches that can pre-empt an operator command: none / low_battery / comms_loss. Drop terminate (an operator-issued command in its own right, acked on its own merits, not a quiet override of another command) and manual_override (not part of the agreed set). Renumber so the value space is exactly the agreed set; nothing on the wire depends on the old numbers yet (FSS_FEATURE_COMMAND_ACK is still unadvertised).

## Summary by Sourcery

Trim command acknowledgement supersede reasons to the agreed autonomous safety latch set and update decoding accordingly.

Enhancements:
- Restrict fss_command_ack_reason to none, low_battery, and comms_loss and renumber values to match the agreed wire format.
- Update command ack reason decoding to align with the reduced and renumbered supersede reason set.