### PR TITLE
feat(client): expose config-load status

### DIFF
--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -44,10 +44,6 @@ flight_safety_system::client_ssl::fss_client::fss_client(const std::string &t_fi
                 this->ca_file, this->private_key_file, this->public_key_file);
             this->addServer(server);
         }
-        if (!this->asset_name.empty() && (!this->servers.empty() || !this->reconnect_servers.empty()))
-        {
-            this->configured = true;
-        }
     }
     catch (const Json::Exception &e)
     {
@@ -99,9 +95,20 @@ void flight_safety_system::client_ssl::fss_client::disconnect()
     }
 }
 
+void flight_safety_system::client_ssl::fss_client::updateConfigured()
+{
+    /* A client is configured once it has an asset name and at least one server
+     * (live or pending reconnect). Centralised here so the file ctor, the
+     * programmatic setAssetName/connectTo path, and any future mutator all keep
+     * isConfigured() in step. */
+    this->configured = !this->asset_name.empty() && (!this->servers.empty() || !this->reconnect_servers.empty());
+}
+
 void flight_safety_system::client_ssl::fss_client::setAssetName(std::string t_asset_name)
 {
+    std::scoped_lock lock(this->servers_lock);
     this->asset_name = std::move(t_asset_name);
+    this->updateConfigured();
 }
 
 void flight_safety_system::client_ssl::fss_client::connectTo(const std::string &t_address, uint16_t t_port,
@@ -225,6 +232,7 @@ void flight_safety_system::client_ssl::fss_client::addServer(
     {
         this->reconnect_servers.push_back(server);
     }
+    this->updateConfigured();
 }
 
 static auto server_list_matches(const std::list<std::shared_ptr<flight_safety_system::client_ssl::fss_server>> &servers,

--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -44,6 +44,10 @@ flight_safety_system::client_ssl::fss_client::fss_client(const std::string &t_fi
                 this->ca_file, this->private_key_file, this->public_key_file);
             this->addServer(server);
         }
+        if (!this->asset_name.empty() && (!this->servers.empty() || !this->reconnect_servers.empty()))
+        {
+            this->configured = true;
+        }
     }
     catch (const Json::Exception &e)
     {
@@ -198,6 +202,11 @@ void flight_safety_system::client_ssl::fss_client::sendMsgAll(
 auto flight_safety_system::client_ssl::fss_client::getAssetName() -> std::string
 {
     return this->asset_name;
+}
+
+auto flight_safety_system::client_ssl::fss_client::isConfigured() const -> bool
+{
+    return this->configured;
 }
 
 void flight_safety_system::client_ssl::fss_client::addServer(

--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -100,13 +100,16 @@ void flight_safety_system::client_ssl::fss_client::updateConfigured()
     /* A client is configured once it has an asset name and at least one server
      * (live or pending reconnect). Centralised here so the file ctor, the
      * programmatic setAssetName/connectTo path, and any future mutator all keep
-     * isConfigured() in step. */
+     * isConfigured() in step. Self-locking so no caller has to remember to. */
+    std::scoped_lock lock(this->servers_lock);
     this->configured = !this->asset_name.empty() && (!this->servers.empty() || !this->reconnect_servers.empty());
 }
 
 void flight_safety_system::client_ssl::fss_client::setAssetName(std::string t_asset_name)
 {
-    std::scoped_lock lock(this->servers_lock);
+    /* asset_name is set once during configuration, before the client is used
+     * concurrently, so it is not guarded by servers_lock (getAssetName() also
+     * reads it unlocked). Recompute the configured flag afterwards. */
     this->asset_name = std::move(t_asset_name);
     this->updateConfigured();
 }
@@ -213,6 +216,7 @@ auto flight_safety_system::client_ssl::fss_client::getAssetName() -> std::string
 
 auto flight_safety_system::client_ssl::fss_client::isConfigured() const -> bool
 {
+    std::scoped_lock lock(this->servers_lock);
     return this->configured;
 }
 
@@ -223,15 +227,19 @@ void flight_safety_system::client_ssl::fss_client::addServer(
      * (whether the server's own connection pointer is set) and does not touch
      * the shared lists. */
     bool is_connected = server->connected();
-    std::scoped_lock lock(this->servers_lock);
-    if (is_connected)
     {
-        this->servers.push_back(server);
+        std::scoped_lock lock(this->servers_lock);
+        if (is_connected)
+        {
+            this->servers.push_back(server);
+        }
+        else
+        {
+            this->reconnect_servers.push_back(server);
+        }
     }
-    else
-    {
-        this->reconnect_servers.push_back(server);
-    }
+    /* updateConfigured() takes servers_lock itself, so recompute after releasing
+     * it here rather than holding it across the call. */
     this->updateConfigured();
 }
 

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -29,12 +29,16 @@ private:
     std::string public_key_file{""};
     std::list<std::shared_ptr<flight_safety_system::client_ssl::fss_server>> servers{};
     std::list<std::shared_ptr<flight_safety_system::client_ssl::fss_server>> reconnect_servers{};
-    std::mutex servers_lock{};
-    std::atomic<bool> configured{false};
+    /* servers_lock guards the server lists and the derived `configured` flag.
+     * It does NOT guard asset_name, which is configuration state set before the
+     * client is used concurrently (mutable so the const isConfigured() can lock
+     * it to read the flag). */
+    mutable std::mutex servers_lock{};
+    bool configured{false}; // guarded by servers_lock
     /* Recompute `configured` from the current asset name + server lists. Called
      * from every path that sets the name or adds a server so isConfigured()
      * stays accurate however the client was built, not just the file ctor.
-     * Caller must hold servers_lock. */
+     * Takes servers_lock itself, so callers must not already hold it. */
     void updateConfigured();
     void notifyConnectionStatus();
     virtual void connectionStatusChange(flight_safety_system::client_ssl::connection_status status);

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -30,6 +30,7 @@ private:
     std::list<std::shared_ptr<flight_safety_system::client_ssl::fss_server>> servers{};
     std::list<std::shared_ptr<flight_safety_system::client_ssl::fss_server>> reconnect_servers{};
     std::mutex servers_lock{};
+    bool configured{false};
     void notifyConnectionStatus();
     virtual void connectionStatusChange(flight_safety_system::client_ssl::connection_status status);
 protected:
@@ -49,6 +50,7 @@ public:
     virtual void disconnect();
     virtual void sendMsgAll(const std::shared_ptr<flight_safety_system::transport::fss_message> &msg);
     virtual auto getAssetName() -> std::string;
+    virtual auto isConfigured() const -> bool;
     virtual void serverRequiresReconnect(fss_server *server);
     virtual void updateServers(const std::shared_ptr<flight_safety_system::transport::fss_message_server_list> &msg);
     /* Called for every command, with the originating server (the connection the

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -30,7 +30,12 @@ private:
     std::list<std::shared_ptr<flight_safety_system::client_ssl::fss_server>> servers{};
     std::list<std::shared_ptr<flight_safety_system::client_ssl::fss_server>> reconnect_servers{};
     std::mutex servers_lock{};
-    bool configured{false};
+    std::atomic<bool> configured{false};
+    /* Recompute `configured` from the current asset name + server lists. Called
+     * from every path that sets the name or adds a server so isConfigured()
+     * stays accurate however the client was built, not just the file ctor.
+     * Caller must hold servers_lock. */
+    void updateConfigured();
     void notifyConnectionStatus();
     virtual void connectionStatusChange(flight_safety_system::client_ssl::connection_status status);
 protected:

--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -104,7 +104,20 @@ TEST_CASE("Client Base")
 TEST_CASE("client: config file not found leaves client with no servers")
 {
     fss::client_ssl::fss_client client("/nonexistent/config.json");
+    REQUIRE_FALSE(client.isConfigured());
     client.attemptReconnect(); // no-op; must not crash
+}
+
+TEST_CASE("client: malformed JSON config leaves client unconfigured")
+{
+    const char *tmppath = "/tmp/fss_test_client_malformed.json";
+    {
+        std::ofstream f(tmppath);
+        f << R"({"name":"test-asset", "ssl": {)";
+    }
+    fss::client_ssl::fss_client client(tmppath);
+    REQUIRE_FALSE(client.isConfigured());
+    std::remove(tmppath);
 }
 
 TEST_CASE("client: processMessage dispatches position_report to handlePositionReport")
@@ -294,6 +307,7 @@ TEST_CASE("client: JSON config with server entry parses name and creates reconne
           << R"("servers":[{"address":"127.0.0.1","port":9999}]})";
     }
     fss::client_ssl::fss_client client(tmppath);
+    REQUIRE(client.isConfigured());
     REQUIRE(client.getAssetName() == "test-asset");
     std::remove(tmppath);
 }

--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -120,6 +120,25 @@ TEST_CASE("client: malformed JSON config leaves client unconfigured")
     std::remove(tmppath);
 }
 
+/* Exposes the protected config setter so a test can drive the programmatic
+ * (non-file) configuration path. */
+class ProgrammaticClient : public fss::client_ssl::fss_client {
+public:
+    using fss::client_ssl::fss_client::setAssetName;
+};
+
+TEST_CASE("client: isConfigured tracks the programmatic setAssetName + connectTo path")
+{
+    /* The file ctor is not the only way to configure a client; isConfigured()
+     * must also reflect a client built via the setAssetName/connectTo setters. */
+    ProgrammaticClient client;
+    REQUIRE_FALSE(client.isConfigured()); // nothing set yet
+    client.setAssetName("test-asset");
+    REQUIRE_FALSE(client.isConfigured());       // a name, but no server yet
+    client.connectTo("127.0.0.1", 9999, false); // adds a reconnect entry; no live connect
+    REQUIRE(client.isConfigured());             // name + at least one server
+}
+
 TEST_CASE("client: processMessage dispatches position_report to handlePositionReport")
 {
     TrackingClient client;


### PR DESCRIPTION
## Description

Add fss_client::isConfigured() so consumers can distinguish a successfully loaded client config from missing or malformed JSON without relying on logs.

Mark the file-based constructor configured only after it has an asset name and at least one configured server, and cover the missing-file, malformed-JSON, and valid-config paths in unit tests.

## Summary by Sourcery

Expose a configured-state indicator on the SSL client and keep it in sync across all configuration paths.

New Features:
- Add fss_client::isConfigured() to report whether the client has a valid asset name and at least one configured server.

Enhancements:
- Centralize configured-state computation in fss_client::updateConfigured() and invoke it from file-based and programmatic configuration flows to keep state consistent.

Tests:
- Extend client tests to cover missing-file and malformed JSON configs as unconfigured, and to verify isConfigured() for both file-based and programmatic configuration paths.