### PR TITLE
Validate configured TCP ports

### DIFF
--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -12,6 +12,30 @@
 #include <json/json.h>
 #pragma GCC diagnostic pop
 
+namespace {
+
+constexpr int min_tcp_port = 1;
+constexpr int max_tcp_port = 65535;
+
+auto read_server_port(const Json::Value &server, unsigned int idx, uint16_t &out) -> bool
+{
+    if (!server.isMember("port") || !server["port"].isInt())
+    {
+        FSS_LOG_ERROR("client", "Invalid server config at index " << idx << ": port must be an integer TCP port");
+        return false;
+    }
+    int port = server["port"].asInt();
+    if (port < min_tcp_port || port > max_tcp_port)
+    {
+        FSS_LOG_ERROR("client", "Invalid server config at index " << idx << ": port " << port << " is outside 1-65535");
+        return false;
+    }
+    out = static_cast<uint16_t>(port);
+    return true;
+}
+
+} // namespace
+
 flight_safety_system::client_ssl::fss_client::fss_client(const std::string &t_fileName)
 {
     /* Open the config file */
@@ -39,9 +63,14 @@ flight_safety_system::client_ssl::fss_client::fss_client(const std::string &t_fi
         /* Load all the known servers from the config */
         for (unsigned int idx = 0; idx < config["servers"].size(); idx++)
         {
+            uint16_t port = 0;
+            if (!read_server_port(config["servers"][idx], idx, port))
+            {
+                continue;
+            }
             auto server = std::make_shared<flight_safety_system::client_ssl::fss_server>(
-                this, config["servers"][idx]["address"].asString(), config["servers"][idx]["port"].asInt(),
-                this->ca_file, this->private_key_file, this->public_key_file);
+                this, config["servers"][idx]["address"].asString(), port, this->ca_file, this->private_key_file,
+                this->public_key_file);
             this->addServer(server);
         }
     }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -29,6 +29,29 @@ namespace flight_safety_system::server {
 auto build_server_list_msg(IDatabase *dbc) -> std::shared_ptr<transport::fss_message_server_list>;
 } // namespace flight_safety_system::server
 
+namespace {
+
+constexpr int min_tcp_port = 1;
+constexpr int max_tcp_port = 65535;
+
+auto read_tcp_port(const Json::Value &node, const char *path, int &out) -> bool
+{
+    if (!node.isInt())
+    {
+        FSS_LOG_ERROR("server", "Invalid config field " << path << ": must be an integer TCP port");
+        return false;
+    }
+    int port = node.asInt();
+    if (port < min_tcp_port || port > max_tcp_port)
+    {
+        FSS_LOG_ERROR("server", "Invalid config field " << path << ": " << port << " is outside 1-65535");
+        return false;
+    }
+    out = port;
+    return true;
+}
+
+} // namespace
 
 volatile sig_atomic_t running = 1;
 volatile sig_atomic_t reload_crl = 0;
@@ -141,10 +164,16 @@ auto main(int argc, char *argv[]) -> int
             return 1;
         }
 
-        listen_port = config["port"].asInt();
+        if (!read_tcp_port(config["port"], "port", listen_port))
+        {
+            return 1;
+        }
         if (config["postgres"].isMember("port"))
         {
-            pg_port = config["postgres"]["port"].asInt();
+            if (!read_tcp_port(config["postgres"]["port"], "postgres.port", pg_port))
+            {
+                return 1;
+            }
         }
         pg_host = config["postgres"]["host"].asString();
         pg_user = config["postgres"]["user"].asString();

--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -118,6 +118,28 @@ TEST_CASE("client: malformed JSON config leaves client unconfigured")
     std::remove(tmppath);
 }
 
+TEST_CASE("client: config file skips server entries with invalid ports")
+{
+    const char *tmppath = "/tmp/fss_test_client_bad_port.json";
+    {
+        std::ofstream f(tmppath);
+        f << R"({
+            "name": "test-asset",
+            "ssl": {
+                "ca_public_key": "ca.pem",
+                "client_private_key": "client.key",
+                "client_public_key": "client.pem"
+            },
+            "servers": [
+                {"address": "localhost", "port": 70000}
+            ]
+        })";
+    }
+    fss::client_ssl::fss_client client(tmppath);
+    REQUIRE_FALSE(client.isConfigured());
+    std::remove(tmppath);
+}
+
 /* Exposes the protected config setter so a test can drive the programmatic
  * (non-file) configuration path. */
 class ProgrammaticClient : public fss::client_ssl::fss_client {


### PR DESCRIPTION
## Summary by Sourcery

Validate TCP port values in client and server configuration and enforce behavior on invalid ports.

Bug Fixes:
- Prevent client from accepting non-integer or out-of-range server TCP ports in its configuration.
- Prevent server and database listener ports from being configured with non-integer or out-of-range TCP port values, exiting on invalid configs.

Tests:
- Add client configuration test ensuring invalid server ports cause the client to remain unconfigured.