### PR TITLE
fix(server): disconnect on any v2 sequence mismatch, not just identity

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -862,26 +862,24 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
         {
             if (msg->getSeq() != wanted)
             {
-                /* This check runs before the rate limiter, so a peer that
-                 * deliberately or buggily sends wrong sequence numbers would
-                 * otherwise hit this WARN once per message at line rate.
-                 * Throttle to first + every 100th (matching the duplicate-
-                 * version and null-frame paths) so one misbehaving peer cannot
-                 * flood the log. */
-                ++this->out_of_order_count;
-                constexpr uint64_t log_every = 100;
-                if (this->out_of_order_count == 1 || (this->out_of_order_count % log_every) == 0)
-                {
-                    FSS_LOG_WARN("server", "Out-of-order or duplicate message seq="
-                                               << msg->getSeq() << " expected=" << wanted
-                                               << " (count=" << this->out_of_order_count << ")");
-                }
-                if (msg->getType() == fss::transport::message_type_identity ||
-                    msg->getType() == fss::transport::message_type_identity_non_aircraft)
-                {
-                    this->client_handler->clientDisconnected(this);
-                    return;
-                }
+                /* todo/39: under this check's own stated assumptions (TLS
+                 * already rules out genuine reorder/replay at the record
+                 * layer), a mismatch on a live connection means either a
+                 * broken/misbehaving peer or a local framing bug (e.g. a
+                 * consumed-but-never-sent id — see todo/38) — either way,
+                 * expected_seq only advances on a match, so silently dropping
+                 * would freeze every subsequent message (positions, status,
+                 * RTT responses included) in a permanent drop loop until the
+                 * 30s liveness timeout eventually reaps the connection.
+                 * Disconnect immediately instead, exactly as the identity
+                 * case already did — a loud failure and clean reconnect beats
+                 * 30s of silently discarded telemetry. Only one such log line
+                 * can ever fire per session now (the session ends here), so
+                 * no throttling counter is needed. */
+                FSS_LOG_WARN("server", "Out-of-order or duplicate message seq=" << msg->getSeq() << " expected="
+                                                                                << wanted << " from " << this->getName()
+                                                                                << "; disconnecting");
+                this->client_handler->clientDisconnected(this);
                 return;
             }
             this->expected_seq.fetch_add(1);

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -275,11 +275,6 @@ private:
      * (never reset); touched only on the recv thread (processMessage), used
      * to throttle the warning. */
     uint64_t duplicate_version_count{0};
-    /* Cumulative out-of-order / duplicate (v2 sequence) messages seen this
-     * session (never reset); touched only on the recv thread (processMessage),
-     * used to throttle the warning so a peer streaming wrong sequence numbers
-     * cannot flood the log (the seq check runs before the rate limiter). */
-    uint64_t out_of_order_count{0};
     /* Per-client outbound writer (todo/21). The server main loop schedules
      * *what* to send by setting these pending flags; the worker thread does the
      * actual blocking socket write, so one black-holed peer can only stall its

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -1247,12 +1247,17 @@ auto establish_v2_session(std::shared_ptr<fss::server::fss_client> &session, uin
 }
 } // namespace
 
-TEST_CASE("session: v2 replayed data message is dropped")
+TEST_CASE("session: v2 replayed data message disconnects (todo/39)")
 {
-    /* m7.1 phase 2: a position report whose seq matches a message the server
-     * already processed (a duplicate within the session) must be discarded.
-     * This is in-order/duplicate detection, not a security replay defence —
-     * TLS already prevents record-layer replay. */
+    /* m7.1 phase 2 established that a position report whose seq matches a
+     * message the server already processed (a duplicate within the session)
+     * must not be forwarded — this is in-order/duplicate detection, not a
+     * security replay defence, since TLS already prevents record-layer
+     * replay. todo/39: expected_seq only ever advances on a match, so
+     * silently dropping (the original m7.1 behaviour) would freeze every
+     * subsequent message in a permanent drop loop until the 30s liveness
+     * timeout eventually reaped the connection. Disconnect immediately
+     * instead, the same as the identity case already did. */
     fss_test::MockDatabase mock;
     mock.asset_ids["craft"] = 1;
 
@@ -1278,7 +1283,42 @@ TEST_CASE("session: v2 replayed data message is dropped")
     replay->setId(next_id); // duplicate seq — replay
     session->processMessage(replay);
     REQUIRE(handler.broadcasts.size() == 1); // not forwarded
-    REQUIRE(handler.disconnects == 0);       // connection stays up
+    REQUIRE(handler.disconnects > 0);        // disconnected, not silently frozen
+}
+
+TEST_CASE("session: a seq mismatch disconnects immediately and names the mismatch in the log (todo/39)")
+{
+    /* Regression per the todo: disconnect must happen on the very next
+     * message (not after waiting out the 30s liveness timeout), and the log
+     * must name the seq/expected values rather than reading as a generic
+     * telemetry drop. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+
+    uint64_t next_id = 1;
+    establish_v2_session(session, next_id);
+    REQUIRE(handler.disconnects == 0);
+
+    fss_test::capture_cerr capture;
+    fss_test::scoped_log_level level("warn");
+
+    /* Jump ahead of expected_seq (next_id) rather than repeat it, so this
+     * exercises a genuine out-of-order gap, not just a duplicate. */
+    auto skipped = make_position_msg(fss::fss_current_timestamp());
+    skipped->setId(next_id + 5);
+    session->processMessage(skipped);
+
+    REQUIRE(handler.disconnects == 1); // immediate — no liveness timeout involved
+    auto log = capture.str();
+    REQUIRE(log.find("seq=") != std::string::npos);
+    REQUIRE(log.find("expected=") != std::string::npos);
 }
 
 TEST_CASE("session: duplicate version message is ignored without derailing the session")


### PR DESCRIPTION
## Description

expected_seq only ever advances on a match, so a single mismatch put a v2 session into a permanent silent drop loop for every message type except identity/identity_non_aircraft (which already disconnected). Positions, status, and RTT responses were all quietly discarded -- until the dropped RTT responses eventually starved liveness tracking and the 30s timeout reaped the connection.

Under the check's own stated assumption (TLS already rules out genuine reorder/replay), a mismatch on a live connection means either a broken/misbehaving peer or a local framing bug (the todo/38 id-gap scenario). Disconnect immediately for every message type, the same as identity already did -- a loud failure and clean reconnect beats 30s of silently discarded telemetry from an aircraft.

Since a disconnect ends the session, at most one such log can ever fire per session now, so the throttling counter this branch used (out_of_order_count) became dead weight and is removed.

## Summary by Sourcery

Tighten v2 session sequence handling so any sequence mismatch immediately disconnects the client instead of silently dropping messages.

Bug Fixes:
- Ensure replayed or out-of-order v2 data messages trigger an immediate disconnect rather than leaving the session in a silent drop loop.
- Include explicit sequence and expected values in the warning log when a sequence mismatch occurs.

Enhancements:
- Simplify sequence-mismatch logging by removing now-unnecessary throttling state for out-of-order counts.

Tests:
- Update the v2 replayed data message test to expect a disconnect and add a regression test verifying immediate disconnect and detailed logging on sequence mismatch.