### PR TITLE
fix(server): route broadcastMsg through per-client outbound workers

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -196,7 +196,8 @@ auto fss::server::fss_client::waitForOutboundWork() -> fss::server::fss_client::
 {
     std::unique_lock<std::mutex> lock(this->outbound_lock);
     this->outbound_cv.wait(lock, [this]() -> bool {
-        return this->outbound_stopping || this->out_command_pending || this->out_rtt_pending || this->out_smm_pending;
+        return this->outbound_stopping || this->out_command_pending || this->out_rtt_pending || this->out_smm_pending ||
+               this->pending_server_list_broadcast != nullptr || !this->pending_position_relay.empty();
     });
     outbound_work work;
     if (this->outbound_stopping)
@@ -210,6 +211,11 @@ auto fss::server::fss_client::waitForOutboundWork() -> fss::server::fss_client::
     this->out_command_pending = false;
     this->out_rtt_pending = false;
     this->out_smm_pending = false;
+    work.server_list_broadcast = std::move(this->pending_server_list_broadcast);
+    this->pending_server_list_broadcast = nullptr;
+    work.position_relay.assign(std::make_move_iterator(this->pending_position_relay.begin()),
+                               std::make_move_iterator(this->pending_position_relay.end()));
+    this->pending_position_relay.clear();
     return work;
 }
 
@@ -226,7 +232,8 @@ void fss::server::fss_client::outboundWorkerRun()
         {
             return;
         }
-        /* Commands are the highest priority — send them before periodic RTT. */
+        /* Commands are the highest priority — send them before periodic RTT,
+         * SMM settings, and broadcasts. */
         if (work.command)
         {
             this->sendCommand();
@@ -240,6 +247,14 @@ void fss::server::fss_client::outboundWorkerRun()
         if (work.smm)
         {
             this->sendSMMSettings();
+        }
+        if (work.server_list_broadcast != nullptr)
+        {
+            this->getConnection()->sendMsg(work.server_list_broadcast);
+        }
+        for (const auto &relay_msg : work.position_relay)
+        {
+            this->getConnection()->sendMsg(relay_msg);
         }
     }
 }
@@ -281,6 +296,51 @@ void fss::server::fss_client::queueSMMSettings()
         this->out_smm_pending = true;
     }
     this->outbound_cv.notify_one();
+}
+
+void fss::server::fss_client::queueServerListBroadcast(std::shared_ptr<fss::transport::fss_message> msg)
+{
+    {
+        std::scoped_lock guard(this->outbound_lock);
+        if (this->outbound_stopping)
+        {
+            return;
+        }
+        this->pending_server_list_broadcast = std::move(msg);
+    }
+    this->outbound_cv.notify_one();
+}
+
+void fss::server::fss_client::queuePositionRelay(std::shared_ptr<fss::transport::fss_message> msg)
+{
+    uint64_t dropped = 0;
+    {
+        std::scoped_lock guard(this->outbound_lock);
+        if (this->outbound_stopping)
+        {
+            return;
+        }
+        if (this->pending_position_relay.size() >= max_pending_position_relay)
+        {
+            this->pending_position_relay.pop_front();
+            dropped = ++this->position_relay_dropped;
+        }
+        this->pending_position_relay.push_back(std::move(msg));
+    }
+    this->outbound_cv.notify_one();
+    /* Logged outside outbound_lock: getName() takes client_lock, and name is
+     * guarded by that lock, not outbound_lock. */
+    if (dropped == 1 || (dropped != 0 && dropped % 100 == 0))
+    {
+        FSS_LOG_WARN("server", "Position relay queue full for " << this->getName()
+                                                                << ", dropping oldest. Total dropped: " << dropped);
+    }
+}
+
+auto fss::server::fss_client::getPositionRelayDropped() -> uint64_t
+{
+    std::scoped_lock guard(this->outbound_lock);
+    return this->position_relay_dropped;
 }
 
 void fss::server::fss_client::requestOutboundStop()

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -7,6 +7,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <deque>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -177,10 +178,14 @@ class fss_client_handler {
 public:
     virtual ~fss_client_handler() = default;
     virtual void clientDisconnected(fss_client *client) = 0;
-    /* Sends msg to every client (bar `except`). Implementations must iterate
-     * the connections sequentially: fss_connection::sendMsg stamps a
-     * per-connection id into msg, so fanning one instance out concurrently
-     * would race that write (todo/12 C8). */
+    /* Sends msg to every client (bar `except`). fss_connection::sendMsg
+     * stamps a per-connection id into the message instance it is given
+     * (todo/12 C8), so implementations must never let two clients' sends run
+     * concurrently against the same instance — either by iterating
+     * sequentially on one thread (reusing one instance is fine there, since
+     * each send fully completes before the next starts), or (todo/36) by
+     * giving each recipient its own independent clone before fanning delivery
+     * out across separate per-client threads. */
     virtual void broadcastMsg(const std::shared_ptr<transport::fss_message> &msg, fss_client *except = nullptr) = 0;
 };
 
@@ -280,6 +285,25 @@ private:
     bool out_command_pending{false};
     bool out_rtt_pending{false};
     bool out_smm_pending{false};
+    /* Broadcasts routed onto this worker too (todo/36), so a black-holed peer
+     * can only stall its own broadcast delivery, never the main loop (server
+     * list, every 15s) or another client's recv thread (position relay).
+     * Coalescing: only the latest server-list matters, so a new one simply
+     * replaces any not-yet-sent previous one. Guarded by outbound_lock. */
+    std::shared_ptr<transport::fss_message> pending_server_list_broadcast{nullptr};
+    /* Bounded, drop-oldest (todo/36): position relay is loss-tolerant
+     * telemetry (mirrors the transport queue's drop policy and todo/20's
+     * command/telemetry distinction), so under sustained backlog the oldest
+     * queued report is dropped rather than growing unboundedly. Guarded by
+     * outbound_lock. */
+    static constexpr size_t max_pending_position_relay = 8;
+    std::deque<std::shared_ptr<transport::fss_message>> pending_position_relay{};
+    /* Cumulative reports dropped for this client by the cap above (never
+     * reset); guarded by outbound_lock alongside the queue it counts.
+     * Exposed so an operator (or a future metrics hook) can see the loss
+     * rather than it being silent, mirroring fss_connection::
+     * getDroppedMessages() for the transport-level inbound queue. */
+    uint64_t position_relay_dropped{0};
     std::thread outbound_worker{};
     /* What the worker should do this wake-up. Returned by waitForOutboundWork so
      * the worker performs the (blocking) sends with no lock held. */
@@ -288,6 +312,8 @@ private:
         bool command{false};
         bool rtt{false};
         bool smm{false};
+        std::shared_ptr<transport::fss_message> server_list_broadcast{nullptr};
+        std::vector<std::shared_ptr<transport::fss_message>> position_relay{};
     };
     /* Block until there is work or a stop request, then atomically take and clear
      * the pending flags. */
@@ -341,6 +367,23 @@ public:
     /* Schedule a cached-SMM-settings send on this client's outbound worker
      * thread (todo/21). Returns immediately; no-op once disconnecting. */
     void queueSMMSettings();
+    /* Schedule a server-list broadcast on this client's outbound worker thread
+     * (todo/36) instead of sending inline, so a black-holed peer cannot stall
+     * the main loop's periodic broadcast for other clients. Coalescing: a new
+     * call simply replaces any not-yet-sent previous one. `msg` must be an
+     * instance not shared with any other client (see broadcastMsg's C8 note).
+     * Returns immediately; no-op once disconnecting. */
+    void queueServerListBroadcast(std::shared_ptr<transport::fss_message> msg);
+    /* Schedule a relayed position report on this client's outbound worker
+     * thread (todo/36) instead of sending inline from the reporting client's
+     * recv thread, so one black-holed peer cannot stall every other client's
+     * telemetry relay. Bounded, drop-oldest: position relay is loss-tolerant.
+     * `msg` must be an instance not shared with any other client (see
+     * broadcastMsg's C8 note). Returns immediately; no-op once disconnecting. */
+    void queuePositionRelay(std::shared_ptr<transport::fss_message> msg);
+    /* Cumulative position reports dropped from this client's relay queue by
+     * the bounded-cap policy above. 0 unless the queue has ever overflowed. */
+    auto getPositionRelayDropped() -> uint64_t;
     auto isAircraft() -> bool;
     auto getCachedAssetId() -> uint64_t { return this->cached_asset_id.load(); }
     /* The smoothed client↔server clock offset (ms; positive = client ahead)

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -279,9 +279,10 @@ public:
     /* Sends one message on this connection. NOTE: this mutates the message —
      * it stamps the per-connection sequence id into msg (setId) before packing.
      * Invariant (todo/12 C8): a single fss_message instance must not be sent
-     * concurrently on multiple connections; the id stamp would race. The one
-     * path that fans a shared instance out — broadcastMsg (one msg to every
-     * client) — iterates the connections sequentially on a single thread.
+     * concurrently on multiple connections; the id stamp would race. Every
+     * broadcaster (server_clients::broadcastMsg, one msg logically bound for
+     * every client) satisfies this by giving each recipient its own
+     * independent clone (todo/36) rather than sharing one instance.
      * sendRTTRequest sends a single message and then reads its assigned id back
      * immediately after this returns, so it too relies on the stamp being
      * synchronous and unraced. (sendSMMSettings builds a fresh message per

--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -147,14 +147,44 @@ public:
             this->clients.erase(it);
         }
     };
+    /* todo/36: broadcasts are scheduled on each client's outbound writer
+     * thread rather than sent inline, so a black-holed peer can only stall its
+     * own broadcast delivery — never the main loop (server-list, every 15s)
+     * or another client's recv thread (position relay, called from the
+     * *reporting* client's recv thread). fss_connection::sendMsg stamps a
+     * per-connection id into the message instance it is given (the C8
+     * invariant), so each client must get its own instance: decode() over
+     * getPacked() builds an independent clone per client rather than sharing
+     * `msg` (packed once, since the bytes don't depend on the recipient). */
     void broadcastMsg(const std::shared_ptr<flight_safety_system::transport::fss_message> &msg,
                       flight_safety_system::server::fss_client *except = nullptr) override
     {
+        bool is_server_list = msg->getType() == flight_safety_system::transport::message_type_server_list;
+        auto packed = msg->getPacked();
+        /* decode() failing is a property of `packed` (truncated/corrupt bytes
+         * or a type it refuses to reconstruct), not of any one recipient, so
+         * check once here rather than per-client: a per-client `continue`
+         * would look like "skip this one client" but actually silently drops
+         * the whole broadcast, one client at a time, with no record of why. */
+        if (flight_safety_system::transport::fss_message::decode(packed) == nullptr)
+        {
+            FSS_LOG_ERROR("server", "broadcastMsg: message of type "
+                                        << msg->getType() << " did not round-trip through pack/decode; dropping");
+            return;
+        }
         for (const auto &client : this->snapshotClients())
         {
             if (client->isAircraft() && client.get() != except)
             {
-                client->sendMsg(msg);
+                auto clone = flight_safety_system::transport::fss_message::decode(packed);
+                if (is_server_list)
+                {
+                    client->queueServerListBroadcast(std::move(clone));
+                }
+                else
+                {
+                    client->queuePositionRelay(std::move(clone));
+                }
             }
         }
     }

--- a/tests/server_clients_test.cpp
+++ b/tests/server_clients_test.cpp
@@ -10,8 +10,11 @@
 #error No catch header
 #endif
 
+#include <chrono>
+#include <condition_variable>
 #include <list>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -24,6 +27,7 @@
 #include "db-write-queue.hpp"
 #include "mock_database.hpp"
 #include "server-clients.hpp"
+#include "test_helpers.hpp"
 
 namespace fss = flight_safety_system;
 
@@ -43,9 +47,65 @@ public:
 
     auto getClientNames() -> std::list<std::string> override { return cert_names; }
     auto isPeerCertRevoked(const std::string & /*crl_file*/) const -> bool override { return revoked; }
+
+    /* Block (true) or release (false) any in-flight or future sendMsg,
+     * modelling a peer whose socket has black-holed (todo/36). Releasing wakes
+     * a blocked writer. */
+    void setBlocked(bool b)
+    {
+        {
+            std::scoped_lock guard(this->block_lock);
+            this->blocked = b;
+        }
+        this->block_cv.notify_all();
+    }
+    auto sentSnapshot() -> std::vector<std::shared_ptr<fss::transport::fss_message>>
+    {
+        std::scoped_lock guard(this->sent_lock);
+        return this->sent;
+    }
+    void disconnect() override
+    {
+        this->setBlocked(false);
+        fss::transport::fss_connection::disconnect();
+    }
 protected:
-    auto sendMsg(const std::shared_ptr<fss::transport::buf_len> & /*bl*/) -> bool override { return true; }
+    auto sendMsg(const std::shared_ptr<fss::transport::buf_len> &bl) -> bool override
+    {
+        {
+            std::unique_lock<std::mutex> lock(this->block_lock);
+            this->block_cv.wait(lock, [this]() -> bool { return !this->blocked; });
+        }
+        auto msg = fss::transport::fss_message::decode(bl);
+        std::scoped_lock guard(this->sent_lock);
+        if (msg != nullptr)
+        {
+            this->sent.push_back(msg);
+        }
+        return true;
+    }
+private:
+    std::mutex sent_lock{};
+    std::mutex block_lock{};
+    std::condition_variable block_cv{};
+    bool blocked{false};
+    std::vector<std::shared_ptr<fss::transport::fss_message>> sent{};
 };
+
+/* Count how many messages in `sent` decoded to a T. */
+template<typename T>
+auto count_sent(const std::vector<std::shared_ptr<fss::transport::fss_message>> &sent) -> std::size_t
+{
+    std::size_t count = 0;
+    for (const auto &m : sent)
+    {
+        if (std::dynamic_pointer_cast<T>(m))
+        {
+            ++count;
+        }
+    }
+    return count;
+}
 
 struct FakeClock : public fss::IClock {
     uint64_t t{0};
@@ -161,6 +221,98 @@ TEST_CASE("server_clients: broadcastMsg reaches aircraft clients only")
     // Broadcast should not crash and should only target aircraft
     auto msg = std::make_shared<fss::transport::fss_message_rtt_request>();
     sc.broadcastMsg(msg);
+}
+
+TEST_CASE("server_clients: broadcastMsg does not block on one black-holed client (todo/36)")
+{
+    /* todo/36: broadcastMsg must schedule sends on each client's outbound
+     * worker rather than sending inline, or a black-holed peer stalls the
+     * caller (the main loop, every 15s, for server-list; a reporting
+     * client's own recv thread for position relay) for up to
+     * TCP_USER_TIMEOUT. Block one client's socket and assert both that the
+     * call itself returns promptly and that the healthy client still
+     * receives the broadcast. */
+    server_clients sc;
+    fss_test::MockDatabase mock;
+    mock.asset_ids["stuck"] = 1;
+    mock.asset_ids["healthy"] = 2;
+
+    auto stuck_conn = std::make_shared<FakeConnection>();
+    stuck_conn->cert_names.push_back("stuck");
+    auto stuck_writer = make_null_writer();
+    auto stuck_client = std::make_shared<fss::server::fss_client>(stuck_conn, &mock, stuck_writer, &sc);
+    stuck_client->processMessage(std::make_shared<fss::transport::fss_message_identity>("stuck"));
+    sc.clientConnected(stuck_client);
+
+    auto healthy_conn = std::make_shared<FakeConnection>();
+    healthy_conn->cert_names.push_back("healthy");
+    auto healthy_writer = make_null_writer();
+    auto healthy_client = std::make_shared<fss::server::fss_client>(healthy_conn, &mock, healthy_writer, &sc);
+    healthy_client->processMessage(std::make_shared<fss::transport::fss_message_identity>("healthy"));
+    sc.clientConnected(healthy_client);
+
+    /* Both clients already received one server_list send as a side effect of
+     * identify (independent of broadcastMsg) — baseline before the broadcast
+     * under test, so the assertions below only see what *this* call
+     * delivers. */
+    std::size_t stuck_before = count_sent<fss::transport::fss_message_server_list>(stuck_conn->sentSnapshot());
+    std::size_t healthy_before = count_sent<fss::transport::fss_message_server_list>(healthy_conn->sentSnapshot());
+
+    stuck_conn->setBlocked(true);
+
+    auto server_list = std::make_shared<fss::transport::fss_message_server_list>();
+    server_list->addServer("10.0.0.1", 1234);
+
+    auto start = std::chrono::steady_clock::now();
+    sc.broadcastMsg(server_list);
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    REQUIRE(elapsed < std::chrono::milliseconds(500));
+
+    REQUIRE(fss_test::wait_for([&]() -> bool {
+        return count_sent<fss::transport::fss_message_server_list>(healthy_conn->sentSnapshot()) == healthy_before + 1;
+    }));
+    /* The stuck client's socket is still blocked, so this broadcast has not
+     * reached it. */
+    REQUIRE(count_sent<fss::transport::fss_message_server_list>(stuck_conn->sentSnapshot()) == stuck_before);
+
+    stuck_conn->setBlocked(false);
+    stuck_client->disconnect();
+    healthy_client->disconnect();
+}
+
+TEST_CASE("server_clients: position relay drops oldest and counts drops once the queue is full (todo/36)")
+{
+    /* Position relay is a bounded, drop-oldest queue (max_pending_position_relay
+     * = 8 in fss-server.hpp, private so hard-coded here) — loss-tolerant
+     * telemetry, but the loss must be observable. Push directly via
+     * queuePositionRelay() without ever starting the outbound worker (skip
+     * activate()/clientConnected()), so nothing drains the queue between
+     * pushes and the resulting drop count is deterministic rather than
+     * racing worker scheduling. */
+    server_clients sc;
+    fss_test::MockDatabase mock;
+    mock.asset_ids["stuck"] = 1;
+
+    auto stuck_conn = std::make_shared<FakeConnection>();
+    stuck_conn->cert_names.push_back("stuck");
+    auto stuck_writer = make_null_writer();
+    /* Deliberately not registered via sc.clientConnected(): that would call
+     * activate(), starting the outbound worker that drains the very queue
+     * this test needs undrained. */
+    auto stuck_client = std::make_shared<fss::server::fss_client>(stuck_conn, &mock, stuck_writer, &sc);
+    stuck_client->processMessage(std::make_shared<fss::transport::fss_message_identity>("stuck"));
+
+    constexpr int reports_sent = 10;
+    constexpr uint64_t queue_cap = 8;
+    for (int i = 0; i < reports_sent; ++i)
+    {
+        auto position = std::make_shared<fss::transport::fss_message_position_report>(
+            0.0, 0.0, 0U, 0U, 0U, int16_t{0}, 0U, std::string{}, 0U, uint8_t{0}, 0U, uint8_t{0}, uint8_t{0},
+            uint64_t{0});
+        stuck_client->queuePositionRelay(position);
+    }
+
+    REQUIRE(stuck_client->getPositionRelayDropped() == reports_sent - queue_cap);
 }
 
 TEST_CASE("server_clients: broadcastMsg skips the 'except' client")


### PR DESCRIPTION
## Description

broadcastMsg() was the one send path todo/21 didn't move off the caller's thread: it iterated all aircraft clients and called sendMsg() inline, sharing one message instance across every recipient. A black-holed peer could block it for up to TCP_USER_TIMEOUT -- freezing the main loop's 15s server-list broadcast fleet-wide, or (for position relay) stalling every other client's recv thread on the *reporting* client's connection.

fss_connection::sendMsg stamps a per-connection id into the message instance it's given, so fanning one instance out across per-client worker threads would race that stamp. broadcastMsg now packs the message once and gives each recipient an independent clone (via fss_message::decode(), since fss_message's copy ctor is deleted), routed to one of two new per-client outbound queues: a coalescing slot for the server list, and a bounded drop-oldest queue for position relay. Both drain on the existing todo/21 outbound worker thread alongside commands/RTT/SMM, so broadcastMsg itself never blocks.

Also closes two gaps a review of the fix itself found: a decode() failure was checked per-client with a silent continue that actually dropped the whole broadcast one client at a time with no record of why (hoisted the check above the loop, now logs once); and position-relay drops were silent (added a per-client dropped-count with the same throttled-WARN pattern already used for the transport-level inbound queue).

## Summary by Sourcery

Route server broadcast messages through per-client outbound workers to avoid blocking on black-holed connections and ensure each client receives an independent message instance.

New Features:
- Track per-client position relay drop counts and expose them via an accessor for observability of telemetry loss.

Bug Fixes:
- Prevent broadcastMsg from blocking the main loop or other clients when one peer's socket is black-holed by scheduling broadcasts on per-client outbound queues.
- Ensure broadcasted messages are cloned per recipient rather than sharing a single instance, avoiding races on per-connection ID stamping.
- Detect and log pack/decode failures for broadcast messages once per broadcast instead of silently dropping delivery per client.

Enhancements:
- Extend client outbound workers to handle server-list broadcasts and position relay queues alongside existing command, RTT, and SMM traffic.
- Coalesce server-list broadcasts per client so only the latest unsent server list is retained, and bound position relay queues with a drop-oldest policy.
- Improve documentation and invariants around broadcast semantics and message ID stamping in transport and server client handler interfaces.

Tests:
- Add server-side tests to verify broadcastMsg no longer blocks when a client socket is black-holed and that healthy clients still receive broadcasts.
- Add tests to confirm position relay uses a bounded, drop-oldest queue and correctly counts dropped reports per client.
- Extend FakeConnection test utility to simulate blocked sends and capture decoded messages for broadcast and relay verification.