### PR TITLE
feat(transport): add supersede_newer_command ack reason

### DIFF
--- a/e2e/test_command_ack.py
+++ b/e2e/test_command_ack.py
@@ -23,10 +23,18 @@ ACK_STATE_ACTIONED = 1
 ACK_STATE_SUPERSEDED = 2
 
 
-def _poll_row(db_conn, dbid: int, timeout: float):
-    """Poll the AssetCommand row until its ack fields are populated, or time out.
-    Returns (dispatch_id, ack_state, ack_timestamp) once ack_state is set."""
+def _poll_row(db_conn, dbid: int, timeout: float, expected_state: int = ACK_STATE_ACTIONED):
+    """Poll the AssetCommand row until ack_state reaches the terminal
+    `expected_state`, or time out.
+
+    The ack is two-phase: the client sends `received` (0) immediately followed
+    by `actioned` (1), persisted as two async writes. Returning as soon as
+    ack_state is merely non-NULL races those writes and can latch the transient
+    `received`; callers assert the terminal outcome, so wait for it. Returns the
+    last row seen (so a timeout still reports what was stored), or None if no ack
+    ever landed."""
     deadline = time.monotonic() + timeout
+    last = None
     while time.monotonic() < deadline:
         # A fresh transaction each poll so we see the server's committed writes.
         db_conn.rollback()
@@ -38,9 +46,11 @@ def _poll_row(db_conn, dbid: int, timeout: float):
             )
             row = cur.fetchone()
         if row is not None and row[1] is not None:
-            return row
+            last = row
+            if row[1] == expected_state:
+                return row
         time.sleep(0.05)
-    return None
+    return last
 
 
 def _poll_field(db_conn, dbid: int, field: str, timeout: float):
@@ -62,6 +72,29 @@ def _poll_field(db_conn, dbid: int, field: str, timeout: float):
             return row[0]
         time.sleep(0.02)
     return None
+
+
+def _poll_ack_state(db_conn, dbid: int, expected: int, timeout: float):
+    """Poll a row's ack_state until it reaches the terminal `expected` value, or
+    time out. See _poll_row for why a bare non-NULL check races the two-phase
+    ack. Returns the last non-NULL state seen (so a timeout reports what was
+    stored), or None if no ack ever landed."""
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        db_conn.rollback()
+        with db_conn.cursor() as cur:
+            cur.execute(
+                "SELECT ack_state FROM assets_assetcommand WHERE id = %s",
+                (dbid,),
+            )
+            row = cur.fetchone()
+        if row is not None and row[0] is not None:
+            last = row[0]
+            if last == expected:
+                return last
+        time.sleep(0.02)
+    return last
 
 
 @pytest.mark.requires_docker
@@ -184,7 +217,7 @@ def test_ack_does_not_cross_assets_on_dispatch_id_collision(
     # Second dispatch to B: should land on collide_dispatch and be acked by B.
     b_second = _dispatch_rtl(db_conn, asset_b)
     b_second_dispatch = _poll_field(db_conn, b_second, "dispatch_id", timeout=10.0)
-    b_second_state = _poll_field(db_conn, b_second, "ack_state", timeout=10.0)
+    b_second_state = _poll_ack_state(db_conn, b_second, ACK_STATE_ACTIONED, timeout=10.0)
 
     # Guard the construction itself: if the collision didn't actually happen the
     # test proves nothing, so fail loudly rather than pass vacuously.
@@ -273,7 +306,7 @@ def test_ack_updates_only_the_latest_row_on_cross_session_dispatch_id_reuse(
     # New dispatch: lands on collide_dispatch with a fresh (newer) timestamp.
     new_dbid = _dispatch_rtl(db_conn, asset)
     new_dispatch = _poll_field(db_conn, new_dbid, "dispatch_id", timeout=10.0)
-    new_state = _poll_field(db_conn, new_dbid, "ack_state", timeout=10.0)
+    new_state = _poll_ack_state(db_conn, new_dbid, ACK_STATE_ACTIONED, timeout=10.0)
 
     assert new_dispatch == collide_dispatch, (
         f"setup failed to reuse dispatch_id: old row={collide_dispatch} but the new "

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -147,6 +147,12 @@ using fss_command_ack_reason = enum fss_command_ack_reason_e {
     supersede_low_battery = 1,
     /* Comms-loss failsafe latch (also an RTL, distinct from low-battery). */
     supersede_comms_loss = 2,
+    /* A newer operator command replaced this one before it was actioned. Unlike
+     * the latches above this is not an autonomous safety override but the normal
+     * "operator changed their mind" case; the FMU acks the stale command with
+     * this reason so the UI shows it was dropped in favour of a later command,
+     * not silently lost. */
+    supersede_newer_command = 3,
 };
 
 using fss_asset_command = enum fss_asset_command_e {

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -100,6 +100,7 @@ static auto decode_command_ack_reason(uint8_t reason) -> flight_safety_system::t
         case static_cast<uint8_t>(supersede_none): return supersede_none;
         case static_cast<uint8_t>(supersede_low_battery): return supersede_low_battery;
         case static_cast<uint8_t>(supersede_comms_loss): return supersede_comms_loss;
+        case static_cast<uint8_t>(supersede_newer_command): return supersede_newer_command;
         /* An unrecognised reason from a newer peer degrades to "none" rather
          * than inventing a cause the operator might act on. */
         default: return supersede_none;

--- a/tests/messages.cpp
+++ b/tests/messages.cpp
@@ -528,6 +528,33 @@ TEST_CASE("Command Ack Message Check - Superseded carries the reason")
     REQUIRE(decoded->getTimeStamp() == timestamp);
 }
 
+TEST_CASE("Command Ack Message Check - Superseded by a newer operator command")
+{
+    auto msg_id = static_cast<uint64_t>(random());
+    auto acked_command_id = static_cast<uint64_t>(random());
+    auto timestamp = static_cast<uint64_t>(random());
+
+    /* A stale command was dropped because the operator issued a newer one before
+     * it was actioned. This is the non-latch supersede reason, distinct from the
+     * autonomous safety latches; it must survive the round trip so the UI can
+     * show "replaced by a newer command" rather than a generic drop. */
+    auto msg = std::make_shared<flight_safety_system::transport::fss_message_command_ack>(
+        acked_command_id, flight_safety_system::transport::asset_command_goto,
+        flight_safety_system::transport::command_ack_superseded,
+        flight_safety_system::transport::supersede_newer_command, timestamp);
+    REQUIRE(msg->getOutcome() == flight_safety_system::transport::command_ack_superseded);
+    REQUIRE(msg->getReason() == flight_safety_system::transport::supersede_newer_command);
+
+    msg->setId(msg_id);
+    auto bl = msg->getPacked();
+    REQUIRE(bl != nullptr);
+    auto decoded = std::make_shared<flight_safety_system::transport::fss_message_command_ack>(msg_id, bl);
+    REQUIRE(decoded->getAckedCommandId() == acked_command_id);
+    REQUIRE(decoded->getOutcome() == flight_safety_system::transport::command_ack_superseded);
+    REQUIRE(decoded->getReason() == flight_safety_system::transport::supersede_newer_command);
+    REQUIRE(decoded->getTimeStamp() == timestamp);
+}
+
 TEST_CASE("Command Ack Message Check - No-op (already in the commanded state)")
 {
     auto msg_id = static_cast<uint64_t>(random());


### PR DESCRIPTION
## Description

Adds reason value 3 to fss_command_ack_reason for a stale command dropped because the operator issued a newer one before it was actioned — the normal "operator changed their mind" case, distinct from the autonomous low-battery/comms-loss safety latches. decode_command_ack_reason maps it through; the wire format is unchanged (same uint8 reason field). Covered by a command_ack round-trip test.

## Summary by Sourcery

Add a new command acknowledgement reason for operator-issued superseding commands and ensure it is preserved through transport decoding.

New Features:
- Introduce a supersede_newer_command reason in fss_command_ack_reason to represent commands replaced by newer operator-issued commands.

Tests:
- Add a round-trip command acknowledgement test verifying supersede_newer_command is correctly encoded, decoded, and reported.