### PR TITLE
fix(transport): fail the send on an unframeable oversized message

### DIFF
--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -194,6 +194,12 @@ public:
     void writeAt(size_t offset, const void *src, size_t len);
     auto getData() -> const char *;
     auto getLength() -> size_t;
+    /* Marks an already-built buffer as unusable (todo/38): clears the content
+     * so isValid() reports false. Used when a packed message turns out too
+     * large to frame — the buffer already holds the unframed bytes by that
+     * point, and this is the ABI-neutral way to fail it (no new data member,
+     * so no layout change to this installed-header class). */
+    void invalidate();
 };
 
 class fss_message_cb {

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -373,6 +373,11 @@ auto flight_safety_system::transport::buf_len::getLength() -> size_t
     return this->data.length();
 }
 
+void flight_safety_system::transport::buf_len::invalidate()
+{
+    this->data.clear();
+}
+
 flight_safety_system::transport::fss_message_cb::fss_message_cb(std::shared_ptr<fss_connection> t_conn)
     : conn(std::move(t_conn))
 {
@@ -517,6 +522,13 @@ void flight_safety_system::transport::fss_message::updateSize(const std::shared_
         if (length > std::numeric_limits<uint16_t>::max())
         {
             FSS_LOG_ERROR("transport", "Message of " << length << " bytes exceeds 16-bit length field; not framing");
+            /* todo/38: bl already holds the unframed header+payload at this
+             * point (createHeader/packData ran before updateSize). Leaving it
+             * as-is would let the caller's isValid() (merely "non-empty")
+             * pass and transmit the whole thing unframed, desyncing the
+             * peer's stream. Invalidate it so sendMsg() fails the send
+             * instead. */
+            bl->invalidate();
             return;
         }
         /* Set the length (the unpadded content length; the receiver re-derives

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -308,13 +308,22 @@ auto flight_safety_system::transport::fss_connection::connectTo(const std::strin
 auto flight_safety_system::transport::fss_connection::sendMsg(const std::shared_ptr<fss_message> &msg) -> bool
 {
     std::scoped_lock lock_holder(this->send_lock);
-    msg->setId(this->getMessageId());
+    uint64_t assigned_id = this->getMessageId();
+    msg->setId(assigned_id);
     auto bl = msg->getPacked();
 #ifdef DEBUG
     std::cout << "Sending message (len=" << bl->getLength() << ") to " << this->fd << std::endl;
 #endif
     if (!bl->isValid())
     {
+        /* todo/38: the message never went out (most commonly because it
+         * exceeds the 16-bit length field and updateSize() invalidated the
+         * buffer), so the id just assigned above must not leave a gap — the
+         * peer's v2 sequence check treats any gap as out-of-order (todo/39).
+         * Roll back under send_lock (still held here), the same lock
+         * getMessageId() incremented it under, so no concurrent sender can
+         * observe or reuse the rolled-back value. */
+        --this->last_msg_id;
         return false;
     }
     bool ret = this->sendMsg(bl);

--- a/tests/oversized_message_test.cpp
+++ b/tests/oversized_message_test.cpp
@@ -15,15 +15,21 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include <chrono>
 #include <cstdint>
 #include <memory>
+#include <string>
 
 #include "fss-transport.hpp"
+#include "secure-string.hpp"
 #include "test_helpers.hpp"
 
+using flight_safety_system::secure_string;
 using flight_safety_system::transport::fss_connection;
 using flight_safety_system::transport::fss_listen;
 using flight_safety_system::transport::fss_message;
+using flight_safety_system::transport::fss_message_rtt_request;
+using flight_safety_system::transport::fss_message_smm_settings;
 using flight_safety_system::transport::message_type_closed;
 
 namespace {
@@ -84,5 +90,59 @@ TEST_CASE("negative: oversized declared length closes connection")
     REQUIRE(n == 0);
 
     ::close(fd);
+    handoff.reset();
+}
+
+TEST_CASE("negative: an oversized message fails the send without consuming a sequence id")
+{
+    /* todo/38: a packed message over the 16-bit length field used to still
+     * transmit unframed (updateSize() left the length placeholder at 0 and
+     * the caller only checked isValid(), which merely means "non-empty").
+     * The receiver read length 0 and then parsed the remaining ~180 KB
+     * payload as a stream of garbage frame headers. sendMsg() must now fail
+     * the send outright, and the failed attempt must not consume a
+     * per-connection message id — otherwise the gap left behind would look
+     * like an out-of-order message to a v2 sequence check (todo/39). */
+    handoff.reset();
+    uint16_t port = fss_test::pick_port();
+    REQUIRE(port != 0);
+    auto listen = std::make_shared<fss_listen>(port, handoff.callback());
+    REQUIRE(listen != nullptr);
+
+    auto conn = std::make_shared<fss_connection>();
+    REQUIRE(conn != nullptr);
+    REQUIRE(conn->connectTo("localhost", port));
+
+    auto server_conn = handoff.wait();
+    REQUIRE(server_conn != nullptr);
+
+    auto get_next = [&]() -> std::shared_ptr<fss_message> {
+        std::shared_ptr<fss_message> msg;
+        REQUIRE(fss_test::wait_for([&]() -> bool {
+            msg = server_conn->getMsg();
+            return msg != nullptr;
+        }));
+        return msg;
+    };
+
+    REQUIRE(conn->sendMsg(std::make_shared<fss_message_rtt_request>()));
+    uint64_t first_id = get_next()->getId();
+
+    /* Three ~60 KB strings, each individually under packStringRaw's 16-bit
+     * per-string clamp, but packing to ~180 KB together — well over the
+     * whole-message 16-bit length field. */
+    std::string huge(60000, 'x');
+    auto oversized = std::make_shared<fss_message_smm_settings>(huge, secure_string(huge), secure_string(huge));
+    REQUIRE_FALSE(conn->sendMsg(oversized));
+
+    /* Nothing from the failed send reaches the peer. */
+    REQUIRE_FALSE(
+        fss_test::wait_for([&]() -> bool { return server_conn->getMsg() != nullptr; }, std::chrono::milliseconds(200)));
+
+    REQUIRE(conn->sendMsg(std::make_shared<fss_message_rtt_request>()));
+    uint64_t second_id = get_next()->getId();
+
+    REQUIRE(second_id == first_id + 1);
+
     handoff.reset();
 }


### PR DESCRIPTION
## Description

fss_message::updateSize() detects a packed message over the wire protocol's 16-bit length field, logs it, and used to just return -- leaving the length placeholder at 0 but the buffer (header + full oversized payload, already written by createHeader/packData before updateSize runs) otherwise intact. sendMsg() only checked bl->isValid(), which just means "non-empty", so the whole unframed buffer was transmitted anyway. The receiver reads the bogus zero-length frame, discards it, then parses the remaining payload bytes as a stream of garbage frame headers -- a poisoned connection instead of a clean local send failure.

buf_len gains invalidate() (clears its backing string; no new data member on an already-polymorphic class, so no ABI break on this installed header), called from updateSize()'s oversized branch so the existing isValid()/sendMsg() guard -- always present, just never triggered -- now actually fires. sendMsg() also rolls the per-connection message id back under send_lock when the pack turns out invalid, so the failed send leaves no id gap for a v2 sequence check to see as out-of-order (todo/39).

## Summary by Sourcery

Ensure oversized messages exceeding the 16-bit framing limit fail locally without corrupting the connection and without consuming a sequence id.

Bug Fixes:
- Prevent oversized, unframeable messages from being transmitted unframed by invalidating their buffer before send.
- Avoid gaps in per-connection message IDs by rolling back the last assigned id when a send fails due to an invalid packed buffer.

Enhancements:
- Add an invalidate() operation to buf_len so message packing can mark a buffer unusable in an ABI-neutral way.
- Extend negative transport tests to cover oversized sends, ensuring the peer receives nothing and sequence ids remain contiguous.

Tests:
- Add a regression test that sends an oversized settings message, verifies the sendMsg() call fails, confirms the server receives no message, and checks that subsequent message IDs are sequential.