### PR TITLE
fix(docker): make .dockerignore patterns match nested build artifacts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,13 @@
 .git/
 
 # ── Everything in .gitignore (build artefacts from a dirty local tree) ────────
-.DS_Store
+# NOTE: bare patterns like `*.o` only match files at the context root, not in
+# subdirectories (unlike .gitignore) -- Docker's ignore-file matching requires
+# an explicit `**/` prefix for that. Patterns below that can appear inside
+# src/, tests/, or examples/ (object files, Makefiles, .libs/, coverage data,
+# ...) are prefixed accordingly so a build/coverage run on the host doesn't
+# leak stale, possibly foreign-ABI artefacts into the image.
+**/.DS_Store
 aclocal.m4
 ar-lib
 autom4te.cache/
@@ -10,35 +16,35 @@ compile
 m4/
 !m4/ax_cxx_compile_stdcxx.m4
 missing
-.libs/
-.deps/
+**/.libs/
+**/.deps/
 install-sh
 libtool
 ltmain.sh
 test-driver
 stamp-h1
-*.dSYM
-*.la
-Makefile
-Makefile.in
+**/*.dSYM
+**/*.la
+**/Makefile
+**/Makefile.in
 configure
 configure.in
 config.*
 depcomp
-*.lo
-*.o
-*.pc
+**/*.lo
+**/*.o
+**/*.pc
 todo/
-*~
+**/*~
 clang-tidy.log
 compile_commands.json
 __pycache__/
 .venv/
 .pytest_cache/
-.dirstamp
+**/.dirstamp
 *.tar.gz
-*.gcno
-*.gcda
+**/*.gcno
+**/*.gcda
 
 # ── Coverage reports (untracked, not in .gitignore) ───────────────────────────
 coverage*.info


### PR DESCRIPTION
## Description

Docker's .dockerignore matching differs from .gitignore: a bare pattern like *.o only excludes files at the build-context root, not in subdirectories. Nearly every pattern in this file (*.o, *.la, .libs/, .deps/, Makefile, *.gcda, ...) needs a `**/` prefix to actually exclude the copies of those files that autotools generates inside src/, tests/, and examples/.

In practice this let a host build/coverage run leak stale, host-toolchain artifacts into docker/db-unit-test.Dockerfile's COPY . /code/ step -- caught this via byte-identical stale .gcda files (confirmed by md5sum) causing gcov "version mismatch" warnings inside a freshly built container, since the host's gcc/gcov version differs from the container's.

## Summary by Sourcery

Bug Fixes:
- Ensure nested autotools-generated build and coverage artifacts are excluded from Docker build contexts to prevent stale host artifacts leaking into images.