### PR TITLE
fix(server): only record command dispatch after a successful send

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -207,57 +207,84 @@ void fss::server::fss_client::sendCommand()
     }
     uint64_t ts = this->clock->now_ms();
     auto ac = this->pending_command;
-    constexpr int timeout_time = 10 * sec_to_msec;
-    if (ac != nullptr && (ac->getDBId() != this->last_command_dbid || ts > (this->last_command_send_ts + timeout_time)))
+    if (ac == nullptr)
     {
-        this->last_command_send_ts = ts;
-        this->last_command_dbid = ac->getDBId();
-        auto command = ac->getCommand();
-        if (command == fss::transport::asset_command_unknown)
-        {
-            FSS_LOG_ERROR("server", "Refusing to dispatch unknown command type to "
-                                        << this->name << " (dbid=" << ac->getDBId() << ")");
-            return;
-        }
-        if (command == fss::transport::asset_command_goto &&
-            !is_valid_coordinate(ac->getLatitude(), ac->getLongitude()))
-        {
-            FSS_LOG_ERROR("server", "Refusing to dispatch GOTO command with invalid coordinates to "
-                                        << this->name << " (dbid=" << ac->getDBId() << ", lat=" << ac->getLatitude()
-                                        << ", lon=" << ac->getLongitude() << ")");
-            return;
-        }
-        if (command == fss::transport::asset_command_altitude && !ac->isAltitudeValid())
-        {
-            /* A NULL altitude must not dispatch as 0 — that is a
-             * descend-to-ground instruction. */
-            FSS_LOG_ERROR("server", "Refusing to dispatch ALT command with NULL altitude to "
-                                        << this->name << " (dbid=" << ac->getDBId() << ")");
-            return;
-        }
-        std::shared_ptr<fss::transport::fss_message_asset_command> msg = nullptr;
-        switch (command)
-        {
-            case fss::transport::asset_command_goto:
-                msg = std::make_shared<fss::transport::fss_message_asset_command>(
-                    command, ac->getTimeStamp(), ac->getLatitude(), ac->getLongitude());
-                break;
-            case fss::transport::asset_command_altitude:
-                msg = std::make_shared<fss::transport::fss_message_asset_command>(command, ac->getTimeStamp(),
-                                                                                  ac->getAltitude());
-                break;
-            default:
-                msg = std::make_shared<fss::transport::fss_message_asset_command>(command, ac->getTimeStamp());
-                break;
-        }
-        this->getConnection()->sendMsg(msg);
-        /* sendMsg stamped the per-connection message id into msg; record it
-         * against the command row (cached_asset_id is non-zero here — the
-         * early return above guarantees it) so a later ack, which echoes this id
-         * as acked_command_id, can be matched back to this specific command. */
-        this->writer->enqueue(command_dispatch_write{ac->getDBId(), msg->getId()});
-        FSS_LOG_INFO("server", "dispatched command dbid=" << ac->getDBId() << " to " << this->name);
+        return;
     }
+    constexpr int timeout_time = 10 * sec_to_msec;
+    bool is_new_command = ac->getDBId() != this->last_command_dbid;
+    bool resend_window_expired = ts > (this->last_command_send_ts + timeout_time);
+    if (!is_new_command && !resend_window_expired)
+    {
+        /* Same command we last handled and still inside the resend window. */
+        return;
+    }
+    /* Mark a command as handled for the current resend window: applied on a
+     * successful dispatch, and on a permanent validation rejection below (which
+     * can never succeed, so re-evaluating it every tick would only spam the
+     * log). Deliberately NOT applied on a transient send failure, which must
+     * stay eligible for retry on the next send tick. Takes the timestamp and
+     * dbid explicitly so the state it writes is visible at each call. */
+    auto mark_handled = [this](uint64_t handled_ts, uint64_t handled_dbid) -> void {
+        this->last_command_send_ts = handled_ts;
+        this->last_command_dbid = handled_dbid;
+    };
+    auto command = ac->getCommand();
+    if (command == fss::transport::asset_command_unknown)
+    {
+        mark_handled(ts, ac->getDBId());
+        FSS_LOG_ERROR("server", "Refusing to dispatch unknown command type to " << this->name
+                                                                                << " (dbid=" << ac->getDBId() << ")");
+        return;
+    }
+    if (command == fss::transport::asset_command_goto && !is_valid_coordinate(ac->getLatitude(), ac->getLongitude()))
+    {
+        mark_handled(ts, ac->getDBId());
+        FSS_LOG_ERROR("server", "Refusing to dispatch GOTO command with invalid coordinates to "
+                                    << this->name << " (dbid=" << ac->getDBId() << ", lat=" << ac->getLatitude()
+                                    << ", lon=" << ac->getLongitude() << ")");
+        return;
+    }
+    if (command == fss::transport::asset_command_altitude && !ac->isAltitudeValid())
+    {
+        /* A NULL altitude must not dispatch as 0 — that is a
+         * descend-to-ground instruction. */
+        mark_handled(ts, ac->getDBId());
+        FSS_LOG_ERROR("server", "Refusing to dispatch ALT command with NULL altitude to "
+                                    << this->name << " (dbid=" << ac->getDBId() << ")");
+        return;
+    }
+    std::shared_ptr<fss::transport::fss_message_asset_command> msg = nullptr;
+    switch (command)
+    {
+        case fss::transport::asset_command_goto:
+            msg = std::make_shared<fss::transport::fss_message_asset_command>(command, ac->getTimeStamp(),
+                                                                              ac->getLatitude(), ac->getLongitude());
+            break;
+        case fss::transport::asset_command_altitude:
+            msg = std::make_shared<fss::transport::fss_message_asset_command>(command, ac->getTimeStamp(),
+                                                                              ac->getAltitude());
+            break;
+        default: msg = std::make_shared<fss::transport::fss_message_asset_command>(command, ac->getTimeStamp()); break;
+    }
+    if (!this->getConnection()->sendMsg(msg))
+    {
+        /* The socket write failed, so the command never reached the aircraft.
+         * Do not record a dispatch and do not advance the resend window: the
+         * command must be retried on the next send tick rather than appearing in
+         * the DB as dispatched. A genuinely dead connection is reaped separately
+         * by the recv thread's closed-message path. */
+        FSS_LOG_WARN("server", "Failed to send command dbid=" << ac->getDBId() << " to " << this->name
+                                                              << "; will retry on next tick");
+        return;
+    }
+    mark_handled(ts, ac->getDBId());
+    /* sendMsg stamped the per-connection message id into msg; record it against
+     * the command row (cached_asset_id is non-zero here — the early return above
+     * guarantees it) so a later ack, which echoes this id as acked_command_id,
+     * can be matched back to this specific command. */
+    this->writer->enqueue(command_dispatch_write{ac->getDBId(), msg->getId()});
+    FSS_LOG_INFO("server", "dispatched command dbid=" << ac->getDBId() << " to " << this->name);
 }
 
 void fss::server::fss_client::setClock(std::shared_ptr<fss::IClock> t_clock)

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -38,6 +38,12 @@ class FakeConnection : public fss::transport::fss_connection {
 public:
     std::vector<std::shared_ptr<fss::transport::fss_message>> sent{};
     std::list<std::string> cert_names{};
+    /* When true, sendMsg() reports the socket write failed (as the real
+     * transport does on EPIPE / a closed fd). The framed message is still
+     * decoded and pushed to send_attempts so a test can count attempts, but it
+     * is NOT added to `sent` — it never reached the peer. */
+    bool fail_sends{false};
+    std::vector<std::shared_ptr<fss::transport::fss_message>> send_attempts{};
 
     FakeConnection() = default;
     FakeConnection(const FakeConnection &) = delete;
@@ -51,6 +57,14 @@ protected:
     auto sendMsg(const std::shared_ptr<fss::transport::buf_len> &bl) -> bool override
     {
         auto msg = fss::transport::fss_message::decode(bl);
+        if (msg != nullptr)
+        {
+            send_attempts.push_back(msg);
+        }
+        if (fail_sends)
+        {
+            return false;
+        }
         if (msg != nullptr)
         {
             sent.push_back(msg);
@@ -409,6 +423,85 @@ TEST_CASE("session: rapid sendCommand does not duplicate a single pending comman
     }
 
     REQUIRE(count_sent<fss::transport::fss_message_asset_command>(conn->sent) == 1);
+}
+
+TEST_CASE("session: a failed command send records no dispatch and retries on the next tick")
+{
+    /* todo/19: a socket write that fails must not mark the command dispatched
+     * (that would record in the DB a command the aircraft never received) and
+     * must not advance the 10 s resend window (the command has to be retried
+     * promptly, not after the timeout). */
+    fss_test::MockDatabase mock;
+    constexpr uint64_t asset_id = 11;
+    mock.asset_ids["craft"] = asset_id;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+    auto clock = std::make_shared<FakeClock>();
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->setClock(clock);
+    /* Identify with no pending command in the DB, so the command queued below is
+     * the first one sendCommand ever attempts. */
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    conn->fail_sends = true;
+    auto cmd = std::make_shared<fss::server::asset_command>(/*dbid*/ 77, /*ts*/ 500, "TERM", 0.0, 0.0, 0);
+    session->setPendingCommand(cmd);
+
+    const std::size_t attempts_before = conn->send_attempts.size();
+    session->sendCommand();
+    /* One attempt was made, but the failed write means nothing reached the peer. */
+    REQUIRE(conn->send_attempts.size() == attempts_before + 1);
+    REQUIRE(count_sent<fss::transport::fss_message_asset_command>(conn->sent) == 0);
+    /* Nothing was enqueued on a failed send, so the sink can never observe a
+     * dispatch — an immediate check is reliable. */
+    REQUIRE(mock.getDispatches().empty());
+
+    /* The clock has not advanced past the 10 s resend window, yet the next tick
+     * must retry because the previous attempt never reached the aircraft. */
+    session->sendCommand();
+    REQUIRE(conn->send_attempts.size() == attempts_before + 2);
+
+    /* Once the socket recovers, the retry goes through and records exactly one
+     * dispatch for this command. */
+    conn->fail_sends = false;
+    session->sendCommand();
+    REQUIRE(count_sent<fss::transport::fss_message_asset_command>(conn->sent) == 1);
+    REQUIRE(fss_test::wait_for([&]() -> bool { return mock.getDispatches().size() == 1; }));
+    REQUIRE(mock.getDispatches().front().command_dbid == 77);
+}
+
+TEST_CASE("session: a successful command send records exactly one dispatch and suppresses resends")
+{
+    /* todo/19: the success path must remain unchanged — one dispatch id is
+     * recorded and repeated ticks within the resend window do not resend or
+     * re-record. */
+    fss_test::MockDatabase mock;
+    constexpr uint64_t asset_id = 12;
+    mock.asset_ids["craft"] = asset_id;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+    auto clock = std::make_shared<FakeClock>();
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->setClock(clock);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    auto cmd = std::make_shared<fss::server::asset_command>(/*dbid*/ 88, /*ts*/ 500, "RTL", 0.0, 0.0, 0);
+    session->setPendingCommand(cmd);
+    for (int i = 0; i < 5; ++i)
+    {
+        session->sendCommand();
+    }
+    REQUIRE(count_sent<fss::transport::fss_message_asset_command>(conn->sent) == 1);
+    REQUIRE(fss_test::wait_for([&]() -> bool { return mock.getDispatches().size() == 1; }));
+    REQUIRE(mock.getDispatches().front().command_dbid == 88);
 }
 
 TEST_CASE("session: a freshly queued command is delivered after the poller updates the cache")


### PR DESCRIPTION
## Description

todo/19: fss_client::sendCommand() stamped last_command_send_ts / last_command_dbid and enqueued command_dispatch_write before checking whether sendMsg() actually wrote the message. A failed socket write could record in the DB a command the aircraft never received, and the advanced resend window delayed retry by up to the 10 s timeout.

Restructure so the resend window and dispatch record advance only after sendMsg() returns true. A transient send failure now logs a warning and leaves the command eligible for the next send tick. Permanent validation rejections (unknown command, invalid GOTO coords, NULL altitude) still mark the command handled so they do not re-log every tick.

Add a controllable failure mode to the test double's FakeConnection and two regression tests: a failed send records no dispatch and retries immediately; a successful send records exactly one dispatch and suppresses resends within the window.

## Summary by Sourcery

Delay recording of command dispatches and advancing the resend window until after a successful socket send, and add regression coverage for failed and successful send scenarios.

Bug Fixes:
- Ensure commands are not marked as dispatched or have their resend window advanced when the socket write fails, preventing phantom dispatch records and delayed retries.
- Avoid repeated validation error logging for permanently invalid commands by marking them handled without attempting dispatch.

Enhancements:
- Extend the test FakeConnection to simulate send failures and track all send attempts separately from successfully sent messages.

Tests:
- Add regression tests to verify failed sends do not enqueue dispatches and are retried promptly, and that successful sends record exactly one dispatch and suppress resends within the window.