### PR TITLE
fix(server): scope command-ack DB match by asset, not just dispatch_id

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -800,11 +800,16 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                     break;
                 }
                 auto ack_msg = std::dynamic_pointer_cast<fss::transport::fss_message_command_ack>(msg);
-                if (ack_msg != nullptr)
+                /* Scope the stored ack to the acking asset: dispatch_id is only
+                 * per-connection unique, so without asset_id the DB update could
+                 * land on a different asset's same-dispatch_id command row. An
+                 * ack from a connection with no identified asset (asset_id == 0)
+                 * cannot be scoped, so it is dropped. */
+                if (ack_msg != nullptr && asset_id != 0)
                 {
-                    this->writer->enqueue(
-                        command_ack_write{ack_msg->getAckedCommandId(), static_cast<uint8_t>(ack_msg->getOutcome()),
-                                          ack_msg->getTimeStamp(), static_cast<uint8_t>(ack_msg->getReason())});
+                    this->writer->enqueue(command_ack_write{
+                        asset_id, ack_msg->getAckedCommandId(), static_cast<uint8_t>(ack_msg->getOutcome()),
+                        ack_msg->getTimeStamp(), static_cast<uint8_t>(ack_msg->getReason())});
                 }
             }
             break;

--- a/src/db-write-queue.hpp
+++ b/src/db-write-queue.hpp
@@ -41,9 +41,13 @@ struct command_dispatch_write {
     uint64_t command_dbid;
     uint64_t dispatch_id;
 };
-/* A command ack to store against the row whose dispatch id matches. ack_state is
- * the fss_command_ack_outcome int, ack_reason the fss_command_ack_reason int. */
+/* A command ack to store against the row whose (asset_id, dispatch_id) matches.
+ * dispatch_id is only per-connection unique (see transport::getMessageId), so the
+ * ack must be scoped to the acking asset or it could clobber another asset's row
+ * that happened to be stamped with the same dispatch_id. ack_state is the
+ * fss_command_ack_outcome int, ack_reason the fss_command_ack_reason int. */
 struct command_ack_write {
+    uint64_t asset_id;
     uint64_t dispatch_id;
     uint8_t ack_state;
     uint64_t ack_timestamp;

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -120,11 +120,12 @@ void flight_safety_system::server::db_connection::recordCommandDispatch(uint64_t
     db_command_set_dispatch_id(write_conn_name, command_dbid, dispatch_id);
 }
 
-void flight_safety_system::server::db_connection::recordCommandAck(uint64_t dispatch_id, uint8_t ack_state,
-                                                                   uint64_t ack_timestamp, uint8_t ack_reason)
+void flight_safety_system::server::db_connection::recordCommandAck(uint64_t asset_id, uint64_t dispatch_id,
+                                                                   uint8_t ack_state, uint64_t ack_timestamp,
+                                                                   uint8_t ack_reason)
 {
     std::scoped_lock guard(this->write_lock);
-    db_command_record_ack(write_conn_name, dispatch_id, static_cast<int>(ack_state), ack_timestamp,
+    db_command_record_ack(write_conn_name, asset_id, dispatch_id, static_cast<int>(ack_state), ack_timestamp,
                           static_cast<int>(ack_reason));
 }
 

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -97,10 +97,12 @@ public:
      * on the command) against the command row, so a later ack can be matched to
      * this specific command. */
     virtual void recordCommandDispatch(uint64_t command_dbid, uint64_t dispatch_id) = 0;
-    /* Stores a command ack against the row whose dispatch id matches; never
-     * regresses an already-terminal outcome. ack_state/ack_reason are the
-     * fss_command_ack_outcome/fss_command_ack_reason ints. */
-    virtual void recordCommandAck(uint64_t dispatch_id, uint8_t ack_state, uint64_t ack_timestamp,
+    /* Stores a command ack against the row whose (asset_id, dispatch_id) matches;
+     * never regresses an already-terminal outcome. dispatch_id is only
+     * per-connection unique, so asset_id scopes the match to the acking asset.
+     * ack_state/ack_reason are the fss_command_ack_outcome/fss_command_ack_reason
+     * ints. */
+    virtual void recordCommandAck(uint64_t asset_id, uint64_t dispatch_id, uint8_t ack_state, uint64_t ack_timestamp,
                                   uint8_t ack_reason) = 0;
     virtual auto getCommand(uint64_t asset_id) -> std::shared_ptr<asset_command> = 0;
     virtual auto getActiveServers() -> std::vector<fss_server_details> = 0;
@@ -148,7 +150,8 @@ public:
     void recordStatus(uint64_t asset_id, uint8_t bat_percent, uint32_t bat_mah_used, double bat_voltage) override;
     void recordSearchStatus(uint64_t asset_id, uint64_t search_id, uint64_t completed, uint64_t total) override;
     void recordCommandDispatch(uint64_t command_dbid, uint64_t dispatch_id) override;
-    void recordCommandAck(uint64_t dispatch_id, uint8_t ack_state, uint64_t ack_timestamp, uint8_t ack_reason) override;
+    void recordCommandAck(uint64_t asset_id, uint64_t dispatch_id, uint8_t ack_state, uint64_t ack_timestamp,
+                          uint8_t ack_reason) override;
     auto getCommand(uint64_t asset_id) -> std::shared_ptr<asset_command> override;
     auto getActiveServers() -> std::vector<fss_server_details> override;
     auto getSmmSettings(uint64_t asset_id) -> std::shared_ptr<smm_settings> override;

--- a/src/server-db.h
+++ b/src/server-db.h
@@ -22,12 +22,14 @@ void db_position_create_entry(const char *conn, unsigned long long asset_id, dou
  * command via dispatch_id == acked_command_id. */
 void db_command_set_dispatch_id(const char *conn, unsigned long long command_dbid, unsigned long long dispatch_id);
 
-/* Updates the ack fields on the assets_assetcommand row whose dispatch_id equals
- * the acked id. ack_state is the fss_command_ack_outcome int, ack_superseded_by
- * the fss_command_ack_reason int, ack_timestamp the FMU wall-clock ms. The
- * update never lowers an already-terminal ack_state back to a non-terminal one
- * (a late "received" cannot clobber a settled outcome). */
-void db_command_record_ack(const char *conn, unsigned long long dispatch_id, int ack_state,
+/* Updates the ack fields on the assets_assetcommand row whose (asset_id,
+ * dispatch_id) matches the acking asset and the acked id. dispatch_id is only
+ * per-connection unique, so asset_id scopes the match to avoid clobbering another
+ * asset's same-dispatch_id row. ack_state is the fss_command_ack_outcome int,
+ * ack_superseded_by the fss_command_ack_reason int, ack_timestamp the FMU
+ * wall-clock ms. The update never lowers an already-terminal ack_state back to a
+ * non-terminal one (a late "received" cannot clobber a settled outcome). */
+void db_command_record_ack(const char *conn, unsigned long long asset_id, unsigned long long dispatch_id, int ack_state,
                            unsigned long long ack_timestamp, int ack_superseded_by);
 
 struct asset_command_s {

--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -156,24 +156,27 @@ void db_command_set_dispatch_id(const char *conn_arg, unsigned long long command
     EXEC SQL AT :conn UPDATE assets_assetcommand SET dispatch_id = :dispatch_id WHERE id = :command_dbid;
 }
 
-void db_command_record_ack(const char *conn_arg, unsigned long long dispatch_id_arg, int ack_state_arg, unsigned long long ack_timestamp_arg, int ack_superseded_by_arg)
+void db_command_record_ack(const char *conn_arg, unsigned long long asset_id_arg, unsigned long long dispatch_id_arg, int ack_state_arg, unsigned long long ack_timestamp_arg, int ack_superseded_by_arg)
 {
     EXEC SQL BEGIN DECLARE SECTION;
     const char *conn = conn_arg;
+    unsigned long long asset_id = asset_id_arg;
     unsigned long long dispatch_id = dispatch_id_arg;
     int ack_state = ack_state_arg;
     unsigned long long ack_timestamp = ack_timestamp_arg;
     int ack_superseded_by = ack_superseded_by_arg;
     EXEC SQL END DECLARE SECTION;
 
-    /* Match the dispatched row by its stamped id and write the latest ack.
+    /* Match the dispatched row by the acking asset and its stamped id: dispatch_id
+     * is only per-connection unique, so without asset_id this could land on a
+     * different asset's same-dispatch_id row and confirm the wrong command.
      * Never regress an already-terminal outcome: a late "received" (state 0)
      * must not clobber a settled actioned/superseded/rejected/noop. So skip the
      * write when the incoming state is 0 and the stored state is already set and
      * non-zero. ack_superseded_by is only meaningful for the superseded state. */
     EXEC SQL AT :conn UPDATE assets_assetcommand
         SET ack_state = :ack_state, ack_timestamp = :ack_timestamp, ack_superseded_by = :ack_superseded_by
-        WHERE dispatch_id = :dispatch_id
+        WHERE asset_id = :asset_id AND dispatch_id = :dispatch_id
           AND NOT (:ack_state = 0 AND ack_state IS NOT NULL AND ack_state <> 0);
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -238,7 +238,7 @@ auto main(int argc, char *argv[]) -> int
                     dbc->recordCommandDispatch(w.command_dbid, w.dispatch_id);
                 },
                 [&](const flight_safety_system::server::command_ack_write &w) -> void {
-                    dbc->recordCommandAck(w.dispatch_id, w.ack_state, w.ack_timestamp, w.ack_reason);
+                    dbc->recordCommandAck(w.asset_id, w.dispatch_id, w.ack_state, w.ack_timestamp, w.ack_reason);
                 },
             },
             task);

--- a/tests/concurrency_client_test.cpp
+++ b/tests/concurrency_client_test.cpp
@@ -103,7 +103,7 @@ public:
     void recordStatus(uint64_t, uint8_t, uint32_t, double) override {}
     void recordSearchStatus(uint64_t, uint64_t, uint64_t, uint64_t) override {}
     void recordCommandDispatch(uint64_t, uint64_t) override {}
-    void recordCommandAck(uint64_t, uint8_t, uint64_t, uint8_t) override {}
+    void recordCommandAck(uint64_t, uint64_t, uint8_t, uint64_t, uint8_t) override {}
     auto getCommand(uint64_t) -> std::shared_ptr<flight_safety_system::server::asset_command> override
     {
         return nullptr;

--- a/tests/crl_revocation_test.cpp
+++ b/tests/crl_revocation_test.cpp
@@ -49,7 +49,7 @@ auto make_writer(fss_test::MockDatabase &mock) -> std::shared_ptr<fss::server::d
                            mock.recordCommandDispatch(w.command_dbid, w.dispatch_id);
                        },
                        [&](const fss::server::command_ack_write &w) -> void {
-                           mock.recordCommandAck(w.dispatch_id, w.ack_state, w.ack_timestamp, w.ack_reason);
+                           mock.recordCommandAck(w.asset_id, w.dispatch_id, w.ack_state, w.ack_timestamp, w.ack_reason);
                        },
                    },
                    task);

--- a/tests/mock_database.hpp
+++ b/tests/mock_database.hpp
@@ -52,6 +52,7 @@ public:
         uint64_t dispatch_id;
     };
     struct recorded_ack {
+        uint64_t asset_id;
         uint64_t dispatch_id;
         uint8_t ack_state;
         uint64_t ack_timestamp;
@@ -100,9 +101,10 @@ public:
         dispatches.push_back({command_dbid, dispatch_id});
     }
 
-    void recordCommandAck(uint64_t dispatch_id, uint8_t ack_state, uint64_t ack_timestamp, uint8_t ack_reason) override
+    void recordCommandAck(uint64_t asset_id, uint64_t dispatch_id, uint8_t ack_state, uint64_t ack_timestamp,
+                          uint8_t ack_reason) override
     {
-        acks.push_back({dispatch_id, ack_state, ack_timestamp, ack_reason});
+        acks.push_back({asset_id, dispatch_id, ack_state, ack_timestamp, ack_reason});
     }
 
     auto getCommand(uint64_t asset_id) -> std::shared_ptr<flight_safety_system::server::asset_command> override

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -116,7 +116,7 @@ auto make_mock_writer(fss_test::MockDatabase &mock) -> std::shared_ptr<fss::serv
                            mock.recordCommandDispatch(w.command_dbid, w.dispatch_id);
                        },
                        [&](const fss::server::command_ack_write &w) -> void {
-                           mock.recordCommandAck(w.dispatch_id, w.ack_state, w.ack_timestamp, w.ack_reason);
+                           mock.recordCommandAck(w.asset_id, w.dispatch_id, w.ack_state, w.ack_timestamp, w.ack_reason);
                        },
                    },
                    task);
@@ -1422,6 +1422,9 @@ TEST_CASE("session: command_ack is stored when the capability is negotiated")
     session->processMessage(ack);
 
     REQUIRE(fss_test::wait_for([&]() { return !mock.acks.empty(); }));
+    /* The ack is scoped to the acking asset (the one this connection identified
+     * as), not just the per-connection dispatch_id. */
+    REQUIRE(mock.acks.front().asset_id == 13);
     REQUIRE(mock.acks.front().dispatch_id == acked_id);
     REQUIRE(mock.acks.front().ack_state == static_cast<uint8_t>(fss::transport::command_ack_superseded));
     REQUIRE(mock.acks.front().ack_timestamp == ack_ts);


### PR DESCRIPTION
## Description

dispatch_id is a per-connection monotonic id (transport::getMessageId), not globally unique, so two assets routinely have commands stamped with the same dispatch_id. db_command_record_ack matched the ack row by dispatch_id alone, with no asset scoping and no UNIQUE constraint, so an ack from asset B could overwrite asset A's same-dispatch_id command row and show the operator a false "actioned" confirmation on asset A.

Thread the acking asset's id (cached_asset_id, from the connection the ack arrived on) through command_ack_write -> recordCommandAck -> db_command_record_ack and add `asset_id = :asset_id` to the UPDATE's WHERE, keeping the existing no-regress guard. The wire format is unchanged: the ack still carries only acked_command_id; the server supplies asset_id from the connection. An ack from a connection with no identified asset (asset_id 0) cannot be scoped and is dropped.

## Summary by Sourcery

Scope command acknowledgement persistence by asset ID as well as dispatch ID to prevent cross-asset acks from updating the wrong command row.

Bug Fixes:
- Prevent command acknowledgements from one asset overwriting another asset's command row when dispatch IDs collide across connections.
- Drop command acknowledgements from connections without an identified asset to avoid unscoped DB updates.

Tests:
- Extend server session tests to assert that stored command acknowledgements are associated with the correct asset ID.