### PR TITLE
fix(transport): validate the wire message type before casting to enum

### DIFF
--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -113,6 +113,39 @@ static auto decode_command_ack_reason(uint8_t reason) -> flight_safety_system::t
     }
 }
 
+/* Validate an untrusted wire value and map it to the matching
+ * fss_message_type enumerator. fss_message_type is an unscoped enum with no
+ * fixed underlying type, so its value range is only the bits needed for its
+ * enumerators (todo/12 C7); casting an arbitrary uint16_t straight into it
+ * (a value like 5000 from a malicious/buggy peer) is undefined behaviour per
+ * [dcl.enum]/8. Any value that is not a defined enumerator maps to
+ * message_type_unknown instead, mirroring decode_asset_command et al. above
+ * — message type is the one wire enum decode() did not already validate this
+ * way, being the very first untrusted field read off the wire. */
+static auto decode_message_type(uint16_t type_n) -> flight_safety_system::transport::fss_message_type
+{
+    using namespace flight_safety_system::transport;
+    switch (type_n)
+    {
+        case static_cast<uint16_t>(message_type_unknown): return message_type_unknown;
+        case static_cast<uint16_t>(message_type_closed): return message_type_closed;
+        case static_cast<uint16_t>(message_type_identity): return message_type_identity;
+        case static_cast<uint16_t>(message_type_rtt_request): return message_type_rtt_request;
+        case static_cast<uint16_t>(message_type_rtt_response): return message_type_rtt_response;
+        case static_cast<uint16_t>(message_type_position_report): return message_type_position_report;
+        case static_cast<uint16_t>(message_type_system_status): return message_type_system_status;
+        case static_cast<uint16_t>(message_type_search_status): return message_type_search_status;
+        case static_cast<uint16_t>(message_type_command): return message_type_command;
+        case static_cast<uint16_t>(message_type_server_list): return message_type_server_list;
+        case static_cast<uint16_t>(message_type_smm_settings): return message_type_smm_settings;
+        case static_cast<uint16_t>(message_type_identity_non_aircraft): return message_type_identity_non_aircraft;
+        case static_cast<uint16_t>(message_type_identity_required): return message_type_identity_required;
+        case static_cast<uint16_t>(message_type_version): return message_type_version;
+        case static_cast<uint16_t>(message_type_command_ack): return message_type_command_ack;
+        default: return message_type_unknown;
+    }
+}
+
 static void packStringRaw(const std::shared_ptr<flight_safety_system::transport::buf_len> &bl, const char *data,
                           size_t str_len)
 {
@@ -1333,7 +1366,7 @@ auto flight_safety_system::transport::fss_message::decode(const std::shared_ptr<
     const char *data = bl->getData();
     uint16_t type_n;
     memcpy(&type_n, data + sizeof(uint16_t), sizeof(uint16_t));
-    auto type = static_cast<fss_message_type>(fss_be16toh(type_n));
+    auto type = decode_message_type(fss_be16toh(type_n));
     uint64_t msg_id;
     memcpy(&msg_id, data + sizeof(uint16_t) + sizeof(uint16_t), sizeof(uint64_t));
     msg_id = fss_be64toh(msg_id);

--- a/tests/malformed_message_test.cpp
+++ b/tests/malformed_message_test.cpp
@@ -296,6 +296,23 @@ TEST_CASE("malformed: decode returns nullptr for unknown message type")
     REQUIRE(fss_message::decode(bl) == nullptr);
 }
 
+TEST_CASE("malformed: decode validates the wire type before casting (todo/40)")
+{
+    /* fss_message_type is an unscoped enum with no fixed underlying type, so
+     * its representable range is only the smallest bit-field that covers its
+     * enumerators (0..15 today, for the 15 values 0..14) — casting an
+     * arbitrary untrusted uint16_t straight into it is UB per [dcl.enum]/8
+     * for anything past that range (e.g. 5000). decode_message_type() must
+     * map every value that isn't a defined enumerator to message_type_unknown
+     * (undecodable) rather than ever performing that cast — checked here one
+     * past the last enumerator (in-range but still not a defined value), a
+     * mid-range unused byte, and the full 16-bit maximum (genuinely UB to
+     * cast). */
+    REQUIRE(fss_message::decode(fss_test::make_framed_buffer(15U, 1, "", 12)) == nullptr);
+    REQUIRE(fss_message::decode(fss_test::make_framed_buffer(255U, 2, "", 12)) == nullptr);
+    REQUIRE(fss_message::decode(fss_test::make_framed_buffer(0xFFFFU, 3, "", 12)) == nullptr);
+}
+
 TEST_CASE("malformed: decode returns nullptr for message_type_unknown")
 {
     auto bl = fss_test::make_framed_buffer(static_cast<uint16_t>(message_type_unknown), 1, "", 12);


### PR DESCRIPTION
## Description

fss_message::decode() cast the untrusted wire type field straight into fss_message_type, an unscoped enum with no fixed underlying type -- a value outside its representable range (e.g. 5000 from a malicious/buggy peer) is undefined behaviour per [dcl.enum]/8. Every other wire enum in this file (asset_command, command_ack_outcome, command_ack_reason) is already decoded through a validating switch on the raw integer before any cast, precisely to avoid this; message type was the one exception, despite being the very first untrusted field decode() reads.

Adds decode_message_type(), mirroring the existing three decoders: switch on the raw uint16_t, map anything that isn't a defined enumerator to message_type_unknown. decode()'s existing dispatch already treats that case as undecodable, so no other change was needed. Static, translation-unit-local, no exported symbol -- no ABI question, unlike giving the enum a fixed underlying type (which the todo explicitly rejected for exactly that reason, since this header is exported by all four shared libs).

## Summary by Sourcery

Validate decoded message types from the wire before using them, ensuring malformed or out-of-range values are treated as unknown and rejected.

Bug Fixes:
- Prevent undefined behaviour by avoiding direct casts from untrusted uint16_t values to fss_message_type and mapping invalid values to message_type_unknown instead.

Tests:
- Add malformed message tests that verify decode() rejects out-of-range and non-enumerator wire message type values by treating them as undecodable.