### PR TITLE
test(db): insert a command fixture so the getCommand DB test passes

### DIFF
--- a/docker/db-unit-test-entrypoint.sh
+++ b/docker/db-unit-test-entrypoint.sh
@@ -25,6 +25,10 @@ INSERT INTO config_assetconfig (asset_id, smm_id, smm_login, smm_password)
 
 INSERT INTO config_serverconfig (address, client_port, active, name, config_port, https)
     VALUES ('fss.example.com', 20202, true, 'test-server', 8090, false);
+
+-- A pending command for test-asset, so the getCommand DB test finds a row.
+INSERT INTO assets_assetcommand (asset_id, command)
+    SELECT a.id, 'RTL' FROM assets_asset a WHERE a.name = 'test-asset';
 SQL
 
 exec /code/tests/all_test "$@"


### PR DESCRIPTION
## Description

The db_connection "getCommand returns non-null for asset with pending command" test expects an assets_assetcommand row for test-asset, but the db-unit-test entrypoint never inserted one, so the test failed whenever the live-DB suite ran. Add the missing RTL command fixture.

## Summary by Sourcery

Tests:
- Add an assets_assetcommand row fixture for test-asset in the DB unit test entrypoint to support the getCommand test.