### PR TITLE
build(lint): gate the e2e Python harness with ruff

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -139,12 +139,17 @@ jobs:
           libjsoncpp-dev libecpg-dev catch2 libgnutls28-dev gnutls-bin \
           cppcheck clang-tidy bear
 
-    # clang-format output is version-dependent; pin the exact version the
-    # tree is formatted with so the formatting gate is reproducible.
+    # clang-format and ruff output is version-dependent; pin the exact versions
+    # the tree is checked with so the gates are reproducible.
     - name: Install pinned clang-format
       run: |
         python3 -m venv /tmp/clang-format-venv
         /tmp/clang-format-venv/bin/pip install -q clang-format==22.1.5
+
+    - name: Install pinned ruff
+      run: |
+        python3 -m venv /tmp/ruff-venv
+        /tmp/ruff-venv/bin/pip install -q -r e2e/requirements-dev.txt
 
     - name: autogen
       run: ./autogen.sh
@@ -155,8 +160,11 @@ jobs:
     - name: build with compile DB
       run: bear -- make -j$(nproc)
 
-    - name: code checks (clang-format, cppcheck, clang-tidy)
-      run: CLANG_FORMAT=/tmp/clang-format-venv/bin/clang-format ./check-code.sh
+    - name: code checks (clang-format, cppcheck, clang-tidy, ruff)
+      run: |
+        CLANG_FORMAT=/tmp/clang-format-venv/bin/clang-format \
+        RUFF=/tmp/ruff-venv/bin/ruff \
+        ./check-code.sh
 
   # ─── 5. End-to-end tests ─────────────────────────────────────────────────
   e2e:

--- a/check-code.sh
+++ b/check-code.sh
@@ -17,3 +17,9 @@ cppcheck --enable=warning,performance,portability,style --error-exitcode=1 \
 
 run-clang-tidy -p . 'src/(?!server-db).*\.cpp$' 2>&1 | tee clang-tidy.log
 ! grep -q "warning:" clang-tidy.log
+
+# Lint the e2e Python harness. ruff's rule set is version-dependent, so CI pins
+# the exact version in a venv and points RUFF at it (see e2e/requirements-dev.txt).
+# Locally, install that pin into a venv and set RUFF, or rely on a ruff on PATH.
+ruff="${RUFF:-ruff}"
+"$ruff" check e2e/

--- a/e2e/requirements-dev.txt
+++ b/e2e/requirements-dev.txt
@@ -1,0 +1,5 @@
+# Tooling for working on the e2e harness — not needed to run the tests.
+# Pinned because ruff's rule set changes between releases; CI installs this same
+# pin so the lint gate is reproducible. Install into a venv, e.g.:
+#   python3 -m venv .venv && .venv/bin/pip install -r requirements-dev.txt
+ruff==0.15.18

--- a/e2e/ruff.toml
+++ b/e2e/ruff.toml
@@ -1,0 +1,19 @@
+# Lint configuration for the e2e Python harness.
+#
+# ruff's rule set drifts between releases, so the version is pinned (see
+# requirements-dev.txt and the static-analysis CI job) the same way clang-format
+# is pinned for the C++ tree — the gate must behave identically locally and in
+# CI.
+line-length = 120
+# The suite carries `from __future__ import annotations`, so PEP 585/604 hints
+# are safe well below this, but keep the floor explicit.
+target-version = "py39"
+
+[lint]
+select = ["E", "W", "F", "I", "B", "C4", "SIM", "RET", "UP", "PT", "S"]
+# This tree is exclusively the test harness, which changes how a few bandit
+# rules should be read:
+#   S101    — asserts are how the tests assert; not a risk here.
+#   S603/S607 — the harness deliberately spawns the server/client binaries with
+#               fixed, in-repo argument lists; there is no untrusted input.
+ignore = ["S101", "S603", "S607"]

--- a/e2e/test_command_read_under_write_stall.py
+++ b/e2e/test_command_read_under_write_stall.py
@@ -21,6 +21,7 @@ import time
 from pathlib import Path
 
 import pytest
+
 from conftest import wait_for_row
 from test_slow_db_does_not_stall import hold_table_lock
 

--- a/e2e/test_db_negative.py
+++ b/e2e/test_db_negative.py
@@ -19,6 +19,7 @@ import subprocess
 import time
 
 import pytest
+
 from conftest import (
     E2E_ROOT,
     REPO_ROOT,

--- a/e2e/test_rtt.py
+++ b/e2e/test_rtt.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import pytest
+
 from conftest import wait_for_row
 
 

--- a/e2e/test_server_restart.py
+++ b/e2e/test_server_restart.py
@@ -10,6 +10,7 @@ from typing import IO
 
 import psycopg2
 import pytest
+
 from conftest import (
     E2E_ROOT,
     REPO_ROOT,

--- a/e2e/test_slow_db_does_not_stall.py
+++ b/e2e/test_slow_db_does_not_stall.py
@@ -14,6 +14,7 @@ from contextlib import contextmanager
 
 import psycopg2
 import pytest
+
 from conftest import wait_for_row
 
 _LOCKABLE_TABLES = frozenset({"assets_assetposition"})


### PR DESCRIPTION
## Description

Wire ruff into the existing static-analysis path now that the harness is lint-clean:
- e2e/ruff.toml pins the rule set (E,W,F,I,B,C4,SIM,RET,UP,PT,S). S101 and S603/S607 are ignored because this tree is exclusively a test harness that asserts and deliberately spawns the in-repo server/client binaries.
- e2e/requirements-dev.txt pins ruff==0.15.18 so the gate is reproducible, mirroring the pinned clang-format.
- check-code.sh runs `ruff check e2e/` via a RUFF override, the same venv-and-env-var pattern already used for clang-format.
- CI installs the pinned ruff into a venv and passes RUFF to check-code.sh.

Also regroups first-party (conftest) imports into their own isort section, which only becomes the canonical ordering once this config defines the project root.

## Summary by Sourcery

Gate the e2e Python test harness with a pinned ruff lint configuration and integrate it into the existing static-analysis pipeline.

Enhancements:
- Add ruff configuration for the e2e Python harness to standardize linting behavior.
- Adjust e2e test imports to follow the new isort-style grouping implied by the ruff configuration.

Build:
- Introduce an e2e development requirements file pinning the ruff version for reproducible linting.

CI:
- Extend the C/C++ static-analysis workflow to install pinned ruff in a virtualenv and run it via check-code.sh alongside existing code checks.