### PR TITLE
fix(transport): normalise command-ack reason to none for non-superseded outcomes

### DIFF
--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -1032,7 +1032,12 @@ flight_safety_system::transport::fss_message_command_ack::fss_message_command_ac
                                                                                   uint64_t t_timestamp)
     : fss_message(message_type_command_ack), acked_command_id(t_acked_command_id),
       command(static_cast<uint8_t>(t_command)), outcome(static_cast<uint8_t>(t_outcome)),
-      reason(static_cast<uint8_t>(t_reason)), timestamp(t_timestamp)
+      /* The reason is only meaningful for a superseded outcome; for any other
+       * outcome it must read back as supersede_none. Enforce that here rather
+       * than trusting every caller, so an inconsistent outcome/reason pair can
+       * never propagate into the wire, logs, or UI. */
+      reason(static_cast<uint8_t>(t_outcome == command_ack_superseded ? t_reason : supersede_none)),
+      timestamp(t_timestamp)
 {
 }
 // NOLINTEND(bugprone-easily-swappable-parameters)

--- a/tests/messages.cpp
+++ b/tests/messages.cpp
@@ -577,6 +577,30 @@ TEST_CASE("Command Ack Message Check - No-op (already in the commanded state)")
     REQUIRE(decoded->getReason() == flight_safety_system::transport::supersede_none);
 }
 
+TEST_CASE("Command Ack Message Check - reason is normalised away for a non-superseded outcome")
+{
+    auto acked_command_id = static_cast<uint64_t>(random());
+    auto timestamp = static_cast<uint64_t>(random());
+
+    /* A reason is only meaningful alongside a superseded outcome. Even if a
+     * caller passes one for any other outcome, the constructor must drop it to
+     * supersede_none so an inconsistent outcome/reason pair never reaches the
+     * wire, logs, or UI. */
+    auto msg = std::make_shared<flight_safety_system::transport::fss_message_command_ack>(
+        acked_command_id, flight_safety_system::transport::asset_command_rtl,
+        flight_safety_system::transport::command_ack_actioned,
+        flight_safety_system::transport::supersede_low_battery, timestamp);
+    REQUIRE(msg->getOutcome() == flight_safety_system::transport::command_ack_actioned);
+    REQUIRE(msg->getReason() == flight_safety_system::transport::supersede_none);
+
+    msg->setId(static_cast<uint64_t>(random()));
+    auto bl = msg->getPacked();
+    REQUIRE(bl != nullptr);
+    auto decoded = std::make_shared<flight_safety_system::transport::fss_message_command_ack>(msg->getId(), bl);
+    REQUIRE(decoded->getOutcome() == flight_safety_system::transport::command_ack_actioned);
+    REQUIRE(decoded->getReason() == flight_safety_system::transport::supersede_none);
+}
+
 TEST_CASE("SMM Settings Message Check")
 {
     auto msg_id = static_cast<uint64_t>(random());

--- a/tests/messages.cpp
+++ b/tests/messages.cpp
@@ -579,8 +579,13 @@ TEST_CASE("Command Ack Message Check - No-op (already in the commanded state)")
 
 TEST_CASE("Command Ack Message Check - reason is normalised away for a non-superseded outcome")
 {
-    auto acked_command_id = static_cast<uint64_t>(random());
-    auto timestamp = static_cast<uint64_t>(random());
+    /* Fixed values keep this regression deterministic: the property under test
+     * (reason normalisation) is independent of the id/timestamp, so randomising
+     * them would only make a failure harder to reproduce. The byte patterns
+     * still cross all 8 bytes to exercise the round trip. */
+    constexpr uint64_t msg_id = 0x0102030405060708ULL;
+    constexpr uint64_t acked_command_id = 0x1122334455667788ULL;
+    constexpr uint64_t timestamp = 0x99AABBCCDDEEFF00ULL;
 
     /* A reason is only meaningful alongside a superseded outcome. Even if a
      * caller passes one for any other outcome, the constructor must drop it to
@@ -588,15 +593,15 @@ TEST_CASE("Command Ack Message Check - reason is normalised away for a non-super
      * wire, logs, or UI. */
     auto msg = std::make_shared<flight_safety_system::transport::fss_message_command_ack>(
         acked_command_id, flight_safety_system::transport::asset_command_rtl,
-        flight_safety_system::transport::command_ack_actioned,
-        flight_safety_system::transport::supersede_low_battery, timestamp);
+        flight_safety_system::transport::command_ack_actioned, flight_safety_system::transport::supersede_low_battery,
+        timestamp);
     REQUIRE(msg->getOutcome() == flight_safety_system::transport::command_ack_actioned);
     REQUIRE(msg->getReason() == flight_safety_system::transport::supersede_none);
 
-    msg->setId(static_cast<uint64_t>(random()));
+    msg->setId(msg_id);
     auto bl = msg->getPacked();
     REQUIRE(bl != nullptr);
-    auto decoded = std::make_shared<flight_safety_system::transport::fss_message_command_ack>(msg->getId(), bl);
+    auto decoded = std::make_shared<flight_safety_system::transport::fss_message_command_ack>(msg_id, bl);
     REQUIRE(decoded->getOutcome() == flight_safety_system::transport::command_ack_actioned);
     REQUIRE(decoded->getReason() == flight_safety_system::transport::supersede_none);
 }


### PR DESCRIPTION
## Description

The reason byte is only meaningful alongside a superseded outcome; for any other outcome it must read back as supersede_none. The reason-carrying constructor previously trusted the caller to keep the pair consistent, so a non-superseded outcome paired with a real reason could propagate onto the wire, into logs, and into the UI. Normalise reason to supersede_none in the constructor whenever the outcome is not command_ack_superseded, and cover it with a regression test. (sourcery, PR #257)

## Summary by Sourcery

Normalise command ack reasons to `supersede_none` for non-superseded outcomes and add regression coverage.

Bug Fixes:
- Ensure command ack messages clear any supersede reason when the outcome is not `command_ack_superseded` to prevent inconsistent outcome/reason pairs reaching external interfaces.

Tests:
- Add a regression test verifying that non-superseded command ack outcomes always encode and decode with a `supersede_none` reason even if a different reason is provided.