### PR TITLE
fix(docker): build all_test before the db-unit-test entrypoint execs it

### DIFF
--- a/docker/db-unit-test.Dockerfile
+++ b/docker/db-unit-test.Dockerfile
@@ -17,7 +17,8 @@ WORKDIR /code
 
 RUN ./autogen.sh \
     && ./configure --enable-tests --enable-server --enable-coverage \
-    && make -j"$(nproc)"
+    && make -j"$(nproc)" \
+    && make -j"$(nproc)" -C tests all_test
 
 WORKDIR /code/tests
 


### PR DESCRIPTION
## Description

all_test is an Automake check_PROGRAMS target, which plain `make`/`make all` never builds. docker/db-unit-test.Dockerfile only ran `make`, so the image never actually built the test binary; the entrypoint's exec then failed at runtime with a misleading "cannot open shared object file" error instead of running the DB-backed unit tests it's meant to.

## Summary by Sourcery

Bug Fixes:
- Fix db-unit-test Docker image so it builds the all_test Automake target instead of relying on plain make.