### PR TITLE
test(tsan): synchronise listener handoffs in the remaining transport tests

### DIFF
--- a/tests/connection_negative_test.cpp
+++ b/tests/connection_negative_test.cpp
@@ -48,13 +48,9 @@ public:
 
 namespace {
 
-std::shared_ptr<fss_connection> accepted;
-
-auto accept_cb(std::shared_ptr<fss_connection> new_conn) -> bool
-{
-    accepted = std::move(new_conn);
-    return true;
-}
+/* The listener's accept callback runs on its worker thread; route the accepted
+ * connection to the main thread through the mutex-guarded handoff. */
+fss_test::connection_handoff handoff;
 
 /* Open a raw IPv6 TCP connection to localhost. Tests use this to play
  * the role of a misbehaving peer (partial writes, long silences). */
@@ -82,7 +78,7 @@ auto raw_connect(uint16_t port) -> int
 TEST_CASE("negative: binding the same port twice fails cleanly")
 {
     constexpr uint16_t port = 20509;
-    auto first = std::make_shared<fss_listen>(port, accept_cb);
+    auto first = std::make_shared<fss_listen>(port, handoff.callback());
     REQUIRE(first != nullptr);
 
     /* Second bind on the same port must not crash or abort the process;
@@ -94,7 +90,7 @@ TEST_CASE("negative: binding the same port twice fails cleanly")
     bool survived = true;
     try
     {
-        auto second = std::make_shared<fss_listen>(port, accept_cb);
+        auto second = std::make_shared<fss_listen>(port, handoff.callback());
         (void)second;
     }
     catch (...)
@@ -107,9 +103,9 @@ TEST_CASE("negative: binding the same port twice fails cleanly")
 
 TEST_CASE("negative: partial peer — header then close yields closed sentinel")
 {
-    accepted = nullptr;
+    handoff.reset();
     constexpr uint16_t port = 20510;
-    auto listen = std::make_shared<fss_listen>(port, accept_cb);
+    auto listen = std::make_shared<fss_listen>(port, handoff.callback());
     REQUIRE(listen != nullptr);
 
     int fd = raw_connect(port);
@@ -121,7 +117,8 @@ TEST_CASE("negative: partial peer — header then close yields closed sentinel")
     REQUIRE(::send(fd, partial, sizeof(partial), 0) == static_cast<ssize_t>(sizeof(partial)));
     ::close(fd);
 
-    REQUIRE(fss_test::wait_for([]() { return accepted != nullptr; }));
+    auto accepted = handoff.wait();
+    REQUIRE(accepted != nullptr);
 
     std::shared_ptr<fss_message> msg;
     REQUIRE(fss_test::wait_for([&]() {
@@ -130,14 +127,14 @@ TEST_CASE("negative: partial peer — header then close yields closed sentinel")
     }));
     REQUIRE(msg->getType() == message_type_closed);
 
-    accepted = nullptr;
+    handoff.reset();
 }
 
 TEST_CASE("negative: slow peer — one byte per 50ms still decodes full message")
 {
-    accepted = nullptr;
+    handoff.reset();
     constexpr uint16_t port = 20511;
-    auto listen = std::make_shared<fss_listen>(port, accept_cb);
+    auto listen = std::make_shared<fss_listen>(port, handoff.callback());
     REQUIRE(listen != nullptr);
 
     /* Build a valid identity message using the library's own packer,
@@ -150,7 +147,8 @@ TEST_CASE("negative: slow peer — one byte per 50ms still decodes full message"
 
     int fd = raw_connect(port);
     REQUIRE(fd >= 0);
-    REQUIRE(fss_test::wait_for([]() { return accepted != nullptr; }));
+    auto accepted = handoff.wait();
+    REQUIRE(accepted != nullptr);
 
     std::thread slow_writer([fd, bytes, len]() {
         for (uint16_t i = 0; i < len; ++i)
@@ -175,7 +173,7 @@ TEST_CASE("negative: slow peer — one byte per 50ms still decodes full message"
     REQUIRE(ident != nullptr);
     REQUIRE(ident->getName() == "slow");
 
-    accepted = nullptr;
+    handoff.reset();
 }
 
 TEST_CASE("negative: zero-length message header is skipped and next message decoded")
@@ -183,15 +181,16 @@ TEST_CASE("negative: zero-length message header is skipped and next message deco
     /* A 2-byte header with data_length==0 triggers the total_length < sizeof(uint16_t)
      * guard in recvMsg(), returning nullptr. processMessages() must log the warning
      * and continue, so the next valid message is still received. */
-    accepted = nullptr;
+    handoff.reset();
     constexpr uint16_t port = 20513;
-    auto listen = std::make_shared<fss_listen>(port, accept_cb);
+    auto listen = std::make_shared<fss_listen>(port, handoff.callback());
     REQUIRE(listen != nullptr);
 
     int fd = raw_connect(port);
     REQUIRE(fd >= 0);
 
-    REQUIRE(fss_test::wait_for([]() { return accepted != nullptr; }));
+    auto accepted = handoff.wait();
+    REQUIRE(accepted != nullptr);
 
     /* Zero-length header: data_length = 0 in network byte order. */
     const uint8_t zero_hdr[2] = {0x00, 0x00};
@@ -214,7 +213,7 @@ TEST_CASE("negative: zero-length message header is skipped and next message deco
     REQUIRE(ident->getName() == "after-zero");
 
     ::close(fd);
-    accepted = nullptr;
+    handoff.reset();
 }
 
 TEST_CASE("sendMsg(buf_len): returns false immediately when fd is -1")

--- a/tests/exception_isolation_test.cpp
+++ b/tests/exception_isolation_test.cpp
@@ -51,30 +51,27 @@ public:
     }
 };
 
-static std::shared_ptr<flight_safety_system::transport::fss_connection> exception_test_conn;
-
-auto exception_test_accept_cb(std::shared_ptr<flight_safety_system::transport::fss_connection> new_conn) -> bool
-{
-    exception_test_conn = std::move(new_conn);
-    return true;
-}
+/* The listener's accept callback runs on its worker thread; hand the accepted
+ * connection to the main thread through the mutex-guarded handoff. */
+fss_test::connection_handoff handoff;
 
 } // namespace
 
 TEST_CASE("processMessages: throwing handler does not kill recv loop")
 {
-    exception_test_conn = nullptr;
+    handoff.reset();
     const auto port = fss_test::pick_port();
     REQUIRE(port != 0);
 
-    auto listen = std::make_shared<flight_safety_system::transport::fss_listen>(port, exception_test_accept_cb);
+    auto listen = std::make_shared<flight_safety_system::transport::fss_listen>(port, handoff.callback());
     REQUIRE(listen != nullptr);
 
     auto sender = std::make_shared<flight_safety_system::transport::fss_connection>();
     REQUIRE(sender != nullptr);
     REQUIRE(sender->connectTo("localhost", port));
 
-    REQUIRE(fss_test::wait_for([]() { return exception_test_conn != nullptr; }));
+    auto exception_test_conn = handoff.wait();
+    REQUIRE(exception_test_conn != nullptr);
 
     auto cb = std::make_shared<throwing_message_cb>(exception_test_conn);
     exception_test_conn->setHandler(cb.get());
@@ -92,4 +89,5 @@ TEST_CASE("processMessages: throwing handler does not kill recv loop")
     cb->disconnect();
     sender = nullptr;
     exception_test_conn = nullptr;
+    handoff.reset();
 }

--- a/tests/oversized_message_test.cpp
+++ b/tests/oversized_message_test.cpp
@@ -28,13 +28,9 @@ using flight_safety_system::transport::message_type_closed;
 
 namespace {
 
-std::shared_ptr<fss_connection> accepted_oversized;
-
-auto accept_oversized_cb(std::shared_ptr<fss_connection> new_conn) -> bool
-{
-    accepted_oversized = std::move(new_conn);
-    return true;
-}
+/* The listener's accept callback runs on its worker thread; hand the accepted
+ * connection to the main thread through the mutex-guarded handoff. */
+fss_test::connection_handoff handoff;
 
 auto raw_connect_oversized(uint16_t port) -> int
 {
@@ -59,16 +55,17 @@ auto raw_connect_oversized(uint16_t port) -> int
 
 TEST_CASE("negative: oversized declared length closes connection")
 {
-    accepted_oversized = nullptr;
+    handoff.reset();
     uint16_t port = fss_test::pick_port();
     REQUIRE(port != 0);
-    auto listen = std::make_shared<fss_listen>(port, accept_oversized_cb);
+    auto listen = std::make_shared<fss_listen>(port, handoff.callback());
     REQUIRE(listen != nullptr);
 
     int fd = raw_connect_oversized(port);
     REQUIRE(fd >= 0);
 
-    REQUIRE(fss_test::wait_for([]() { return accepted_oversized != nullptr; }));
+    auto accepted_oversized = handoff.wait();
+    REQUIRE(accepted_oversized != nullptr);
 
     /* Declare 0xFFFF bytes — well over FSS_MAX_MESSAGE_BYTES. */
     const uint8_t header[2] = {0xFF, 0xFF};
@@ -87,5 +84,5 @@ TEST_CASE("negative: oversized declared length closes connection")
     REQUIRE(n == 0);
 
     ::close(fd);
-    accepted_oversized = nullptr;
+    handoff.reset();
 }

--- a/tests/queue_test.cpp
+++ b/tests/queue_test.cpp
@@ -29,13 +29,10 @@ using flight_safety_system::transport::message_type_rtt_request;
 
 namespace {
 
-std::shared_ptr<fss_connection> server_side_conn;
-
-auto accept_cb(std::shared_ptr<fss_connection> new_conn) -> bool
-{
-    server_side_conn = std::move(new_conn);
-    return true;
-}
+/* The listener runs its accept callback on its own worker thread; hand the
+ * accepted connection to the main thread through a mutex-guarded handoff so the
+ * two do not race on the shared_ptr (or the connection's state). */
+fss_test::connection_handoff handoff;
 
 class large_queue_listen : public fss_listen {
 public:
@@ -58,9 +55,9 @@ protected:
 
 TEST_CASE("queue: FIFO ordering is preserved across many messages")
 {
-    server_side_conn = nullptr;
+    handoff.reset();
     constexpr uint16_t port = 20502;
-    auto listen = std::make_shared<fss_listen>(port, accept_cb);
+    auto listen = std::make_shared<fss_listen>(port, handoff.callback());
     REQUIRE(listen != nullptr);
 
     auto client = std::make_shared<fss_connection>();
@@ -74,7 +71,8 @@ TEST_CASE("queue: FIFO ordering is preserved across many messages")
     }
     client = nullptr;
 
-    REQUIRE(fss_test::wait_for([&]() { return server_side_conn != nullptr; }));
+    auto server_side_conn = handoff.wait();
+    REQUIRE(server_side_conn != nullptr);
 
     int received = 0;
     while (received < count)
@@ -97,21 +95,22 @@ TEST_CASE("queue: FIFO ordering is preserved across many messages")
     }
     REQUIRE(received == count);
 
-    server_side_conn = nullptr;
+    handoff.reset();
 }
 
 TEST_CASE("queue: getMsg returns closed sentinel then nullptr on peer disconnect")
 {
-    server_side_conn = nullptr;
+    handoff.reset();
     constexpr uint16_t port = 20503;
-    auto listen = std::make_shared<fss_listen>(port, accept_cb);
+    auto listen = std::make_shared<fss_listen>(port, handoff.callback());
     REQUIRE(listen != nullptr);
 
     auto client = std::make_shared<fss_connection>();
     REQUIRE(client->connectTo("localhost", port));
     REQUIRE(client->sendMsg(std::make_shared<fss_message_identity>("client1")));
 
-    REQUIRE(fss_test::wait_for([&]() { return server_side_conn != nullptr; }));
+    auto server_side_conn = handoff.wait();
+    REQUIRE(server_side_conn != nullptr);
 
     client = nullptr;
 
@@ -131,20 +130,21 @@ TEST_CASE("queue: getMsg returns closed sentinel then nullptr on peer disconnect
 
     REQUIRE(server_side_conn->getMsg() == nullptr);
 
-    server_side_conn = nullptr;
+    handoff.reset();
 }
 
 TEST_CASE("queue: 10k messages over loopback with no drops")
 {
-    server_side_conn = nullptr;
+    handoff.reset();
     constexpr uint16_t port = 20504;
-    auto listen = std::make_shared<large_queue_listen>(port, accept_cb);
+    auto listen = std::make_shared<large_queue_listen>(port, handoff.callback());
     REQUIRE(listen != nullptr);
 
     auto client = std::make_shared<fss_connection>();
     REQUIRE(client->connectTo("localhost", port));
 
-    REQUIRE(fss_test::wait_for([&]() { return server_side_conn != nullptr; }));
+    auto server_side_conn = handoff.wait();
+    REQUIRE(server_side_conn != nullptr);
 
     constexpr int count = 10000;
     std::atomic<int> produced{0};
@@ -183,4 +183,5 @@ TEST_CASE("queue: 10k messages over loopback with no drops")
 
     client = nullptr;
     server_side_conn = nullptr;
+    handoff.reset();
 }

--- a/tests/reconnect_test.cpp
+++ b/tests/reconnect_test.cpp
@@ -32,17 +32,14 @@ constexpr const char* SERVER_PUBLIC_FILE = "certs/localhost.public.pem";
 constexpr const char* CLIENT_PRIVATE_FILE = "certs/client.private.pem";
 constexpr const char* CLIENT_PUBLIC_FILE = "certs/client.public.pem";
 
-std::shared_ptr<flight_safety_system::transport::fss_connection> accepted_conn;
-
-auto accept_cb(std::shared_ptr<flight_safety_system::transport::fss_connection> new_conn) -> bool
-{
-    accepted_conn = std::move(new_conn);
-    return true;
-}
+/* The listener runs its accept callback on its own worker thread; the handoff
+ * publishes the accepted connection to the main thread with a happens-before
+ * edge. reset() between connections lets a test wait for the *next* accept. */
+fss_test::connection_handoff handoff;
 
 auto make_listener(uint16_t port)
 {
-    return std::make_shared<flight_safety_system::transport_ssl::fss_listen>(port, accept_cb, CA_PUBLIC_FILE,
+    return std::make_shared<flight_safety_system::transport_ssl::fss_listen>(port, handoff.callback(), CA_PUBLIC_FILE,
                                                                              SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
 }
 
@@ -73,7 +70,7 @@ protected:
 
 TEST_CASE("reconnect: client reconnects after listener bounce")
 {
-    accepted_conn = nullptr;
+    handoff.reset();
     constexpr uint16_t port = 20505;
 
     auto listen = make_listener(port);
@@ -83,9 +80,9 @@ TEST_CASE("reconnect: client reconnects after listener bounce")
                                                                                  CLIENT_PUBLIC_FILE);
     client->connectTo("localhost", port, /*connect*/ true);
 
-    REQUIRE(fss_test::wait_for([]() { return accepted_conn != nullptr; }));
-    auto original = accepted_conn;
-    accepted_conn = nullptr;
+    auto original = handoff.wait();
+    REQUIRE(original != nullptr);
+    handoff.reset();
 
     /* Drop the listener and the accepted connection — from the client's
      * perspective, the server side has gone away.  With the shared_ptr-capture
@@ -111,11 +108,11 @@ TEST_CASE("reconnect: client reconnects after listener bounce")
     REQUIRE(fss_test::wait_for(
         [&]() {
             client->attemptReconnect();
-            return accepted_conn != nullptr;
+            return handoff.get() != nullptr;
         },
         std::chrono::milliseconds(15000), std::chrono::milliseconds(200)));
 
-    accepted_conn = nullptr;
+    handoff.reset();
 }
 
 TEST_CASE("reconnect: attemptReconnect is throttled within the retry window")
@@ -304,18 +301,18 @@ TEST_CASE("reconnect: multi-server failover keeps secondary reachable")
     REQUIRE(listen_primary != nullptr);
     REQUIRE(listen_secondary != nullptr);
 
-    accepted_conn = nullptr;
+    handoff.reset();
     auto client = std::make_shared<flight_safety_system::client_ssl::fss_client>(CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE,
                                                                                  CLIENT_PUBLIC_FILE);
     client->connectTo("localhost", port_primary, /*connect*/ true);
-    REQUIRE(fss_test::wait_for([]() { return accepted_conn != nullptr; }));
-    auto primary_conn = accepted_conn;
-    accepted_conn = nullptr;
+    auto primary_conn = handoff.wait();
+    REQUIRE(primary_conn != nullptr);
+    handoff.reset();
 
     client->connectTo("localhost", port_secondary, /*connect*/ true);
-    REQUIRE(fss_test::wait_for([]() { return accepted_conn != nullptr; }));
-    auto secondary_conn = accepted_conn;
-    accepted_conn = nullptr;
+    auto secondary_conn = handoff.wait();
+    REQUIRE(secondary_conn != nullptr);
+    handoff.reset();
 
     /* Kill the primary; secondary must still accept traffic. */
     primary_conn = nullptr;


### PR DESCRIPTION
## Description

Same worker->main race as the SSL/plaintext connection tests, across the rest of the listener-driven suites: queue_test, reconnect_test, oversized_message_test, connection_negative_test and exception_isolation_test each stashed the accepted connection in a bare global written by the listener's accept-worker thread and polled from the main thread. Route them all through the shared connection_handoff helper (reset()/callback()/wait()), grabbing a local connection at each wait site so the test bodies are otherwise unchanged. reconnect_test resets between connections to wait for the next accept. These groups are now race-clean under TSan. (todo/13 item 3)

## Summary by Sourcery

Route listener-accepted connections in transport-related tests through the shared mutex-guarded connection_handoff helper to eliminate worker/main thread races.

Bug Fixes:
- Eliminated data races between listener worker threads and main thread in queue, reconnect, oversized message, negative connection, and exception isolation tests by synchronizing accepted connection handoffs.

Tests:
- Updated multiple listener-driven transport tests to use the shared connection_handoff helper instead of global shared_ptrs for accepted connections.