### PR TITLE
fix(server): drop phantom RTT requests on send failure

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -349,6 +349,7 @@ auto fss::server::fss_client::isTimedOut() -> bool
 void fss::server::fss_client::sendRTTRequest(const std::shared_ptr<fss::transport::fss_message_rtt_request> &rtt_req)
 {
     bool timed_out = false;
+    bool send_failed = false;
     {
         std::scoped_lock guard(this->client_lock);
         uint64_t now = this->clock->now_ms();
@@ -365,12 +366,32 @@ void fss::server::fss_client::sendRTTRequest(const std::shared_ptr<fss::transpor
         }
         if (!timed_out)
         {
-            this->getConnection()->sendMsg(rtt_req);
-            this->outstanding_rtt_requests.push_back(std::make_shared<fss_client_rtt>(now, rtt_req->getId()));
+            /* Only track an outstanding request once the write actually went out.
+             * todo/22: pushing on a failed send would leave a phantom request the
+             * peer never received, and would arm the retry throttle on a send
+             * that never happened — later timeout behaviour would then reflect a
+             * local send failure rather than peer silence. */
+            if (this->getConnection()->sendMsg(rtt_req))
+            {
+                this->outstanding_rtt_requests.push_back(std::make_shared<fss_client_rtt>(now, rtt_req->getId()));
+            }
+            else
+            {
+                send_failed = true;
+            }
         }
     }
     if (timed_out)
     {
+        this->client_handler->clientDisconnected(this);
+    }
+    else if (send_failed)
+    {
+        /* The socket write failed, so the connection is broken. Reap the client
+         * now rather than waiting out the liveness timeout against a peer that
+         * can never answer (the recv thread's closed-message path would also get
+         * here, but disconnecting directly is immediate and idempotent). */
+        FSS_LOG_WARN("server", "Failed to send RTT request to " << this->getName() << "; disconnecting");
         this->client_handler->clientDisconnected(this);
     }
 }

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -1926,6 +1926,41 @@ TEST_CASE("session: sendRTTRequest skips second request within retry interval")
     REQUIRE(handler.disconnects == 0);
 }
 
+TEST_CASE("session: a failed RTT send creates no outstanding request and is not throttled")
+{
+    /* todo/22: a failed RTT write must not create a phantom outstanding request.
+     * If it did, the retry throttle would suppress the next request and the
+     * liveness timeout would later fire against a local send failure rather than
+     * genuine peer silence. The chosen failure policy disconnects the client. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 5;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+    auto clock = std::make_shared<FakeClock>();
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->setClock(clock);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    conn->fail_sends = true;
+    const std::size_t attempts_before = conn->send_attempts.size();
+
+    auto rtt1 = std::make_shared<fss::transport::fss_message_rtt_request>();
+    session->sendRTTRequest(rtt1);
+    REQUIRE(conn->send_attempts.size() == attempts_before + 1);
+    /* Failure policy: the broken connection is reaped immediately. */
+    REQUIRE(handler.disconnects > 0);
+
+    /* No outstanding request was recorded, so a second request issued within the
+     * rtt_retry_interval (clock not advanced) is NOT throttled — it is attempted
+     * again rather than silently suppressed. */
+    auto rtt2 = std::make_shared<fss::transport::fss_message_rtt_request>();
+    session->sendRTTRequest(rtt2);
+    REQUIRE(conn->send_attempts.size() == attempts_before + 2);
+}
+
 TEST_CASE("asset_command: altitude above uint16_t max survives pack/decode round-trip")
 {
     /* Regression: altitude was stored as uint16_t, silently truncating any


### PR DESCRIPTION
## Description

todo/22: fss_client::sendRTTRequest() ignored the sendMsg() return and pushed an outstanding_rtt_requests entry regardless. A failed socket write left the server tracking a request the peer never received, armed the retry throttle on a send that never happened, and made later liveness timeouts reflect a local send failure rather than peer silence.

Now the outstanding request is recorded only when sendMsg() succeeds. On failure the broken connection is reaped immediately (consistent with the existing RTT-timeout disconnect path) rather than waiting out the liveness timeout against a peer that can never answer.

Regression test: a failed RTT send creates no outstanding request, so a second request within the retry interval is not throttled, and the client is disconnected.

## Summary by Sourcery

Guard RTT request tracking on successful send and disconnect clients on failed RTT sends to avoid phantom outstanding requests and incorrect liveness timeouts.

Bug Fixes:
- Prevent RTT retry throttling from being armed by failed socket writes that never reach the peer.
- Ensure clients are immediately disconnected when RTT sends fail instead of waiting for liveness timeouts.

Tests:
- Add regression test verifying failed RTT sends create no outstanding request, are not throttled, and trigger client disconnect.