### PR TITLE
build,ci: run the full unit suite under ThreadSanitizer

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -219,7 +219,7 @@ jobs:
         cd e2e
         .venv/bin/pytest -v --timeout=120
 
-  # ─── 6. ThreadSanitizer concurrency tests ────────────────────────────────
+  # ─── 6. ThreadSanitizer: full unit suite + concurrency stress tests ──────
   thread-sanitizer:
     runs-on: ubuntu-latest
     needs: build-and-check
@@ -235,16 +235,27 @@ jobs:
     - name: autogen
       run: ./autogen.sh
 
-    # --enable-tsan is mutually exclusive with --enable-coverage; this job is
-    # separate from the coverage job for that reason.
+    # --enable-tsan instruments the whole tree (libraries + tests + concurrency
+    # binary), so the full all_test runs race-checked — not just the dedicated
+    # concurrency binary. Mutually exclusive with --enable-coverage, so this is
+    # its own job.
     - name: configure with thread sanitizer
       run: ./configure --enable-tests --enable-tsan
 
     - name: make
       run: make -j$(nproc)
 
-    - name: run thread sanitizer tests
+    # check-tsan runs the full all_test *and* the concurrency stress binary under
+    # TSan in one step, with tests/tsan.supp (narrowly-scoped, documented
+    # kernel-synchronised false positives). `make check` would also run all_test
+    # under TSan (AM_TESTS_ENVIRONMENT wires the suppressions in), but that would
+    # double-run the slow suite, so this job uses check-tsan alone.
+    - name: run the full suite + concurrency stress tests under TSan
       run: make -C tests check-tsan
+
+    - name: show test logs on failure
+      if: failure()
+      run: cat tests/*.log 2>/dev/null || true
 
   # ─── 7. AddressSanitizer + UndefinedBehaviorSanitizer ────────────────────
   sanitizers:

--- a/configure.ac
+++ b/configure.ac
@@ -28,7 +28,7 @@ AC_ARG_ENABLE([server],AS_HELP_STRING([--enable-server], [Build the server (fss-
 AC_ARG_ENABLE([tests],AS_HELP_STRING([--enable-tests], [Build the tests (Requires catch2)]))
 AC_ARG_ENABLE([coverage],AS_HELP_STRING([--enable-coverage], [Build with coverage support (gcov)]))
 AC_ARG_ENABLE([fake-client],AS_HELP_STRING([--enable-fake-client], [Build the example client (fss-fake-client)]))
-AC_ARG_ENABLE([tsan],AS_HELP_STRING([--enable-tsan], [Build the ThreadSanitizer concurrency test binary (requires --enable-tests; mutually exclusive with --enable-coverage)]))
+AC_ARG_ENABLE([tsan],AS_HELP_STRING([--enable-tsan], [Build the whole tree (libraries, tests, and the dedicated concurrency binary) under ThreadSanitizer so "make check" runs the full unit suite race-checked (requires --enable-tests; mutually exclusive with --enable-coverage)]))
 
 AM_CONDITIONAL([SERVER], [test "x$enable_server" == "xyes"])
 AM_CONDITIONAL([ENABLE_TESTS], [test "x$enable_tests" == "xyes"])
@@ -43,8 +43,12 @@ AS_IF([test "x$enable_tsan" == "xyes" -a "x$enable_tests" != "xyes"], [
     AC_MSG_ERROR([--enable-tsan requires --enable-tests])
 ])
 
+# Whole-tree ThreadSanitizer. These flags are appended to AM_CXXFLAGS/AM_LDFLAGS
+# in src/, tests/ and examples/ (the same way --enable-coverage instruments the
+# tree) so the libraries all_test links are instrumented too — a per-target flag
+# on just the concurrency binary would leave the rest of the suite blind.
 AS_IF([test "x$enable_tsan" == "xyes"], [
-    TSAN_CXXFLAGS="-fsanitize=thread -O1 -g -fno-omit-frame-pointer"
+    TSAN_CXXFLAGS="-fsanitize=thread -fno-omit-frame-pointer"
     TSAN_LDFLAGS="-fsanitize=thread"
 ], [
     TSAN_CXXFLAGS=""

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -2,6 +2,11 @@ AUTOMAKE_OPTIONS = subdir-objects
 ACLOCAL_AMFLAGS = $(ACLOCAL_FLAGS)
 AM_CXXFLAGS = -pthread -fPIC -std=c++17 -I. -Werror -Wall -Wshadow -Wunused -Wnull-dereference -Wformat=2 -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wpedantic -Weffc++ -I$(top_srcdir)/src -include config.h
 
+# Whole-tree ThreadSanitizer (empty unless --enable-tsan): the example binaries
+# link the instrumented libraries, so they must be built/linked with TSan too.
+AM_CXXFLAGS += $(TSAN_CXXFLAGS)
+AM_LDFLAGS = $(TSAN_LDFLAGS)
+
 bin_PROGRAMS =
 
 # fss-server.service.in is distributed unconditionally: a source template must

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,6 +10,11 @@ AM_CXXFLAGS += $(CODE_COVERAGE_CXXFLAGS)
 AM_CPPFLAGS += $(CODE_COVERAGE_CPPFLAGS)
 AM_LDFLAGS = $(CODE_COVERAGE_LDFLAGS)
 
+# Whole-tree ThreadSanitizer (empty unless --enable-tsan). Coverage and TSan are
+# mutually exclusive at configure time, so at most one of these is non-empty.
+AM_CXXFLAGS += $(TSAN_CXXFLAGS)
+AM_LDFLAGS += $(TSAN_LDFLAGS)
+
 bin_PROGRAMS =
 sbin_PROGRAMS =
 lib_LTLIBRARIES = libfss.la libfss-transport.la

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,6 +2,18 @@ AUTOMAKE_OPTIONS = subdir-objects
 ACLOCAL_AMFLAGS = $(ACLOCAL_FLAGS)
 AM_CXXFLAGS = -pthread -fPIC -std=c++17 -I. -Werror -Wall -Wshadow -Wunused -Wnull-dereference -Wformat=2 -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wpedantic -Weffc++ -I$(top_srcdir)/src -include config.h $(CODE_COVERAGE_CXXFLAGS)
 
+# Whole-tree ThreadSanitizer (empty unless --enable-tsan): instrument the test
+# objects and link all_test against the (also-instrumented) libraries with TSan.
+AM_CXXFLAGS += $(TSAN_CXXFLAGS)
+AM_LDFLAGS = $(TSAN_LDFLAGS)
+
+if ENABLE_TSAN
+# Under --enable-tsan the whole suite runs instrumented, so `make check` needs
+# the suppression file in the environment or the documented kernel-synchronised
+# false positives (see tsan.supp) would fail the run.
+AM_TESTS_ENVIRONMENT = TSAN_OPTIONS='suppressions=$(abs_srcdir)/tsan.supp halt_on_error=1'; export TSAN_OPTIONS;
+endif
+
 if ENABLE_TESTS
 TESTS = all_test
 check_PROGRAMS = all_test
@@ -98,11 +110,12 @@ certs/empty.crl.pem: certs
 	  --outfile certs/empty.crl.pem
 
 if ENABLE_TSAN
-# Separate binary built with -fsanitize=thread. NOT added to TESTS — it runs
-# only via `make check-tsan` so regular `make check` is unaffected. Shares no
-# objects with all_test because TSan instrumentation must reach into the
-# transport-layer sources (compiled in directly here, not linked via the .la
-# archive which is built without TSan flags).
+# Dedicated concurrency stress binary. It is NOT in TESTS (so `make check`
+# doesn't run it), and compiles the transport-layer sources in directly to keep
+# its own focused harness; under --enable-tsan the whole tree is instrumented,
+# so this binary is TSan-built via the AM_CXXFLAGS/AM_LDFLAGS above. The
+# per-target CXXFLAGS only forces object renaming (main.cpp is shared with
+# all_test).
 check_PROGRAMS += concurrency_tsan_test
 concurrency_tsan_test_SOURCES = main.cpp \
 	concurrency_connection_test.cpp \
@@ -113,15 +126,19 @@ concurrency_tsan_test_SOURCES = main.cpp \
 	../src/client_session.cpp \
 	../src/db-write-queue.cpp \
 	../src/fss-main.cpp
-concurrency_tsan_test_CXXFLAGS = $(AM_CXXFLAGS) $(TSAN_CXXFLAGS)
-concurrency_tsan_test_LDFLAGS = $(TSAN_LDFLAGS)
+concurrency_tsan_test_CXXFLAGS = $(AM_CXXFLAGS)
 concurrency_tsan_test_LDADD = $(CATCH2_LIBS) $(pthread_LIBS)
 
 EXTRA_DIST += tsan.supp
 
+# Run the full unit suite *and* the concurrency stress binary under TSan in one
+# command. `make check` already runs all_test under TSan (TESTS +
+# AM_TESTS_ENVIRONMENT); this target adds the concurrency binary, which is not
+# in TESTS, and re-runs all_test so a single command covers everything.
 .PHONY: check-tsan
 check-tsan:
-	$(MAKE) $(AM_MAKEFLAGS) concurrency_tsan_test
+	$(MAKE) $(AM_MAKEFLAGS) all_test concurrency_tsan_test
+	TSAN_OPTIONS="suppressions=$(srcdir)/tsan.supp halt_on_error=1" ./all_test
 	TSAN_OPTIONS="suppressions=$(srcdir)/tsan.supp halt_on_error=1" ./concurrency_tsan_test
 endif
 endif


### PR DESCRIPTION
## Description

The thread-sanitizer job built only the dedicated concurrency binary with per-target TSan flags, leaving the transport/server libraries all_test links uninstrumented — so the whole unit suite never ran under TSan.

Make --enable-tsan instrument the whole tree: append the TSan flags to AM_CXXFLAGS/AM_LDFLAGS in src/, tests/ and examples/ (the same way --enable-coverage already does), so the libraries — and therefore all_test — are race-checked. Under --enable-tsan, AM_TESTS_ENVIRONMENT points the test harness at tests/tsan.supp so a plain `make check` runs the full suite cleanly, and `make check-tsan` runs all_test plus the concurrency stress binary in one command. The concurrency binary no longer needs its own TSan flags (the whole-tree ones cover it); its per-target CXXFLAGS now only forces object renaming. CI just configures `--enable-tsan` and runs `make check-tsan`.

This closes todo/13 item 3 and makes the full-suite TSan run reproducible locally (./configure --enable-tests --enable-tsan && make check), which the previous CI-only CXXFLAGS override did not.

## Summary by Sourcery

Instrument the entire codebase with ThreadSanitizer when enabled and run the full unit suite plus concurrency stress tests under TSan locally and in CI.

New Features:
- Add support for building libraries, tests, and examples with ThreadSanitizer instrumentation via --enable-tsan so the full all_test suite is race-checked.
- Introduce a make check-tsan target that executes the complete unit test suite and the dedicated concurrency stress binary under ThreadSanitizer in one command.

Enhancements:
- Update the ThreadSanitizer configure option description to reflect whole-tree instrumentation rather than a single concurrency binary.
- Wire ThreadSanitizer suppression handling into the test harness so make check runs the TSan-instrumented suite cleanly when enabled.
- Adjust the concurrency_tsan_test binary to rely on shared ThreadSanitizer flags instead of bespoke per-target sanitizer flags.

CI:
- Change the ThreadSanitizer CI job to configure the project with --enable-tsan, run make -C tests check-tsan, and surface test logs on failure.