### PR TITLE
test(e2e): wait for client readiness instead of a fixed sleep

### DIFF
--- a/e2e/test_command_ack.py
+++ b/e2e/test_command_ack.py
@@ -23,6 +23,26 @@ ACK_STATE_ACTIONED = 1
 ACK_STATE_SUPERSEDED = 2
 
 
+def _wait_for_client_ready(server_proc, name: str, timeout: float = 15.0) -> bool:
+    """Block until the server reports that the aircraft client `name` identified.
+
+    The fake client connects, runs the protocol-version handshake (which is when
+    the command-ack capability is negotiated) and only then identifies; the
+    server logs "Aircraft client identified: <name>" at that point. Waiting for
+    that line is a precise readiness signal — the connection exists and the
+    capability is negotiated — and replaces a blind fixed sleep that was both
+    slower and prone to flaking under load. Returns True once seen, False on
+    timeout."""
+    needle = f"Aircraft client identified: {name}"
+    log_path = server_proc["log"]
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if needle in log_path.read_text(errors="replace"):
+            return True
+        time.sleep(0.05)
+    return False
+
+
 def _poll_row(db_conn, dbid: int, timeout: float, expected_state: int = ACK_STATE_ACTIONED):
     """Poll the AssetCommand row until ack_state reaches the terminal
     `expected_state`, or time out.
@@ -108,9 +128,12 @@ def test_command_ack_is_stored(db_conn, fake_client, server_proc):
 
     fake_client("test1")
 
-    # Let the client connect, identify, and negotiate the version handshake
-    # (the command-ack capability is only negotiated then).
-    time.sleep(5)
+    # Wait for the client to connect, negotiate the handshake (where the
+    # command-ack capability is agreed) and identify, rather than blind-sleeping.
+    assert _wait_for_client_ready(server_proc, "test1"), (
+        "client test1 never identified; server log:\n"
+        + server_proc["log"].read_text(errors="replace")
+    )
 
     with db_conn.cursor() as cur:
         cur.execute(
@@ -184,7 +207,10 @@ def test_ack_does_not_cross_assets_on_dispatch_id_collision(
     # Only asset B gets a live client; asset A is a database-only asset whose
     # command row we craft to collide with B's dispatch_id.
     fake_client("test2")
-    time.sleep(5)
+    assert _wait_for_client_ready(server_proc, "test2"), (
+        "client test2 never identified; server log:\n"
+        + server_proc["log"].read_text(errors="replace")
+    )
 
     # First dispatch to B: learn the dispatch_id its connection is currently at.
     b_first = _dispatch_rtl(db_conn, asset_b)
@@ -274,7 +300,10 @@ def test_ack_updates_only_the_latest_row_on_cross_session_dispatch_id_reuse(
     db_conn.commit()
 
     fake_client("test1")
-    time.sleep(5)
+    assert _wait_for_client_ready(server_proc, "test1"), (
+        "client test1 never identified; server log:\n"
+        + server_proc["log"].read_text(errors="replace")
+    )
 
     # First dispatch: learn the connection's current dispatch_id.
     first = _dispatch_rtl(db_conn, asset)

--- a/e2e/test_command_ack.py
+++ b/e2e/test_command_ack.py
@@ -23,7 +23,7 @@ ACK_STATE_ACTIONED = 1
 ACK_STATE_SUPERSEDED = 2
 
 
-def _wait_for_client_ready(server_proc, name: str, timeout: float = 15.0) -> bool:
+def _wait_for_client_ready(server_proc, name: str, timeout: float = 15.0) -> None:
     """Block until the server reports that the aircraft client `name` identified.
 
     The fake client connects, runs the protocol-version handshake (which is when
@@ -31,16 +31,29 @@ def _wait_for_client_ready(server_proc, name: str, timeout: float = 15.0) -> boo
     server logs "Aircraft client identified: <name>" at that point. Waiting for
     that line is a precise readiness signal — the connection exists and the
     capability is negotiated — and replaces a blind fixed sleep that was both
-    slower and prone to flaking under load. Returns True once seen, False on
-    timeout."""
-    needle = f"Aircraft client identified: {name}"
+    slower and prone to flaking under load.
+
+    Returns once the line is seen; raises AssertionError with the full server log
+    on timeout, so callers need not repeat that check. The log is tailed from the
+    last read offset each poll rather than re-read whole, so the cost does not
+    grow with the log."""
+    needle = f"Aircraft client identified: {name}".encode()
     log_path = server_proc["log"]
     deadline = time.monotonic() + timeout
+    seen = b""
+    offset = 0
     while time.monotonic() < deadline:
-        if needle in log_path.read_text(errors="replace"):
-            return True
+        with log_path.open("rb") as fp:
+            fp.seek(offset)
+            seen += fp.read()
+            offset = fp.tell()
+        if needle in seen:
+            return
         time.sleep(0.05)
-    return False
+    raise AssertionError(
+        f"client {name} never identified within {timeout:.0f}s; server log:\n"
+        + seen.decode(errors="replace")
+    )
 
 
 def _poll_row(db_conn, dbid: int, timeout: float, expected_state: int = ACK_STATE_ACTIONED):
@@ -130,10 +143,7 @@ def test_command_ack_is_stored(db_conn, fake_client, server_proc):
 
     # Wait for the client to connect, negotiate the handshake (where the
     # command-ack capability is agreed) and identify, rather than blind-sleeping.
-    assert _wait_for_client_ready(server_proc, "test1"), (
-        "client test1 never identified; server log:\n"
-        + server_proc["log"].read_text(errors="replace")
-    )
+    _wait_for_client_ready(server_proc, "test1")
 
     with db_conn.cursor() as cur:
         cur.execute(
@@ -207,10 +217,7 @@ def test_ack_does_not_cross_assets_on_dispatch_id_collision(
     # Only asset B gets a live client; asset A is a database-only asset whose
     # command row we craft to collide with B's dispatch_id.
     fake_client("test2")
-    assert _wait_for_client_ready(server_proc, "test2"), (
-        "client test2 never identified; server log:\n"
-        + server_proc["log"].read_text(errors="replace")
-    )
+    _wait_for_client_ready(server_proc, "test2")
 
     # First dispatch to B: learn the dispatch_id its connection is currently at.
     b_first = _dispatch_rtl(db_conn, asset_b)
@@ -300,10 +307,7 @@ def test_ack_updates_only_the_latest_row_on_cross_session_dispatch_id_reuse(
     db_conn.commit()
 
     fake_client("test1")
-    assert _wait_for_client_ready(server_proc, "test1"), (
-        "client test1 never identified; server log:\n"
-        + server_proc["log"].read_text(errors="replace")
-    )
+    _wait_for_client_ready(server_proc, "test1")
 
     # First dispatch: learn the connection's current dispatch_id.
     first = _dispatch_rtl(db_conn, asset)


### PR DESCRIPTION
## Description

Each command-ack test slept a fixed 5s after spawning the fake client to let it connect and negotiate the capability before dispatching. That is both slower than necessary and prone to flaking under load. Replace the three blind sleeps with a poll for the server's "Aircraft client identified" log line — a precise signal that the connection exists and (since the version handshake runs first) the command-ack capability is negotiated. (sourcery, PRs #261, #264, #265)

## Summary by Sourcery

Poll server logs for aircraft client identification to determine readiness in command-ack e2e tests instead of relying on fixed sleep delays.

Tests:
- Introduce a helper to wait for aircraft client identification via server logs before proceeding in command-ack e2e tests.
- Replace fixed 5-second sleeps with readiness polling to reduce flakiness and speed up command-ack e2e tests.