### PR TITLE
test(e2e): address pytest-style lints

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -200,7 +200,7 @@ def db_conn(migrated_db: dict[str, object]) -> Iterator[psycopg2.extensions.conn
 
 
 @pytest.fixture
-def reset_db(db_conn: psycopg2.extensions.connection) -> Iterator[None]:
+def reset_db(db_conn: psycopg2.extensions.connection) -> None:
     """Truncate FSS tables before the test so state doesn't bleed between cases."""
     tables = [
         "assets_assetposition",
@@ -216,7 +216,6 @@ def reset_db(db_conn: psycopg2.extensions.connection) -> Iterator[None]:
     with db_conn.cursor() as cur:
         # sourcery skip: sqlalchemy-execute-raw-query
         cur.execute("TRUNCATE " + ", ".join(tables) + " RESTART IDENTITY CASCADE")
-    yield
 
 
 @pytest.fixture(scope="session")

--- a/e2e/test_command_ack.py
+++ b/e2e/test_command_ack.py
@@ -187,7 +187,8 @@ def test_command_ack_is_stored(db_conn, fake_client, server_proc):
     # latest-wins / no-regression rule means the terminal state must win over the
     # earlier received.
     assert ack_state == ACK_STATE_ACTIONED, f"expected ack_state actioned, got {ack_state}"
-    assert ack_timestamp is not None and ack_timestamp > 0, "ack_timestamp was not stored"
+    assert ack_timestamp is not None, "ack_timestamp was not stored"
+    assert ack_timestamp > 0, f"ack_timestamp should be positive, got {ack_timestamp}"
 
 
 def _dispatch_rtl(db_conn, asset_id: int) -> int:

--- a/e2e/test_db_negative.py
+++ b/e2e/test_db_negative.py
@@ -98,7 +98,10 @@ def test_server_exits_when_db_host_invalid(certs_dir, tmp_path, migrated_db):
     # Sanity: the chosen port should not be left listening after exit.
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.settimeout(0.2)
-        with pytest.raises(OSError):
+        # A closed local port returns an immediate RST, so connect raises
+        # ConnectionRefusedError specifically (not a timeout) — assert that
+        # precise type rather than the broad OSError base.
+        with pytest.raises(ConnectionRefusedError):
             s.connect(("127.0.0.1", port))
 
 


### PR DESCRIPTION
## Description

- reset_db does no teardown, so make it a plain setup fixture: return instead of yield, and type it -> None.
- Split the compound ack_timestamp assertion into two, each with its own message, so a failure points at the exact condition.
- Narrow the closed-port check from the broad OSError to ConnectionRefusedError (a closed local port returns an immediate RST, never a timeout).

Addresses ruff PT022, PT018 and PT011.

## Summary by Sourcery

Update e2e tests and fixtures to conform to pytest and ruff style recommendations.

Bug Fixes:
- Tighten socket error expectation in server exit test to specifically assert ConnectionRefusedError.
- Split command ack timestamp assertion so failures clearly indicate whether it was missing or non-positive.

Enhancements:
- Convert reset_db fixture from a generator to a simple setup fixture that only truncates tables before tests.

Tests:
- Refine e2e tests to improve assertion clarity and align with pytest-style best practices.