### PR TITLE
fix(server): exempt rtt_response from rate limiting, give command_ack its own bucket

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -983,9 +983,56 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
     }
     else
     {
-        if (!this->msg_rate.consume(this->clock->now_ms()))
+        /* todo/37: rtt_response must never be rate-limited alongside bulk
+         * telemetry — a dropped response makes a live, healthy connection
+         * look timed out, since isTimedOut() only advances on a matched
+         * response. It is exempted outright rather than given its own bucket:
+         * an unmatched response only ever does bounded work (outstanding_rtt_
+         * requests and stray_rtt_responses are both small and hard-capped),
+         * so there is no flood vector to size a bucket against.
+         *
+         * command_ack gets its own small bucket instead of a blanket
+         * exemption. A dropped ack is a permanent loss of the command/ack
+         * audit link (the FMU sends one exactly once and never resends), but
+         * unlike rtt_response an ack is *not* naturally bounded: nothing
+         * in-session validates it against a command this server actually
+         * dispatched before enqueueing, and command_ack_write is a protected
+         * task in the shared db_write_queue that can evict other assets'
+         * telemetry and even other command writes under sustained pressure
+         * (todo/20). Fully exempting it would let one identified peer flood
+         * that queue at line rate. The dedicated bucket is sized well above
+         * any legitimate cadence (a command produces at most two acks) while
+         * still capping a flood far below "unbounded". */
+        bool exempt_from_rate_limit = msg->getType() == fss::transport::message_type_rtt_response;
+        bool is_command_ack = msg->getType() == fss::transport::message_type_command_ack;
+        bool rate_ok = exempt_from_rate_limit || (is_command_ack ? this->command_ack_rate.consume(this->clock->now_ms())
+                                                                 : this->msg_rate.consume(this->clock->now_ms()));
+        if (!rate_ok)
         {
             auto now_ms = this->clock->now_ms();
+            if (is_command_ack)
+            {
+                /* Distinct counters/log from telemetry drops (todo/37 item
+                 * 3): a lost ack must never look like an ordinary telemetry
+                 * drop in the logs. */
+                ++this->ack_rate_limit_rejects;
+                FSS_LOG_DEBUG("server", "Rate-limiting command_ack from "
+                                            << this->name << " (rejects=" << this->ack_rate_limit_rejects << ")");
+                if (this->last_ack_rate_limit_log_ms == 0)
+                {
+                    this->last_ack_rate_limit_log_ms = now_ms;
+                }
+                else if (now_ms - this->last_ack_rate_limit_log_ms >= 1000)
+                {
+                    FSS_LOG_WARN("server", "Rate-limiting command_ack from "
+                                               << this->name << " - dropped " << this->ack_rate_limit_rejects
+                                               << " acks in the last " << (now_ms - this->last_ack_rate_limit_log_ms)
+                                               << "ms");
+                    this->ack_rate_limit_rejects = 0;
+                    this->last_ack_rate_limit_log_ms = now_ms;
+                }
+                return;
+            }
             ++this->rate_limit_rejects;
             FSS_LOG_DEBUG("server",
                           "Rate-limiting client " << this->name << " (rejects=" << this->rate_limit_rejects << ")");

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -238,6 +238,15 @@ private:
     rate_limiter msg_rate{100, 20};
     uint64_t rate_limit_rejects{0};
     uint64_t last_rate_limit_log_ms{0};
+    /* todo/37: command_ack gets its own bucket rather than sharing msg_rate
+     * (which would make it a bulk-telemetry casualty) or being exempted
+     * outright (unlike rtt_response, an ack is not naturally bounded — see
+     * the comment in processMessage()). Sized well above any legitimate
+     * cadence (a command produces at most two acks) while still capping a
+     * flood of unvalidated acks into the shared db_write_queue. */
+    rate_limiter command_ack_rate{10, 5};
+    uint64_t ack_rate_limit_rejects{0};
+    uint64_t last_ack_rate_limit_log_ms{0};
     /* Cumulative position reports discarded for having no GPS fix (NaN
      * coordinates) this session; touched only on the recv thread
      * (processMessage), used to throttle the warning. */

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -1091,6 +1091,107 @@ TEST_CASE("rate limiter: refill allows messages after bucket drains")
     REQUIRE(handler.disconnects == 0);
 }
 
+TEST_CASE("rate limiter: rtt_response and command_ack are exempt (todo/37)")
+{
+    /* rtt_response and command_ack must never be casualties of the bucket
+     * that protects the server from bulk telemetry: a dropped rtt_response
+     * makes a live connection look timed out, and a dropped command_ack is a
+     * permanent loss of the command/ack audit link (the FMU never resends
+     * one). Drain a tiny, non-refilling bucket with position reports, then
+     * prove both message types still land. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    conn->setNegotiatedFeatureFlags(fss::transport::FSS_FEATURE_COMMAND_ACK);
+    NullClientHandler handler;
+
+    auto clock = std::make_shared<FakeClock>();
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->setClock(clock);
+    session->setRateLimits(2, 0); // 2-message burst, no refill
+
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    /* A real outstanding request to reconcile the response against. */
+    auto rtt_req = std::make_shared<fss::transport::fss_message_rtt_request>();
+    session->sendRTTRequest(rtt_req);
+    uint64_t assigned_id = rtt_req->getId();
+    clock->advance(20000);
+
+    /* Drain (and exceed) the tiny bucket with ordinary telemetry. */
+    auto pos = std::make_shared<fss::transport::fss_message_position_report>(
+        0.0, 0.0, 0U, 0U, 0U, int16_t{0}, 0U, std::string{}, 0U, uint8_t{0}, 0U, uint8_t{0}, uint8_t{0}, uint64_t{0});
+    for (int i = 0; i < 10; ++i)
+    {
+        session->processMessage(pos);
+    }
+    REQUIRE(handler.broadcasts.size() == 2); // only the burst capacity got through
+
+    /* Bucket is still drained: without the fix this would be dropped too,
+     * leaving last_rtt_response_time stale. */
+    session->processMessage(std::make_shared<fss::transport::fss_message_rtt_response>(assigned_id));
+    clock->advance(25000); // 45s since identify, but only 25s since the response
+    REQUIRE_FALSE(session->isTimedOut());
+    clock->advance(6000); // 31s since the response
+    REQUIRE(session->isTimedOut());
+
+    /* Bucket is still drained: without the fix this ack would be silently
+     * dropped before ever reaching the writer. */
+    constexpr uint64_t acked_id = 42;
+    auto ack = std::make_shared<fss::transport::fss_message_command_ack>(acked_id, fss::transport::asset_command_hold,
+                                                                         fss::transport::command_ack_actioned,
+                                                                         fss::transport::supersede_none, uint64_t{500});
+    session->processMessage(ack);
+    REQUIRE(fss_test::wait_for([&]() -> bool { return !mock.getAcks().empty(); }));
+    REQUIRE(mock.getAcks().front().dispatch_id == acked_id);
+}
+
+TEST_CASE("rate limiter: a command_ack flood is capped, not exempted outright (todo/37)")
+{
+    /* Unlike rtt_response, a command_ack is not naturally bounded: nothing
+     * in-session validates it against a command this server actually
+     * dispatched before enqueueing, and command_ack_write is a protected task
+     * in the shared db_write_queue that can evict other assets' telemetry
+     * and even other command writes under sustained pressure. A blanket
+     * exemption would let one identified peer flood that queue at line rate,
+     * so command_ack gets its own small bucket (10 burst, 5/s refill in
+     * fss-server.hpp) instead. Flood well past that cap and assert only the
+     * bucket's worth land. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    conn->setNegotiatedFeatureFlags(fss::transport::FSS_FEATURE_COMMAND_ACK);
+    NullClientHandler handler;
+
+    auto clock = std::make_shared<FakeClock>();
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->setClock(clock);
+
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    constexpr int acks_sent = 30;
+    for (int i = 0; i < acks_sent; ++i)
+    {
+        auto ack = std::make_shared<fss::transport::fss_message_command_ack>(
+            static_cast<uint64_t>(i), fss::transport::asset_command_hold, fss::transport::command_ack_actioned,
+            fss::transport::supersede_none, uint64_t{500});
+        session->processMessage(ack);
+    }
+
+    /* FakeClock never advances during the flood, so the bucket's lazy refill
+     * never triggers: exactly its 10-token burst capacity gets through,
+     * deterministically. */
+    constexpr std::size_t bucket_capacity = 10;
+    REQUIRE(fss_test::wait_for([&]() -> bool { return mock.getAcks().size() >= bucket_capacity; }));
+    REQUIRE(mock.getAcks().size() == bucket_capacity);
+}
+
 TEST_CASE("session: legacy client (no version handshake) is accepted")
 {
     /* Pre-versioning clients send identity directly. The server must


### PR DESCRIPTION
## Description

fss_client::processMessage() ran every post-identify message through one token bucket meant to protect the server from bulk telemetry. Two message types should never be casualties of it: a dropped rtt_response makes a live, healthy connection look timed out (isTimedOut() only advances on a matched response), and a dropped command_ack is a permanent loss of the command/ack audit link, since the FMU sends one exactly once and never resends it.

rtt_response is exempted outright -- it's structurally bounded regardless of the limiter (outstanding_rtt_requests stays small via the server's own request cadence and timeout reap; an unmatched response lands in the already-capped stray_rtt_responses list from the client_lock fix). command_ack is not naturally bounded the same way: nothing in-session validates an ack against a command actually dispatched before it's enqueued, and command_ack_write is a protected task in the shared db_write_queue that can evict other assets' telemetry and command writes under sustained pressure. A blanket exemption (an earlier draft of this fix) would let one identified peer flood that queue at line rate, so command_ack gets its own small dedicated bucket instead -- sized well above any legitimate cadence but still capping a flood -- plus its own throttled drop log so a capped ack flood doesn't read as an ordinary telemetry drop.

## Summary by Sourcery

Adjust server-side rate limiting to ensure critical RTT responses are never dropped and command acknowledgements use a dedicated, capped bucket with distinct logging.

Enhancements:
- Introduce a separate rate limiter and logging path for command_ack messages, preventing them from being treated as bulk telemetry while still capping abusive floods.

Tests:
- Add server session tests verifying rtt_response messages bypass rate limiting and command_ack messages are constrained by their own bucket rather than the bulk telemetry limiter.