### PR TITLE
feat(server): schedule RTT requests on the per-client writer thread

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -192,26 +192,49 @@ void fss::server::fss_client::activate()
     this->getConnection()->setHandler(this);
 }
 
+auto fss::server::fss_client::waitForOutboundWork() -> fss::server::fss_client::outbound_work
+{
+    std::unique_lock<std::mutex> lock(this->outbound_lock);
+    this->outbound_cv.wait(lock, [this]() -> bool {
+        return this->outbound_stopping || this->out_command_pending || this->out_rtt_pending;
+    });
+    outbound_work work;
+    if (this->outbound_stopping)
+    {
+        work.stop = true;
+        return work;
+    }
+    work.command = this->out_command_pending;
+    work.rtt = this->out_rtt_pending;
+    this->out_command_pending = false;
+    this->out_rtt_pending = false;
+    return work;
+}
+
 void fss::server::fss_client::outboundWorkerRun()
 {
     for (;;)
     {
+        auto work = this->waitForOutboundWork();
+        /* Periodic sends are best-effort: anything not yet written is
+         * re-scheduled on the next tick if the client survives, and a
+         * disconnecting client has nothing left to say. Exit promptly on stop so
+         * a join never waits on a send. */
+        if (work.stop)
         {
-            std::unique_lock<std::mutex> lock(this->outbound_lock);
-            this->outbound_cv.wait(lock,
-                                   [this]() -> bool { return this->outbound_stopping || this->out_command_pending; });
-            if (this->outbound_stopping)
-            {
-                /* Periodic sends are best-effort: a command not yet written will
-                 * be re-scheduled on the next tick if the client survives, and a
-                 * disconnecting client has nothing left to say. Exit promptly
-                 * rather than draining, so a join never waits on a send. */
-                return;
-            }
-            /* The only non-stop wake reason is a pending command. */
-            this->out_command_pending = false;
+            return;
         }
-        this->sendCommand();
+        /* Commands are the highest priority — send them before periodic RTT. */
+        if (work.command)
+        {
+            this->sendCommand();
+        }
+        if (work.rtt)
+        {
+            /* A fresh request per client: never a shared instance (see the C8
+             * invariant on fss_connection::sendMsg). */
+            this->sendRTTRequest(std::make_shared<fss::transport::fss_message_rtt_request>());
+        }
     }
 }
 
@@ -224,6 +247,19 @@ void fss::server::fss_client::queueCommandSend()
             return;
         }
         this->out_command_pending = true;
+    }
+    this->outbound_cv.notify_one();
+}
+
+void fss::server::fss_client::queueRTTRequest()
+{
+    {
+        std::scoped_lock guard(this->outbound_lock);
+        if (this->outbound_stopping)
+        {
+            return;
+        }
+        this->out_rtt_pending = true;
     }
     this->outbound_cv.notify_one();
 }

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -266,9 +266,20 @@ private:
     bool outbound_stopping{false};
     bool outbound_started{false};
     bool out_command_pending{false};
+    bool out_rtt_pending{false};
     std::thread outbound_worker{};
-    /* The worker loop: waits for a pending flag, then performs the blocking
-     * send(s) off the main loop. */
+    /* What the worker should do this wake-up. Returned by waitForOutboundWork so
+     * the worker performs the (blocking) sends with no lock held. */
+    struct outbound_work {
+        bool stop{false};
+        bool command{false};
+        bool rtt{false};
+    };
+    /* Block until there is work or a stop request, then atomically take and clear
+     * the pending flags. */
+    auto waitForOutboundWork() -> outbound_work;
+    /* The worker loop: waits for work, then performs the blocking send(s) off the
+     * main loop. */
     void outboundWorkerRun();
     /* Idempotent: set the stop flag and wake the worker. The single place that
      * owns the stop signal, so disconnect() and stopOutboundWorker() cannot
@@ -308,6 +319,11 @@ public:
      * delay command dispatch to other clients. No-op once disconnecting, or if
      * the worker was never started (activate() starts it). */
     void queueCommandSend();
+    /* Schedule an RTT request on this client's outbound worker thread (todo/21).
+     * The worker builds a fresh rtt_request per client — the request instance is
+     * never shared across connections, so the per-connection id stamp cannot
+     * race (the C8 invariant). Returns immediately; no-op once disconnecting. */
+    void queueRTTRequest();
     auto isAircraft() -> bool;
     auto getCachedAssetId() -> uint64_t { return this->cached_asset_id.load(); }
     /* The smoothed client↔server clock offset (ms; positive = client ahead)

--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -196,11 +196,15 @@ public:
         std::scoped_lock guard(this->lock);
         return this->cached_server_list;
     };
-    void sendRTTRequest(const std::shared_ptr<flight_safety_system::transport::fss_message_rtt_request> &rtt_req)
+    void sendRTTRequest()
     {
+        /* Schedule on each client's outbound writer thread (todo/21). Each client
+         * builds its own request, so there is no shared rtt_request instance to
+         * race the per-connection id stamp, and a stalled peer cannot hold up RTT
+         * scheduling for the others. */
         for (const auto &client : this->snapshotClients())
         {
-            client->sendRTTRequest(rtt_req);
+            client->queueRTTRequest();
         }
     };
     void pollCommands(flight_safety_system::server::IDatabase *dbc)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -344,8 +344,7 @@ auto main(int argc, char *argv[]) -> int
             {
                 clients->cleanupRemovableClients();
                 clients->checkTimeouts();
-                auto rtt_req = std::make_shared<flight_safety_system::transport::fss_message_rtt_request>();
-                clients->sendRTTRequest(rtt_req);
+                clients->sendRTTRequest();
                 static uint64_t last_failure_count = 0;
                 uint64_t current_failures = writer->write_failure_count();
                 if (current_failures != last_failure_count)

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -619,6 +619,29 @@ TEST_CASE("session: a blocked client's writer does not stall command dispatch fo
     client_b->disconnect();
 }
 
+TEST_CASE("session: queueRTTRequest sends an RTT request on the outbound worker thread")
+{
+    /* todo/21: RTT requests are scheduled on the writer thread too, each client
+     * building its own request instance. Verify one reaches the wire. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 3;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+    session->activate();
+
+    REQUIRE(count_sent<fss::transport::fss_message_rtt_request>(conn->sentSnapshot()) == 0);
+    session->queueRTTRequest();
+    REQUIRE(fss_test::wait_for(
+        [&]() -> bool { return count_sent<fss::transport::fss_message_rtt_request>(conn->sentSnapshot()) == 1; }));
+
+    session->disconnect();
+}
+
 TEST_CASE("session: a freshly queued command is delivered after the poller updates the cache")
 {
     /* Commands are delivered in two steps: the background poller fetches


### PR DESCRIPTION
## Description

todo/21 (commit 2/3): the main loop built one rtt_request and sent it to every client inline, each doing a blocking write. A black-holed peer could stall RTT scheduling — and the timeout checks that follow it — for all clients.

RTT requests now go through each client's outbound writer thread via queueRTTRequest(). The worker builds a fresh rtt_request per client, so no request instance is shared across connections (the C8 id-stamp invariant holds), and the read-back of the assigned id in sendRTTRequest still runs synchronously on that same worker thread. server_clients::sendRTTRequest() and the main loop no longer construct or fan out a shared request.

The worker's pending flags are now taken via an out-of-line waitForOutboundWork() helper that returns which work to do, dispatching commands before RTT.

Test: queueRTTRequest delivers an rtt_request via the worker thread.

## Summary by Sourcery

Schedule RTT requests per client on their outbound writer threads instead of sending a shared request from the main loop, ensuring blocking writes happen off the main thread and cannot stall other clients.

New Features:
- Add per-client queueing of RTT requests to be processed by each client's outbound worker thread.

Enhancements:
- Extend the outbound worker to handle both command and RTT work via a unified waitForOutboundWork helper that atomically consumes pending flags and prioritizes commands over RTT sends.

Tests:
- Add a server session test verifying that queueRTTRequest results in an RTT request being sent via the outbound worker thread.