### PR TITLE
test(tsan): synchronise the SSL test connection handoff

### DIFF
--- a/tests/connection-ssl.cpp
+++ b/tests/connection-ssl.cpp
@@ -40,21 +40,19 @@ TEST_CASE("SSL - Connection Create (failure)")
     REQUIRE(!conn->connectTo("this.host.does.not.exist", 1));
 }
 
-static std::shared_ptr<flight_safety_system::transport::fss_connection> client_conn = nullptr;
-static auto test_client_connect_cb(std::shared_ptr<flight_safety_system::transport::fss_connection> new_conn) -> bool
-{
-    client_conn = std::move(new_conn);
-    return true;
-}
+/* The listener invokes its accept callback on its own worker thread; route the
+ * accepted connection through a mutex-guarded handoff so the main thread reads
+ * it (and the connection's gnutls state) with a happens-before edge. */
+static fss_test::connection_handoff client_handoff;
 
 
 TEST_CASE("SSL - Listen Socket")
 {
-    client_conn = nullptr;
+    client_handoff.reset();
     const uint16_t listen_port = fss_test::pick_port();
     REQUIRE(listen_port != 0);
     auto listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(
-        listen_port, test_client_connect_cb, CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
+        listen_port, client_handoff.callback(), CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
     REQUIRE(listen != nullptr);
 
     std::shared_ptr<flight_safety_system::transport::fss_connection> conn =
@@ -65,14 +63,15 @@ TEST_CASE("SSL - Listen Socket")
     auto send_msg = std::make_shared<flight_safety_system::transport::fss_message_identity>("testClient");
     conn->sendMsg(send_msg);
 
-    REQUIRE(fss_test::wait_for([]() { return client_conn != nullptr; }));
+    auto server_conn = client_handoff.wait();
+    REQUIRE(server_conn != nullptr);
 
     // Drain identity before dropping the client connection.  Dropping conn
     // while the server's recv thread hasn't yet dequeued the identity bytes
     // causes a race where message_type_closed arrives first.
     std::shared_ptr<flight_safety_system::transport::fss_message> msg;
     REQUIRE(fss_test::wait_for([&]() {
-        msg = client_conn->getMsg();
+        msg = server_conn->getMsg();
         return msg != nullptr;
     }));
     REQUIRE(msg->getType() == flight_safety_system::transport::message_type_identity);
@@ -80,39 +79,25 @@ TEST_CASE("SSL - Listen Socket")
     conn = nullptr;
 
     REQUIRE(fss_test::wait_for([&]() {
-        msg = client_conn->getMsg();
+        msg = server_conn->getMsg();
         return msg != nullptr;
     }));
     REQUIRE(msg->getType() == flight_safety_system::transport::message_type_closed);
 
-    msg = client_conn->getMsg();
+    msg = server_conn->getMsg();
     REQUIRE(msg == nullptr);
 
-    client_conn = nullptr;
+    client_handoff.reset();
 }
-
-class test_ssl_message_cb : public flight_safety_system::transport::fss_message_cb {
-private:
-    std::shared_ptr<flight_safety_system::transport::fss_message> first{};
-public:
-    explicit test_ssl_message_cb(std::shared_ptr<flight_safety_system::transport::fss_connection> t_conn)
-        : fss_message_cb(std::move(t_conn)) {};
-    auto getFirstMsg() -> std::shared_ptr<flight_safety_system::transport::fss_message> { return this->first; }
-    void processMessage(std::shared_ptr<flight_safety_system::transport::fss_message> message) override
-    {
-        this->first = std::move(message);
-    }
-};
-
 
 TEST_CASE("SSL - Listen - Callback")
 {
-    client_conn = nullptr;
+    client_handoff.reset();
     const uint16_t listen_port = fss_test::pick_port();
     REQUIRE(listen_port != 0);
 
     auto listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(
-        listen_port, test_client_connect_cb, CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
+        listen_port, client_handoff.callback(), CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
     REQUIRE(listen != nullptr);
 
     std::shared_ptr<flight_safety_system::transport::fss_connection> conn =
@@ -123,14 +108,15 @@ TEST_CASE("SSL - Listen - Callback")
 
     conn->sendMsg(std::make_shared<flight_safety_system::transport::fss_message_identity>("testClient"));
 
-    REQUIRE(fss_test::wait_for([]() { return client_conn != nullptr; }));
+    auto server_conn = client_handoff.wait();
+    REQUIRE(server_conn != nullptr);
 
-    auto cb = std::make_shared<test_ssl_message_cb>(client_conn);
+    auto cb = std::make_shared<fss_test::recording_message_cb>(server_conn);
     REQUIRE(cb->connected());
-    REQUIRE(cb->getConnection() == client_conn);
-    client_conn->setHandler(cb.get());
+    REQUIRE(cb->getConnection() == server_conn);
+    server_conn->setHandler(cb.get());
 
-    REQUIRE(client_conn->getMsg() == nullptr);
+    REQUIRE(server_conn->getMsg() == nullptr);
 
     cb->sendMsg(std::make_shared<flight_safety_system::transport::fss_message_rtt_request>());
 
@@ -139,56 +125,49 @@ TEST_CASE("SSL - Listen - Callback")
     cb->disconnect();
     REQUIRE(!cb->connected());
 
-    client_conn = nullptr;
+    client_handoff.reset();
 }
 
 TEST_CASE("ssl: isPeerCertRevoked detects revoked cert via CRL")
 {
     const uint16_t port = fss_test::pick_port();
     REQUIRE(port != 0);
-    std::shared_ptr<flight_safety_system::transport::fss_connection> server_conn;
+    fss_test::connection_handoff handoff;
 
     auto listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(
-        port,
-        [&server_conn](std::shared_ptr<flight_safety_system::transport::fss_connection> c) -> bool {
-            server_conn = std::move(c);
-            return true;
-        },
-        CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
+        port, handoff.callback(), CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
     REQUIRE(listen != nullptr);
 
     auto client = std::make_shared<flight_safety_system::transport_ssl::fss_connection_client>(
         CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
     REQUIRE(client->connectTo("localhost", port));
 
-    REQUIRE(fss_test::wait_for([&] { return server_conn != nullptr; }));
+    auto server_conn = handoff.wait();
+    REQUIRE(server_conn != nullptr);
 
     REQUIRE(server_conn->isPeerCertRevoked(CLIENT_CRL_FILE));
     REQUIRE_FALSE(server_conn->isPeerCertRevoked(EMPTY_CRL_FILE));
     REQUIRE_FALSE(server_conn->isPeerCertRevoked(""));
 
     server_conn = nullptr;
+    handoff.reset();
 }
 
 TEST_CASE("ssl: disconnect after CRL revocation terminates client session")
 {
     const uint16_t port = fss_test::pick_port();
     REQUIRE(port != 0);
-    std::shared_ptr<flight_safety_system::transport::fss_connection> server_conn;
+    fss_test::connection_handoff handoff;
 
     auto listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(
-        port,
-        [&server_conn](std::shared_ptr<flight_safety_system::transport::fss_connection> c) -> bool {
-            server_conn = std::move(c);
-            return true;
-        },
-        CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
+        port, handoff.callback(), CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
     REQUIRE(listen != nullptr);
 
     auto client = flight_safety_system::transport_ssl::fss_connection_client::create(
         CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE, "localhost", port);
     REQUIRE(client != nullptr);
-    REQUIRE(fss_test::wait_for([&] { return server_conn != nullptr; }));
+    auto server_conn = handoff.wait();
+    REQUIRE(server_conn != nullptr);
 
     REQUIRE(server_conn->isPeerCertRevoked(CLIENT_CRL_FILE));
     server_conn->disconnect();
@@ -199,16 +178,17 @@ TEST_CASE("ssl: disconnect after CRL revocation terminates client session")
     }));
 
     server_conn = nullptr;
+    handoff.reset();
 }
 
 TEST_CASE("SSL - Negotiated cipher suite is AEAD (TLS 1.2+)")
 {
     const uint16_t listen_port = fss_test::pick_port();
     REQUIRE(listen_port != 0);
-    client_conn = nullptr;
+    client_handoff.reset();
 
     auto listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(
-        listen_port, test_client_connect_cb, CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
+        listen_port, client_handoff.callback(), CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
     REQUIRE(listen != nullptr);
 
     auto conn = std::make_shared<flight_safety_system::transport_ssl::fss_connection_client>(
@@ -227,5 +207,5 @@ TEST_CASE("SSL - Negotiated cipher suite is AEAD (TLS 1.2+)")
                 desc.find("-CCM") != std::string::npos;
     REQUIRE(aead);
 
-    client_conn = nullptr;
+    client_handoff.reset();
 }

--- a/tests/ssl_failure_test.cpp
+++ b/tests/ssl_failure_test.cpp
@@ -299,25 +299,22 @@ TEST_CASE("ssl: isPeerCertRevoked with non-existent CRL file returns false")
 {
     const uint16_t port = fss_test::pick_port();
     REQUIRE(port != 0);
-    std::shared_ptr<flight_safety_system::transport::fss_connection> server_conn;
+    fss_test::connection_handoff handoff;
 
     auto listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(
-        port,
-        [&server_conn](std::shared_ptr<flight_safety_system::transport::fss_connection> c) -> bool {
-            server_conn = std::move(c);
-            return true;
-        },
-        CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
+        port, handoff.callback(), CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
 
     auto client = std::make_shared<flight_safety_system::transport_ssl::fss_connection_client>(
         CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
     REQUIRE(client->connectTo("localhost", port));
 
-    REQUIRE(fss_test::wait_for([&] { return server_conn != nullptr; }));
+    auto server_conn = handoff.wait();
+    REQUIRE(server_conn != nullptr);
 
     REQUIRE_FALSE(server_conn->isPeerCertRevoked("/nonexistent/path/crl.pem"));
 
     server_conn = nullptr;
+    handoff.reset();
 }
 
 TEST_CASE("ssl: a silent peer does not block other clients' handshakes", "[ssl_handshake_dos]")

--- a/tests/test_helpers.hpp
+++ b/tests/test_helpers.hpp
@@ -7,6 +7,7 @@
 #include <functional>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <sstream>
 #include <streambuf>
 #include <string>
@@ -38,6 +39,95 @@ inline auto wait_for(const std::function<bool()> &pred,
     }
     return pred();
 }
+
+/* Thread-safe handoff of an accepted connection from a listener's accept
+ * callback to the main test thread.
+ *
+ * A listener invokes its accept callback on its own setup-worker thread, so
+ * stashing the connection in a bare global/local shared_ptr and then polling it
+ * from the main thread with wait_for() is a data race: the poll establishes no
+ * happens-before edge, so TSan flags both the shared_ptr access and — because
+ * the worker is still the last writer of the connection's gnutls state — any
+ * later read of that connection (e.g. isPeerCertRevoked). Funnelling every
+ * access through one mutex publishes the worker's write to the reader. */
+class connection_handoff {
+public:
+    using connection_ptr = std::shared_ptr<flight_safety_system::transport::fss_connection>;
+
+    connection_handoff() = default;
+    connection_handoff(const connection_handoff &) = delete;
+    connection_handoff(connection_handoff &&) = delete;
+    auto operator=(const connection_handoff &) -> connection_handoff & = delete;
+    auto operator=(connection_handoff &&) -> connection_handoff & = delete;
+    ~connection_handoff() = default;
+
+    /* An fss_connect_cb that stores the accepted connection under the lock. */
+    auto callback() -> std::function<bool(connection_ptr)>
+    {
+        return [this](connection_ptr c) -> bool {
+            const std::scoped_lock lock(this->mtx);
+            this->conn = std::move(c);
+            return true;
+        };
+    }
+
+    [[nodiscard]] auto get() -> connection_ptr
+    {
+        const std::scoped_lock lock(this->mtx);
+        return this->conn;
+    }
+
+    void reset()
+    {
+        const std::scoped_lock lock(this->mtx);
+        this->conn = nullptr;
+    }
+
+    /* Block until a connection has been accepted, then return it (or nullptr if
+     * none arrived within the timeout). The returned copy is safe to use from
+     * the main thread: the mutex hands ownership over with a happens-before edge
+     * to every write the worker made while building the connection. */
+    auto wait(std::chrono::milliseconds timeout = std::chrono::milliseconds(2000)) -> connection_ptr
+    {
+        wait_for([this]() { return this->get() != nullptr; }, timeout);
+        return this->get();
+    }
+
+private:
+    std::mutex mtx{};
+    connection_ptr conn{};
+};
+
+/* An fss_message_cb that records the first message it receives, with the
+ * recv-thread write and the test-thread read synchronised. processMessage()
+ * runs on the connection's recv thread; getFirstMsg() is polled from the test
+ * thread, so the stored shared_ptr needs a lock to avoid a data race. */
+class recording_message_cb : public flight_safety_system::transport::fss_message_cb {
+public:
+    explicit recording_message_cb(std::shared_ptr<flight_safety_system::transport::fss_connection> t_conn)
+        : fss_message_cb(std::move(t_conn))
+    {
+    }
+    recording_message_cb(const recording_message_cb &) = delete;
+    recording_message_cb(recording_message_cb &&) = delete;
+    auto operator=(const recording_message_cb &) -> recording_message_cb & = delete;
+    auto operator=(recording_message_cb &&) -> recording_message_cb & = delete;
+    ~recording_message_cb() override = default;
+    auto getFirstMsg() -> std::shared_ptr<flight_safety_system::transport::fss_message>
+    {
+        const std::scoped_lock lock(this->first_lock);
+        return this->first;
+    }
+    void processMessage(std::shared_ptr<flight_safety_system::transport::fss_message> message) override
+    {
+        const std::scoped_lock lock(this->first_lock);
+        this->first = std::move(message);
+    }
+
+private:
+    std::mutex first_lock{};
+    std::shared_ptr<flight_safety_system::transport::fss_message> first{};
+};
 
 /* Obtain a free ephemeral TCP port by binding to port 0, reading the assigned
  * port, then closing. Caller accepts the TOCTOU risk (another process can grab

--- a/tests/test_helpers.hpp
+++ b/tests/test_helpers.hpp
@@ -83,13 +83,18 @@ public:
         this->conn = nullptr;
     }
 
-    /* Block until a connection has been accepted, then return it (or nullptr if
-     * none arrived within the timeout). The returned copy is safe to use from
-     * the main thread: the mutex hands ownership over with a happens-before edge
-     * to every write the worker made while building the connection. */
+    /* Block until a connection has been accepted, then return it. A successful
+     * handoff always stores a non-null connection, so the return value is null
+     * if and only if the wait timed out — callers assert the handoff happened
+     * with REQUIRE(wait() != nullptr). The returned copy is safe to use from the
+     * main thread: the mutex hands ownership over with a happens-before edge to
+     * every write the worker made while building the connection. */
     auto wait(std::chrono::milliseconds timeout = std::chrono::milliseconds(2000)) -> connection_ptr
     {
-        wait_for([this]() { return this->get() != nullptr; }, timeout);
+        if (!wait_for([this]() { return this->get() != nullptr; }, timeout))
+        {
+            return nullptr;
+        }
         return this->get();
     }
 
@@ -121,7 +126,13 @@ public:
     void processMessage(std::shared_ptr<flight_safety_system::transport::fss_message> message) override
     {
         const std::scoped_lock lock(this->first_lock);
-        this->first = std::move(message);
+        /* Keep the *first* message, as the name promises: later arrivals do not
+         * overwrite it, so a test that sends one request and waits for one reply
+         * reads exactly that reply. */
+        if (this->first == nullptr)
+        {
+            this->first = std::move(message);
+        }
     }
 
 private:

--- a/tests/test_helpers.hpp
+++ b/tests/test_helpers.hpp
@@ -97,7 +97,6 @@ public:
         }
         return this->get();
     }
-
 private:
     std::mutex mtx{};
     connection_ptr conn{};
@@ -134,7 +133,6 @@ public:
             this->first = std::move(message);
         }
     }
-
 private:
     std::mutex first_lock{};
     std::shared_ptr<flight_safety_system::transport::fss_message> first{};


### PR DESCRIPTION
## Description

Under -fsanitize=thread the SSL listener tests reported data races: the accept callback runs on the listener's setup-worker thread and stashed the accepted connection in a bare shared_ptr that the main thread then read via a wait_for() poll. The poll establishes no happens-before edge, so TSan flagged both the shared_ptr and — since the worker was the last writer of the connection's gnutls state — every later read of it (isPeerCertRevoked, getMsg).

Add two reusable helpers to test_helpers.hpp:
- connection_handoff: a mutex-guarded set/get/wait for the worker->main connection handoff, publishing the worker's writes to the reader.
- recording_message_cb: an fss_message_cb whose stored message is guarded, for the processMessage (recv thread) vs getFirstMsg (main thread) handoff.

Convert connection-ssl.cpp and the local-handoff test in ssl_failure_test.cpp to use them. all_test "ssl: *"/"SSL*" is now race-clean under TSan; this is the first of several commits clearing the suite. (todo/13 item 3)

## Summary by Sourcery

Synchronise SSL listener test connection and message handoffs to eliminate data races under ThreadSanitizer.

Enhancements:
- Introduce reusable connection_handoff helper to safely transfer accepted SSL connections between listener worker threads and main test threads.
- Add recording_message_cb helper to synchronise access to first received messages between recv and main threads.

Tests:
- Refactor SSL listener and certificate revocation tests to use thread-safe connection and message handoff helpers, making the SSL test suite race-free under TSan.