### PR TITLE
test(tsan): make MockDatabase record sinks thread-safe

### DIFF
--- a/tests/mock_database.hpp
+++ b/tests/mock_database.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -10,8 +11,11 @@
 
 namespace fss_test {
 
-/* In-memory IDatabase for unit tests. No thread-safety: tests drive the
- * session synchronously. Commands are held newest-first so getCommand
+/* In-memory IDatabase for unit tests. The record* sinks are written by the
+ * async db-write-queue worker thread while tests poll/inspect them from the
+ * main thread, so those sinks are guarded by records_lock and exposed only via
+ * snapshot accessors (getPositions() etc.) that copy under the lock — a bare
+ * public vector would race. Commands are held newest-first so getCommand
  * returns the most recently pushed entry, matching the production
  * "ORDER BY timestamp DESC LIMIT 1" semantics. */
 class MockDatabase : public flight_safety_system::server::IDatabase {
@@ -59,13 +63,6 @@ public:
         uint8_t ack_reason;
     };
 
-    std::vector<recorded_rtt> rtts{};
-    std::vector<recorded_pos> positions{};
-    std::vector<recorded_status> statuses{};
-    std::vector<recorded_search> searches{};
-    std::vector<recorded_dispatch> dispatches{};
-    std::vector<recorded_ack> acks{};
-
     MockDatabase() = default;
     MockDatabase(const MockDatabase &) = delete;
     MockDatabase(MockDatabase &&) = delete;
@@ -81,30 +78,72 @@ public:
 
     void recordPosition(uint64_t asset_id, double latitude, double longitude, uint32_t altitude) override
     {
+        const std::scoped_lock lock(records_lock);
         positions.push_back({asset_id, latitude, longitude, altitude});
     }
 
-    void recordRtt(uint64_t asset_id, uint64_t rtt_ms) override { rtts.push_back({asset_id, rtt_ms}); }
+    void recordRtt(uint64_t asset_id, uint64_t rtt_ms) override
+    {
+        const std::scoped_lock lock(records_lock);
+        rtts.push_back({asset_id, rtt_ms});
+    }
 
     void recordStatus(uint64_t asset_id, uint8_t bat_percent, uint32_t bat_mah_used, double bat_voltage) override
     {
+        const std::scoped_lock lock(records_lock);
         statuses.push_back({asset_id, bat_percent, bat_mah_used, bat_voltage});
     }
 
     void recordSearchStatus(uint64_t asset_id, uint64_t search_id, uint64_t completed, uint64_t total) override
     {
+        const std::scoped_lock lock(records_lock);
         searches.push_back({asset_id, search_id, completed, total});
     }
 
     void recordCommandDispatch(uint64_t command_dbid, uint64_t dispatch_id) override
     {
+        const std::scoped_lock lock(records_lock);
         dispatches.push_back({command_dbid, dispatch_id});
     }
 
     void recordCommandAck(uint64_t asset_id, uint64_t dispatch_id, uint8_t ack_state, uint64_t ack_timestamp,
                           uint8_t ack_reason) override
     {
+        const std::scoped_lock lock(records_lock);
         acks.push_back({asset_id, dispatch_id, ack_state, ack_timestamp, ack_reason});
+    }
+
+    /* Snapshot accessors: copy the sink under the lock so a test can inspect it
+     * without racing the write-queue worker that fills it. */
+    auto getPositions() const -> std::vector<recorded_pos>
+    {
+        const std::scoped_lock lock(records_lock);
+        return positions;
+    }
+    auto getRtts() const -> std::vector<recorded_rtt>
+    {
+        const std::scoped_lock lock(records_lock);
+        return rtts;
+    }
+    auto getStatuses() const -> std::vector<recorded_status>
+    {
+        const std::scoped_lock lock(records_lock);
+        return statuses;
+    }
+    auto getSearches() const -> std::vector<recorded_search>
+    {
+        const std::scoped_lock lock(records_lock);
+        return searches;
+    }
+    auto getDispatches() const -> std::vector<recorded_dispatch>
+    {
+        const std::scoped_lock lock(records_lock);
+        return dispatches;
+    }
+    auto getAcks() const -> std::vector<recorded_ack>
+    {
+        const std::scoped_lock lock(records_lock);
+        return acks;
     }
 
     auto getCommand(uint64_t asset_id) -> std::shared_ptr<flight_safety_system::server::asset_command> override
@@ -152,6 +191,16 @@ public:
     {
         commands[asset_id].push_back(std::move(cmd));
     }
+private:
+    /* Written by the async write-queue worker, read via the snapshot accessors
+     * above; all access is under records_lock. */
+    mutable std::mutex records_lock{};
+    std::vector<recorded_rtt> rtts{};
+    std::vector<recorded_pos> positions{};
+    std::vector<recorded_status> statuses{};
+    std::vector<recorded_search> searches{};
+    std::vector<recorded_dispatch> dispatches{};
+    std::vector<recorded_ack> acks{};
 };
 
 } // namespace fss_test

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -941,8 +941,8 @@ TEST_CASE("session: no-fix (NaN) position report is discarded, not stored or bro
         std::string{}, 0U, uint8_t{0}, 0U, uint8_t{0}, uint8_t{0}, fss::fss_current_timestamp());
     session->processMessage(no_fix);
 
-    REQUIRE(mock.positions.empty());     // not stored
-    REQUIRE(handler.broadcasts.empty()); // not broadcast
+    REQUIRE(mock.getPositions().empty()); // not stored
+    REQUIRE(handler.broadcasts.empty());  // not broadcast
     /* Logged distinctly as a no-fix, not the generic invalid-coordinate path. */
     REQUIRE(cap.str().find("no GPS fix") != std::string::npos);
 
@@ -1394,9 +1394,10 @@ TEST_CASE("session: system_status message is forwarded to db writer")
         std::make_shared<fss::transport::fss_message_system_status>(uint8_t{80}, uint32_t{1000}, double{12.5});
     session->processMessage(status);
 
-    REQUIRE(fss_test::wait_for([&]() { return !mock.statuses.empty(); }));
-    REQUIRE(mock.statuses.front().asset_id == asset_id);
-    REQUIRE(mock.statuses.front().bat_percent == 80);
+    REQUIRE(fss_test::wait_for([&]() { return !mock.getStatuses().empty(); }));
+    auto statuses = mock.getStatuses();
+    REQUIRE(statuses.front().asset_id == asset_id);
+    REQUIRE(statuses.front().bat_percent == 80);
 }
 
 TEST_CASE("session: command_ack is stored when the capability is negotiated")
@@ -1421,14 +1422,15 @@ TEST_CASE("session: command_ack is stored when the capability is negotiated")
                                                                          fss::transport::supersede_low_battery, ack_ts);
     session->processMessage(ack);
 
-    REQUIRE(fss_test::wait_for([&]() { return !mock.acks.empty(); }));
+    REQUIRE(fss_test::wait_for([&]() { return !mock.getAcks().empty(); }));
     /* The ack is scoped to the acking asset (the one this connection identified
      * as), not just the per-connection dispatch_id. */
-    REQUIRE(mock.acks.front().asset_id == 13);
-    REQUIRE(mock.acks.front().dispatch_id == acked_id);
-    REQUIRE(mock.acks.front().ack_state == static_cast<uint8_t>(fss::transport::command_ack_superseded));
-    REQUIRE(mock.acks.front().ack_timestamp == ack_ts);
-    REQUIRE(mock.acks.front().ack_reason == static_cast<uint8_t>(fss::transport::supersede_low_battery));
+    auto acks = mock.getAcks();
+    REQUIRE(acks.front().asset_id == 13);
+    REQUIRE(acks.front().dispatch_id == acked_id);
+    REQUIRE(acks.front().ack_state == static_cast<uint8_t>(fss::transport::command_ack_superseded));
+    REQUIRE(acks.front().ack_timestamp == ack_ts);
+    REQUIRE(acks.front().ack_reason == static_cast<uint8_t>(fss::transport::supersede_low_battery));
 }
 
 TEST_CASE("session: command_ack is dropped when the capability is not negotiated")
@@ -1452,7 +1454,7 @@ TEST_CASE("session: command_ack is dropped when the capability is not negotiated
 
     /* Give the async writer a brief chance to run, then confirm nothing was
      * stored. A short timeout suffices: a real write would land near-instantly. */
-    REQUIRE_FALSE(fss_test::wait_for([&]() { return !mock.acks.empty(); }, std::chrono::milliseconds(200)));
+    REQUIRE_FALSE(fss_test::wait_for([&]() { return !mock.getAcks().empty(); }, std::chrono::milliseconds(200)));
 }
 
 TEST_CASE("session: search_status message is forwarded to db writer")
@@ -1472,11 +1474,12 @@ TEST_CASE("session: search_status message is forwarded to db writer")
     auto search = std::make_shared<fss::transport::fss_message_search_status>(uint64_t{5}, uint64_t{3}, uint64_t{10});
     session->processMessage(search);
 
-    REQUIRE(fss_test::wait_for([&]() { return !mock.searches.empty(); }));
-    REQUIRE(mock.searches.front().asset_id == asset_id);
-    REQUIRE(mock.searches.front().search_id == 5);
-    REQUIRE(mock.searches.front().completed == 3);
-    REQUIRE(mock.searches.front().total == 10);
+    REQUIRE(fss_test::wait_for([&]() { return !mock.getSearches().empty(); }));
+    auto searches = mock.getSearches();
+    REQUIRE(searches.front().asset_id == asset_id);
+    REQUIRE(searches.front().search_id == 5);
+    REQUIRE(searches.front().completed == 3);
+    REQUIRE(searches.front().total == 10);
 }
 
 TEST_CASE("session: rtt_request from client triggers rtt_response reply")
@@ -1527,7 +1530,7 @@ TEST_CASE("session: position report with out-of-range latitude is rejected")
     /* Must not be broadcast. */
     REQUIRE(handler.broadcasts.empty());
     /* Must not be written to the database. */
-    REQUIRE(mock.positions.empty());
+    REQUIRE(mock.getPositions().empty());
     /* Connection must stay up. */
     REQUIRE(handler.disconnects == 0);
     /* A warning must be logged. */
@@ -1540,8 +1543,8 @@ TEST_CASE("session: position report with out-of-range latitude is rejected")
     session->processMessage(good_pos);
 
     REQUIRE(handler.broadcasts.size() == 1);
-    REQUIRE(fss_test::wait_for([&]() { return !mock.positions.empty(); }));
-    REQUIRE(mock.positions.front().asset_id == asset_id);
+    REQUIRE(fss_test::wait_for([&]() { return !mock.getPositions().empty(); }));
+    REQUIRE(mock.getPositions().front().asset_id == asset_id);
 }
 
 TEST_CASE("session: position report with invalid longitude or non-finite coords is rejected")
@@ -1576,7 +1579,7 @@ TEST_CASE("session: position report with invalid longitude or non-finite coords 
     }
 
     REQUIRE(handler.broadcasts.empty());
-    REQUIRE(mock.positions.empty());
+    REQUIRE(mock.getPositions().empty());
     REQUIRE(handler.disconnects == 0);
 }
 


### PR DESCRIPTION
## Description

The record* sinks (positions/statuses/searches/acks/rtts/dispatches) are filled by the async db-write-queue worker thread while the session tests poll and inspect them from the main thread — a data race TSan flags on the bare public vectors. Guard the sinks with a mutex, expose them only through snapshot accessors (getPositions() etc.) that copy under the lock, and switch the server_session_test reads to those accessors (grabbing one snapshot per multi-field assertion). (todo/13 item 3)

## Summary by Sourcery

Guard MockDatabase record sinks with a mutex and expose them via snapshot accessors to eliminate test data races, updating session tests to use the new accessors.

Bug Fixes:
- Fix data races on MockDatabase record sinks accessed concurrently by the async writer and test code.

Enhancements:
- Add thread-safe snapshot accessors for MockDatabase recorded positions, statuses, searches, dispatches, RTTs, and acks, and adjust tests to use them.