### PR TITLE
feat(server): route and store command acks; enable the capability

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -251,6 +251,11 @@ void fss::server::fss_client::sendCommand()
                 break;
         }
         this->getConnection()->sendMsg(msg);
+        /* sendMsg stamped the per-connection message id into msg; record it
+         * against the command row (cached_asset_id is non-zero here — the
+         * early return above guarantees it) so a later ack, which echoes this id
+         * as acked_command_id, can be matched back to this specific command. */
+        this->writer->enqueue(command_dispatch_write{ac->getDBId(), msg->getId()});
         FSS_LOG_INFO("server", "dispatched command dbid=" << ac->getDBId() << " to " << this->name);
     }
 }
@@ -785,15 +790,24 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                 }
             }
             break;
-            /* message_type_command_ack (todo/17 item 1): an aircraft client
-             * acking a command we sent. The message type and wire format exist,
-             * but routing to operators and storage against the asset land in a
-             * follow-up commit (the storage shape is still being agreed). Until
-             * then FSS_FEATURE_COMMAND_ACK is deliberately NOT in
-             * FSS_SUPPORTED_FEATURES, so a conforming client never negotiates the
-             * capability and never sends this; dropping a stray ack is safe and
-             * groups with the other message types the server does not act on. */
-            case fss::transport::message_type_command_ack:
+            case fss::transport::message_type_command_ack: {
+                /* An aircraft client acking a command we sent (todo/17 item 1).
+                 * Only honour it when the peer negotiated the capability — a
+                 * conforming client never sends one otherwise, so an ack without
+                 * the flag is from a misbehaving/forged peer and is dropped. */
+                if ((this->getConnection()->getNegotiatedFeatureFlags() & fss::transport::FSS_FEATURE_COMMAND_ACK) == 0)
+                {
+                    break;
+                }
+                auto ack_msg = std::dynamic_pointer_cast<fss::transport::fss_message_command_ack>(msg);
+                if (ack_msg != nullptr)
+                {
+                    this->writer->enqueue(
+                        command_ack_write{ack_msg->getAckedCommandId(), static_cast<uint8_t>(ack_msg->getOutcome()),
+                                          ack_msg->getTimeStamp(), static_cast<uint8_t>(ack_msg->getReason())});
+                }
+            }
+            break;
             case fss::transport::message_type_command:
             case fss::transport::message_type_server_list:
             case fss::transport::message_type_smm_settings: break;

--- a/src/db-write-queue.hpp
+++ b/src/db-write-queue.hpp
@@ -35,8 +35,23 @@ struct search_status_write {
     uint64_t completed;
     uint64_t total;
 };
+/* The dispatch id (per-connection message id) stamped on a command, recorded
+ * against the command row so a later ack can be matched to it. */
+struct command_dispatch_write {
+    uint64_t command_dbid;
+    uint64_t dispatch_id;
+};
+/* A command ack to store against the row whose dispatch id matches. ack_state is
+ * the fss_command_ack_outcome int, ack_reason the fss_command_ack_reason int. */
+struct command_ack_write {
+    uint64_t dispatch_id;
+    uint8_t ack_state;
+    uint64_t ack_timestamp;
+    uint8_t ack_reason;
+};
 
-using db_write_task = std::variant<rtt_write, position_write, status_write, search_status_write>;
+using db_write_task = std::variant<rtt_write, position_write, status_write, search_status_write, command_dispatch_write,
+                                   command_ack_write>;
 using db_write_sink = std::function<void(const db_write_task &)>;
 
 /* C++17 overload helper for std::visit. */

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -114,6 +114,20 @@ void flight_safety_system::server::db_connection::recordSearchStatus(uint64_t as
     db_search_status_create_entry(write_conn_name, asset_id, search_id, completed, total);
 }
 
+void flight_safety_system::server::db_connection::recordCommandDispatch(uint64_t command_dbid, uint64_t dispatch_id)
+{
+    std::scoped_lock guard(this->write_lock);
+    db_command_set_dispatch_id(write_conn_name, command_dbid, dispatch_id);
+}
+
+void flight_safety_system::server::db_connection::recordCommandAck(uint64_t dispatch_id, uint8_t ack_state,
+                                                                   uint64_t ack_timestamp, uint8_t ack_reason)
+{
+    std::scoped_lock guard(this->write_lock);
+    db_command_record_ack(write_conn_name, dispatch_id, static_cast<int>(ack_state), ack_timestamp,
+                          static_cast<int>(ack_reason));
+}
+
 void flight_safety_system::server::db_connection::recordPosition(uint64_t asset_id, double latitude, double longitude,
                                                                  uint32_t altitude)
 {

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -93,6 +93,15 @@ public:
     virtual void recordRtt(uint64_t asset_id, uint64_t rtt_ms) = 0;
     virtual void recordStatus(uint64_t asset_id, uint8_t bat_percent, uint32_t bat_mah_used, double bat_voltage) = 0;
     virtual void recordSearchStatus(uint64_t asset_id, uint64_t search_id, uint64_t completed, uint64_t total) = 0;
+    /* Records the dispatch id (the per-connection message id the server stamped
+     * on the command) against the command row, so a later ack can be matched to
+     * this specific command. */
+    virtual void recordCommandDispatch(uint64_t command_dbid, uint64_t dispatch_id) = 0;
+    /* Stores a command ack against the row whose dispatch id matches; never
+     * regresses an already-terminal outcome. ack_state/ack_reason are the
+     * fss_command_ack_outcome/fss_command_ack_reason ints. */
+    virtual void recordCommandAck(uint64_t dispatch_id, uint8_t ack_state, uint64_t ack_timestamp,
+                                  uint8_t ack_reason) = 0;
     virtual auto getCommand(uint64_t asset_id) -> std::shared_ptr<asset_command> = 0;
     virtual auto getActiveServers() -> std::vector<fss_server_details> = 0;
     virtual auto getSmmSettings(uint64_t asset_id) -> std::shared_ptr<smm_settings> = 0;
@@ -138,6 +147,8 @@ public:
     void recordRtt(uint64_t asset_id, uint64_t rtt_ms) override;
     void recordStatus(uint64_t asset_id, uint8_t bat_percent, uint32_t bat_mah_used, double bat_voltage) override;
     void recordSearchStatus(uint64_t asset_id, uint64_t search_id, uint64_t completed, uint64_t total) override;
+    void recordCommandDispatch(uint64_t command_dbid, uint64_t dispatch_id) override;
+    void recordCommandAck(uint64_t dispatch_id, uint8_t ack_state, uint64_t ack_timestamp, uint8_t ack_reason) override;
     auto getCommand(uint64_t asset_id) -> std::shared_ptr<asset_command> override;
     auto getActiveServers() -> std::vector<fss_server_details> override;
     auto getSmmSettings(uint64_t asset_id) -> std::shared_ptr<smm_settings> override;

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -47,7 +47,7 @@ static constexpr uint16_t FSS_PROTOCOL_MIN_VERSION = 1;
 static constexpr uint32_t FSS_FEATURE_RTT_OFFSET = 0x1U;    /* todo/17 item 3 */
 static constexpr uint32_t FSS_FEATURE_COMMAND_ACK = 0x2U;   /* todo/17 item 1 */
 static constexpr uint32_t FSS_FEATURE_SYSTEM_HEALTH = 0x4U; /* todo/17 item 2 */
-static constexpr uint32_t FSS_SUPPORTED_FEATURES = FSS_FEATURE_RTT_OFFSET;
+static constexpr uint32_t FSS_SUPPORTED_FEATURES = FSS_FEATURE_RTT_OFFSET | FSS_FEATURE_COMMAND_ACK;
 
 /* The capability set to adopt for a peer that advertised peer_flags: the
  * intersection with what this build implements, so a peer can never enable a

--- a/src/server-db.h
+++ b/src/server-db.h
@@ -16,6 +16,20 @@ void db_search_status_create_entry(const char *conn, unsigned long long asset_id
 void db_position_create_entry(const char *conn, unsigned long long asset_id, double latitude, double longitude,
                               int altitude);
 
+/* Records the per-connection message id the server stamped onto the dispatched
+ * command, on the assets_assetcommand row identified by its primary key
+ * (command_dbid). Lets a later command-ack be matched back to this specific
+ * command via dispatch_id == acked_command_id. */
+void db_command_set_dispatch_id(const char *conn, unsigned long long command_dbid, unsigned long long dispatch_id);
+
+/* Updates the ack fields on the assets_assetcommand row whose dispatch_id equals
+ * the acked id. ack_state is the fss_command_ack_outcome int, ack_superseded_by
+ * the fss_command_ack_reason int, ack_timestamp the FMU wall-clock ms. The
+ * update never lowers an already-terminal ack_state back to a non-terminal one
+ * (a late "received" cannot clobber a settled outcome). */
+void db_command_record_ack(const char *conn, unsigned long long dispatch_id, int ack_state,
+                           unsigned long long ack_timestamp, int ack_superseded_by);
+
 struct asset_command_s {
     char *command;
     unsigned long long timestamp;

--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -145,6 +145,38 @@ void db_position_create_entry(const char *conn_arg, unsigned long long asset_id_
     EXEC SQL AT :conn INSERT INTO assets_assetposition (asset_id, position, altitude, timestamp) VALUES (:asset_id, ST_SetSRID(ST_MakePoint(:lng, :lat), 4326), :alt, NOW());
 }
 
+void db_command_set_dispatch_id(const char *conn_arg, unsigned long long command_dbid_arg, unsigned long long dispatch_id_arg)
+{
+    EXEC SQL BEGIN DECLARE SECTION;
+    const char *conn = conn_arg;
+    unsigned long long command_dbid = command_dbid_arg;
+    unsigned long long dispatch_id = dispatch_id_arg;
+    EXEC SQL END DECLARE SECTION;
+
+    EXEC SQL AT :conn UPDATE assets_assetcommand SET dispatch_id = :dispatch_id WHERE id = :command_dbid;
+}
+
+void db_command_record_ack(const char *conn_arg, unsigned long long dispatch_id_arg, int ack_state_arg, unsigned long long ack_timestamp_arg, int ack_superseded_by_arg)
+{
+    EXEC SQL BEGIN DECLARE SECTION;
+    const char *conn = conn_arg;
+    unsigned long long dispatch_id = dispatch_id_arg;
+    int ack_state = ack_state_arg;
+    unsigned long long ack_timestamp = ack_timestamp_arg;
+    int ack_superseded_by = ack_superseded_by_arg;
+    EXEC SQL END DECLARE SECTION;
+
+    /* Match the dispatched row by its stamped id and write the latest ack.
+     * Never regress an already-terminal outcome: a late "received" (state 0)
+     * must not clobber a settled actioned/superseded/rejected/noop. So skip the
+     * write when the incoming state is 0 and the stored state is already set and
+     * non-zero. ack_superseded_by is only meaningful for the superseded state. */
+    EXEC SQL AT :conn UPDATE assets_assetcommand
+        SET ack_state = :ack_state, ack_timestamp = :ack_timestamp, ack_superseded_by = :ack_superseded_by
+        WHERE dispatch_id = :dispatch_id
+          AND NOT (:ack_state = 0 AND ack_state IS NOT NULL AND ack_state <> 0);
+}
+
 struct asset_command_s *
 db_asset_command_get(const char *conn_arg, unsigned long long asset_id_arg)
 {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -234,6 +234,12 @@ auto main(int argc, char *argv[]) -> int
                 [&](const flight_safety_system::server::search_status_write &w) -> void {
                     dbc->recordSearchStatus(w.asset_id, w.search_id, w.completed, w.total);
                 },
+                [&](const flight_safety_system::server::command_dispatch_write &w) -> void {
+                    dbc->recordCommandDispatch(w.command_dbid, w.dispatch_id);
+                },
+                [&](const flight_safety_system::server::command_ack_write &w) -> void {
+                    dbc->recordCommandAck(w.dispatch_id, w.ack_state, w.ack_timestamp, w.ack_reason);
+                },
             },
             task);
     };

--- a/tests/async_db_write_test.cpp
+++ b/tests/async_db_write_test.cpp
@@ -41,13 +41,19 @@ struct CapturingSink {
             std::this_thread::sleep_for(delay);
         }
         std::lock_guard<std::mutex> guard(mtx);
-        std::visit(fss::server::overloaded{
-                       [&](const fss::server::rtt_write &w) -> void { asset_ids.push_back(w.asset_id); },
-                       [&](const fss::server::position_write &w) -> void { asset_ids.push_back(w.asset_id); },
-                       [&](const fss::server::status_write &w) -> void { asset_ids.push_back(w.asset_id); },
-                       [&](const fss::server::search_status_write &w) -> void { asset_ids.push_back(w.asset_id); },
-                   },
-                   task);
+        std::visit(
+            fss::server::overloaded{
+                [&](const fss::server::rtt_write &w) -> void { asset_ids.push_back(w.asset_id); },
+                [&](const fss::server::position_write &w) -> void { asset_ids.push_back(w.asset_id); },
+                [&](const fss::server::status_write &w) -> void { asset_ids.push_back(w.asset_id); },
+                [&](const fss::server::search_status_write &w) -> void { asset_ids.push_back(w.asset_id); },
+                /* Command writes are keyed by command/dispatch id, not
+                 * asset id; these tests don't enqueue them, but the visit
+                 * must cover every alternative, so record the id present. */
+                [&](const fss::server::command_dispatch_write &w) -> void { asset_ids.push_back(w.command_dbid); },
+                [&](const fss::server::command_ack_write &w) -> void { asset_ids.push_back(w.dispatch_id); },
+            },
+            task);
         count.fetch_add(1);
     }
 

--- a/tests/concurrency_client_test.cpp
+++ b/tests/concurrency_client_test.cpp
@@ -102,6 +102,8 @@ public:
     void recordRtt(uint64_t, uint64_t) override {}
     void recordStatus(uint64_t, uint8_t, uint32_t, double) override {}
     void recordSearchStatus(uint64_t, uint64_t, uint64_t, uint64_t) override {}
+    void recordCommandDispatch(uint64_t, uint64_t) override {}
+    void recordCommandAck(uint64_t, uint8_t, uint64_t, uint8_t) override {}
     auto getCommand(uint64_t) -> std::shared_ptr<flight_safety_system::server::asset_command> override
     {
         return nullptr;

--- a/tests/crl_revocation_test.cpp
+++ b/tests/crl_revocation_test.cpp
@@ -45,6 +45,12 @@ auto make_writer(fss_test::MockDatabase &mock) -> std::shared_ptr<fss::server::d
                        [&](const fss::server::search_status_write &w) -> void {
                            mock.recordSearchStatus(w.asset_id, w.search_id, w.completed, w.total);
                        },
+                       [&](const fss::server::command_dispatch_write &w) -> void {
+                           mock.recordCommandDispatch(w.command_dbid, w.dispatch_id);
+                       },
+                       [&](const fss::server::command_ack_write &w) -> void {
+                           mock.recordCommandAck(w.dispatch_id, w.ack_state, w.ack_timestamp, w.ack_reason);
+                       },
                    },
                    task);
     };

--- a/tests/mock_database.hpp
+++ b/tests/mock_database.hpp
@@ -47,11 +47,23 @@ public:
         uint64_t completed;
         uint64_t total;
     };
+    struct recorded_dispatch {
+        uint64_t command_dbid;
+        uint64_t dispatch_id;
+    };
+    struct recorded_ack {
+        uint64_t dispatch_id;
+        uint8_t ack_state;
+        uint64_t ack_timestamp;
+        uint8_t ack_reason;
+    };
 
     std::vector<recorded_rtt> rtts{};
     std::vector<recorded_pos> positions{};
     std::vector<recorded_status> statuses{};
     std::vector<recorded_search> searches{};
+    std::vector<recorded_dispatch> dispatches{};
+    std::vector<recorded_ack> acks{};
 
     MockDatabase() = default;
     MockDatabase(const MockDatabase &) = delete;
@@ -81,6 +93,16 @@ public:
     void recordSearchStatus(uint64_t asset_id, uint64_t search_id, uint64_t completed, uint64_t total) override
     {
         searches.push_back({asset_id, search_id, completed, total});
+    }
+
+    void recordCommandDispatch(uint64_t command_dbid, uint64_t dispatch_id) override
+    {
+        dispatches.push_back({command_dbid, dispatch_id});
+    }
+
+    void recordCommandAck(uint64_t dispatch_id, uint8_t ack_state, uint64_t ack_timestamp, uint8_t ack_reason) override
+    {
+        acks.push_back({dispatch_id, ack_state, ack_timestamp, ack_reason});
     }
 
     auto getCommand(uint64_t asset_id) -> std::shared_ptr<flight_safety_system::server::asset_command> override

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -112,6 +112,12 @@ auto make_mock_writer(fss_test::MockDatabase &mock) -> std::shared_ptr<fss::serv
                        [&](const fss::server::search_status_write &w) -> void {
                            mock.recordSearchStatus(w.asset_id, w.search_id, w.completed, w.total);
                        },
+                       [&](const fss::server::command_dispatch_write &w) -> void {
+                           mock.recordCommandDispatch(w.command_dbid, w.dispatch_id);
+                       },
+                       [&](const fss::server::command_ack_write &w) -> void {
+                           mock.recordCommandAck(w.dispatch_id, w.ack_state, w.ack_timestamp, w.ack_reason);
+                       },
                    },
                    task);
     };
@@ -1391,6 +1397,59 @@ TEST_CASE("session: system_status message is forwarded to db writer")
     REQUIRE(fss_test::wait_for([&]() { return !mock.statuses.empty(); }));
     REQUIRE(mock.statuses.front().asset_id == asset_id);
     REQUIRE(mock.statuses.front().bat_percent == 80);
+}
+
+TEST_CASE("session: command_ack is stored when the capability is negotiated")
+{
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 13;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    /* The peer negotiated command-ack, so the server honours the ack. */
+    conn->setNegotiatedFeatureFlags(fss::transport::FSS_FEATURE_COMMAND_ACK);
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    constexpr uint64_t acked_id = 0xABCDEF;
+    constexpr uint64_t ack_ts = 1750000000000ULL;
+    auto ack = std::make_shared<fss::transport::fss_message_command_ack>(acked_id, fss::transport::asset_command_manual,
+                                                                         fss::transport::command_ack_superseded,
+                                                                         fss::transport::supersede_low_battery, ack_ts);
+    session->processMessage(ack);
+
+    REQUIRE(fss_test::wait_for([&]() { return !mock.acks.empty(); }));
+    REQUIRE(mock.acks.front().dispatch_id == acked_id);
+    REQUIRE(mock.acks.front().ack_state == static_cast<uint8_t>(fss::transport::command_ack_superseded));
+    REQUIRE(mock.acks.front().ack_timestamp == ack_ts);
+    REQUIRE(mock.acks.front().ack_reason == static_cast<uint8_t>(fss::transport::supersede_low_battery));
+}
+
+TEST_CASE("session: command_ack is dropped when the capability is not negotiated")
+{
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 13;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    /* No negotiated flags: a conforming client never sends an ack, so one that
+     * arrives is from a misbehaving peer and must be ignored. */
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    auto ack = std::make_shared<fss::transport::fss_message_command_ack>(
+        uint64_t{0xABCDEF}, fss::transport::asset_command_rtl, fss::transport::command_ack_actioned, uint64_t{1});
+    session->processMessage(ack);
+
+    /* Give the async writer a brief chance to run, then confirm nothing was
+     * stored. A short timeout suffices: a real write would land near-instantly. */
+    REQUIRE_FALSE(fss_test::wait_for([&]() { return !mock.acks.empty(); }, std::chrono::milliseconds(200)));
 }
 
 TEST_CASE("session: search_status message is forwarded to db writer")


### PR DESCRIPTION
## Description

Server-side half of command-ack (todo/17 item 1). When the server dispatches a command it records the stamped per-connection message id against the command row (dispatch_id); when an aircraft acks, it matches the row by dispatch_id == acked_command_id and updates the ack fields. Both go through the async db-write queue, like telemetry, so the recv/dispatch paths never block on the DB.

- transport: enable FSS_FEATURE_COMMAND_ACK in FSS_SUPPORTED_FEATURES — the capability now works end to end, so it is advertised and negotiated (still no protocol-version bump; legacy peers see 0).
- client_session: stamp+record dispatch_id after sendMsg in sendCommand(); handle inbound command_ack, gated on the negotiated flag so a flagless peer's ack (which a conforming client never sends) is dropped as forged/misbehaving.
- db: two ECPG UPDATEs on assets_assetcommand — set dispatch_id by the row's primary key, and record the ack by dispatch_id. The ack update never regresses an already-terminal ack_state with a late "received". Columns match web's migration 0008 (dispatch_id, ack_state, ack_timestamp epoch-ms, ack_superseded_by); web owns the schema, the server only writes it.
- write-queue: two new task variants (command_dispatch_write/command_ack_write).
- tests: ack stored when negotiated, dropped when not; mock + all sinks cover the new variants.

## Summary by Sourcery

Persist command dispatch IDs and acknowledgements on the server side and enable negotiated command-ack capability.

New Features:
- Advertise and negotiate the command-ack feature flag so aircraft can send command acknowledgements that the server will honour when enabled.

Enhancements:
- Record dispatched command message IDs against command database rows and asynchronously persist corresponding command acknowledgements via the DB write queue.

Tests:
- Add server session, async writer, and CRL tests to cover command dispatch/ack write variants and verify acks are stored only when the capability is negotiated.