### PR TITLE
release: prepare 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-07-06
+
+### Fixed
+- `sendCommand`/`sendRTTRequest` no longer hold `client_lock` across a
+  blocking send (up to 30 s on a black-holed peer); the main loop's
+  `checkTimeouts()` takes the same lock, so one stuck peer could freeze the
+  100 ms command-dispatch tick fleet-wide. Completes todo/21's per-client
+  writer-thread guarantee, which this partially reopened. (todo/35)
+- `broadcastMsg` now routes through the per-client outbound workers (each
+  recipient gets its own message clone) instead of sending inline: the 15 s
+  server-list broadcast no longer blocks the main loop, and position relay no
+  longer blocks the reporting client's recv thread per message. (todo/36)
+- `rtt_response` and `command_ack` are now exempt from the per-client rate
+  limiter (acks get their own bucket), fixing a spurious liveness reap of a
+  chatty-but-healthy client and a permanent audit-link loss when an ack got
+  rate-limited (acks are never resent). (todo/37)
+- A message too large to frame (>64 KB) is no longer transmitted unframed
+  with a zero length field — which desynced the peer's stream into a
+  mass-undecodable-frame disconnect. `sendMsg()` now fails the send outright
+  and rolls back the consumed message id so no sequence gap is left behind.
+  (todo/38)
+- A v2 sequence mismatch now disconnects the session immediately, matching
+  the existing identity-mismatch behaviour, instead of silently freezing
+  `expected_seq` and discarding all further telemetry until the 30 s liveness
+  reap. (todo/39)
+- The wire message type is now validated (via a new `decode_message_type`
+  helper) before being cast to `fss_message_type`, closing the last wire enum
+  that was cast straight from an untrusted byte without validation. (todo/40)
+- `db_active_fss_servers_get` now fails the read when a FETCH truncates a
+  server address instead of silently shipping the partial list as complete:
+  the mid-cursor `database_error` guard now also fires on the
+  `WHENEVER SQLWARNING DO BREAK` exit path, so the poller keeps its previous
+  good cache. (todo/41)
+- The PF_INET6 listener now explicitly sets `IPV6_V6ONLY=0` before `bind()`,
+  so IPv4 clients are no longer silently refused on hosts with
+  `net.ipv6.bindv6only=1`. (todo/42)
+
 ## [1.1.0] - 2026-06-22
 
 ### Added

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([flight-safety-system], [1.1.0], [sjp@canterburyairpatrol.org])
+AC_INIT([flight-safety-system], [1.1.1], [sjp@canterburyairpatrol.org])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign -Wno-portability])
 
 m4_include([m4/ax_cxx_compile_stdcxx.m4])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,25 @@
+flight-safety-system (1.1.1) stable; urgency=medium
+
+  * Release client_lock before the blocking send in sendCommand/sendRTTRequest
+    so a black-holed peer can no longer freeze the main-loop's command-dispatch
+    tick fleet-wide.
+  * Route broadcastMsg through the per-client outbound workers instead of
+    sending inline, so the server-list broadcast and position relay can no
+    longer block the main loop or a reporting client's recv thread.
+  * Exempt rtt_response and command_ack from the per-client rate limiter,
+    fixing spurious liveness reaps and permanent audit-link loss.
+  * Fail sendMsg() outright on a message too large to frame instead of
+    transmitting it unframed and desyncing the peer's stream.
+  * Disconnect immediately on any v2 sequence mismatch instead of silently
+    freezing the session until the liveness timeout.
+  * Validate the wire message type before casting it to fss_message_type.
+  * Fail the active-server read when a FETCH truncates a server address,
+    instead of shipping a partial list as complete.
+  * Set IPV6_V6ONLY=0 on the PF_INET6 listener so IPv4 clients are not
+    silently refused on bindv6only=1 hosts.
+
+ -- Scott Parlane <sjp@canterburyairpatrol.org>  Mon, 06 Jul 2026 00:00:00 +0000
+
 flight-safety-system (1.1.0) stable; urgency=medium
 
   * Add command acknowledgements: the FMU acks each asset_command and the


### PR DESCRIPTION
## Description

Bump AC_INIT to 1.1.1, promote the CHANGELOG [Unreleased] section to [1.1.1] - 2026-07-06, and add the matching debian/changelog stanza.

All eight items from the 2026-07-04 critical review (todo/35-42) are fixed on develop: client_lock released across blocking sends, broadcastMsg routed through per-client workers, rate limiter exempts rtt_response/ command_ack, oversized sends fail instead of desyncing the stream, v2 sequence mismatches disconnect immediately, the wire message type is validated before casting, truncated active-server reads fail instead of shipping a partial list, and the PF_INET6 listener requests dual-stack explicitly. All are bug fixes with no new features and no installed-header ABI break (buf_len::invalidate() is a non-virtual addition with no new data member, per the todo/38 resolution), so -version-info stays 2:0:0.

./check-code.sh and `make check` both pass clean.

## Summary by Sourcery

Release version 1.1.1 with updated metadata and documented fixes for recent stability and networking issues.

Bug Fixes:
- Resolve multiple client communication and main-loop blocking issues, including lock handling across blocking sends and routing broadcasts through per-client workers.
- Fix rate limiting behaviour for acknowledgements and RTT responses to prevent false liveness reaps and audit link loss.
- Ensure oversized messages and v2 sequence mismatches fail fast with clean disconnects instead of desynchronizing or silently freezing telemetry.
- Validate wire message types before casting and treat truncated active-server reads as failures to avoid propagating partial or corrupt state.
- Allow IPv4 clients to connect to the IPv6 listener on dual-stack hosts by explicitly disabling IPv6-only binding.

Build:
- Bump project version to 1.1.1 in build configuration and Debian packaging metadata.

Documentation:
- Promote CHANGELOG Unreleased entries into the 1.1.1 release section with detailed notes on the fixed issues.