### PR TITLE
test(e2e): prove the command-ack DB-storage leg end to end

### DIFF
--- a/e2e/schema/001_init.sql
+++ b/e2e/schema/001_init.sql
@@ -52,7 +52,15 @@ CREATE TABLE assets_assetcommand (
     command     VARCHAR(8) NOT NULL,
     position    GEOGRAPHY(POINT, 4326),
     altitude    INTEGER,
-    timestamp   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+    timestamp   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    -- Command-acknowledgement columns (mirror fss-web migration 0008; the
+    -- server writes these, see todo/17 item 1). dispatch_id is the stamped
+    -- per-connection message id; the ack_* fields are filled when the asset
+    -- acks. All nullable: a command with no ack yet leaves them NULL.
+    dispatch_id       BIGINT,
+    ack_state         SMALLINT,
+    ack_timestamp     BIGINT,
+    ack_superseded_by SMALLINT
 );
 
 CREATE TABLE config_smmconfig (

--- a/e2e/test_command_ack.py
+++ b/e2e/test_command_ack.py
@@ -1,0 +1,82 @@
+"""End-to-end check of the command-acknowledgement storage leg (todo/17 item 1).
+
+When the command-ack capability is negotiated, the fake client replies to a
+dispatched command with the two-phase ack (received, then actioned). This test
+drives a command through the real server and asserts the server:
+  - records the dispatched message id on the command row (dispatch_id), and
+  - stores the ack against that row (ack_state advances to actioned,
+    ack_timestamp populated).
+
+This exercises the server routing + DB write that unit tests cover only against
+a mock — here it runs through the live transport, processMessage, and the async
+write queue into the database."""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+
+# Mirror flight_safety_system::transport::fss_command_ack_outcome.
+ACK_STATE_RECEIVED = 0
+ACK_STATE_ACTIONED = 1
+
+
+def _poll_row(db_conn, dbid: int, timeout: float):
+    """Poll the AssetCommand row until its ack fields are populated, or time out.
+    Returns (dispatch_id, ack_state, ack_timestamp) once ack_state is set."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        # A fresh transaction each poll so we see the server's committed writes.
+        db_conn.rollback()
+        with db_conn.cursor() as cur:
+            cur.execute(
+                "SELECT dispatch_id, ack_state, ack_timestamp "
+                "FROM assets_assetcommand WHERE id = %s",
+                (dbid,),
+            )
+            row = cur.fetchone()
+        if row is not None and row[1] is not None:
+            return row
+        time.sleep(0.05)
+    return None
+
+
+@pytest.mark.requires_docker
+def test_command_ack_is_stored(db_conn, fake_client, server_proc):
+    """A dispatched command, once acked by the client, lands its ack on the
+    command row: dispatch_id set and ack_state advanced to actioned."""
+    with db_conn.cursor() as cur:
+        cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
+        asset_id = cur.fetchone()[0]
+    db_conn.commit()
+
+    fake_client("test1")
+
+    # Let the client connect, identify, and negotiate the version handshake
+    # (the command-ack capability is only negotiated then).
+    time.sleep(5)
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO assets_assetcommand (asset_id, command, position, altitude) "
+            "VALUES (%s, 'RTL', ST_SetSRID(ST_MakePoint(0, 0), 4326)::geography, 0) "
+            "RETURNING id",
+            (asset_id,),
+        )
+        new_dbid = cur.fetchone()[0]
+    db_conn.commit()
+
+    row = _poll_row(db_conn, new_dbid, timeout=10.0)
+    assert row is not None, (
+        f"command dbid={new_dbid} never got an ack stored; server log:\n"
+        + server_proc["log"].read_text(errors="replace")
+    )
+    dispatch_id, ack_state, ack_timestamp = row
+    # The server records the stamped dispatch id so the ack can correlate.
+    assert dispatch_id is not None, "dispatch_id was not recorded at dispatch time"
+    # The fake client always reports actioned as its terminal outcome; the
+    # latest-wins / no-regression rule means the terminal state must win over the
+    # earlier received.
+    assert ack_state == ACK_STATE_ACTIONED, f"expected ack_state actioned, got {ack_state}"
+    assert ack_timestamp is not None and ack_timestamp > 0, "ack_timestamp was not stored"

--- a/examples/fake_client.cpp
+++ b/examples/fake_client.cpp
@@ -34,9 +34,27 @@ static auto commandName(fss::transport::fss_asset_command cmd) -> std::string
 class logging_client : public fss::client_ssl::fss_client {
 public:
     using fss::client_ssl::fss_client::fss_client;
-    void handleCommand(const std::shared_ptr<fss::transport::fss_message_asset_command> &msg) override
+    void handleCommandFrom(const std::shared_ptr<fss::transport::fss_message_asset_command> &msg,
+                           fss::client_ssl::fss_server *origin) override
     {
         std::cout << "RCVD_CMD: " << commandName(msg->getCommand()) << std::endl;
+        /* When the server negotiated command-ack, reply on the originating
+         * connection with the two-phase ack (received, then actioned) so the
+         * server's routing+storage path is exercised end to end. A real FMU
+         * picks the terminal outcome from its state machine; this example always
+         * reports "actioned" since it has no flight logic. */
+        auto conn = origin->getConnection();
+        if (conn == nullptr || (conn->getNegotiatedFeatureFlags() & fss::transport::FSS_FEATURE_COMMAND_ACK) == 0)
+        {
+            return;
+        }
+        const uint64_t acked_id = msg->getId();
+        const auto command = msg->getCommand();
+        origin->sendMsg(std::make_shared<fss::transport::fss_message_command_ack>(
+            acked_id, command, fss::transport::command_ack_received, fss::fss_current_timestamp()));
+        origin->sendMsg(std::make_shared<fss::transport::fss_message_command_ack>(
+            acked_id, command, fss::transport::command_ack_actioned, fss::fss_current_timestamp()));
+        std::cout << "SENT_ACK: " << commandName(command) << std::endl;
     }
 };
 


### PR DESCRIPTION
## Description

The unit tests cover the server's ack routing/storage against a mock DB; this closes the remaining leg through the real transport + PostGIS. The example fake_client now emits the two-phase ack (received then actioned, echoing the command's id, gated on the negotiated FSS_FEATURE_COMMAND_ACK) from handleCommandFrom, so a dispatched command produces a real ack for the server to store. test_command_ack.py drives a command through the live fss-server and asserts the row gains dispatch_id and ack_state=actioned with a populated ack_timestamp, matched by dispatch_id == acked_command_id.

The e2e fallback schema gains the four ack columns mirroring fss-web migration 0008 so the server's UPDATEs land. Verified: the new e2e passes against docker/PostGIS (12.8s), and the existing command e2e tests still pass.

## Summary by Sourcery

Add end-to-end coverage for command acknowledgement storage by wiring fake client acks through the real server and database schema.

New Features:
- Enable the fake example client to emit two-phase command acknowledgements when the command-ack capability is negotiated.
- Introduce an end-to-end test that drives a command through the live server and asserts its acknowledgement is stored in the database.

Enhancements:
- Extend the e2e database schema to include command acknowledgement fields on asset commands so server updates persist during tests.

Tests:
- Add a pytest-based e2e test that verifies dispatched commands record dispatch_id and terminal ack_state with a populated ack_timestamp via the real transport and async write path.