### PR TITLE
fix(transport): explicitly request dual-stack on the PF_INET6 listener

### DIFF
--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -723,6 +723,19 @@ auto flight_safety_system::transport::fss_listen::startListening() -> bool
     {
         FSS_PERROR("transport", "setsockopt SO_REUSEADDR failed on port " + std::to_string(this->port));
     }
+    /* Explicitly request dual-stack: this socket must accept both IPv6 and
+     * IPv4-mapped connections, matching connectTo()'s ability to reach either
+     * family. Without this, whether IPv4 clients can connect at all depends
+     * on the host's net.ipv6.bindv6only sysctl -- 0 (the Linux default)
+     * happens to give dual-stack, but 1 (some hardening baselines, and the
+     * default on some BSDs) silently refuses every IPv4 client with nothing
+     * in the log to say why. A failed setsockopt here just means the sysctl
+     * default applies, same as before this call existed. */
+    int v6only = 0;
+    if (setsockopt(this->getFd(), IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(v6only)) < 0)
+    {
+        FSS_PERROR("transport", "setsockopt IPV6_V6ONLY failed on port " + std::to_string(this->port));
+    }
     struct sockaddr_in6 bind_addr = {};
     bind_addr.sin6_family = AF_INET6;
     bind_addr.sin6_port = htons(this->port);

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -16,6 +16,7 @@
 #include <csignal>
 #include <thread>
 
+#include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <pthread.h>
 #include <sys/socket.h>
@@ -238,6 +239,64 @@ TEST_CASE("set_tcp_keepalive bounds unacked data with TCP_USER_TIMEOUT")
     REQUIRE(::getsockopt(sock, IPPROTO_TCP, TCP_USER_TIMEOUT, &val, &len) == 0);
     REQUIRE(val == 30000);
 #endif
+}
+
+namespace {
+/* Exposes the protected fd so a test can pin socket options on it (todo/42);
+ * otherwise identical to the base fss_listen. */
+class fd_visible_listen : public flight_safety_system::transport::fss_listen {
+public:
+    fd_visible_listen(uint16_t t_port, flight_safety_system::transport::fss_connect_cb t_cb)
+        : fss_listen(t_port, std::move(t_cb), defer_start_t{})
+    {
+        /* Start the accept thread only once this derived object is fully
+         * constructed; the auto-starting base constructor would let the thread
+         * virtual-dispatch into newConnection() before the vptr settles
+         * (the same TSan-flagged vptr-race hazard small_queue_listen above
+         * already avoids this way). */
+        this->startListening();
+    }
+    auto testGetFd() -> int { return this->getFd(); }
+};
+} // namespace
+
+TEST_CASE("fss_listen: startListening requests dual-stack (IPV6_V6ONLY=0) (todo/42)")
+{
+    /* Regression-pin that startListening() explicitly requests dual-stack,
+     * the same pin-the-socket-option pattern as TCP_USER_TIMEOUT above.
+     * Without this, whether an IPv4 client can connect at all silently
+     * depends on the host's net.ipv6.bindv6only sysctl. */
+    client_handoff.reset();
+    const auto port = fss_test::pick_port();
+    REQUIRE(port != 0);
+    fd_visible_listen listener(port, client_handoff.callback());
+
+    int val = -1;
+    socklen_t len = sizeof(val);
+    REQUIRE(::getsockopt(listener.testGetFd(), IPPROTO_IPV6, IPV6_V6ONLY, &val, &len) == 0);
+    REQUIRE(val == 0);
+
+    /* Functional case: an IPv4 (well, IPv4-mapped, since connectTo always
+     * resolves and connects over the family the address returns) client can
+     * still complete a message round-trip. This already passes today on the
+     * default sysctl -- the option pin above is what protects a hardened
+     * host where it would otherwise silently refuse. */
+    auto conn = std::make_shared<flight_safety_system::transport::fss_connection>();
+    REQUIRE(conn != nullptr);
+    REQUIRE(conn->connectTo("127.0.0.1", port));
+    conn->sendMsg(std::make_shared<flight_safety_system::transport::fss_message_identity>("v4Client"));
+
+    auto server_conn = client_handoff.wait();
+    REQUIRE(server_conn != nullptr);
+
+    std::shared_ptr<flight_safety_system::transport::fss_message> msg;
+    REQUIRE(fss_test::wait_for([&]() -> bool {
+        msg = server_conn->getMsg();
+        return msg != nullptr;
+    }));
+    REQUIRE(msg->getType() == flight_safety_system::transport::message_type_identity);
+
+    client_handoff.reset();
 }
 
 TEST_CASE("fss_connection: base isPeerCertRevoked always returns false")


### PR DESCRIPTION
## Description

fss_listen::startListening() opens a single PF_INET6 socket and binds the v6 wildcard, relying on IPv4-mapped addresses so IPv4 clients can connect too. It never set IPV6_V6ONLY, so whether that actually worked depended entirely on the host's net.ipv6.bindv6only sysctl -- 0 (the Linux default) gives dual-stack, but 1 (some hardening baselines, and the default on some BSDs) makes the socket v6-only and silently refuses every IPv4 client, with nothing in the log to say why. connectTo() is unaffected (it picks the family from the resolved address), so the failure is one-sided and confusing to diagnose.

Explicitly clears IPV6_V6ONLY after opening the socket and before bind() (the only valid ordering -- Linux rejects the option on an already-bound socket), matching the existing SO_REUSEADDR handling style: log and continue on failure, since that just means the sysctl default applies, same as before this call existed.

Verified against the actual failure mode, not just the socket option: with net.ipv6.bindv6only forced to 1, the fix correctly overrides it and an IPv4 client completes a full round-trip; reverted, the same forced setting reproduces the bug exactly as described.

## Summary by Sourcery

Ensure IPv6 listener sockets explicitly operate in dual-stack mode so IPv4 clients can reliably connect regardless of host sysctl configuration.

Bug Fixes:
- Force the PF_INET6 listener socket to clear IPV6_V6ONLY so IPv4 clients are accepted even on hardened hosts where the sysctl would otherwise make the socket IPv6-only.

Tests:
- Add a regression test that verifies fss_listen requests IPV6_V6ONLY=0 and that an IPv4 client can complete a full message round-trip to the IPv6 listener.