### PR TITLE
feat(client): pass the originating server to a command handler

### DIFF
--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -306,6 +306,16 @@ void flight_safety_system::client_ssl::fss_client::connectionStatusChange(
 {
 }
 
+void flight_safety_system::client_ssl::fss_client::handleCommandFrom(
+    const std::shared_ptr<flight_safety_system::transport::fss_message_asset_command> &msg,
+    flight_safety_system::client_ssl::fss_server *origin __attribute__((unused)))
+{
+    /* Default: ignore the originating connection and fall back to the
+     * connection-agnostic handler, so a subclass that only overrode
+     * handleCommand() still sees the command. */
+    this->handleCommand(msg);
+}
+
 void flight_safety_system::client_ssl::fss_client::handleCommand(
     const std::shared_ptr<flight_safety_system::transport::fss_message_asset_command> &msg __attribute__((unused)))
 {
@@ -549,7 +559,10 @@ void flight_safety_system::client_ssl::fss_server::processMessage(
                     std::dynamic_pointer_cast<flight_safety_system::transport::fss_message_asset_command>(msg);
                 if (command_msg != nullptr)
                 {
-                    this->getClient()->handleCommand(command_msg);
+                    /* Pass the originating server so an override can reply to
+                     * this specific connection (command-ack id and negotiated
+                     * feature flags are per-connection). */
+                    this->getClient()->handleCommandFrom(command_msg, this);
                 }
             }
             break;

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -51,6 +51,17 @@ public:
     virtual auto getAssetName() -> std::string;
     virtual void serverRequiresReconnect(fss_server *server);
     virtual void updateServers(const std::shared_ptr<flight_safety_system::transport::fss_message_server_list> &msg);
+    /* Called for every command, with the originating server (the connection the
+     * command arrived on). A subclass that needs to reply to that specific
+     * connection — e.g. to send a command-ack, whose id and negotiated feature
+     * flags are per-connection — overrides this and uses
+     * origin->sendMsg()/origin->getConnection(). The default delegates to the
+     * connection-agnostic handleCommand() below, so a subclass that only cares
+     * about the command (the common case) overrides that one and is unaffected.
+     * Distinct name rather than an overload so neither hides the other. */
+    virtual void
+    handleCommandFrom(const std::shared_ptr<flight_safety_system::transport::fss_message_asset_command> &msg,
+                      flight_safety_system::client_ssl::fss_server *origin);
     virtual void handleCommand(const std::shared_ptr<flight_safety_system::transport::fss_message_asset_command> &msg
                                __attribute__((unused)));
     virtual void

--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -129,6 +129,47 @@ TEST_CASE("client: processMessage dispatches command to handleCommand")
     REQUIRE(client.handle_command_called);
 }
 
+TEST_CASE("client: handleCommandFrom receives the originating server")
+{
+    /* A client that overrides the connection-aware handler captures the origin
+     * so it can reply to that specific connection (the command-ack path). */
+    class OriginTrackingClient : public fss::client_ssl::fss_client {
+    public:
+        OriginTrackingClient() : fss_client() {}
+        OriginTrackingClient(const OriginTrackingClient &) = delete;
+        OriginTrackingClient(OriginTrackingClient &&) = delete;
+        auto operator=(const OriginTrackingClient &) -> OriginTrackingClient & = delete;
+        auto operator=(OriginTrackingClient &&) -> OriginTrackingClient & = delete;
+        ~OriginTrackingClient() override = default;
+        fss::client_ssl::fss_server *seen_origin{nullptr};
+        void handleCommandFrom(const std::shared_ptr<fss::transport::fss_message_asset_command> &,
+                               fss::client_ssl::fss_server *origin) override
+        {
+            seen_origin = origin;
+        }
+    };
+    OriginTrackingClient client;
+    auto server = std::make_shared<fss::client_ssl::fss_server>(&client, "localhost", uint16_t{0}, CA_PUBLIC_FILE,
+                                                                CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+    auto msg =
+        std::make_shared<fss::transport::fss_message_asset_command>(fss::transport::asset_command_rtl, uint64_t{0});
+    server->processMessage(msg);
+    REQUIRE(client.seen_origin == server.get());
+}
+
+TEST_CASE("client: handleCommandFrom default delegates to handleCommand")
+{
+    /* A client that only overrides the connection-agnostic handler still sees
+     * commands: the default handleCommandFrom delegates to handleCommand. */
+    TrackingClient client;
+    auto server = std::make_shared<fss::client_ssl::fss_server>(&client, "localhost", uint16_t{0}, CA_PUBLIC_FILE,
+                                                                CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+    auto msg =
+        std::make_shared<fss::transport::fss_message_asset_command>(fss::transport::asset_command_hold, uint64_t{0});
+    server->processMessage(msg);
+    REQUIRE(client.handle_command_called);
+}
+
 TEST_CASE("client: processMessage dispatches smm_settings to handleSMMSettings")
 {
     TrackingClient client;


### PR DESCRIPTION
## Description

The command-ack path (todo/17 item 1) needs to reply on the connection a command arrived on: the ack's id and the negotiated feature flags are both per-connection. The existing fss_client::handleCommand(msg) override sees only the message, and the sole client-level send (sendMsgAll) broadcasts to every server, so a subclass could neither read the right connection's negotiated flag nor target its reply.

Add fss_client::handleCommandFrom(msg, origin), called by fss_server with itself as origin. A subclass replies via origin->sendMsg() and reads origin->getConnection()->getNegotiatedFeatureFlags(). The default delegates to handleCommand(msg), so subclasses that only care about the command (the common case, including the bundled examples/tests) are unchanged. Kept as a distinct name rather than an overload so neither hides the other under -Werror=overloaded-virtual.

## Summary by Sourcery

Add a connection-aware command handler entry point on the SSL client and route command messages through it while preserving existing connection-agnostic behavior by default.

New Features:
- Introduce fss_client::handleCommandFrom to receive commands along with their originating server connection, enabling connection-specific replies such as command acknowledgements.

Tests:
- Add tests verifying that handleCommandFrom receives the originating server instance and that its default implementation delegates to handleCommand.