### PR TITLE
fix(db): fail active-server read when a FETCH truncates a host variable

### DIFF
--- a/docker/db-unit-test-entrypoint.sh
+++ b/docker/db-unit-test-entrypoint.sh
@@ -26,6 +26,15 @@ INSERT INTO config_assetconfig (asset_id, smm_id, smm_login, smm_password)
 INSERT INTO config_serverconfig (address, client_port, active, name, config_port, https)
     VALUES ('fss.example.com', 20202, true, 'test-server', 8090, false);
 
+-- todo/41 fixture: an address of 255 two-byte UTF-8 characters (510 bytes)
+-- fits VARCHAR(255) (which counts characters, not bytes) but overflows the
+-- 256-byte ECPG host variable server_address is fetched into, triggering a
+-- truncation warning. Seeded inactive so it is invisible to every other
+-- getActiveServers() test; the todo/41 regression test flips it active for
+-- the duration of that one test only.
+INSERT INTO config_serverconfig (address, client_port, active, name, config_port, https)
+    VALUES (repeat('é', 255), 20203, false, 'test-server-truncated', 8091, false);
+
 -- A pending command for test-asset, so the getCommand DB test finds a row.
 INSERT INTO assets_assetcommand (asset_id, command)
     SELECT a.id, 'RTL' FROM assets_asset a WHERE a.name = 'test-asset';

--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -408,6 +408,28 @@ db_active_fss_servers_get(const char *conn_arg, int *error_out)
         *error_out = 1;
     }
 
+    /* A FETCH that truncates server_address (longer than SMM_SERVER_LEN-1)
+     * raises a warning, not an error: WHENEVER SQLWARNING DO BREAK above ends
+     * the loop with sqlcode staying >= 0, so the check above alone misses it.
+     * The truncated row is never appended (same as a real fetch failure) and
+     * no further rows are read -- but without this check the caller would see
+     * fetch_error == 0 and ship the partial list as the complete set, exactly
+     * what the mid-cursor guard above exists to prevent. Treat it identically:
+     * fail the whole read, mirroring the truncation guards in
+     * db_asset_command_get / db_asset_smm_settings_get. */
+    if (error_out != NULL && sqlca.sqlwarn[0] == 'W')
+    {
+        /* server_address is not guaranteed NUL-terminated when this is the
+         * fetch that truncated it -- ECPG fills the buffer to capacity with
+         * no room left for a terminator. Bound the print with the buffer
+         * size as a precision (stopping at an earlier NUL if present, but
+         * never reading past it) rather than "%s", which would read past the
+         * end of the buffer into adjacent stack memory. */
+        fprintf(stderr, "active server list FETCH truncated a host variable (address='%.*s'); failing the read\n",
+                (int)sizeof(server_address), server_address);
+        *error_out = 1;
+    }
+
     EXEC SQL AT :conn CLOSE cur1;
     EXEC SQL AT :conn SET AUTOCOMMIT TO ON;
 

--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -164,6 +164,68 @@ TEST_CASE("db_connection: getActiveServers returns pre-configured server")
     REQUIRE(found);
 }
 
+namespace {
+/* Flip the todo/41 truncation-fixture row's active flag via psql, mirroring
+ * docker/db-unit-test-entrypoint.sh's own fixture-seeding approach (no raw
+ * SQL capability is exposed through db_connection's public API). The row is
+ * seeded inactive by that script so no other getActiveServers() test ever
+ * sees it; this helper activates it only for the duration of one test. */
+auto set_truncated_server_active(bool active) -> int
+{
+    const char *host = std::getenv("TEST_DB_HOST");
+    const char *port = std::getenv("TEST_DB_PORT");
+    const char *user = std::getenv("TEST_DB_USER");
+    const char *pass = std::getenv("TEST_DB_PASS");
+    const char *dbname = std::getenv("TEST_DB_NAME");
+    std::string cmd = "PGPASSWORD='";
+    cmd += (pass != nullptr ? pass : "password");
+    cmd += "' psql -h ";
+    cmd += (host != nullptr ? host : "db");
+    cmd += " -p ";
+    cmd += (port != nullptr ? port : "5432");
+    cmd += " -U ";
+    cmd += (user != nullptr ? user : "postgres");
+    cmd += " -d ";
+    cmd += (dbname != nullptr ? dbname : "postgres");
+    cmd += " -c \"UPDATE config_serverconfig SET active = ";
+    cmd += (active ? "true" : "false");
+    cmd += " WHERE name = 'test-server-truncated'\" > /dev/null";
+    return std::system(cmd.c_str());
+}
+
+/* RAII: guarantees the fixture row is deactivated again even if the body of
+ * the test that activated it fails an assertion partway through. The
+ * deactivate call in the destructor uses CHECK, not REQUIRE: this destructor
+ * is implicitly noexcept, and a REQUIRE failure throws Catch2's internal
+ * test-failure exception, which would call std::terminate if thrown from
+ * here -- especially likely to happen exactly when unwinding from the
+ * activating test's own REQUIRE failure. */
+class scoped_truncated_server_active {
+public:
+    scoped_truncated_server_active() { REQUIRE(set_truncated_server_active(true) == 0); }
+    scoped_truncated_server_active(const scoped_truncated_server_active &) = delete;
+    scoped_truncated_server_active(scoped_truncated_server_active &&) = delete;
+    auto operator=(const scoped_truncated_server_active &) -> scoped_truncated_server_active & = delete;
+    auto operator=(scoped_truncated_server_active &&) -> scoped_truncated_server_active & = delete;
+    ~scoped_truncated_server_active() { CHECK(set_truncated_server_active(false) == 0); }
+};
+} // namespace
+
+TEST_CASE("db_connection: getActiveServers throws when a server address is truncated (todo/41)")
+{
+    /* A FETCH that truncates server_address ends the cursor loop with a
+     * warning (sqlcode >= 0), not an error. Before todo/41's fix, getActive
+     * Servers() would see fetch_error == 0 and return whatever was
+     * accumulated before the bad row as the complete set -- silently
+     * dropping every server sorted after it. It must now throw
+     * database_error instead, exactly like a mid-cursor read error, so the
+     * poller's exception_guard keeps the previous good cache rather than
+     * shipping a partial list to aircraft. */
+    LIVE_DB_OR_SKIP(dbc);
+    scoped_truncated_server_active guard;
+    REQUIRE_THROWS_AS(dbc->getActiveServers(), flight_safety_system::server::database_error);
+}
+
 TEST_CASE("db_connection: tryReconnectIfNeeded returns when connection is healthy")
 {
     LIVE_DB_OR_SKIP(dbc);


### PR DESCRIPTION
## Description

WHENEVER SQLWARNING DO BREAK ends db_active_fss_servers_get's cursor loop on a truncated server_address (an address longer than SMM_SERVER_LEN-1), but the loop only captured sqlcode < 0 -- a warning leaves sqlcode >= 0, so the caller saw fetch_error == 0 and shipped whatever was accumulated before the bad row as the complete active-server list. Aircraft would silently lose knowledge of every server sorted after the truncated row -- exactly the outcome the mid-cursor error guard exists to prevent, and inconsistent with the truncation guards the sibling getters already have.

Also check sqlca.sqlwarn[0] (matches the generated break condition exactly, so it's neither over- nor under-broad) and fail the read the same way as a mid-cursor error, so the poller's exception_guard keeps the previous good cache.

## Summary by Sourcery

Treat truncated server addresses in active-server queries as failures rather than returning partial results.

Bug Fixes:
- Ensure getActiveServers fails when a FETCH truncates the server_address host variable instead of returning a partial active-server list.

Deployment:
- Extend the DB unit test entrypoint to seed a truncated server address fixture row used only by the new regression test.

Tests:
- Add a live-DB regression test that activates a specially seeded truncated server row and asserts getActiveServers throws a database_error when its address is truncated.