### PR TITLE
feat(server): log command-acks dropped for want of an identified asset

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -811,6 +811,16 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                         asset_id, ack_msg->getAckedCommandId(), static_cast<uint8_t>(ack_msg->getOutcome()),
                         ack_msg->getTimeStamp(), static_cast<uint8_t>(ack_msg->getReason())});
                 }
+                else if (ack_msg != nullptr)
+                {
+                    /* asset_id == 0: the connection has no identified asset, so the
+                     * ack cannot be scoped and is dropped. A conforming client only
+                     * acks after identifying, so this is unexpected — log it so an
+                     * unscoped ack can be investigated rather than vanishing. */
+                    FSS_LOG_WARN("server", "Dropping command-ack for acked-command "
+                                               << ack_msg->getAckedCommandId()
+                                               << " from connection with no identified asset (asset_id==0)");
+                }
             }
             break;
             case fss::transport::message_type_command:


### PR DESCRIPTION
## Description

An ack arriving on a connection with no identified asset (asset_id == 0) cannot be scoped to a command row and is dropped. A conforming client only acks after identifying, so an unscoped ack is unexpected; log it at WARN so it can be investigated in production rather than failing silently. (sourcery, PR #263)

## Summary by Sourcery

Bug Fixes:
- Ensure command acknowledgment messages received before asset identification are dropped with a warning log instead of being silently ignored.