### PR TITLE
test(e2e): tidy imports — drop unused, sort the rest

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -10,7 +10,6 @@ Layout:
 """
 from __future__ import annotations
 
-import json
 import os
 import shutil
 import signal

--- a/e2e/test_cert_rejection.py
+++ b/e2e/test_cert_rejection.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import shutil
 import subprocess
 import time
-from pathlib import Path
 
 import pytest
 

--- a/e2e/test_command_ack.py
+++ b/e2e/test_command_ack.py
@@ -16,7 +16,6 @@ import time
 
 import pytest
 
-
 # Mirror flight_safety_system::transport::fss_command_ack_outcome.
 ACK_STATE_RECEIVED = 0
 ACK_STATE_ACTIONED = 1

--- a/e2e/test_command_latency.py
+++ b/e2e/test_command_latency.py
@@ -9,7 +9,6 @@ import time
 
 import pytest
 
-
 _DISPATCH_RE = re.compile(r"dispatched command dbid=(\d+)")
 
 # Should match flight_safety_system::server::command_poll_ms in src/fss-server.hpp

--- a/e2e/test_command_read_under_write_stall.py
+++ b/e2e/test_command_read_under_write_stall.py
@@ -21,7 +21,6 @@ import time
 from pathlib import Path
 
 import pytest
-
 from conftest import wait_for_row
 from test_slow_db_does_not_stall import hold_table_lock
 

--- a/e2e/test_db_negative.py
+++ b/e2e/test_db_negative.py
@@ -19,7 +19,6 @@ import subprocess
 import time
 
 import pytest
-
 from conftest import (
     E2E_ROOT,
     REPO_ROOT,
@@ -27,7 +26,6 @@ from conftest import (
     _pick_port,
     _render_template,
 )
-
 
 # RFC-5737 documentation block — guaranteed not to route to a real Postgres.
 UNREACHABLE_DB_HOST = "192.0.2.1"

--- a/e2e/test_rtt.py
+++ b/e2e/test_rtt.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import pytest
-
 from conftest import wait_for_row
 
 

--- a/e2e/test_server_restart.py
+++ b/e2e/test_server_restart.py
@@ -6,12 +6,10 @@ import signal
 import socket
 import subprocess
 import time
-from pathlib import Path
-from typing import Iterator, IO
+from typing import IO
 
 import psycopg2
 import pytest
-
 from conftest import (
     E2E_ROOT,
     REPO_ROOT,

--- a/e2e/test_slow_db_does_not_stall.py
+++ b/e2e/test_slow_db_does_not_stall.py
@@ -14,9 +14,7 @@ from typing import Dict, Iterator
 
 import psycopg2
 import pytest
-
 from conftest import wait_for_row
-
 
 _LOCKABLE_TABLES = frozenset({"assets_assetposition"})
 


### PR DESCRIPTION
## Description

Remove unused imports (json, pathlib.Path, typing.Iterator, …) and apply isort ordering across the e2e suite. Pure import hygiene, no behaviour change; first of several passes to make the Python lint-clean before the gate is turned on. Addresses ruff F401 and I001.

## Summary by Sourcery

Enhancements:
- Remove unused imports and sort remaining imports in e2e tests to conform to isort and ruff rules.