### PR TITLE
fix(server): throttle out-of-order/duplicate message warning

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -730,8 +730,20 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
         {
             if (msg->getSeq() != wanted)
             {
-                FSS_LOG_WARN("server",
-                             "Out-of-order or duplicate message seq=" << msg->getSeq() << " expected=" << wanted);
+                /* This check runs before the rate limiter, so a peer that
+                 * deliberately or buggily sends wrong sequence numbers would
+                 * otherwise hit this WARN once per message at line rate.
+                 * Throttle to first + every 100th (matching the duplicate-
+                 * version and null-frame paths) so one misbehaving peer cannot
+                 * flood the log. */
+                ++this->out_of_order_count;
+                constexpr uint64_t log_every = 100;
+                if (this->out_of_order_count == 1 || (this->out_of_order_count % log_every) == 0)
+                {
+                    FSS_LOG_WARN("server", "Out-of-order or duplicate message seq="
+                                               << msg->getSeq() << " expected=" << wanted
+                                               << " (count=" << this->out_of_order_count << ")");
+                }
                 if (msg->getType() == fss::transport::message_type_identity ||
                     msg->getType() == fss::transport::message_type_identity_non_aircraft)
                 {

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -254,6 +254,11 @@ private:
      * (never reset); touched only on the recv thread (processMessage), used
      * to throttle the warning. */
     uint64_t duplicate_version_count{0};
+    /* Cumulative out-of-order / duplicate (v2 sequence) messages seen this
+     * session (never reset); touched only on the recv thread (processMessage),
+     * used to throttle the warning so a peer streaming wrong sequence numbers
+     * cannot flood the log (the seq check runs before the rate limiter). */
+    uint64_t out_of_order_count{0};
     /* Per-client outbound writer (todo/21). The server main loop schedules
      * *what* to send by setting these pending flags; the worker thread does the
      * actual blocking socket write, so one black-holed peer can only stall its


### PR DESCRIPTION
## Description

The v2 in-order sequence check runs before the per-client rate limiter, so an authenticated peer streaming wrong sequence numbers would hit this WARN once per message at line rate — a log-flood from a single misbehaving peer. Throttle it to first + every 100th (matching the duplicate-version and null-frame paths) via a recv-thread-only counter.

## Summary by Sourcery

Throttle server logging for out-of-order or duplicate v2 sequence messages to prevent log flooding from misbehaving peers.

Bug Fixes:
- Limit the frequency of the out-of-order or duplicate message warning so a single client sending bad sequence numbers cannot flood the logs.

Enhancements:
- Track a per-session count of out-of-order or duplicate v2 sequence messages for use in warning throttling.