### PR TITLE
fix(server): protect command DB writes from telemetry queue drops

### DIFF
--- a/src/db-write-queue.cpp
+++ b/src/db-write-queue.cpp
@@ -20,10 +20,25 @@ db_write_queue::~db_write_queue()
     this->stop();
 }
 
+auto db_write_queue::evict_oldest_telemetry() -> bool
+{
+    auto it = std::find_if(this->q.begin(), this->q.end(),
+                           [](const db_write_task &t) -> bool { return !is_command_task(t); });
+    if (it == this->q.end())
+    {
+        return false;
+    }
+    this->q.erase(it);
+    return true;
+}
+
 void db_write_queue::enqueue(db_write_task task)
 {
-    bool did_drop = false;
-    uint64_t total_dropped = 0;
+    bool dropped_telemetry = false;
+    bool dropped_command = false;
+    uint64_t total_telemetry_dropped = 0;
+    uint64_t total_command_dropped = 0;
+    bool enqueued = true;
     {
         std::scoped_lock guard(this->mtx);
         if (this->stopping)
@@ -32,22 +47,65 @@ void db_write_queue::enqueue(db_write_task task)
         }
         if (this->q.size() >= this->max_depth)
         {
-            this->q.pop_front();
-            total_dropped = this->dropped.fetch_add(1) + 1;
-            did_drop = true;
+            /* At capacity. Make room by evicting the oldest loss-tolerant
+             * telemetry task first — a command dispatch/ack carries safety/audit
+             * state and must never be discarded under telemetry pressure
+             * (todo/20). */
+            if (this->evict_oldest_telemetry())
+            {
+                dropped_telemetry = true;
+                total_telemetry_dropped = this->dropped.fetch_add(1) + 1;
+            }
+            else if (is_command_task(task))
+            {
+                /* The whole queue is command writes and another command has
+                 * arrived: genuine command overload, not telemetry pressure.
+                 * Drop the oldest command to stay bounded, but on a distinct,
+                 * observable path rather than the generic telemetry drop. */
+                this->q.pop_front();
+                dropped_command = true;
+                total_command_dropped = this->command_dropped.fetch_add(1) + 1;
+            }
+            else
+            {
+                /* Incoming telemetry with no telemetry to evict (queue full of
+                 * protected command writes): reject the new telemetry rather
+                 * than evicting a command. Use the fetch_add result for the
+                 * logged count, matching the eviction branch. */
+                dropped_telemetry = true;
+                total_telemetry_dropped = this->dropped.fetch_add(1) + 1;
+                enqueued = false;
+            }
         }
-        this->q.push_back(task);
-    }
-    this->cv.notify_one();
-    if (did_drop)
-    {
-        /* Rate-limited: first drop and every 1000th after that. All current
-         * tasks are telemetry; if command writes are added later they should
-         * bypass this policy. */
-        constexpr uint64_t log_every = 1000;
-        if (total_dropped == 1 || (total_dropped % log_every) == 0)
+        if (enqueued)
         {
-            FSS_LOG_WARN("db-writer", "dropped oldest DB write (total dropped=" << total_dropped << ")");
+            this->q.push_back(task);
+        }
+    }
+    if (enqueued)
+    {
+        this->cv.notify_one();
+    }
+    if (dropped_command)
+    {
+        /* Rate-limited error (first, then every 100th): a dropped command write
+         * loses the link between a command and its ack, so it is far more
+         * serious than a telemetry drop and must be loud. */
+        constexpr uint64_t log_every = 100;
+        if (total_command_dropped == 1 || (total_command_dropped % log_every) == 0)
+        {
+            FSS_LOG_ERROR("db-writer", "dropped a command DB write under command overload (total command dropped="
+                                           << total_command_dropped << ")");
+        }
+    }
+    else if (dropped_telemetry)
+    {
+        /* Rate-limited: first drop and every 1000th after that. */
+        constexpr uint64_t log_every = 1000;
+        if (total_telemetry_dropped == 1 || (total_telemetry_dropped % log_every) == 0)
+        {
+            FSS_LOG_WARN("db-writer",
+                         "dropped oldest telemetry DB write (total dropped=" << total_telemetry_dropped << ")");
         }
     }
 }
@@ -84,6 +142,11 @@ void db_write_queue::stop()
 auto db_write_queue::dropped_count() const -> uint64_t
 {
     return this->dropped.load();
+}
+
+auto db_write_queue::command_dropped_count() const -> uint64_t
+{
+    return this->command_dropped.load();
 }
 
 auto db_write_queue::write_failure_count() const -> uint64_t

--- a/src/db-write-queue.hpp
+++ b/src/db-write-queue.hpp
@@ -58,6 +58,14 @@ using db_write_task = std::variant<rtt_write, position_write, status_write, sear
                                    command_ack_write>;
 using db_write_sink = std::function<void(const db_write_task &)>;
 
+/* Command dispatch/ack writes carry safety/audit state (the link between a sent
+ * command and its ack) and must not be silently dropped under telemetry
+ * pressure, unlike the loss-tolerant telemetry tasks (todo/20). */
+inline auto is_command_task(const db_write_task &task) -> bool
+{
+    return std::holds_alternative<command_dispatch_write>(task) || std::holds_alternative<command_ack_write>(task);
+}
+
 /* C++17 overload helper for std::visit. */
 template<class... Ts> struct overloaded : Ts... {
     using Ts::operator()...;
@@ -73,10 +81,14 @@ private:
     std::deque<db_write_task> q{};
     bool stopping{false};
     std::atomic<uint64_t> dropped{0};
+    std::atomic<uint64_t> command_dropped{0};
     std::atomic<uint64_t> write_failures{0};
     std::thread worker{};
 
     void run();
+    /* Remove the oldest telemetry (non-command) task from the queue, if any.
+     * Caller must hold mtx. Returns true if one was evicted. */
+    auto evict_oldest_telemetry() -> bool;
 public:
     db_write_queue(std::size_t t_max_depth, db_write_sink t_sink);
     ~db_write_queue();
@@ -88,6 +100,7 @@ public:
     void enqueue(db_write_task task);
     void stop();
     auto dropped_count() const -> uint64_t;
+    auto command_dropped_count() const -> uint64_t;
     auto write_failure_count() const -> uint64_t;
     auto pending_count() const -> std::size_t;
 };

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -353,6 +353,13 @@ auto main(int argc, char *argv[]) -> int
                     FSS_LOG_ERROR("server", "DB write failures since start: " << current_failures);
                     last_failure_count = current_failures;
                 }
+                static uint64_t last_command_dropped = 0;
+                uint64_t current_command_dropped = writer->command_dropped_count();
+                if (current_command_dropped != last_command_dropped)
+                {
+                    FSS_LOG_ERROR("server", "command DB writes dropped since start: " << current_command_dropped);
+                    last_command_dropped = current_command_dropped;
+                }
                 dbc->tryReconnectIfNeeded();
             }
             if ((tick_counter % send_config_period_ticks) == 0)

--- a/tests/async_db_write_test.cpp
+++ b/tests/async_db_write_test.cpp
@@ -10,8 +10,10 @@
 #error No catch header
 #endif
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -33,9 +35,30 @@ struct CapturingSink {
     std::vector<uint64_t> asset_ids{};
     std::atomic<uint64_t> count{0};
     std::chrono::milliseconds delay{0};
+    /* Optional gate: while closed, the worker parks at the start of the sink
+     * (after recording that it entered) so a test can hold the queue in a known
+     * state. Open by default, so existing tests are unaffected. */
+    std::mutex gate_mtx{};
+    std::condition_variable gate_cv{};
+    bool gate_open{true};
+    std::atomic<uint64_t> entered{0};
+
+    void open_gate()
+    {
+        {
+            std::lock_guard<std::mutex> guard(gate_mtx);
+            gate_open = true;
+        }
+        gate_cv.notify_all();
+    }
 
     void operator()(const fss::server::db_write_task &task)
     {
+        entered.fetch_add(1);
+        {
+            std::unique_lock<std::mutex> gate(gate_mtx);
+            gate_cv.wait(gate, [this]() -> bool { return gate_open; });
+        }
         if (delay.count() > 0)
         {
             std::this_thread::sleep_for(delay);
@@ -219,6 +242,136 @@ TEST_CASE("db_write_queue: drop log message appears on stderr when queue fills")
     auto out = cerr_capture.str();
     REQUIRE(out.find("db-writer") != std::string::npos);
     REQUIRE(out.find("dropped") != std::string::npos);
+}
+
+TEST_CASE("db_write_queue: a command dispatch survives a telemetry overflow")
+{
+    /* todo/20: telemetry pressure must never evict a queued command write. Fill
+     * the queue with telemetry, slip in a command dispatch, then bury it under
+     * far more telemetry. The command must still reach the sink, and no command
+     * may be counted as dropped. */
+    auto cap = std::make_shared<CapturingSink>();
+    cap->delay = std::chrono::milliseconds(50); /* slow sink so the queue stays full */
+
+    constexpr std::size_t depth = 5;
+    fss::server::db_write_queue q(depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+
+    constexpr uint64_t cmd_id = 1000000; /* distinct from any telemetry asset id below */
+    for (uint64_t i = 1; i <= depth; ++i)
+    {
+        q.enqueue(fss::server::rtt_write{i, 0});
+    }
+    q.enqueue(fss::server::command_dispatch_write{cmd_id, 7});
+    for (uint64_t i = 100; i < 200; ++i)
+    {
+        q.enqueue(fss::server::rtt_write{i, 0});
+    }
+
+    q.stop(); /* drains remaining work */
+
+    auto seen = cap->snapshot();
+    REQUIRE(std::find(seen.begin(), seen.end(), cmd_id) != seen.end());
+    REQUIRE(q.command_dropped_count() == 0);
+}
+
+TEST_CASE("db_write_queue: a command ack survives a telemetry overflow")
+{
+    /* todo/20: same protection for command acks — losing one drops the recorded
+     * outcome of a dispatched command. */
+    auto cap = std::make_shared<CapturingSink>();
+    cap->delay = std::chrono::milliseconds(50);
+
+    constexpr std::size_t depth = 5;
+    fss::server::db_write_queue q(depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+
+    constexpr uint64_t ack_dispatch_id = 2000000;
+    for (uint64_t i = 1; i <= depth; ++i)
+    {
+        q.enqueue(fss::server::position_write{i, 0.0, 0.0, 0});
+    }
+    q.enqueue(fss::server::command_ack_write{42, ack_dispatch_id, 0, 0, 0});
+    for (uint64_t i = 100; i < 200; ++i)
+    {
+        q.enqueue(fss::server::position_write{i, 0.0, 0.0, 0});
+    }
+
+    q.stop();
+
+    auto seen = cap->snapshot();
+    REQUIRE(std::find(seen.begin(), seen.end(), ack_dispatch_id) != seen.end());
+    REQUIRE(q.command_dropped_count() == 0);
+}
+
+TEST_CASE("db_write_queue: command overload drops on a distinct command-specific path")
+{
+    /* todo/20: if the queue fills entirely with command writes (genuine command
+     * overload, not telemetry pressure) a command may have to be dropped to stay
+     * bounded — but on a distinct, observable error path, never the generic
+     * telemetry drop counter/log. */
+    auto cap = std::make_shared<CapturingSink>();
+    cap->delay = std::chrono::milliseconds(50);
+
+    fss_test::scoped_log_level guard("error");
+    fss_test::capture_cerr cerr_capture;
+
+    {
+        constexpr std::size_t depth = 3;
+        fss::server::db_write_queue q(depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+        for (uint64_t i = 1; i <= 10; ++i)
+        {
+            q.enqueue(fss::server::command_dispatch_write{i, i});
+        }
+        q.stop();
+
+        REQUIRE(q.command_dropped_count() > 0);
+        /* The telemetry drop path must not have been used. */
+        REQUIRE(q.dropped_count() == 0);
+    }
+
+    auto out = cerr_capture.str();
+    REQUIRE(out.find("db-writer") != std::string::npos);
+    REQUIRE(out.find("command") != std::string::npos);
+}
+
+TEST_CASE("db_write_queue: telemetry is rejected without evicting a command when the queue is full of commands")
+{
+    /* todo/20: the complement of the eviction tests. When the queue is full of
+     * protected command writes and a telemetry task arrives, there is nothing to
+     * evict — the telemetry must be rejected outright, never displacing a
+     * command. Gate the sink so the queue can be held full deterministically. */
+    auto cap = std::make_shared<CapturingSink>();
+    cap->gate_open = false; /* the worker will park on the first task */
+
+    constexpr std::size_t depth = 3;
+    fss::server::db_write_queue q(depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+
+    /* Park the worker on a first command so the remaining slots fill predictably. */
+    q.enqueue(fss::server::command_dispatch_write{1, 1});
+    REQUIRE(fss_test::wait_for([&]() -> bool { return cap->entered.load() >= 1; }));
+
+    /* Fill the queue to capacity with commands — reaching depth exactly drops
+     * nothing. */
+    for (uint64_t i = 2; i <= depth + 1; ++i)
+    {
+        q.enqueue(fss::server::command_dispatch_write{i, i});
+    }
+    REQUIRE(q.pending_count() == depth);
+    REQUIRE(q.command_dropped_count() == 0);
+    REQUIRE(q.dropped_count() == 0);
+
+    /* Telemetry arrives with no telemetry to evict: it is rejected, and no
+     * command is dropped to make room. */
+    constexpr uint64_t telemetry_id = 9999;
+    q.enqueue(fss::server::rtt_write{telemetry_id, 0});
+    REQUIRE(q.command_dropped_count() == 0);
+    REQUIRE(q.dropped_count() == 1);
+    REQUIRE(q.pending_count() == depth);
+
+    /* Release the worker and drain: the rejected telemetry was never recorded. */
+    cap->open_gate();
+    q.stop();
+    auto seen = cap->snapshot();
+    REQUIRE(std::find(seen.begin(), seen.end(), telemetry_id) == seen.end());
 }
 
 TEST_CASE("db_write_queue: write_failure_count tracks sink exceptions")


### PR DESCRIPTION
## Description

todo/20: db_write_queue used one bounded FIFO with a drop-oldest policy for every task. That queue now also carries command dispatch and ack writes — safety/audit state linking a sent command to its ack. Under a DB stall plus a telemetry burst, drop-oldest could silently evict those records while reporting only the generic "dropped oldest DB write".

Split overflow handling by task class. At capacity, evict the oldest loss-tolerant telemetry task first; a queued command dispatch/ack is never evicted to make room for telemetry. Incoming telemetry that finds no telemetry to evict (queue full of protected commands) is rejected rather than displacing a command. Only genuine command overload — the queue entirely commands with another command arriving — drops a command, and then on a distinct, observable path: a separate command_dropped counter and an ERROR log, surfaced periodically by the server alongside the existing write-failure metric.

The all-telemetry path is unchanged (evicting the oldest telemetry is the old drop-oldest), so existing bounded/monotonic telemetry tests still hold.

Regression tests: a command dispatch and a command ack each survive a telemetry overflow; command overload drops via the command-specific counter and error log, not the telemetry path.

## Summary by Sourcery

Protect command DB write tasks from being silently dropped under telemetry load by separating command vs telemetry overflow handling, adding dedicated metrics/logging for dropped commands, and surfacing these drops in the server loop.

Bug Fixes:
- Ensure command dispatch and ack DB writes are never evicted by telemetry overflow, only under genuine command overload on a separate error path.
- Prevent telemetry tasks from displacing queued command writes when the DB write queue is full of commands by rejecting excess telemetry instead.

Enhancements:
- Introduce separate accounting and rate-limited error logging for dropped command DB writes, distinct from telemetry drop reporting.
- Expose command drop counts in the server's periodic DB writer status logging.
- Add a helper to classify command vs telemetry tasks in the DB write queue for differentiated overflow policy.
- Extend the DB write test sink with a controllable gate to hold the queue in a known full state for deterministic testing.

Tests:
- Add regression tests confirming command dispatch and ack writes survive telemetry overflow without being dropped or miscounted.
- Add tests verifying command overload uses the command-specific drop counter and error log instead of the generic telemetry drop path.
- Add a test ensuring telemetry is rejected without evicting commands when the queue is full of command tasks.