### PR TITLE
fix(server): target only the latest command row when recording an ack

### DIFF
--- a/e2e/test_command_ack.py
+++ b/e2e/test_command_ack.py
@@ -213,3 +213,89 @@ def test_ack_does_not_cross_assets_on_dispatch_id_collision(
         f"ack_timestamp={a_ts}, ack_superseded_by={a_reason}; server log:\n"
         + server_proc["log"].read_text(errors="replace")
     )
+
+
+@pytest.mark.requires_docker
+def test_ack_updates_only_the_latest_row_on_cross_session_dispatch_id_reuse(
+    db_conn, fake_client, server_proc
+):
+    """Within a single asset, an ack must update only the newest command sharing
+    a dispatch_id, not an old already-settled one from a prior session.
+
+    dispatch_id is the connection's last_msg_id, which resets to 0 on every
+    reconnect, so the same asset accumulates several historical command rows that
+    share a dispatch_id across sessions. The ack is for the command just
+    dispatched on the current connection — the latest row — so the UPDATE targets
+    the newest match. An ack must never reach back and rewrite a long-settled
+    historical row that happens to carry the same dispatch_id.
+
+    We give the asset one live client, seed an OLD command row with a terminal
+    "superseded" sentinel and an old timestamp at the dispatch_id the next live
+    command will use, then dispatch a NEW command that lands on that same
+    dispatch_id. The client's ack must advance only the NEW row and leave the OLD
+    sentinel untouched.
+    """
+    with db_conn.cursor() as cur:
+        cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
+        asset = cur.fetchone()[0]
+    db_conn.commit()
+
+    fake_client("test1")
+    time.sleep(5)
+
+    # First dispatch: learn the connection's current dispatch_id.
+    first = _dispatch_rtl(db_conn, asset)
+    first_dispatch = _poll_field(db_conn, first, "dispatch_id", timeout=10.0)
+    assert first_dispatch is not None, (
+        f"first command dbid={first} never recorded a dispatch_id; server log:\n"
+        + server_proc["log"].read_text(errors="replace")
+    )
+    _poll_field(db_conn, first, "ack_state", timeout=10.0)
+
+    # Seed an OLD already-acked row for the SAME asset at the dispatch_id the next
+    # live command will use, with an explicitly older timestamp so the newest-row
+    # subselect must not pick it.
+    collide_dispatch = first_dispatch + 1
+    sentinel_ts = 222
+    sentinel_reason = 3
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO assets_assetcommand "
+            "(asset_id, command, position, altitude, timestamp, dispatch_id, "
+            " ack_state, ack_timestamp, ack_superseded_by) "
+            "VALUES (%s, 'RTL', ST_SetSRID(ST_MakePoint(0, 0), 4326)::geography, 0, "
+            "        NOW() - INTERVAL '1 hour', %s, %s, %s, %s) RETURNING id",
+            (asset, collide_dispatch, ACK_STATE_SUPERSEDED, sentinel_ts, sentinel_reason),
+        )
+        old_dbid = cur.fetchone()[0]
+    db_conn.commit()
+
+    # New dispatch: lands on collide_dispatch with a fresh (newer) timestamp.
+    new_dbid = _dispatch_rtl(db_conn, asset)
+    new_dispatch = _poll_field(db_conn, new_dbid, "dispatch_id", timeout=10.0)
+    new_state = _poll_field(db_conn, new_dbid, "ack_state", timeout=10.0)
+
+    assert new_dispatch == collide_dispatch, (
+        f"setup failed to reuse dispatch_id: old row={collide_dispatch} but the new "
+        f"command got dispatch_id={new_dispatch}"
+    )
+    # The new (latest) row is the one the ack must land on.
+    assert new_state == ACK_STATE_ACTIONED, (
+        f"the new command should have been acked actioned, got {new_state}"
+    )
+
+    # The old, already-settled row must be untouched.
+    db_conn.rollback()
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT ack_state, ack_timestamp, ack_superseded_by "
+            "FROM assets_assetcommand WHERE id = %s",
+            (old_dbid,),
+        )
+        old_state, old_ts, old_reason = cur.fetchone()
+    assert (old_state, old_ts, old_reason) == (ACK_STATE_SUPERSEDED, sentinel_ts, sentinel_reason), (
+        "the old already-acked command row was rewritten by an ack meant for the "
+        f"newer command sharing dispatch_id={collide_dispatch}: got "
+        f"ack_state={old_state}, ack_timestamp={old_ts}, ack_superseded_by={old_reason}; "
+        "server log:\n" + server_proc["log"].read_text(errors="replace")
+    )

--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -167,16 +167,24 @@ void db_command_record_ack(const char *conn_arg, unsigned long long asset_id_arg
     int ack_superseded_by = ack_superseded_by_arg;
     EXEC SQL END DECLARE SECTION;
 
-    /* Match the dispatched row by the acking asset and its stamped id: dispatch_id
-     * is only per-connection unique, so without asset_id this could land on a
-     * different asset's same-dispatch_id row and confirm the wrong command.
+    /* Match the dispatched row by the acking asset and its stamped id, and
+     * update only the NEWEST such row. dispatch_id is the per-connection
+     * last_msg_id: it is not globally unique (so asset_id is needed to avoid a
+     * different asset's row) AND it resets to 0 on every reconnect, so one asset
+     * accumulates several historical command rows sharing a dispatch_id across
+     * sessions. An ack is always for the command just dispatched on the current
+     * connection — the latest such row — so target it alone via a subselect
+     * ordered by timestamp; matching all of them would let this ack rewrite a
+     * long-settled historical row.
      * Never regress an already-terminal outcome: a late "received" (state 0)
      * must not clobber a settled actioned/superseded/rejected/noop. So skip the
      * write when the incoming state is 0 and the stored state is already set and
      * non-zero. ack_superseded_by is only meaningful for the superseded state. */
     EXEC SQL AT :conn UPDATE assets_assetcommand
         SET ack_state = :ack_state, ack_timestamp = :ack_timestamp, ack_superseded_by = :ack_superseded_by
-        WHERE asset_id = :asset_id AND dispatch_id = :dispatch_id
+        WHERE id = (SELECT id FROM assets_assetcommand
+                    WHERE asset_id = :asset_id AND dispatch_id = :dispatch_id
+                    ORDER BY timestamp DESC LIMIT 1)
           AND NOT (:ack_state = 0 AND ack_state IS NOT NULL AND ack_state <> 0);
 }
 


### PR DESCRIPTION
## Description

dispatch_id is the connection's last_msg_id, which resets to 0 on every reconnect, so one asset accumulates multiple historical command rows that share a dispatch_id across sessions (AssetCommand.asset is a plain FK — many rows per asset). The asset-scoped UPDATE still matched ALL of them, so an ack could reach back and rewrite a long-settled historical row, and the no-regress guard does not stop a terminal-over-terminal overwrite.

Scope the UPDATE to the newest matching row via a timestamp-ordered subselect; an ack is always for the command just dispatched on the current connection. Add an e2e regression that seeds an old already-acked row and a new row sharing a dispatch_id for one asset and asserts the ack lands only on the new row. It fails against the all-rows UPDATE.

## Summary by Sourcery

Ensure command acknowledgements update only the most recent matching command row per asset when dispatch IDs are reused across sessions.

Bug Fixes:
- Prevent acknowledgements from overwriting historical command rows that share a dispatch_id with a newly dispatched command on the same asset.

Tests:
- Add an end-to-end regression test verifying that an ack only updates the latest command row when dispatch_id is reused across sessions for a single asset.