### PR TITLE
test: tag Catch2 unit tests with TC-FSS-* traceability IDs

### DIFF
--- a/tests/alignment_regression_test.cpp
+++ b/tests/alignment_regression_test.cpp
@@ -67,7 +67,7 @@ auto pack_position_report(const std::string &callsign) -> size_t
 
 } // namespace
 
-TEST_CASE("alignment: non-aligned callsign lengths add no extra padding")
+TEST_CASE("alignment: non-aligned callsign lengths add no extra padding", "[TC-FSS-001]")
 {
     /* These lengths never hit the aligned edge in the buggy formula, so they
      * must pass both before and after the fix — guarding against regression
@@ -81,7 +81,7 @@ TEST_CASE("alignment: non-aligned callsign lengths add no extra padding")
     }
 }
 
-TEST_CASE("alignment: 8-byte-aligned callsign length adds 0 padding, not 8", "[bug10]")
+TEST_CASE("alignment: 8-byte-aligned callsign length adds 0 padding, not 8", "[bug10][TC-FSS-001]")
 {
     /* L where (header + fixed + 2 + L) % 8 == 0 triggers the bug.
      * header(12) + fixed_before_cs(32) + 2 = 46; L such that (46 + L) % 8 == 0:

--- a/tests/coordinate_precision_test.cpp
+++ b/tests/coordinate_precision_test.cpp
@@ -66,7 +66,7 @@ auto round_trip_voltage(double voltage) -> double
 
 } // namespace
 
-TEST_CASE("coord: -43.5, 172.5 round-trip accurate to 1e-6")
+TEST_CASE("coord: -43.5, 172.5 round-trip accurate to 1e-6", "[TC-FSS-001]")
 {
     double lat = 0.0, lng = 0.0;
     std::tie(lat, lng) = round_trip(-43.5, 172.5);
@@ -74,21 +74,21 @@ TEST_CASE("coord: -43.5, 172.5 round-trip accurate to 1e-6")
     REQUIRE(std::fabs(lng - 172.5) < 1e-6);
 }
 
-TEST_CASE("coord: near +180 wraparound round-trip")
+TEST_CASE("coord: near +180 wraparound round-trip", "[TC-FSS-001]")
 {
     double lat = 0.0, lng = 0.0;
     std::tie(lat, lng) = round_trip(0.0, 179.999999);
     REQUIRE(std::fabs(lng - 179.999999) < 1e-6);
 }
 
-TEST_CASE("coord: near -180 wraparound round-trip")
+TEST_CASE("coord: near -180 wraparound round-trip", "[TC-FSS-001]")
 {
     double lat = 0.0, lng = 0.0;
     std::tie(lat, lng) = round_trip(0.0, -179.999999);
     REQUIRE(std::fabs(lng - (-179.999999)) < 1e-6);
 }
 
-TEST_CASE("coord: near zero round-trip")
+TEST_CASE("coord: near zero round-trip", "[TC-FSS-001]")
 {
     double lat = 0.0, lng = 0.0;
     std::tie(lat, lng) = round_trip(0.000001, 0.000001);
@@ -96,7 +96,7 @@ TEST_CASE("coord: near zero round-trip")
     REQUIRE(std::fabs(lng - 0.000001) < 1e-6);
 }
 
-TEST_CASE("coord: exact zero round-trip")
+TEST_CASE("coord: exact zero round-trip", "[TC-FSS-001]")
 {
     double lat = 0.0, lng = 0.0;
     std::tie(lat, lng) = round_trip(0.0, 0.0);
@@ -104,7 +104,7 @@ TEST_CASE("coord: exact zero round-trip")
     REQUIRE(lng == 0.0);
 }
 
-TEST_CASE("coord: southernmost latitudes round-trip")
+TEST_CASE("coord: southernmost latitudes round-trip", "[TC-FSS-001]")
 {
     for (double target : {-85.0, -89.0, -89.999999})
     {
@@ -115,7 +115,7 @@ TEST_CASE("coord: southernmost latitudes round-trip")
     }
 }
 
-TEST_CASE("coord: northernmost latitudes round-trip")
+TEST_CASE("coord: northernmost latitudes round-trip", "[TC-FSS-001]")
 {
     for (double target : {85.0, 89.0, 89.999999})
     {
@@ -126,7 +126,7 @@ TEST_CASE("coord: northernmost latitudes round-trip")
     }
 }
 
-TEST_CASE("coord: 7-decimal-place precision preserved")
+TEST_CASE("coord: 7-decimal-place precision preserved", "[TC-FSS-001]")
 {
     /* FSS_COORD_SCALE = 1e-7 gives int32 resolution of 0.1 µdegree, so
      * 7-decimal-place coordinates round-trip without loss. */
@@ -147,7 +147,7 @@ TEST_CASE("coord: 7-decimal-place precision preserved")
  * above the sentinel) so a clamped real value can never alias it.
  */
 
-TEST_CASE("coord: asset_command RTL (NaN lat/lng) round-trips to NaN, not Null Island")
+TEST_CASE("coord: asset_command RTL (NaN lat/lng) round-trips to NaN, not Null Island", "[TC-FSS-001]")
 {
     /* RTL constructed with (command, timestamp) leaves latitude and longitude
      * as NaN (it carries no position). That must decode back to NaN, not to
@@ -161,7 +161,7 @@ TEST_CASE("coord: asset_command RTL (NaN lat/lng) round-trips to NaN, not Null I
     REQUIRE(std::isnan(decoded->getLongitude()));
 }
 
-TEST_CASE("coord: asset_command HOLD (NaN lat/lng) round-trips to NaN, not Null Island")
+TEST_CASE("coord: asset_command HOLD (NaN lat/lng) round-trips to NaN, not Null Island", "[TC-FSS-001]")
 {
     auto orig = std::make_shared<fss_message_asset_command>(asset_command_hold, /*timestamp*/ 12345ULL);
     orig->setId(2);
@@ -172,7 +172,7 @@ TEST_CASE("coord: asset_command HOLD (NaN lat/lng) round-trips to NaN, not Null 
     REQUIRE(std::isnan(decoded->getLongitude()));
 }
 
-TEST_CASE("coord: position_report NaN lat/lng round-trips to NaN, not Null Island")
+TEST_CASE("coord: position_report NaN lat/lng round-trips to NaN, not Null Island", "[TC-FSS-001]")
 {
     /* A client with no GPS fix sends the default-NaN position. It must not be
      * indistinguishable from a real report at 0N 0E. */
@@ -190,7 +190,7 @@ TEST_CASE("coord: position_report NaN lat/lng round-trips to NaN, not Null Islan
     REQUIRE(std::isnan(decoded->getLongitude()));
 }
 
-TEST_CASE("coord: position_report Inf lat/lng round-trips to NaN, not Null Island")
+TEST_CASE("coord: position_report Inf lat/lng round-trips to NaN, not Null Island", "[TC-FSS-001]")
 {
     /* Infinity is also non-finite and maps to the no-fix sentinel. */
     auto orig = std::make_shared<fss_message_position_report>(
@@ -207,7 +207,7 @@ TEST_CASE("coord: position_report Inf lat/lng round-trips to NaN, not Null Islan
     REQUIRE(std::isnan(decoded->getLongitude()));
 }
 
-TEST_CASE("coord: out-of-range latitude clamps rather than wrapping")
+TEST_CASE("coord: out-of-range latitude clamps rather than wrapping", "[TC-FSS-001]")
 {
     /* A coordinate of 1e12 degrees scaled by 1e-7 exceeds INT32_MAX.
      * pack_scaled_coord must clamp to INT32_MAX rather than invoking UB. */
@@ -221,7 +221,7 @@ TEST_CASE("coord: out-of-range latitude clamps rather than wrapping")
     REQUIRE(lat > 0.0);
 }
 
-TEST_CASE("coord: large negative out-of-range latitude clamps rather than wrapping")
+TEST_CASE("coord: large negative out-of-range latitude clamps rather than wrapping", "[TC-FSS-001]")
 {
     double neg_large = -1e12;
     double lat = 0.0, lng = 0.0;
@@ -237,19 +237,19 @@ TEST_CASE("coord: large negative out-of-range latitude clamps rather than wrappi
 /* The system-status battery voltage is packed through the same scaled-int
  * helper, so it needs the same NaN/Inf/out-of-range guarding. */
 
-TEST_CASE("voltage: NaN and Inf battery voltage pack to zero")
+TEST_CASE("voltage: NaN and Inf battery voltage pack to zero", "[TC-FSS-001]")
 {
     REQUIRE(round_trip_voltage(std::numeric_limits<double>::quiet_NaN()) == 0.0);
     REQUIRE(round_trip_voltage(std::numeric_limits<double>::infinity()) == 0.0);
     REQUIRE(round_trip_voltage(-std::numeric_limits<double>::infinity()) == 0.0);
 }
 
-TEST_CASE("voltage: negative battery voltage clamps to zero")
+TEST_CASE("voltage: negative battery voltage clamps to zero", "[TC-FSS-001]")
 {
     REQUIRE(round_trip_voltage(-5.0) == 0.0);
 }
 
-TEST_CASE("voltage: out-of-range battery voltage clamps rather than wrapping")
+TEST_CASE("voltage: out-of-range battery voltage clamps rather than wrapping", "[TC-FSS-001]")
 {
     const double voltage = round_trip_voltage(1e12);
     REQUIRE(std::isfinite(voltage));

--- a/tests/endianness_test.cpp
+++ b/tests/endianness_test.cpp
@@ -51,7 +51,7 @@ auto to_bytes(const std::shared_ptr<buf_len> &bl) -> std::vector<uint8_t>
 
 } // namespace
 
-TEST_CASE("endianness: identity decode matches hand-authored big-endian bytes")
+TEST_CASE("endianness: identity decode matches hand-authored big-endian bytes", "[TC-FSS-001]")
 {
     /* Layout:
      *   [0..1]  length       = 0x0010 (16 bytes declared length — "test" is 4 chars)
@@ -77,7 +77,7 @@ TEST_CASE("endianness: identity decode matches hand-authored big-endian bytes")
     REQUIRE(ident->getName() == "test");
 }
 
-TEST_CASE("endianness: identity pack produces the documented big-endian bytes")
+TEST_CASE("endianness: identity pack produces the documented big-endian bytes", "[TC-FSS-001]")
 {
     auto msg = std::make_shared<fss_message_identity>("test");
     msg->setId(42);
@@ -106,7 +106,7 @@ TEST_CASE("endianness: identity pack produces the documented big-endian bytes")
     REQUIRE(bytes[15] == 't');
 }
 
-TEST_CASE("endianness: rtt_response pack/unpack uses big-endian 64-bit id")
+TEST_CASE("endianness: rtt_response pack/unpack uses big-endian 64-bit id", "[TC-FSS-001]")
 {
     auto msg = std::make_shared<fss_message_rtt_response>(0x0102030405060708ULL);
     msg->setId(0xAABBCCDDEEFF0011ULL);
@@ -144,7 +144,7 @@ TEST_CASE("endianness: rtt_response pack/unpack uses big-endian 64-bit id")
     REQUIRE(rr->getRequestId() == 0x0102030405060708ULL);
 }
 
-TEST_CASE("endianness: search_status uses big-endian 64-bit fields")
+TEST_CASE("endianness: search_status uses big-endian 64-bit fields", "[TC-FSS-001]")
 {
     auto msg = std::make_shared<fss_message_search_status>(
         /*search_id*/ 0x1111111111111111ULL,

--- a/tests/malformed_message_test.cpp
+++ b/tests/malformed_message_test.cpp
@@ -48,7 +48,7 @@ using flight_safety_system::transport::message_type_smm_settings;
 using flight_safety_system::transport::message_type_system_status;
 using flight_safety_system::transport::message_type_unknown;
 
-TEST_CASE("malformed: undecodable frame stream is log-throttled and survivable")
+TEST_CASE("malformed: undecodable frame stream is log-throttled and survivable", "[TC-FSS-004]")
 {
     /* A connected peer streaming garbage frames used to emit one WARN per
      * frame — unbounded log growth at line rate.  The log is now throttled
@@ -98,7 +98,7 @@ TEST_CASE("malformed: undecodable frame stream is log-throttled and survivable")
     REQUIRE(occurrences == 3);
 }
 
-TEST_CASE("malformed: valid message mid-stream re-arms the log throttle")
+TEST_CASE("malformed: valid message mid-stream re-arms the log throttle", "[TC-FSS-004]")
 {
     /* The throttle counter resets on every successfully decoded message, so
      * a second garbage burst must log from its own frame 1 again - proving
@@ -156,7 +156,7 @@ TEST_CASE("malformed: valid message mid-stream re-arms the log throttle")
  * be updated alongside it. */
 static constexpr uint64_t kNullMsgDisconnectThreshold = 1000;
 
-TEST_CASE("malformed: a garbage-only stream is disconnected after the threshold")
+TEST_CASE("malformed: a garbage-only stream is disconnected after the threshold", "[TC-FSS-004]")
 {
     /* A peer streaming nothing but undecodable frames must be closed once it
      * crosses null_msg_disconnect_threshold consecutive nulls, rather than
@@ -195,7 +195,7 @@ TEST_CASE("malformed: a garbage-only stream is disconnected after the threshold"
     REQUIRE(logged.find("consecutive undecodable frames, closing") != std::string::npos);
 }
 
-TEST_CASE("malformed: a peer just below the threshold is not disconnected")
+TEST_CASE("malformed: a peer just below the threshold is not disconnected", "[TC-FSS-004]")
 {
     /* Boundary: threshold - 1 consecutive nulls must leave the session up,
      * and a following valid message resets the counter and is delivered. */
@@ -231,7 +231,7 @@ TEST_CASE("malformed: a peer just below the threshold is not disconnected")
     REQUIRE(capture.str().find("consecutive undecodable frames, closing") == std::string::npos);
 }
 
-TEST_CASE("malformed: valid traffic interleaved with garbage keeps the session alive")
+TEST_CASE("malformed: valid traffic interleaved with garbage keeps the session alive", "[TC-FSS-004]")
 {
     /* Forward-compat: a version-skewed peer sends the odd unknown message type
      * interleaved with valid traffic. Each valid message resets the
@@ -272,7 +272,7 @@ TEST_CASE("malformed: valid traffic interleaved with garbage keeps the session a
     REQUIRE(capture.str().find("consecutive undecodable frames, closing") == std::string::npos);
 }
 
-TEST_CASE("malformed: decode returns nullptr for buffer shorter than header")
+TEST_CASE("malformed: decode returns nullptr for buffer shorter than header", "[TC-FSS-004]")
 {
     /* Header is 2 + 2 + 8 = 12 bytes. Anything shorter must not crash. */
     auto bl = std::make_shared<buf_len>("\x00", 1);
@@ -283,20 +283,20 @@ TEST_CASE("malformed: decode returns nullptr for buffer shorter than header")
     REQUIRE(fss_message::decode(bl2) == nullptr);
 }
 
-TEST_CASE("malformed: decode returns nullptr for empty buffer")
+TEST_CASE("malformed: decode returns nullptr for empty buffer", "[TC-FSS-004]")
 {
     auto bl = std::make_shared<buf_len>();
     REQUIRE(fss_message::decode(bl) == nullptr);
 }
 
-TEST_CASE("malformed: decode returns nullptr for unknown message type")
+TEST_CASE("malformed: decode returns nullptr for unknown message type", "[TC-FSS-004]")
 {
     /* 0x00FF is an unused enum value; decode must not crash. */
     auto bl = fss_test::make_framed_buffer(0x00FFU, 42, "", 12);
     REQUIRE(fss_message::decode(bl) == nullptr);
 }
 
-TEST_CASE("malformed: decode validates the wire type before casting (todo/40)")
+TEST_CASE("malformed: decode validates the wire type before casting (todo/40)", "[TC-FSS-004]")
 {
     /* fss_message_type is an unscoped enum with no fixed underlying type, so
      * its representable range is only the smallest bit-field that covers its
@@ -313,13 +313,13 @@ TEST_CASE("malformed: decode validates the wire type before casting (todo/40)")
     REQUIRE(fss_message::decode(fss_test::make_framed_buffer(0xFFFFU, 3, "", 12)) == nullptr);
 }
 
-TEST_CASE("malformed: decode returns nullptr for message_type_unknown")
+TEST_CASE("malformed: decode returns nullptr for message_type_unknown", "[TC-FSS-004]")
 {
     auto bl = fss_test::make_framed_buffer(static_cast<uint16_t>(message_type_unknown), 1, "", 12);
     REQUIRE(fss_message::decode(bl) == nullptr);
 }
 
-TEST_CASE("malformed: wrong-type dynamic_pointer_cast returns nullptr, no UB")
+TEST_CASE("malformed: wrong-type dynamic_pointer_cast returns nullptr, no UB", "[TC-FSS-004]")
 {
     /* Regression for todo/13-dynamic-cast-null-checks.md:
      * a message decoded as identity must not be cast-convertible to an
@@ -336,7 +336,7 @@ TEST_CASE("malformed: wrong-type dynamic_pointer_cast returns nullptr, no UB")
     REQUIRE(wrong_cast == nullptr);
 }
 
-TEST_CASE("malformed: zero-length string field decodes to empty string")
+TEST_CASE("malformed: zero-length string field decodes to empty string", "[TC-FSS-004]")
 {
     auto original = std::make_shared<fss_message_identity>("");
     original->setId(1);
@@ -348,7 +348,7 @@ TEST_CASE("malformed: zero-length string field decodes to empty string")
 /* Regression for todo/13: decode() must return a message whose getType()
  * matches the type field in the header.  These round-trip each concrete
  * message class through getPacked() → decode() and verify the invariant. */
-TEST_CASE("decode type consistency: identity")
+TEST_CASE("decode type consistency: identity", "[TC-FSS-004]")
 {
     auto orig = std::make_shared<fss_message_identity>("asset");
     orig->setId(1);
@@ -358,7 +358,7 @@ TEST_CASE("decode type consistency: identity")
     REQUIRE(std::dynamic_pointer_cast<fss_message_identity>(decoded) != nullptr);
 }
 
-TEST_CASE("decode type consistency: rtt_request")
+TEST_CASE("decode type consistency: rtt_request", "[TC-FSS-004]")
 {
     auto orig = std::make_shared<fss_message_rtt_request>();
     orig->setId(2);
@@ -368,7 +368,7 @@ TEST_CASE("decode type consistency: rtt_request")
     REQUIRE(std::dynamic_pointer_cast<fss_message_rtt_request>(decoded) != nullptr);
 }
 
-TEST_CASE("decode type consistency: rtt_response")
+TEST_CASE("decode type consistency: rtt_response", "[TC-FSS-004]")
 {
     auto orig = std::make_shared<fss_message_rtt_response>(99ULL);
     orig->setId(3);
@@ -378,7 +378,7 @@ TEST_CASE("decode type consistency: rtt_response")
     REQUIRE(std::dynamic_pointer_cast<fss_message_rtt_response>(decoded) != nullptr);
 }
 
-TEST_CASE("decode type consistency: system_status")
+TEST_CASE("decode type consistency: system_status", "[TC-FSS-004]")
 {
     auto orig = std::make_shared<fss_message_system_status>(80, 1200, 12.4);
     orig->setId(4);
@@ -388,7 +388,7 @@ TEST_CASE("decode type consistency: system_status")
     REQUIRE(std::dynamic_pointer_cast<fss_message_system_status>(decoded) != nullptr);
 }
 
-TEST_CASE("decode type consistency: search_status")
+TEST_CASE("decode type consistency: search_status", "[TC-FSS-004]")
 {
     auto orig = std::make_shared<fss_message_search_status>(1ULL, 50ULL, 100ULL);
     orig->setId(5);
@@ -398,7 +398,7 @@ TEST_CASE("decode type consistency: search_status")
     REQUIRE(std::dynamic_pointer_cast<fss_message_search_status>(decoded) != nullptr);
 }
 
-TEST_CASE("decode type consistency: server_list")
+TEST_CASE("decode type consistency: server_list", "[TC-FSS-004]")
 {
     auto orig = std::make_shared<fss_message_server_list>();
     orig->setId(6);
@@ -408,7 +408,7 @@ TEST_CASE("decode type consistency: server_list")
     REQUIRE(std::dynamic_pointer_cast<fss_message_server_list>(decoded) != nullptr);
 }
 
-TEST_CASE("decode type consistency: identity_non_aircraft")
+TEST_CASE("decode type consistency: identity_non_aircraft", "[TC-FSS-004]")
 {
     auto orig = std::make_shared<fss_message_identity_non_aircraft>();
     orig->setId(7);
@@ -418,7 +418,7 @@ TEST_CASE("decode type consistency: identity_non_aircraft")
     REQUIRE(std::dynamic_pointer_cast<fss_message_identity_non_aircraft>(decoded) != nullptr);
 }
 
-TEST_CASE("malformed: string alignment overshoot does not read past the buffer")
+TEST_CASE("malformed: string alignment overshoot does not read past the buffer", "[TC-FSS-004]")
 {
     /* Regression for a heap over-read: unpackString rounds the offset up to
      * an 8-byte boundary, which can push it past the declared buffer length;
@@ -456,7 +456,7 @@ TEST_CASE("malformed: string alignment overshoot does not read past the buffer")
     REQUIRE(servers[0].second == 1);
 }
 
-TEST_CASE("decode type consistency: position_report")
+TEST_CASE("decode type consistency: position_report", "[TC-FSS-004]")
 {
     auto orig =
         std::make_shared<fss_message_position_report>(-33.8688, 151.2093, 100, 0, 0, 0, 0, "TEST", 0, 0, 0, 0, 0, 0ULL);
@@ -467,7 +467,7 @@ TEST_CASE("decode type consistency: position_report")
     REQUIRE(std::dynamic_pointer_cast<fss_message_position_report>(decoded) != nullptr);
 }
 
-TEST_CASE("decode type consistency: command")
+TEST_CASE("decode type consistency: command", "[TC-FSS-004]")
 {
     auto orig = std::make_shared<fss_message_asset_command>(asset_command_rtl, 0ULL);
     orig->setId(9);
@@ -477,7 +477,7 @@ TEST_CASE("decode type consistency: command")
     REQUIRE(std::dynamic_pointer_cast<fss_message_asset_command>(decoded) != nullptr);
 }
 
-TEST_CASE("decode type consistency: smm_settings")
+TEST_CASE("decode type consistency: smm_settings", "[TC-FSS-004]")
 {
     auto orig = std::make_shared<fss_message_smm_settings>(
         "http://example.com", flight_safety_system::secure_string(std::string_view("user")),
@@ -489,7 +489,7 @@ TEST_CASE("decode type consistency: smm_settings")
     REQUIRE(std::dynamic_pointer_cast<fss_message_smm_settings>(decoded) != nullptr);
 }
 
-TEST_CASE("decode type consistency: identity_required")
+TEST_CASE("decode type consistency: identity_required", "[TC-FSS-004]")
 {
     auto orig = std::make_shared<fss_message_identity_required>();
     orig->setId(8);
@@ -503,7 +503,7 @@ TEST_CASE("decode type consistency: identity_required")
  * out-of-range wire byte to fss_asset_command was undefined behaviour.
  * After the fix decode_asset_command() validates the byte first and maps
  * any unrecognised value to asset_command_unknown. */
-TEST_CASE("malformed: out-of-range asset command byte decodes to asset_command_unknown")
+TEST_CASE("malformed: out-of-range asset command byte decodes to asset_command_unknown", "[TC-FSS-004]")
 {
     /* Build a valid asset_command message via getPacked(), then replace the
      * last byte (the command byte on the wire) with an out-of-range value.
@@ -534,7 +534,7 @@ TEST_CASE("malformed: out-of-range asset command byte decodes to asset_command_u
 
 /* Regression for todo/13: a cast to the wrong subclass must yield nullptr,
  * not a non-null pointer to a mismatched object — checked for every type. */
-TEST_CASE("decode type consistency: wrong cast always returns nullptr")
+TEST_CASE("decode type consistency: wrong cast always returns nullptr", "[TC-FSS-004]")
 {
     auto id_msg = std::make_shared<fss_message_identity>("x");
     id_msg->setId(1);
@@ -549,7 +549,7 @@ TEST_CASE("decode type consistency: wrong cast always returns nullptr")
 
 /* Defensive: the length field in the header claims more bytes than the
  * buffer actually contains. decode() must not read past the buffer. */
-TEST_CASE("malformed: oversized declared length does not read past buffer")
+TEST_CASE("malformed: oversized declared length does not read past buffer", "[TC-FSS-004]")
 {
     /* Declare 0xFFFF in the length prefix but only provide a header + a tiny
      * payload. The identity decode path reads the declared length as the

--- a/tests/messages.cpp
+++ b/tests/messages.cpp
@@ -176,7 +176,7 @@ TEST_CASE("RTT Response without a timestamp is byte-identical to a legacy respon
     REQUIRE(bl_with_ts->getLength() == bl_without->getLength() + sizeof(uint64_t));
 }
 
-TEST_CASE("Position Report Message Check")
+TEST_CASE("Position Report Message Check", "[TC-FSS-001]")
 {
     auto msg_id = static_cast<uint64_t>(random());
     constexpr double pos_lat = -43.5;
@@ -341,7 +341,7 @@ TEST_CASE("Search Status Message Check")
     REQUIRE(decoded_generic_search->getSearchTotal() == search_total);
 }
 
-TEST_CASE("Asset Command Message Check - Basic")
+TEST_CASE("Asset Command Message Check - Basic", "[TC-FSS-002]")
 {
     auto msg_id = static_cast<uint64_t>(random());
     auto timestamp = static_cast<uint64_t>(random());
@@ -376,7 +376,7 @@ TEST_CASE("Asset Command Message Check - Basic")
     REQUIRE(decoded_generic_command->getTimeStamp() == timestamp);
 }
 
-TEST_CASE("Asset Command Message Check - Position")
+TEST_CASE("Asset Command Message Check - Position", "[TC-FSS-002]")
 {
     auto msg_id = static_cast<uint64_t>(random());
     auto timestamp = static_cast<uint64_t>(random());
@@ -420,7 +420,7 @@ TEST_CASE("Asset Command Message Check - Position")
     REQUIRE(decoded_generic->getLongitude() == goto_lng);
 }
 
-TEST_CASE("Asset Command Message Check - Altitude")
+TEST_CASE("Asset Command Message Check - Altitude", "[TC-FSS-002]")
 {
     auto msg_id = static_cast<uint64_t>(random());
     auto timestamp = static_cast<uint64_t>(random());
@@ -645,7 +645,7 @@ TEST_CASE("SMM Settings Message Check")
     REQUIRE(decoded_generic_smm->getPassword() == "password1");
 }
 
-TEST_CASE("Server List Message Check")
+TEST_CASE("Server List Message Check", "[TC-FSS-003]")
 {
     auto msg_id = static_cast<uint64_t>(random());
     constexpr int port_max = 65535;

--- a/tests/oversized_message_test.cpp
+++ b/tests/oversized_message_test.cpp
@@ -59,7 +59,7 @@ auto raw_connect_oversized(uint16_t port) -> int
 
 } // namespace
 
-TEST_CASE("negative: oversized declared length closes connection")
+TEST_CASE("negative: oversized declared length closes connection", "[TC-FSS-004]")
 {
     handoff.reset();
     uint16_t port = fss_test::pick_port();
@@ -93,7 +93,7 @@ TEST_CASE("negative: oversized declared length closes connection")
     handoff.reset();
 }
 
-TEST_CASE("negative: an oversized message fails the send without consuming a sequence id")
+TEST_CASE("negative: an oversized message fails the send without consuming a sequence id", "[TC-FSS-004]")
 {
     /* todo/38: a packed message over the 16-bit length field used to still
      * transmit unframed (updateSize() left the length placeholder at 0 and


### PR DESCRIPTION
## Description

todo/27: mark the tests that already verify master-plan TC-FSS-001..004 so a collector can report their evidence to the test-plan audit.
- TC-FSS-001: position round-trip + coordinate_precision_test + endianness_test + alignment_regression_test
- TC-FSS-002: all asset-command-type round-trips
- TC-FSS-003: server-list round-trip
- TC-FSS-004 (unit share): malformed_message_test + oversized_message_test

## Summary by Sourcery

Tag existing Catch2 unit tests with TC-FSS-* traceability IDs for master test-plan linkage.

Tests:
- Annotate coordinate precision, endianness, alignment, and position report tests with TC-FSS-001 traceability ID.
- Annotate asset command round-trip tests with TC-FSS-002 traceability ID.
- Annotate server list round-trip tests with TC-FSS-003 traceability ID.
- Annotate malformed and oversized message behaviour and decode-consistency tests with TC-FSS-004 traceability ID.