### PR TITLE
test(e2e): annotate the throwaway test DB password for bandit

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -107,7 +107,7 @@ def pg_container() -> Iterator[dict[str, object]]:
         pytest.skip("docker daemon not reachable")
 
     container = f"fss-e2e-pg-{uuid.uuid4().hex[:8]}"
-    password = "e2e"
+    password = "e2e"  # noqa: S105 — throwaway password for an ephemeral local test container
     user = "postgres"
     db = "postgres"
 


### PR DESCRIPTION
## Description

The e2e Postgres container is spun up fresh per session with a fixed throwaway password; it is never a real secret. Mark it `# noqa: S105` with that rationale so the bandit check stays meaningful for genuine findings. Addresses ruff S105.

## Summary by Sourcery

Enhancements:
- Clarify that the hardcoded e2e Postgres password is a throwaway value for a local ephemeral test database to keep Bandit checks focused on real secrets.