### PR TITLE
test(db): catch database_error by reference in the todo/41 regression test

### DIFF
--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -223,7 +223,19 @@ TEST_CASE("db_connection: getActiveServers throws when a server address is trunc
      * shipping a partial list to aircraft. */
     LIVE_DB_OR_SKIP(dbc);
     scoped_truncated_server_active guard;
-    REQUIRE_THROWS_AS(dbc->getActiveServers(), flight_safety_system::server::database_error);
+    /* Assert the throw manually rather than via REQUIRE_THROWS_AS: older Catch2
+     * expands that macro to a by-value catch clause, which trips
+     * -Werror=catch-value on the polymorphic database_error type. */
+    bool threw_database_error = false;
+    try
+    {
+        dbc->getActiveServers();
+    }
+    catch (const flight_safety_system::server::database_error &)
+    {
+        threw_database_error = true;
+    }
+    REQUIRE(threw_database_error);
 }
 
 TEST_CASE("db_connection: tryReconnectIfNeeded returns when connection is healthy")


### PR DESCRIPTION
## Description

REQUIRE_THROWS_AS(dbc->getActiveServers(), ...database_error) failed to build under -Werror=catch-value on distros still packaging Catch2 v2 (e.g. bookworm): that macro's older expansion catches by value, and database_error is polymorphic. server_session_test.cpp already hit and documented this exact issue; apply the same manual try/catch-by-reference pattern here instead of the macro.

## Summary by Sourcery

Tests:
- Adjust the getActiveServers truncation regression test to assert database_error is thrown via manual try/catch instead of REQUIRE_THROWS_AS.