### PR TITLE
fix(security): close secure_string wiping gaps for smm_settings wire frames and pg pass

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -14,7 +14,7 @@ extern "C" {
 #include <vector>
 
 flight_safety_system::server::db_connection::db_connection(
-    std::string host, int port, std::string user, std::string pass,
+    std::string host, int port, std::string user, secure_string pass,
     std::string db) // NOLINT(bugprone-easily-swappable-parameters)
     : read_lock(), write_lock(), host_(std::move(host)), port_(port), user_(std::move(user)), pass_(std::move(pass)),
       db_(std::move(db))
@@ -25,7 +25,13 @@ flight_safety_system::server::db_connection::db_connection(
 
 auto flight_safety_system::server::db_connection::connectOne(const char *conn_name) -> bool
 {
-    return db_connect(conn_name, host_.c_str(), port_, user_.c_str(), pass_.c_str(), db_.c_str()) == 1;
+    /* pass_ is shared by both the read and write connections, each
+     * reconnected from its own thread under its own mutex (see
+     * fss-server.hpp), so a local toNulTerminated() copy is used here
+     * instead of a cached pointer on pass_ itself — see secure_string's
+     * comment. */
+    std::string pass_nt = pass_.toNulTerminated();
+    return db_connect(conn_name, host_.c_str(), port_, user_.c_str(), pass_nt.c_str(), db_.c_str()) == 1;
 }
 
 auto flight_safety_system::server::db_connection::isConnected() const -> bool

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -132,7 +132,9 @@ private:
     std::string host_;
     int port_{5432};
     std::string user_;
-    std::string pass_;
+    /* todo/43: held wiped (secure_string) rather than as a plain std::string
+     * resident for the life of the connection. */
+    secure_string pass_;
     std::string db_;
     auto connectOne(const char *conn_name) -> bool;
     void reconnectOne(const char *conn_name, std::atomic<bool> &connected_flag);
@@ -141,7 +143,7 @@ public:
      * connection (e.g. force one closed) without duplicating the literals. */
     static constexpr const char *read_conn_name = "fss_read";
     static constexpr const char *write_conn_name = "fss_write";
-    db_connection(std::string host, int port, std::string user, std::string pass, std::string db);
+    db_connection(std::string host, int port, std::string user, secure_string pass, std::string db);
     db_connection(db_connection &) = delete;
     db_connection(db_connection &&) = delete;
     auto operator=(db_connection &) -> db_connection & = delete;

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -200,6 +200,13 @@ public:
      * point, and this is the ABI-neutral way to fail it (no new data member,
      * so no layout change to this installed-header class). */
     void invalidate();
+    /* Scrubs the packed bytes with explicit_bzero before releasing them
+     * (todo/43): used for messages carrying credentials, where leaving the
+     * plaintext resident until the buffer's plain deallocation is an
+     * avoidable gap. Distinct from invalidate() (todo/38), which exists to
+     * fail a future send, not to scrub memory — though the end state
+     * (isValid() == false) is the same. */
+    void wipeSecure();
 };
 
 class fss_message_cb {

--- a/src/secure-string.hpp
+++ b/src/secure-string.hpp
@@ -2,11 +2,28 @@
 
 #include <cstring>
 #include <strings.h>
+#include <string>
 #include <string_view>
 #include <vector>
 
 namespace flight_safety_system {
 
+/* Scope decision (todo/43, 2026-07-10): secure_string's goal is limiting
+ * *long-lived resident copies* of credentials — cache/member fields such as
+ * smm_settings' username/password and db_connection::pass_ — not eliminating
+ * every transient copy a credential passes through on its way there. Wire
+ * I/O buffers and the parsed Json::Value config are explicitly out of scope:
+ * they are freed promptly and scrubbing them would require invasive changes
+ * (a wiping allocator for std::string / jsoncpp) for a defence-in-depth gain
+ * against an adversary who can already read process memory. Two cheap
+ * exceptions are closed directly instead of left inconsistent: the recv-side
+ * frame for message_type_smm_settings is wiped right after decode
+ * (buf_len::wipeSecure(), called from fss_connection::recvMsg), and the
+ * packed buf_len for an outgoing smm_settings message is wiped right after
+ * the send attempt (fss_connection::sendMsg). Full coverage of every
+ * transient std::string/Json::Value the credential passes through is not the
+ * goal.
+ */
 class secure_string {
     std::vector<char> data_;
 public:
@@ -48,6 +65,15 @@ public:
     }
     [[nodiscard]] auto data() const -> const char * { return data_.data(); }
     [[nodiscard]] auto size() const -> std::size_t { return data_.size(); }
+    /* A fresh NUL-terminated copy for C APIs that need a c_str()-style
+     * pointer (data()/size() stay exact, un-padded, for wire packing).
+     * Returns by value rather than caching a scratch buffer on this object:
+     * db_connection holds one secure_string pass_ shared by its read and
+     * write ECPG connections, each reconnected from its own thread under its
+     * own mutex (see fss-server.hpp), so a cached mutable member here would
+     * be a data race between them. The returned std::string is a transient
+     * copy, out of scope for wiping per the policy above. */
+    [[nodiscard]] auto toNulTerminated() const -> std::string { return {data_.begin(), data_.end()}; }
     [[nodiscard]] auto empty() const -> bool { return data_.empty(); }
     auto operator==(const secure_string &o) const -> bool { return data_ == o.data_; }
     auto operator!=(const secure_string &o) const -> bool { return data_ != o.data_; }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -114,7 +114,9 @@ auto main(int argc, char *argv[]) -> int
     int pg_port = default_pg_port;
     std::string pg_host;
     std::string pg_user;
-    std::string pg_pass;
+    /* todo/43: held wiped (secure_string) rather than resident as a plain
+     * std::string for the process's whole lifetime. */
+    flight_safety_system::secure_string pg_pass;
     std::string pg_db;
     std::size_t db_queue_depth = default_db_queue_depth;
     uint64_t client_timeout_sec = default_client_timeout_sec;
@@ -177,7 +179,7 @@ auto main(int argc, char *argv[]) -> int
         }
         pg_host = config["postgres"]["host"].asString();
         pg_user = config["postgres"]["user"].asString();
-        pg_pass = config["postgres"]["pass"].asString();
+        pg_pass = flight_safety_system::secure_string(config["postgres"]["pass"].asString());
         pg_db = config["postgres"]["db"].asString();
         if (config.isMember("db_queue_depth"))
         {
@@ -241,7 +243,8 @@ auto main(int argc, char *argv[]) -> int
         return 1;
     }
 
-    auto dbc = std::make_shared<flight_safety_system::server::db_connection>(pg_host, pg_port, pg_user, pg_pass, pg_db);
+    auto dbc = std::make_shared<flight_safety_system::server::db_connection>(pg_host, pg_port, pg_user,
+                                                                             std::move(pg_pass), pg_db);
 
     if (!dbc->isConnected())
     {

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -411,6 +411,15 @@ void flight_safety_system::transport::buf_len::invalidate()
     this->data.clear();
 }
 
+void flight_safety_system::transport::buf_len::wipeSecure()
+{
+    if (!this->data.empty())
+    {
+        explicit_bzero(this->data.data(), this->data.size());
+        this->data.clear();
+    }
+}
+
 flight_safety_system::transport::fss_message_cb::fss_message_cb(std::shared_ptr<fss_connection> t_conn)
     : conn(std::move(t_conn))
 {

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -327,6 +327,13 @@ auto flight_safety_system::transport::fss_connection::sendMsg(const std::shared_
         return false;
     }
     bool ret = this->sendMsg(bl);
+    if (msg->getType() == flight_safety_system::transport::message_type_smm_settings)
+    {
+        /* todo/43: scrub the packed credential bytes once the send attempt
+         * is done (success or failure) rather than leaving them resident
+         * until bl's refcount drops. */
+        bl->wipeSecure();
+    }
     return ret;
 }
 
@@ -517,6 +524,15 @@ auto flight_safety_system::transport::fss_connection::recvMsg()
         print_bl(bl);
 #endif
         msg = flight_safety_system::transport::fss_message::decode(bl);
+        if (msg != nullptr && msg->getType() == flight_safety_system::transport::message_type_smm_settings)
+        {
+            /* todo/43: unpackData() has already copied the credentials into
+             * secure_string members; scrub both transient copies of the
+             * plaintext frame — this vector and bl's internal buffer —
+             * rather than leaving them resident until deallocation. */
+            explicit_bzero(data.data(), data.size());
+            bl->wipeSecure();
+        }
     }
     else
     {

--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -16,6 +16,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <string_view>
 
 #include "fss-server.hpp"
 
@@ -27,7 +28,8 @@ TEST_CASE("db_connection: invalid host reports not connected")
 {
     /* Use a host that is guaranteed to refuse the connection so the test
      * does not depend on a running PostgreSQL instance. */
-    flight_safety_system::server::db_connection dbc("db.invalid", 5432, "user", "pass", "db");
+    flight_safety_system::server::db_connection dbc(
+        "db.invalid", 5432, "user", flight_safety_system::secure_string(std::string_view{"pass"}), "db");
     REQUIRE_FALSE(dbc.isConnected());
 }
 
@@ -48,7 +50,8 @@ auto make_live_db() -> std::unique_ptr<flight_safety_system::server::db_connecti
     const char *pass = std::getenv("TEST_DB_PASS");
     const char *dbname = std::getenv("TEST_DB_NAME");
     auto dbc = std::make_unique<flight_safety_system::server::db_connection>(
-        host, port, user != nullptr ? user : "postgres", pass != nullptr ? pass : "password",
+        host, port, user != nullptr ? user : "postgres",
+        flight_safety_system::secure_string(std::string_view{pass != nullptr ? pass : "password"}),
         dbname != nullptr ? dbname : "postgres");
     REQUIRE(dbc->isConnected());
     return dbc;

--- a/tests/messages.cpp
+++ b/tests/messages.cpp
@@ -645,6 +645,30 @@ TEST_CASE("SMM Settings Message Check")
     REQUIRE(decoded_generic_smm->getPassword() == "password1");
 }
 
+// buf_len::wipeSecure() (todo/43): scrubs the packed credential bytes for an
+// smm_settings message. Unlike the memory-scrub itself, isValid()/getLength()
+// going to the empty state afterward is directly assertable.
+TEST_CASE("messages: buf_len wipeSecure clears content and invalidates the buffer")
+{
+    using flight_safety_system::transport::buf_len;
+    buf_len bl("secret-password", 15);
+    REQUIRE(bl.isValid());
+    REQUIRE(bl.getLength() == 15);
+    bl.wipeSecure();
+    REQUIRE_FALSE(bl.isValid());
+    REQUIRE(bl.getLength() == 0);
+}
+
+TEST_CASE("messages: buf_len wipeSecure on an already-empty buffer is a no-op")
+{
+    using flight_safety_system::transport::buf_len;
+    buf_len bl;
+    REQUIRE_FALSE(bl.isValid());
+    bl.wipeSecure();
+    REQUIRE_FALSE(bl.isValid());
+    REQUIRE(bl.getLength() == 0);
+}
+
 TEST_CASE("Server List Message Check", "[TC-FSS-003]")
 {
     auto msg_id = static_cast<uint64_t>(random());

--- a/tests/secure_string_test.cpp
+++ b/tests/secure_string_test.cpp
@@ -115,3 +115,25 @@ TEST_CASE("secure_string: data() returns pointer to content")
     REQUIRE(s.data() != nullptr);
     REQUIRE(std::string_view(s.data(), s.size()) == "test");
 }
+
+TEST_CASE("secure_string: toNulTerminated() matches content and is NUL-terminated")
+{
+    fss::secure_string s(std::string_view{"p4ssw0rd"});
+    std::string nt = s.toNulTerminated();
+    REQUIRE(nt == "p4ssw0rd");
+    REQUIRE(nt.c_str()[nt.size()] == '\0');
+}
+
+TEST_CASE("secure_string: toNulTerminated() on empty string is empty")
+{
+    fss::secure_string s;
+    REQUIRE(s.toNulTerminated().empty());
+}
+
+TEST_CASE("secure_string: toNulTerminated() does not disturb data()/size()")
+{
+    fss::secure_string s(std::string_view{"unchanged"});
+    (void)s.toNulTerminated();
+    REQUIRE(s.size() == 9);
+    REQUIRE(std::string_view(s.data(), s.size()) == "unchanged");
+}


### PR DESCRIPTION
## Description

Documents the accepted scope in secure-string.hpp (long-lived resident copies only) and closes the two cheap gaps: buf_len::wipeSecure() scrubs the recv-side frame and packed buffer for smm_settings messages, and pg_pass/db_connection::pass_ are now held as secure_string. The ECPG accessor returns a fresh std::string per call rather than caching a NUL-terminated buffer on the object, since pass_ is shared by the read and write connections reconnecting concurrently from separate threads under separate mutexes — an earlier cached-buffer draft raced there and produced a reproducible heap-corruption abort under make check.

## Summary by Sourcery

Tighten handling of database and SMM settings credentials by using secure_string for long-lived storage and wiping transient buffers that carry plaintext passwords.

New Features:
- Add secure_string::toNulTerminated() helper to provide a transient NUL-terminated copy for C-style APIs.
- Introduce buf_len::wipeSecure() to securely clear packed message buffers carrying credentials.

Bug Fixes:
- Avoid heap corruption and data races in db_connection by using per-call NUL-terminated password copies instead of a cached mutable buffer shared across threads.
- Ensure SMM settings transport paths scrub plaintext credential frames after send and receive rather than leaving them resident in memory.

Enhancements:
- Clarify secure_string’s intended scope and policy around long-lived vs transient credential copies.

Tests:
- Extend message and secure_string tests to cover buf_len::wipeSecure() behavior and toNulTerminated() semantics.
- Update db_connection tests to construct connections with secure_string-based passwords.