### PR TITLE
ci: merge Catch2 + e2e traceability into one CI-run artifact

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -31,6 +31,16 @@ jobs:
     - name: make check
       run: make check
 
+    - name: collect Catch2 traceability
+      run: python3 tools/collect_catch2_traceability.py
+
+    - name: Upload Catch2 traceability artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: catch2-traceability
+        path: tests/catch2-traceability.json
+        retention-days: 14
+
     - name: prepare venv for distcheck
       run: |
         python3 -m venv .venv
@@ -219,7 +229,44 @@ jobs:
         cd e2e
         .venv/bin/pytest -v --timeout=120
 
-  # ─── 6. ThreadSanitizer: full unit suite + concurrency stress tests ──────
+    - name: Upload e2e traceability artifact
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: e2e-traceability
+        path: e2e/traceability.json
+        retention-days: 14
+
+  # ─── 6. Merge traceability evidence ──────────────────────────────────────
+  traceability:
+    runs-on: ubuntu-latest
+    needs: [ build-and-check, e2e ]
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Download Catch2 traceability artifact
+      uses: actions/download-artifact@v7
+      with:
+        name: catch2-traceability
+        path: tests
+
+    - name: Download e2e traceability artifact
+      uses: actions/download-artifact@v7
+      with:
+        name: e2e-traceability
+        path: e2e
+
+    - name: Merge into one report
+      run: python3 tools/merge_traceability.py tests/catch2-traceability.json e2e/traceability.json
+
+    - name: Upload merged traceability artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: traceability-report
+        path: traceability-report.json
+        retention-days: 14
+
+  # ─── 7. ThreadSanitizer: full unit suite + concurrency stress tests ──────
   thread-sanitizer:
     runs-on: ubuntu-latest
     needs: build-and-check
@@ -257,7 +304,7 @@ jobs:
       if: failure()
       run: cat tests/*.log 2>/dev/null || true
 
-  # ─── 7. AddressSanitizer + UndefinedBehaviorSanitizer ────────────────────
+  # ─── 8. AddressSanitizer + UndefinedBehaviorSanitizer ────────────────────
   sanitizers:
     runs-on: ubuntu-latest
     needs: build-and-check

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ __pycache__/
 # gcov coverage artefacts
 *.gcno
 *.gcda
+# Traceability report artifacts (todo/27)
+traceability-report.json

--- a/tools/merge_traceability.py
+++ b/tools/merge_traceability.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+Merge per-suite traceability artifacts (Catch2 tests/catch2-traceability.json,
+pytest e2e/traceability.json) into one CI-run artifact.
+
+Each input has the shape {"generated": iso8601, "test_ids": {tc_id: [{"nodeid",
+"outcome"}, ...]}}. A TC ID covered by more than one suite keeps every
+suite's entries rather than deduping — per todo/27, the master-plan audit
+distinguishes tiers by which report an ID appears in, so evidence from two
+tiers should both surface, not collapse into one.
+"""
+import argparse
+import datetime
+import json
+import pathlib
+import sys
+from collections import defaultdict
+
+
+def merge_reports(paths):
+    """
+    Read each traceability JSON in `paths` and union their test_ids maps.
+    """
+    merged = defaultdict(list)
+    for path in paths:
+        payload = json.loads(path.read_text(encoding='utf-8'))
+        for tc_id, entries in payload.get('test_ids', {}).items():
+            merged[tc_id].extend(entries)
+    return dict(sorted(merged.items()))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        'inputs', nargs='+', type=pathlib.Path,
+        help='traceability JSON artifacts to merge')
+    parser.add_argument(
+        '--output', type=pathlib.Path, default=pathlib.Path('traceability-report.json'),
+        help='where to write the merged artifact')
+    args = parser.parse_args()
+
+    missing = [path for path in args.inputs if not path.is_file()]
+    if missing:
+        for path in missing:
+            print(f'error: no such traceability artifact: {path}', file=sys.stderr)
+        return 1
+
+    merged = merge_reports(args.inputs)
+    payload = {
+        'generated': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        'sources': [str(path) for path in args.inputs],
+        'test_ids': merged,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2) + '\n', encoding='utf-8')
+    print(f'merged traceability report: {args.output} ({len(merged)} TC IDs)')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Description

todo/27: adds a `traceability` job (needs build-and-check + e2e) that downloads the tests/catch2-traceability.json and e2e/traceability.json artifacts each of those jobs now uploads and unions them via tools/merge_traceability.py into traceability-report.json. A TC ID covered by both tiers keeps entries from both rather than deduping, so the master-plan audit can see which tier(s) evidence a given ID.

## Summary by Sourcery

Add a CI traceability aggregation job that merges unit and e2e test coverage into a single artifact for each run.

Enhancements:
- Add a merge_traceability.py utility to combine multiple traceability JSON reports while preserving per-tier evidence.

CI:
- Upload separate Catch2 and e2e traceability JSON artifacts from their respective CI jobs.
- Introduce a dedicated traceability job that downloads per-suite artifacts, merges them, and uploads a unified traceability-report.json.