### PR TITLE
fix(server): release client_lock before blocking sends in sendCommand/RTTRequest

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -369,91 +369,129 @@ void fss::server::fss_client::setPendingCommand(std::shared_ptr<fss::server::ass
 
 void fss::server::fss_client::sendCommand()
 {
-    std::scoped_lock guard(this->client_lock);
-    if (this->cached_asset_id.load() == 0)
-    {
-        return;
-    }
-    uint64_t ts = this->clock->now_ms();
-    auto ac = this->pending_command;
-    if (ac == nullptr)
-    {
-        return;
-    }
-    constexpr int timeout_time = 10 * sec_to_msec;
-    bool is_new_command = ac->getDBId() != this->last_command_dbid;
-    bool resend_window_expired = ts > (this->last_command_send_ts + timeout_time);
-    if (!is_new_command && !resend_window_expired)
-    {
-        /* Same command we last handled and still inside the resend window. */
-        return;
-    }
-    /* Mark a command as handled for the current resend window: applied on a
-     * successful dispatch, and on a permanent validation rejection below (which
-     * can never succeed, so re-evaluating it every tick would only spam the
-     * log). Deliberately NOT applied on a transient send failure, which must
-     * stay eligible for retry on the next send tick. Takes the timestamp and
-     * dbid explicitly so the state it writes is visible at each call. */
-    auto mark_handled = [this](uint64_t handled_ts, uint64_t handled_dbid) -> void {
-        this->last_command_send_ts = handled_ts;
-        this->last_command_dbid = handled_dbid;
-    };
-    auto command = ac->getCommand();
-    if (command == fss::transport::asset_command_unknown)
-    {
-        mark_handled(ts, ac->getDBId());
-        FSS_LOG_ERROR("server", "Refusing to dispatch unknown command type to " << this->name
-                                                                                << " (dbid=" << ac->getDBId() << ")");
-        return;
-    }
-    if (command == fss::transport::asset_command_goto && !is_valid_coordinate(ac->getLatitude(), ac->getLongitude()))
-    {
-        mark_handled(ts, ac->getDBId());
-        FSS_LOG_ERROR("server", "Refusing to dispatch GOTO command with invalid coordinates to "
-                                    << this->name << " (dbid=" << ac->getDBId() << ", lat=" << ac->getLatitude()
-                                    << ", lon=" << ac->getLongitude() << ")");
-        return;
-    }
-    if (command == fss::transport::asset_command_altitude && !ac->isAltitudeValid())
-    {
-        /* A NULL altitude must not dispatch as 0 — that is a
-         * descend-to-ground instruction. */
-        mark_handled(ts, ac->getDBId());
-        FSS_LOG_ERROR("server", "Refusing to dispatch ALT command with NULL altitude to "
-                                    << this->name << " (dbid=" << ac->getDBId() << ")");
-        return;
-    }
+    /* todo/35: the dbid/resend-window checks and validation run under
+     * client_lock, but the send itself must not — a black-holed peer can
+     * block sendMsg() for up to TCP_USER_TIMEOUT, and isTimedOut() (called
+     * every main-loop tick, for every client) takes the same lock. Holding it
+     * across the send would freeze the whole fleet's command cadence behind
+     * one stuck peer. */
     std::shared_ptr<fss::transport::fss_message_asset_command> msg = nullptr;
-    switch (command)
+    uint64_t ts = 0;
+    uint64_t dbid = 0;
+    std::string client_name;
+    uint64_t prev_send_ts = 0;
+    uint64_t prev_dbid = 0;
     {
-        case fss::transport::asset_command_goto:
-            msg = std::make_shared<fss::transport::fss_message_asset_command>(command, ac->getTimeStamp(),
-                                                                              ac->getLatitude(), ac->getLongitude());
-            break;
-        case fss::transport::asset_command_altitude:
-            msg = std::make_shared<fss::transport::fss_message_asset_command>(command, ac->getTimeStamp(),
-                                                                              ac->getAltitude());
-            break;
-        default: msg = std::make_shared<fss::transport::fss_message_asset_command>(command, ac->getTimeStamp()); break;
-    }
+        std::scoped_lock guard(this->client_lock);
+        if (this->cached_asset_id.load() == 0)
+        {
+            return;
+        }
+        ts = this->clock->now_ms();
+        auto ac = this->pending_command;
+        if (ac == nullptr)
+        {
+            return;
+        }
+        client_name = this->name;
+        constexpr int timeout_time = 10 * sec_to_msec;
+        dbid = ac->getDBId();
+        bool is_new_command = dbid != this->last_command_dbid;
+        bool resend_window_expired = ts > (this->last_command_send_ts + timeout_time);
+        if (!is_new_command && !resend_window_expired)
+        {
+            /* Same command we last handled and still inside the resend window. */
+            return;
+        }
+        /* Mark a command as handled for the current resend window: applied on a
+         * permanent validation rejection below (which can never succeed, so
+         * re-evaluating it every tick would only spam the log). Deliberately
+         * NOT applied on a transient send failure, which must stay eligible
+         * for retry on the next send tick. */
+        auto mark_handled = [this](uint64_t handled_ts, uint64_t handled_dbid) -> void {
+            this->last_command_send_ts = handled_ts;
+            this->last_command_dbid = handled_dbid;
+        };
+        auto command = ac->getCommand();
+        if (command == fss::transport::asset_command_unknown)
+        {
+            mark_handled(ts, dbid);
+            FSS_LOG_ERROR("server",
+                          "Refusing to dispatch unknown command type to " << client_name << " (dbid=" << dbid << ")");
+            return;
+        }
+        if (command == fss::transport::asset_command_goto &&
+            !is_valid_coordinate(ac->getLatitude(), ac->getLongitude()))
+        {
+            mark_handled(ts, dbid);
+            FSS_LOG_ERROR("server", "Refusing to dispatch GOTO command with invalid coordinates to "
+                                        << client_name << " (dbid=" << dbid << ", lat=" << ac->getLatitude()
+                                        << ", lon=" << ac->getLongitude() << ")");
+            return;
+        }
+        if (command == fss::transport::asset_command_altitude && !ac->isAltitudeValid())
+        {
+            /* A NULL altitude must not dispatch as 0 — that is a
+             * descend-to-ground instruction. */
+            mark_handled(ts, dbid);
+            FSS_LOG_ERROR("server", "Refusing to dispatch ALT command with NULL altitude to "
+                                        << client_name << " (dbid=" << dbid << ")");
+            return;
+        }
+        switch (command)
+        {
+            case fss::transport::asset_command_goto:
+                msg = std::make_shared<fss::transport::fss_message_asset_command>(
+                    command, ac->getTimeStamp(), ac->getLatitude(), ac->getLongitude());
+                break;
+            case fss::transport::asset_command_altitude:
+                msg = std::make_shared<fss::transport::fss_message_asset_command>(command, ac->getTimeStamp(),
+                                                                                  ac->getAltitude());
+                break;
+            default:
+                msg = std::make_shared<fss::transport::fss_message_asset_command>(command, ac->getTimeStamp());
+                break;
+        }
+        /* Claim the resend window now, atomically with the check above, not
+         * after the send returns: the recv thread can also call sendCommand()
+         * directly (identify handling) while this outbound-worker call is
+         * still mid-flight in the blocking send below, and without an
+         * immediate claim both calls would see the stale (pre-send)
+         * last_command_dbid/ts and dispatch the same command twice. Rolled
+         * back on send failure, below, so a transient failure still retries
+         * on the very next tick rather than waiting out the resend window. */
+        prev_send_ts = this->last_command_send_ts;
+        prev_dbid = this->last_command_dbid;
+        this->last_command_send_ts = ts;
+        this->last_command_dbid = dbid;
+    } // client_lock released before the blocking send
+
     if (!this->getConnection()->sendMsg(msg))
     {
         /* The socket write failed, so the command never reached the aircraft.
-         * Do not record a dispatch and do not advance the resend window: the
-         * command must be retried on the next send tick rather than appearing in
-         * the DB as dispatched. A genuinely dead connection is reaped separately
-         * by the recv thread's closed-message path. */
-        FSS_LOG_WARN("server", "Failed to send command dbid=" << ac->getDBId() << " to " << this->name
-                                                              << "; will retry on next tick");
+         * Undo the claim above so the command is retried on the next send tick
+         * rather than appearing in the DB as dispatched — but only if nobody
+         * else has since claimed a newer command; otherwise leave their claim
+         * alone. A genuinely dead connection is reaped separately by the recv
+         * thread's closed-message path. */
+        {
+            std::scoped_lock guard(this->client_lock);
+            if (this->last_command_dbid == dbid && this->last_command_send_ts == ts)
+            {
+                this->last_command_dbid = prev_dbid;
+                this->last_command_send_ts = prev_send_ts;
+            }
+        }
+        FSS_LOG_WARN("server",
+                     "Failed to send command dbid=" << dbid << " to " << client_name << "; will retry on next tick");
         return;
     }
-    mark_handled(ts, ac->getDBId());
     /* sendMsg stamped the per-connection message id into msg; record it against
      * the command row (cached_asset_id is non-zero here — the early return above
      * guarantees it) so a later ack, which echoes this id as acked_command_id,
      * can be matched back to this specific command. */
-    this->writer->enqueue(command_dispatch_write{ac->getDBId(), msg->getId()});
-    FSS_LOG_INFO("server", "dispatched command dbid=" << ac->getDBId() << " to " << this->name);
+    this->writer->enqueue(command_dispatch_write{dbid, msg->getId()});
+    FSS_LOG_INFO("server", "dispatched command dbid=" << dbid << " to " << client_name);
 }
 
 void fss::server::fss_client::setClock(std::shared_ptr<fss::IClock> t_clock)
@@ -517,44 +555,37 @@ auto fss::server::fss_client::isTimedOut() -> bool
 
 void fss::server::fss_client::sendRTTRequest(const std::shared_ptr<fss::transport::fss_message_rtt_request> &rtt_req)
 {
+    /* todo/35: as in sendCommand(), client_lock must not be held across the
+     * blocking send. Unlike sendCommand, the outstanding-request bookkeeping
+     * must be keyed by the message id sendMsg() stamps onto rtt_req — and
+     * that stamp only happens inside sendMsg() itself (fss_connection::
+     * sendMsg, under its own send_lock, before the blocking write), so the
+     * real id is not known until the call returns. The entry is therefore
+     * pushed immediately after a successful send (todo/22: only a request
+     * that actually went out is tracked), not before it. */
     bool timed_out = false;
-    bool send_failed = false;
     {
         std::scoped_lock guard(this->client_lock);
-        uint64_t now = this->clock->now_ms();
+        uint64_t check_now = this->clock->now_ms();
         if (!this->outstanding_rtt_requests.empty())
         {
-            if (now - this->outstanding_rtt_requests.front()->getTimeStamp() > this->client_timeout_ms)
+            if (check_now - this->outstanding_rtt_requests.front()->getTimeStamp() > this->client_timeout_ms)
             {
                 timed_out = true;
             }
-            else if (now - this->outstanding_rtt_requests.back()->getTimeStamp() < rtt_retry_interval)
+            else if (check_now - this->outstanding_rtt_requests.back()->getTimeStamp() < rtt_retry_interval)
             {
                 return;
-            }
-        }
-        if (!timed_out)
-        {
-            /* Only track an outstanding request once the write actually went out.
-             * todo/22: pushing on a failed send would leave a phantom request the
-             * peer never received, and would arm the retry throttle on a send
-             * that never happened — later timeout behaviour would then reflect a
-             * local send failure rather than peer silence. */
-            if (this->getConnection()->sendMsg(rtt_req))
-            {
-                this->outstanding_rtt_requests.push_back(std::make_shared<fss_client_rtt>(now, rtt_req->getId()));
-            }
-            else
-            {
-                send_failed = true;
             }
         }
     }
     if (timed_out)
     {
         this->client_handler->clientDisconnected(this);
+        return;
     }
-    else if (send_failed)
+    uint64_t now = this->clock->now_ms();
+    if (!this->getConnection()->sendMsg(rtt_req))
     {
         /* The socket write failed, so the connection is broken. Reap the client
          * now rather than waiting out the liveness timeout against a peer that
@@ -562,6 +593,47 @@ void fss::server::fss_client::sendRTTRequest(const std::shared_ptr<fss::transpor
          * here, but disconnecting directly is immediate and idempotent). */
         FSS_LOG_WARN("server", "Failed to send RTT request to " << this->getName() << "; disconnecting");
         this->client_handler->clientDisconnected(this);
+        return;
+    }
+    uint64_t assigned_id = rtt_req->getId();
+    std::shared_ptr<fss_client_rtt> stray;
+    {
+        std::scoped_lock guard(this->client_lock);
+        auto found = std::find_if(
+            this->stray_rtt_responses.begin(), this->stray_rtt_responses.end(),
+            [assigned_id](const auto &candidate) -> bool { return candidate->getRequestId() == assigned_id; });
+        if (found != this->stray_rtt_responses.end())
+        {
+            stray = *found;
+        }
+        if (stray != nullptr)
+        {
+            /* The response for this very request already arrived and was
+             * recorded as unmatched (see the rtt_response handler) before this
+             * function could push its own bookkeeping entry. Consume it now
+             * instead of adding an outstanding entry that would otherwise
+             * never be answered and eventually force a false liveness
+             * disconnect. */
+            this->stray_rtt_responses.remove(stray);
+            this->last_rtt_response_time = this->clock->now_ms();
+        }
+        else
+        {
+            this->outstanding_rtt_requests.push_back(std::make_shared<fss_client_rtt>(now, assigned_id));
+        }
+    }
+    if (stray != nullptr)
+    {
+        uint64_t asset_id = this->cached_asset_id.load();
+        if (asset_id != 0)
+        {
+            /* stray->getTimeStamp() is when the response was actually
+             * received, which predates `now` (when this function resumed
+             * after the send) — using it gives a truer round-trip duration
+             * than clamping to `now` would. */
+            uint64_t rtt_ms = stray->getTimeStamp() > now ? stray->getTimeStamp() - now : 0;
+            this->writer->enqueue(rtt_write{asset_id, rtt_ms});
+        }
     }
 }
 
@@ -907,6 +979,23 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                     {
                         this->outstanding_rtt_requests.remove(rtt_req);
                         this->last_rtt_response_time = this->clock->now_ms();
+                    }
+                    else
+                    {
+                        /* todo/35: sendRTTRequest() cannot push its bookkeeping
+                         * entry until sendMsg() returns (the id is only stamped
+                         * onto the message inside that call), so an
+                         * exceptionally fast response can arrive here first and
+                         * find no match. Remember it, bounded, so
+                         * sendRTTRequest() can reconcile instead of the request
+                         * being reaped as timed out despite an already-answered
+                         * peer. */
+                        if (this->stray_rtt_responses.size() >= max_stray_rtt_responses)
+                        {
+                            this->stray_rtt_responses.pop_front();
+                        }
+                        this->stray_rtt_responses.push_back(
+                            std::make_shared<fss_client_rtt>(current_ts, rtt_resp_msg->getRequestId()));
                     }
                 }
                 if (rtt_req != nullptr)

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -199,6 +199,13 @@ private:
     std::string name{};
     std::mutex client_lock{};
     std::list<std::shared_ptr<fss_client_rtt>> outstanding_rtt_requests{};
+    /* Responses that arrived before sendRTTRequest() could push its matching
+     * outstanding entry (todo/35 — see the rtt_response handler and
+     * sendRTTRequest() in client_session.cpp). Bounded FIFO: legitimate
+     * traffic never needs more than one slot at a time; the cap defends
+     * against a peer spamming bogus ids growing this list unboundedly. */
+    static constexpr size_t max_stray_rtt_responses = 4;
+    std::list<std::shared_ptr<fss_client_rtt>> stray_rtt_responses{};
     auto getName() -> std::string;
     /* Fold one RTT round trip into the smoothed client↔server clock offset that
      * feeds the staleness gate (todo/17 item 3). client_timestamp is the peer's

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -82,6 +82,20 @@ public:
         return this->sent;
     }
 
+    /* Thread-safe snapshot of the message currently parked in a blocked send
+     * (nullptr if none). This is a separate, independently-decoded clone —
+     * never the caller's own message object — so a test can safely read its
+     * id (e.g. to inject a matching response) while the sending thread is
+     * still inside the blocked write. Reading the id off the caller's own
+     * message object from another thread would race fss_message::setId(),
+     * which fss_connection::sendMsg() calls without any lock a test
+     * participates in. */
+    auto inFlightMessage() -> std::shared_ptr<fss::transport::fss_message>
+    {
+        std::scoped_lock guard(this->sent_lock);
+        return this->in_flight;
+    }
+
     /* Releasing a blocked send is also needed when the connection is torn down,
      * so a worker parked in sendMsg can exit and be joined. */
     void disconnect() override
@@ -92,12 +106,17 @@ public:
 protected:
     auto sendMsg(const std::shared_ptr<fss::transport::buf_len> &bl) -> bool override
     {
+        auto msg = fss::transport::fss_message::decode(bl);
+        {
+            std::scoped_lock guard(this->sent_lock);
+            this->in_flight = msg;
+        }
         {
             std::unique_lock<std::mutex> lock(this->block_lock);
             this->block_cv.wait(lock, [this]() -> bool { return !this->blocked; });
         }
-        auto msg = fss::transport::fss_message::decode(bl);
         std::scoped_lock guard(this->sent_lock);
+        this->in_flight = nullptr;
         if (msg != nullptr)
         {
             send_attempts.push_back(msg);
@@ -114,6 +133,7 @@ protected:
     }
 private:
     std::mutex sent_lock{};
+    std::shared_ptr<fss::transport::fss_message> in_flight{nullptr};
     std::mutex block_lock{};
     std::condition_variable block_cv{};
     bool blocked{false};
@@ -743,9 +763,15 @@ TEST_CASE("session: sendRTTRequest reconciles a response that raced the bookkeep
     std::thread sender([&]() -> void { session->sendRTTRequest(rtt_req); });
 
     /* setId() happens synchronously inside fss_connection::sendMsg before the
-     * blocked write, so the id is already correct once it stops being 0. */
-    REQUIRE(fss_test::wait_for([&]() -> bool { return rtt_req->getId() != 0; }));
-    uint64_t assigned_id = rtt_req->getId();
+     * blocked write, so the id is already correct once the connection has a
+     * message parked in the blocked send. Read it off inFlightMessage()'s
+     * independently-decoded clone, never off rtt_req itself: the sender
+     * thread's call into fss_message::setId() is not synchronized against
+     * this (the test's) thread, so polling rtt_req->getId() here would be a
+     * data race (caught by TSan) even though it happens to read the right
+     * value in practice. */
+    REQUIRE(fss_test::wait_for([&]() -> bool { return conn->inFlightMessage() != nullptr; }));
+    uint64_t assigned_id = conn->inFlightMessage()->getId();
 
     session->processMessage(std::make_shared<fss::transport::fss_message_rtt_response>(assigned_id));
 

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -10,6 +10,8 @@
 #error No catch header
 #endif
 
+#include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <cmath>
 #include <limits>
@@ -17,6 +19,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "fss-transport.hpp"
@@ -628,6 +631,182 @@ TEST_CASE("session: a blocked client's writer does not stall command dispatch fo
     /* disconnect() releases the block and joins A's writer cleanly. */
     client_a->disconnect();
     client_b->disconnect();
+}
+
+TEST_CASE("session: isTimedOut() is not blocked by the same client's stuck command send (todo/35)")
+{
+    /* todo/35: sendCommand() must release client_lock before the blocking
+     * send, or the main loop's once-per-tick isTimedOut() call — which takes
+     * the same lock — parks behind a black-holed peer's writer thread for up
+     * to TCP_USER_TIMEOUT. Probe isTimedOut() from a second thread while the
+     * writer is parked in a blocked send and require it to return well within
+     * that window. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+    NullClientHandler handler;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+    session->activate();
+
+    conn->setBlocked(true);
+    session->setPendingCommand(
+        std::make_shared<fss::server::asset_command>(/*dbid*/ 1, /*ts*/ 500, "RTL", 0.0, 0.0, 0));
+    session->queueCommandSend();
+
+    /* Give the outbound worker a moment to reach the blocked send before
+     * probing isTimedOut() below. */
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    std::atomic<bool> check_done{false};
+    std::thread checker([&]() -> void {
+        session->isTimedOut();
+        check_done.store(true);
+    });
+
+    bool returned_promptly =
+        fss_test::wait_for([&]() -> bool { return check_done.load(); }, std::chrono::milliseconds(500));
+
+    /* Unblock so the writer (and, if the fix regressed, the checker thread
+     * too) can finish before teardown — this join must never be reached with
+     * the checker still holding the mutex wait unresolved. */
+    conn->setBlocked(false);
+    checker.join();
+    session->disconnect();
+
+    REQUIRE(returned_promptly);
+}
+
+TEST_CASE("session: isTimedOut() is not blocked by the same client's stuck RTT send (todo/35)")
+{
+    /* Same guarantee as above, for sendRTTRequest()'s writer-thread path. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+    NullClientHandler handler;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+    session->activate();
+
+    conn->setBlocked(true);
+    session->queueRTTRequest();
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    std::atomic<bool> check_done{false};
+    std::thread checker([&]() -> void {
+        session->isTimedOut();
+        check_done.store(true);
+    });
+
+    bool returned_promptly =
+        fss_test::wait_for([&]() -> bool { return check_done.load(); }, std::chrono::milliseconds(500));
+
+    conn->setBlocked(false);
+    checker.join();
+    session->disconnect();
+
+    REQUIRE(returned_promptly);
+}
+
+TEST_CASE("session: sendRTTRequest reconciles a response that raced the bookkeeping push (todo/35)")
+{
+    /* sendRTTRequest() cannot push its outstanding-request bookkeeping entry
+     * until sendMsg() returns (the id is only stamped inside that call), so a
+     * response that arrives first finds no match. Prove the stray-response
+     * reconciliation path picks it up rather than leaving a bookkeeping entry
+     * that can never be answered and would eventually force a false liveness
+     * disconnect. The blocked send lets the response be processed while the
+     * send is still in flight — deterministic, not timing-dependent — which
+     * exercises the same "no match yet" code path the real (much narrower)
+     * race hits. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+    NullClientHandler handler;
+    auto clock = std::make_shared<FakeClock>();
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->setClock(clock);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    conn->setBlocked(true);
+    auto rtt_req = std::make_shared<fss::transport::fss_message_rtt_request>();
+    std::thread sender([&]() -> void { session->sendRTTRequest(rtt_req); });
+
+    /* setId() happens synchronously inside fss_connection::sendMsg before the
+     * blocked write, so the id is already correct once it stops being 0. */
+    REQUIRE(fss_test::wait_for([&]() -> bool { return rtt_req->getId() != 0; }));
+    uint64_t assigned_id = rtt_req->getId();
+
+    session->processMessage(std::make_shared<fss::transport::fss_message_rtt_response>(assigned_id));
+
+    conn->setBlocked(false);
+    sender.join();
+
+    /* Reconciled: last_rtt_response_time was refreshed and no outstanding
+     * entry was left behind to time out. */
+    REQUIRE_FALSE(session->isTimedOut());
+    clock->advance(30001);
+    REQUIRE(session->isTimedOut());
+
+    session->disconnect();
+}
+
+TEST_CASE("session: concurrent identify-time and worker-scheduled sendCommand do not double-dispatch (todo/35)")
+{
+    /* sendCommand() must claim the resend window atomically with its check,
+     * before releasing client_lock for the blocking send — not after the send
+     * succeeds — or two callers racing the same pending command (the recv
+     * thread calls sendCommand() directly at identify time; the outbound
+     * worker calls it via queueCommandSend()) can both pass the check and
+     * both dispatch. Block the send so the identify-time call is still
+     * in-flight when the worker's call races it. */
+    fss_test::MockDatabase mock;
+    constexpr uint64_t asset_id = 77;
+    mock.asset_ids["craft"] = asset_id;
+    auto cmd = std::make_shared<fss::server::asset_command>(/*dbid*/ 5, /*ts*/ 500, "RTL", 0.0, 0.0, 0);
+    mock.pushCommand(asset_id, cmd);
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->activate();
+
+    conn->setBlocked(true);
+
+    /* Simulates the recv thread: identify sets the pending command from the DB
+     * and calls sendCommand() directly, which blocks on the send below. */
+    std::thread identify_thread(
+        [&]() -> void { session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft")); });
+
+    /* Give the identify call time to claim the resend window and park in the
+     * blocked send before the worker's call races it. */
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    session->queueCommandSend();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    conn->setBlocked(false);
+    identify_thread.join();
+
+    REQUIRE(fss_test::wait_for(
+        [&]() -> bool { return count_sent<fss::transport::fss_message_asset_command>(conn->sentSnapshot()) >= 1; }));
+    /* Give an incorrect second dispatch a chance to land before asserting
+     * there is exactly one. */
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    REQUIRE(count_sent<fss::transport::fss_message_asset_command>(conn->sentSnapshot()) == 1);
+
+    session->disconnect();
 }
 
 TEST_CASE("session: queueRTTRequest sends an RTT request on the outbound worker thread")


### PR DESCRIPTION
## Description

A black-holed peer's writer thread could park inside client_lock for up to TCP_USER_TIMEOUT (30s) while sendCommand()/sendRTTRequest() held the lock across the blocking socket write. The main loop's per-second isTimedOut() check takes the same lock, so one stuck peer froze command dispatch (and the 100ms TERM/DISARM cadence) fleet-wide -- reopening part of the guarantee todo/21 shipped in 1.1.0.

Both functions now do their bookkeeping under the lock, release it, and send outside it. sendRTTRequest's outstanding-request entry can only be pushed once sendMsg() assigns the real message id (only known after the call returns), which reopened a narrower race where a very fast response could arrive and find no match before the entry was pushed; closed with a small bounded stray-response list that sendRTTRequest reconciles against. Also fixed two issues introduced by moving the send out of the whole-function lock: an unlocked read of the client's name in sendCommand's post-send logging, and a window where the recv-thread's identify-time sendCommand() call and the outbound worker's call could both dispatch the same command before either completed.

## Summary by Sourcery

Prevent client-level mutex contention from stalling fleet-wide timeouts and command dispatch by releasing client_lock before blocking sends in command and RTT request paths, and tightening related concurrency and bookkeeping.

Bug Fixes:
- Ensure sendCommand does not hold client_lock across blocking socket writes, avoiding global command/TERM cadence stalls when a peer is black-holed.
- Ensure sendRTTRequest does not hold client_lock across blocking RTT sends, preventing liveness checks from blocking on stuck writer threads.
- Prevent concurrent identify-time and worker-scheduled sendCommand calls from double-dispatching the same command by atomically claiming the resend window before releasing the lock.
- Handle RTT responses that arrive before their bookkeeping entry is pushed by tracking and reconciling stray responses, avoiding false liveness timeouts and disconnects.
- Fix logging and state handling around command send failures so resend windows and client names are updated safely without races.

Tests:
- Add tests that verify isTimedOut is not blocked by a client's stuck command send.
- Add tests that verify isTimedOut is not blocked by a client's stuck RTT send.
- Add tests that verify sendRTTRequest correctly reconciles RTT responses that race the bookkeeping push.
- Add tests that verify concurrent identify-time and worker-scheduled sendCommand calls do not double-dispatch commands.