### PR TITLE
feat(server): schedule SMM-settings sends on the per-client writer thread

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -196,7 +196,7 @@ auto fss::server::fss_client::waitForOutboundWork() -> fss::server::fss_client::
 {
     std::unique_lock<std::mutex> lock(this->outbound_lock);
     this->outbound_cv.wait(lock, [this]() -> bool {
-        return this->outbound_stopping || this->out_command_pending || this->out_rtt_pending;
+        return this->outbound_stopping || this->out_command_pending || this->out_rtt_pending || this->out_smm_pending;
     });
     outbound_work work;
     if (this->outbound_stopping)
@@ -206,8 +206,10 @@ auto fss::server::fss_client::waitForOutboundWork() -> fss::server::fss_client::
     }
     work.command = this->out_command_pending;
     work.rtt = this->out_rtt_pending;
+    work.smm = this->out_smm_pending;
     this->out_command_pending = false;
     this->out_rtt_pending = false;
+    this->out_smm_pending = false;
     return work;
 }
 
@@ -235,6 +237,10 @@ void fss::server::fss_client::outboundWorkerRun()
              * invariant on fss_connection::sendMsg). */
             this->sendRTTRequest(std::make_shared<fss::transport::fss_message_rtt_request>());
         }
+        if (work.smm)
+        {
+            this->sendSMMSettings();
+        }
     }
 }
 
@@ -260,6 +266,19 @@ void fss::server::fss_client::queueRTTRequest()
             return;
         }
         this->out_rtt_pending = true;
+    }
+    this->outbound_cv.notify_one();
+}
+
+void fss::server::fss_client::queueSMMSettings()
+{
+    {
+        std::scoped_lock guard(this->outbound_lock);
+        if (this->outbound_stopping)
+        {
+            return;
+        }
+        this->out_smm_pending = true;
     }
     this->outbound_cv.notify_one();
 }

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -267,6 +267,7 @@ private:
     bool outbound_started{false};
     bool out_command_pending{false};
     bool out_rtt_pending{false};
+    bool out_smm_pending{false};
     std::thread outbound_worker{};
     /* What the worker should do this wake-up. Returned by waitForOutboundWork so
      * the worker performs the (blocking) sends with no lock held. */
@@ -274,6 +275,7 @@ private:
         bool stop{false};
         bool command{false};
         bool rtt{false};
+        bool smm{false};
     };
     /* Block until there is work or a stop request, then atomically take and clear
      * the pending flags. */
@@ -324,6 +326,9 @@ public:
      * never shared across connections, so the per-connection id stamp cannot
      * race (the C8 invariant). Returns immediately; no-op once disconnecting. */
     void queueRTTRequest();
+    /* Schedule a cached-SMM-settings send on this client's outbound worker
+     * thread (todo/21). Returns immediately; no-op once disconnecting. */
+    void queueSMMSettings();
     auto isAircraft() -> bool;
     auto getCachedAssetId() -> uint64_t { return this->cached_asset_id.load(); }
     /* The smoothed client↔server clock offset (ms; positive = client ahead)

--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -171,10 +171,12 @@ public:
     };
     void sendSMMSettings()
     {
-        /* Sends cached settings only; the poller refreshes the caches. */
+        /* Sends cached settings only; the poller refreshes the caches. Scheduled
+         * on each client's outbound writer thread (todo/21) so a stalled peer
+         * cannot hold up the periodic config push to the others. */
         for (const auto &client : this->snapshotClients())
         {
-            client->sendSMMSettings();
+            client->queueSMMSettings();
         }
     };
     /* Synchronous DB reads; poller thread only — see the main-loop DB

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -1597,6 +1597,34 @@ TEST_CASE("session: sendSMMSettings sends smm_settings message when db returns s
     REQUIRE(find_sent<fss::transport::fss_message_smm_settings>(conn->sent) != nullptr);
 }
 
+TEST_CASE("session: queueSMMSettings sends cached settings on the outbound worker thread")
+{
+    /* todo/21: the periodic SMM-settings push is scheduled on the writer thread
+     * too. Verify a queued send reaches the wire via that thread. */
+    fss_test::MockDatabase mock;
+    constexpr uint64_t asset_id = 13;
+    mock.asset_ids["craft"] = asset_id;
+    mock.smm[asset_id] = std::make_shared<fss::server::smm_settings>("https://smm.test", fss::secure_string{"u"},
+                                                                     fss::secure_string{"p"});
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+    session->activate();
+
+    /* identify already pushed one set of settings synchronously. */
+    const std::size_t before = count_sent<fss::transport::fss_message_smm_settings>(conn->sentSnapshot());
+    session->queueSMMSettings();
+    REQUIRE(fss_test::wait_for([&]() -> bool {
+        return count_sent<fss::transport::fss_message_smm_settings>(conn->sentSnapshot()) == before + 1;
+    }));
+
+    session->disconnect();
+}
+
 TEST_CASE("MonotonicClock: now_ms is non-decreasing")
 {
     /* Sanity check: two back-to-back calls must return a non-decreasing


### PR DESCRIPTION
## Description

todo/21 (commit 3/3): the periodic SMM-settings push was the last main-loop send still done inline per client. Route it through the outbound writer thread via queueSMMSettings() so a black-holed peer can only stall its own writer, completing the decoupling of the main loop from socket write latency for the per-client periodic sends (command, RTT, SMM).

Broadcast (server list / position-report fan-out) is intentionally left synchronous for now: it shares one fss_message instance across connections, so making it async needs per-client message copies — a larger change, and out of scope for the item's command/RTT Done-when.

Test: queueSMMSettings delivers a cached settings message via the worker.

## Summary by Sourcery

Route periodic SMM settings sends through each client’s outbound writer thread to decouple the main loop from per-client socket latency.

Enhancements:
- Add a queued SMM-settings send path on fss_client, tracked via an outbound work flag and processed by the outbound worker thread.
- Change the server-wide SMM settings broadcaster to schedule per-client sends asynchronously via queueSMMSettings instead of sending inline from the main loop.

Tests:
- Add a session test verifying that queueSMMSettings delivers cached SMM settings via the outbound worker thread.