### PR TITLE
feat(server): dispatch commands on a per-client writer thread

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -8,6 +8,8 @@
 #include <iostream>
 #include <memory>
 #include <mutex>
+#include <system_error>
+#include <thread>
 #include <utility>
 
 namespace fss = flight_safety_system;
@@ -176,10 +178,122 @@ void fss::server::fss_client::activate()
         this->activated_ms = this->clock->now_ms();
         this->activated = true;
     }
+    {
+        /* Start the outbound writer thread (todo/21) before wiring the handler,
+         * so it is ready for any send scheduled as a side effect of the first
+         * flushed message. */
+        std::scoped_lock guard(this->outbound_lock);
+        if (!this->outbound_started && !this->outbound_stopping)
+        {
+            this->outbound_started = true;
+            this->outbound_worker = std::thread(&fss_client::outboundWorkerRun, this);
+        }
+    }
     this->getConnection()->setHandler(this);
 }
 
-fss::server::fss_client::~fss_client() = default;
+void fss::server::fss_client::outboundWorkerRun()
+{
+    for (;;)
+    {
+        {
+            std::unique_lock<std::mutex> lock(this->outbound_lock);
+            this->outbound_cv.wait(lock,
+                                   [this]() -> bool { return this->outbound_stopping || this->out_command_pending; });
+            if (this->outbound_stopping)
+            {
+                /* Periodic sends are best-effort: a command not yet written will
+                 * be re-scheduled on the next tick if the client survives, and a
+                 * disconnecting client has nothing left to say. Exit promptly
+                 * rather than draining, so a join never waits on a send. */
+                return;
+            }
+            /* The only non-stop wake reason is a pending command. */
+            this->out_command_pending = false;
+        }
+        this->sendCommand();
+    }
+}
+
+void fss::server::fss_client::queueCommandSend()
+{
+    {
+        std::scoped_lock guard(this->outbound_lock);
+        if (this->outbound_stopping)
+        {
+            return;
+        }
+        this->out_command_pending = true;
+    }
+    this->outbound_cv.notify_one();
+}
+
+void fss::server::fss_client::requestOutboundStop()
+{
+    {
+        std::scoped_lock guard(this->outbound_lock);
+        if (this->outbound_stopping)
+        {
+            return;
+        }
+        this->outbound_stopping = true;
+    }
+    this->outbound_cv.notify_all();
+}
+
+void fss::server::fss_client::stopOutboundWorker()
+{
+    this->requestOutboundStop();
+    if (!this->outbound_worker.joinable())
+    {
+        return;
+    }
+    if (this->outbound_worker.get_id() == std::this_thread::get_id())
+    {
+        /* The worker must never join itself; detach so it can finish. This is
+         * not expected (the worker only performs sends, never disconnects), but
+         * mirrors the recv-thread guard in fss_connection::disconnect(). */
+        this->outbound_worker.detach();
+        this->outbound_worker = std::thread();
+        return;
+    }
+    try
+    {
+        this->outbound_worker.join();
+    }
+    catch (const std::system_error &e)
+    {
+        FSS_LOG_ERROR("server", "outbound_worker.join() failed, detaching: " << e.what());
+        this->outbound_worker.detach();
+        this->outbound_worker = std::thread();
+    }
+}
+
+void fss::server::fss_client::disconnect()
+{
+    /* Order matters (todo/21): signal the worker to stop, then close the socket
+     * so a worker blocked in a send() returns, then join it — all before the
+     * base class clears the connection. The worker only ever sees a non-null
+     * connection (its sends fail fast once the fd is closed), so it can never
+     * dereference a cleared connection. */
+    this->requestOutboundStop();
+    auto active_conn = this->getConnection();
+    if (active_conn != nullptr)
+    {
+        active_conn->disconnect(); // closes the fd (unblocking a stalled worker send) and joins the recv thread
+    }
+    this->stopOutboundWorker();
+    fss_message_cb::disconnect(); // a second disconnect() on the connection here is a safe no-op
+}
+
+fss::server::fss_client::~fss_client()
+{
+    /* Single teardown entry point: disconnect() stops the worker (closing the fd
+     * first so a blocked send returns) and clears the connection. It is
+     * idempotent, so this is safe whether or not disconnect() was already
+     * called. */
+    fss_client::disconnect();
+}
 
 auto fss::server::fss_client::isAircraft() -> bool
 {

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -6,11 +6,13 @@
 #include "rate-limiter.hpp"
 
 #include <atomic>
+#include <condition_variable>
 #include <memory>
 #include <stdexcept>
 #include <string>
 #include <list>
 #include <mutex>
+#include <thread>
 #include <vector>
 
 namespace flight_safety_system {
@@ -252,6 +254,31 @@ private:
      * (never reset); touched only on the recv thread (processMessage), used
      * to throttle the warning. */
     uint64_t duplicate_version_count{0};
+    /* Per-client outbound writer (todo/21). The server main loop schedules
+     * *what* to send by setting these pending flags; the worker thread does the
+     * actual blocking socket write, so one black-holed peer can only stall its
+     * own writer, never command dispatch or RTT handling for other clients.
+     * Flags coalesce — at most one of each kind is ever queued — which keeps the
+     * queue bounded and lets a command never sit behind stale periodic work.
+     * All four bools and the thread handle are guarded by outbound_lock. */
+    std::mutex outbound_lock{};
+    std::condition_variable outbound_cv{};
+    bool outbound_stopping{false};
+    bool outbound_started{false};
+    bool out_command_pending{false};
+    std::thread outbound_worker{};
+    /* The worker loop: waits for a pending flag, then performs the blocking
+     * send(s) off the main loop. */
+    void outboundWorkerRun();
+    /* Idempotent: set the stop flag and wake the worker. The single place that
+     * owns the stop signal, so disconnect() and stopOutboundWorker() cannot
+     * drift apart. */
+    void requestOutboundStop();
+    /* Idempotent: request the stop (above) and join the worker. Safe to call more
+     * than once and from any thread other than the worker itself. The caller must
+     * have already closed the connection's fd if the worker might be blocked in
+     * a socket send, otherwise the join can hang for the send timeout. */
+    void stopOutboundWorker();
 public:
     fss_client(std::shared_ptr<transport::fss_connection> conn, IDatabase *t_dbc,
                std::shared_ptr<db_write_queue> t_writer, fss_client_handler *t_handler);
@@ -263,6 +290,10 @@ public:
     /* Wire this client as the connection's message handler. Call only after
      * per-client config (timeout, rate limits) is set; see the constructor. */
     void activate();
+    /* Stops the per-client outbound writer thread and the connection (todo/21).
+     * Overrides fss_message_cb::disconnect so a stalled writer is unblocked and
+     * joined before the connection is torn down. */
+    void disconnect() override;
     void processMessage(std::shared_ptr<transport::fss_message> message) override;
     void sendRTTRequest(const std::shared_ptr<transport::fss_message_rtt_request> &rtt_req);
     /* Synchronous DB read; called from the command poller thread (and once
@@ -271,6 +302,12 @@ public:
     /* Sends the cached settings only; no DB access. */
     void sendSMMSettings();
     void sendCommand();
+    /* Schedule a command send on this client's outbound worker thread instead of
+     * sending inline (todo/21). Returns immediately; the worker performs the
+     * blocking write. The server main loop uses this so a stalled peer cannot
+     * delay command dispatch to other clients. No-op once disconnecting, or if
+     * the worker was never started (activate() starts it). */
+    void queueCommandSend();
     auto isAircraft() -> bool;
     auto getCachedAssetId() -> uint64_t { return this->cached_asset_id.load(); }
     /* The smoothed client↔server clock offset (ms; positive = client ahead)

--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -216,9 +216,12 @@ public:
     };
     void sendCommand()
     {
+        /* Schedule on each client's outbound writer thread rather than sending
+         * inline (todo/21): a peer with a black-holed socket can then only stall
+         * its own writer, never command dispatch for the other clients. */
         for (const auto &client : this->snapshotClients())
         {
-            client->sendCommand();
+            client->queueCommandSend();
         }
     };
     auto disconnectRevokedClients(const std::string &crl_file) -> std::size_t

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -10,10 +10,12 @@
 #error No catch header
 #endif
 
+#include <condition_variable>
 #include <cmath>
 #include <limits>
 #include <list>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -36,6 +38,11 @@ namespace {
  * back into an fss_message so tests can assert on outbound traffic. */
 class FakeConnection : public fss::transport::fss_connection {
 public:
+    /* sent/send_attempts are written by sendMsg, which the outbound writer
+     * thread (todo/21) may run; guard them with sent_lock so a test thread can
+     * observe them without racing. Synchronous tests that touch `sent` directly
+     * only ever do so on the same thread that called the send, so they stay
+     * race-free too. */
     std::vector<std::shared_ptr<fss::transport::fss_message>> sent{};
     std::list<std::string> cert_names{};
     /* When true, sendMsg() reports the socket write failed (as the real
@@ -53,10 +60,41 @@ public:
     ~FakeConnection() override = default;
 
     auto getClientNames() -> std::list<std::string> override { return cert_names; }
+
+    /* Block (true) or release (false) any in-flight or future sendMsg, modelling
+     * a peer whose socket has black-holed. Releasing wakes a blocked writer. */
+    void setBlocked(bool b)
+    {
+        {
+            std::scoped_lock guard(this->block_lock);
+            this->blocked = b;
+        }
+        this->block_cv.notify_all();
+    }
+
+    /* Thread-safe snapshot of the messages that actually went out. */
+    auto sentSnapshot() -> std::vector<std::shared_ptr<fss::transport::fss_message>>
+    {
+        std::scoped_lock guard(this->sent_lock);
+        return this->sent;
+    }
+
+    /* Releasing a blocked send is also needed when the connection is torn down,
+     * so a worker parked in sendMsg can exit and be joined. */
+    void disconnect() override
+    {
+        this->setBlocked(false);
+        fss::transport::fss_connection::disconnect();
+    }
 protected:
     auto sendMsg(const std::shared_ptr<fss::transport::buf_len> &bl) -> bool override
     {
+        {
+            std::unique_lock<std::mutex> lock(this->block_lock);
+            this->block_cv.wait(lock, [this]() -> bool { return !this->blocked; });
+        }
         auto msg = fss::transport::fss_message::decode(bl);
+        std::scoped_lock guard(this->sent_lock);
         if (msg != nullptr)
         {
             send_attempts.push_back(msg);
@@ -71,6 +109,11 @@ protected:
         }
         return true;
     }
+private:
+    std::mutex sent_lock{};
+    std::mutex block_lock{};
+    std::condition_variable block_cv{};
+    bool blocked{false};
 };
 
 /* Return the first message in `sent` (at or after `from`) that decoded to a T,
@@ -502,6 +545,78 @@ TEST_CASE("session: a successful command send records exactly one dispatch and s
     REQUIRE(count_sent<fss::transport::fss_message_asset_command>(conn->sent) == 1);
     REQUIRE(fss_test::wait_for([&]() -> bool { return mock.getDispatches().size() == 1; }));
     REQUIRE(mock.getDispatches().front().command_dbid == 88);
+}
+
+TEST_CASE("session: queueCommandSend dispatches a command on the outbound worker thread")
+{
+    /* todo/21: the server main loop schedules a command via queueCommandSend()
+     * and returns immediately; the per-client writer thread performs the actual
+     * send. Verify the command does reach the wire via that thread. */
+    fss_test::MockDatabase mock;
+    constexpr uint64_t asset_id = 21;
+    mock.asset_ids["craft"] = asset_id;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+    session->activate(); /* starts the outbound writer thread */
+
+    session->setPendingCommand(
+        std::make_shared<fss::server::asset_command>(/*dbid*/ 57, /*ts*/ 500, "RTL", 0.0, 0.0, 0));
+    session->queueCommandSend();
+
+    REQUIRE(fss_test::wait_for(
+        [&]() -> bool { return count_sent<fss::transport::fss_message_asset_command>(conn->sentSnapshot()) == 1; }));
+
+    session->disconnect();
+}
+
+TEST_CASE("session: a blocked client's writer does not stall command dispatch for another client")
+{
+    /* todo/21 Done-when: a black-holed socket on one client must not delay
+     * command dispatch for unrelated clients. Block client A's writer mid-send,
+     * then dispatch to client B and require B's command to go out regardless. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["alpha"] = 1;
+    mock.asset_ids["bravo"] = 2;
+    NullClientHandler handler;
+
+    auto conn_a = std::make_shared<FakeConnection>();
+    conn_a->cert_names.push_back("alpha");
+    auto writer_a = make_mock_writer(mock);
+    auto client_a = std::make_shared<fss::server::fss_client>(conn_a, &mock, writer_a, &handler);
+    client_a->processMessage(std::make_shared<fss::transport::fss_message_identity>("alpha"));
+    client_a->activate();
+
+    auto conn_b = std::make_shared<FakeConnection>();
+    conn_b->cert_names.push_back("bravo");
+    auto writer_b = make_mock_writer(mock);
+    auto client_b = std::make_shared<fss::server::fss_client>(conn_b, &mock, writer_b, &handler);
+    client_b->processMessage(std::make_shared<fss::transport::fss_message_identity>("bravo"));
+    client_b->activate();
+
+    /* A's socket black-holes: its writer thread will park inside send(). */
+    conn_a->setBlocked(true);
+    client_a->setPendingCommand(
+        std::make_shared<fss::server::asset_command>(/*dbid*/ 10, /*ts*/ 500, "RTL", 0.0, 0.0, 0));
+    client_a->queueCommandSend();
+
+    /* B's command must still be delivered while A's writer is stuck. */
+    client_b->setPendingCommand(
+        std::make_shared<fss::server::asset_command>(/*dbid*/ 20, /*ts*/ 500, "HOLD", 0.0, 0.0, 0));
+    client_b->queueCommandSend();
+
+    REQUIRE(fss_test::wait_for(
+        [&]() -> bool { return count_sent<fss::transport::fss_message_asset_command>(conn_b->sentSnapshot()) == 1; }));
+    /* A's command has not gone out — its writer is blocked, not crashed. */
+    REQUIRE(count_sent<fss::transport::fss_message_asset_command>(conn_a->sentSnapshot()) == 0);
+
+    /* disconnect() releases the block and joins A's writer cleanly. */
+    client_a->disconnect();
+    client_b->disconnect();
 }
 
 TEST_CASE("session: a freshly queued command is delivered after the poller updates the cache")


### PR DESCRIPTION
## Description

todo/21 (commit 1/3): the server main loop called clients->sendCommand() inline, doing a blocking socket write per client. One black-holed peer could stall command dispatch for every other client for up to the TCP_USER_TIMEOUT (~30 s).

Give each fss_client an outbound writer thread. The main loop now schedules a command with queueCommandSend() (sets a coalescing pending flag and returns immediately); the writer thread performs the blocking send off the main loop. A stalled peer can therefore only stall its own writer.

The writer just runs the existing sendCommand() body, so item 19's "record dispatch only after a successful send" stays synchronous and intact. Lifecycle: the thread starts in activate() and is torn down in a new disconnect() override and the destructor — both close the fd first so a writer parked in send() returns, then join it before the connection is cleared, so the worker never sees a null connection. send_lock already makes each sendMsg atomic, so an extra sender thread does not affect message-id/wire ordering.

Tests: FakeConnection gains thread-safe send capture and a blockable send. New regression tests cover async dispatch via the worker and the core guarantee — a blocked client's writer does not stall another client's command dispatch.

## Summary by Sourcery

Route per-client command sends through a dedicated outbound writer thread so a blocked socket cannot stall other clients, and add tests and test infrastructure to validate the new asynchronous dispatch behavior.

New Features:
- Introduce a per-client outbound writer thread that performs blocking command sends off the main server loop.
- Add a queueCommandSend API so the server schedules command dispatch asynchronously per client instead of sending inline.

Bug Fixes:
- Ensure a black-holed client socket can no longer stall command dispatch or RTT handling for other clients by isolating blocking sends to that client's writer thread.

Enhancements:
- Override client disconnect and destructor logic to cleanly stop, unblock, and join the outbound writer thread without racing the connection teardown.
- Extend the FakeConnection test double with thread-safe send tracking and controllable blocking to simulate stalled peers.

Tests:
- Add regression tests to verify commands are dispatched via the outbound writer thread and that a blocked client writer does not delay dispatch to other clients.