### PR TITLE
feat(transport): log unknown command-ack supersede reasons on decode

### DIFF
--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -102,8 +102,14 @@ static auto decode_command_ack_reason(uint8_t reason) -> flight_safety_system::t
         case static_cast<uint8_t>(supersede_comms_loss): return supersede_comms_loss;
         case static_cast<uint8_t>(supersede_newer_command): return supersede_newer_command;
         /* An unrecognised reason from a newer peer degrades to "none" rather
-         * than inventing a cause the operator might act on. */
-        default: return supersede_none;
+         * than inventing a cause the operator might act on, but log it: the ack
+         * is reported as supersede_none to the operator while the raw code is
+         * preserved here so a version mismatch or protocol drift stays
+         * diagnosable instead of vanishing silently. */
+        default:
+            FSS_LOG_WARN("transport", "Unknown command-ack supersede reason " << static_cast<unsigned>(reason)
+                                                                              << "; treating as supersede_none");
+            return supersede_none;
     }
 }
 

--- a/tests/messages.cpp
+++ b/tests/messages.cpp
@@ -1021,6 +1021,27 @@ TEST_CASE("messages: truncated command_ack decodes to safe defaults")
     REQUIRE(decoded->getTimeStamp() == 0);
 }
 
+TEST_CASE("messages: unknown command_ack reason degrades to supersede_none")
+{
+    using flight_safety_system::transport::message_type_command_ack;
+    /* A newer peer can send a supersede reason this build does not recognise.
+     * Such a code must decode back to supersede_none (the operator is never
+     * shown an invented cause); the raw code is only logged for diagnosis. */
+    std::string payload;
+    payload.append(sizeof(uint64_t), '\0'); // acked_command_id = 0
+    payload.push_back(static_cast<char>(flight_safety_system::transport::asset_command_rtl));
+    payload.push_back(static_cast<char>(flight_safety_system::transport::command_ack_superseded));
+    payload.push_back(static_cast<char>(0xEE)); // a reason code no build assigns
+    payload.append(sizeof(uint64_t), '\0');     // timestamp = 0
+    const size_t total = framed_header_len + payload.size();
+    auto bl = fss_test::make_framed_buffer(static_cast<uint16_t>(message_type_command_ack), 1, payload, total);
+    auto decoded = std::dynamic_pointer_cast<flight_safety_system::transport::fss_message_command_ack>(
+        flight_safety_system::transport::fss_message::decode(bl));
+    REQUIRE(decoded != nullptr);
+    REQUIRE(decoded->getOutcome() == flight_safety_system::transport::command_ack_superseded);
+    REQUIRE(decoded->getReason() == flight_safety_system::transport::supersede_none);
+}
+
 /* readUint32 failure (line 129): version message truncated after the two
  * uint16 version fields, so the uint32_t feature_flags read fails. */
 TEST_CASE("messages: BufferReader readUint32 short-read returns false")


### PR DESCRIPTION
## Description

Decoding an unrecognised supersede reason still degrades to supersede_none so the operator is never shown an invented cause, but it did so silently — hiding that a newer peer is speaking a reason this build does not know. Log the raw code at WARN when it degrades so a version mismatch or protocol drift stays diagnosable from the acks used for post-hoc debugging. Add a regression test covering the degrade. (sourcery, PR #266)

## Summary by Sourcery

Log unknown command-ack supersede reasons during message decode and add a regression test for the degradation behavior.

Bug Fixes:
- Ensure unknown command-ack supersede reasons degrade to supersede_none while logging the raw reason code for diagnosis.

Tests:
- Add a regression test verifying that unknown command-ack supersede reasons decode to supersede_none while preserving the superseded outcome.