### PR TITLE
test(e2e): tag e2e suites with TC-SRV-* traceability IDs

### DIFF
--- a/e2e/test_command_ack.py
+++ b/e2e/test_command_ack.py
@@ -150,6 +150,7 @@ def _poll_ack_state(db_conn, dbid: int, expected: int, timeout: float):
     return row[0] if row is not None else None
 
 
+@pytest.mark.satisfies("TC-SRV-004")
 @pytest.mark.requires_docker
 def test_command_ack_is_stored(db_conn, fake_client, server_proc):
     """A dispatched command, once acked by the client, lands its ack on the
@@ -206,6 +207,7 @@ def _dispatch_rtl(db_conn, asset_id: int) -> int:
     return new_dbid
 
 
+@pytest.mark.satisfies("TC-SRV-004")
 @pytest.mark.requires_docker
 def test_ack_does_not_cross_assets_on_dispatch_id_collision(
     db_conn, fake_client, server_proc
@@ -316,6 +318,7 @@ def test_ack_does_not_cross_assets_on_dispatch_id_collision(
         )
 
 
+@pytest.mark.satisfies("TC-SRV-004")
 @pytest.mark.requires_docker
 def test_ack_updates_only_the_latest_row_on_cross_session_dispatch_id_reuse(
     db_conn, fake_client, server_proc

--- a/e2e/test_command_injection.py
+++ b/e2e/test_command_injection.py
@@ -6,6 +6,7 @@ import time
 import pytest
 
 
+@pytest.mark.satisfies("TC-SRV-004")
 @pytest.mark.requires_docker
 def test_goto_command_delivered(db_conn, fake_client):
     """Server polls assets_assetcommand and sends asset_command_goto to any

--- a/e2e/test_command_read_under_write_stall.py
+++ b/e2e/test_command_read_under_write_stall.py
@@ -39,6 +39,7 @@ WRITER_SETTLE_S = 2.0
 COMMAND_DELIVERY_TIMEOUT_S = 8.0
 
 
+@pytest.mark.satisfies("TC-SRV-007")
 @pytest.mark.requires_docker
 @pytest.mark.slow
 def test_command_read_not_blocked_by_write_stall(db_conn, fake_client, migrated_db, server_proc):

--- a/e2e/test_db_negative.py
+++ b/e2e/test_db_negative.py
@@ -32,6 +32,7 @@ from conftest import (
 UNREACHABLE_DB_HOST = "192.0.2.1"
 
 
+@pytest.mark.satisfies("TC-SRV-007")
 @pytest.mark.requires_docker
 def test_server_exits_when_db_host_invalid(certs_dir, tmp_path, migrated_db):
     """fss-server must fail-stop when its configured DB host is unreachable.
@@ -106,6 +107,7 @@ def test_server_exits_when_db_host_invalid(certs_dir, tmp_path, migrated_db):
             s.connect(("127.0.0.1", port))
 
 
+@pytest.mark.satisfies("TC-SRV-007")
 @pytest.mark.requires_docker
 def test_unknown_asset_name_persists_no_data(db_conn, fake_client):
     """A client whose CN is signed by the trusted CA but not enrolled as an

--- a/e2e/test_position_flow.py
+++ b/e2e/test_position_flow.py
@@ -6,6 +6,7 @@ import time
 import pytest
 
 
+@pytest.mark.satisfies("TC-SRV-001")
 @pytest.mark.requires_docker
 def test_position_report_persisted(db_conn, fake_client):
     """fake-client sends position(lat=-43.5, lng=172.5) every 5s; after ~15s
@@ -34,6 +35,7 @@ def test_position_report_persisted(db_conn, fake_client):
         assert alt == 300
 
 
+@pytest.mark.satisfies("TC-SRV-001")
 @pytest.mark.requires_docker
 def test_status_and_search_persisted(db_conn, fake_client):
     with db_conn.cursor() as cur:

--- a/e2e/test_rtt.py
+++ b/e2e/test_rtt.py
@@ -6,6 +6,7 @@ import pytest
 from conftest import wait_for_row
 
 
+@pytest.mark.satisfies("TC-SRV-005")
 @pytest.mark.requires_docker
 @pytest.mark.slow
 def test_rtt_round_trip_recorded(db_conn, fake_client):

--- a/e2e/test_server_list.py
+++ b/e2e/test_server_list.py
@@ -10,6 +10,7 @@ import time
 import pytest
 
 
+@pytest.mark.satisfies("TC-SRV-003")
 @pytest.mark.requires_docker
 def test_server_list_does_not_disrupt_session(db_conn, fake_client):
     with db_conn.cursor() as cur:
@@ -40,6 +41,7 @@ def test_server_list_does_not_disrupt_session(db_conn, fake_client):
     assert count >= 1, "no positions after server_list delivery"
 
 
+@pytest.mark.satisfies("TC-SRV-003")
 @pytest.mark.requires_docker
 def test_server_list_with_full_serverconfig_columns(db_conn, fake_client):
     """Rows with name/config_port/https populated must not break server_list delivery.

--- a/e2e/test_slow_db_does_not_stall.py
+++ b/e2e/test_slow_db_does_not_stall.py
@@ -44,6 +44,7 @@ def hold_table_lock(db_info: dict[str, object], table: str) -> Iterator[None]:
         conn.close()
 
 
+@pytest.mark.satisfies("TC-SRV-007")
 @pytest.mark.requires_docker
 @pytest.mark.slow
 def test_slow_db_does_not_stall(db_conn, fake_client, migrated_db, server_proc):


### PR DESCRIPTION
## Description

todo/27: apply the satisfies marker vendored in the previous commit to the tests that already verify each TC-SRV ID per the per-repo-verification mapping:
- TC-SRV-001: test_position_flow.py
- TC-SRV-003: test_server_list.py
- TC-SRV-004: test_command_injection.py, test_command_ack.py
- TC-SRV-005: test_rtt.py
- TC-SRV-007: test_db_negative.py, test_slow_db_does_not_stall.py, test_command_read_under_write_stall.py

## Summary by Sourcery

Tag existing end-to-end test suites with satisfies markers for TC-SRV traceability IDs.

Enhancements:
- Associate e2e tests with their corresponding TC-SRV-* traceability IDs using the pytest satisfies marker for position flow, server list, command injection/ack, RTT, and DB-related scenarios.

Tests:
- Update existing e2e tests to declare which TC-SRV-* requirements they validate, improving requirements-to-test traceability.