### PR TITLE
feat(server): todo/31 configurable duplicate-identity policy

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -418,9 +418,17 @@ def fake_client(
     def _launch(
         name: str = "test1",
         ca_override: Path | None = None,
+        client_id: str | None = None,
     ) -> dict[str, object]:
-        config_path = tmp_path / f"client-{name}.json"
-        log_path = tmp_path / f"client-{name}.log"
+        # client_id labels this launch's config/log file paths; defaults to
+        # `name` (existing behaviour for every caller with one client per
+        # name). Pass a distinct client_id when launching a second process
+        # under the *same* asset name/cert (e.g. duplicate-identity tests) --
+        # otherwise both launches would open the same log path in "wb" and
+        # the second truncates the first's file out from under it.
+        label = client_id if client_id is not None else name
+        config_path = tmp_path / f"client-{label}.json"
+        log_path = tmp_path / f"client-{label}.log"
         _render_template(
             E2E_ROOT / "fixtures" / "client.json.tmpl",
             config_path,

--- a/e2e/test_duplicate_identity.py
+++ b/e2e/test_duplicate_identity.py
@@ -1,0 +1,96 @@
+"""Two clients presenting the same asset identity (todo/31, TC-MAV-015 server
+share): decided policy is a configurable server setting, defaulting to
+reject-newcomer. Keep the existing session; refuse the new connection at
+identify. Commands must route to exactly one session, never two."""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+
+def _server_log_text(server_proc) -> str:
+    return server_proc["log"].read_text(errors="replace")
+
+
+def _wait_for_identify_count(server_proc, name: str, count: int, timeout: float = 15.0) -> bool:
+    """Block until "Aircraft client identified: <name>" appears `count` times
+    in the server log, or time out."""
+    needle = f"Aircraft client identified: {name}"
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if _server_log_text(server_proc).count(needle) >= count:
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def _wait_for_text(server_proc, needle: str, timeout: float = 15.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if needle in _server_log_text(server_proc):
+            return True
+        time.sleep(0.05)
+    return False
+
+
+@pytest.mark.requires_docker
+def test_duplicate_identity_rejects_newcomer_by_default(db_conn, fake_client, server_proc):
+    """Default policy (duplicate_identity_reject_newcomer): the first session
+    stays up; a second connection presenting the same identity is rejected
+    at identify and never receives commands."""
+    with db_conn.cursor() as cur:
+        cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
+        asset_id = cur.fetchone()[0]
+
+    # Same identity/cert (name="test1") for both, but distinct client_id so
+    # each gets its own config/log file path.
+    first = fake_client("test1", client_id="test1-first")
+    assert _wait_for_identify_count(server_proc, "test1", 1), (
+        "first client never identified\n" + _server_log_text(server_proc)
+    )
+
+    second = fake_client("test1", client_id="test1-second")
+    assert _wait_for_text(server_proc, "Rejecting duplicate identity for asset_id"), (
+        "server never logged a duplicate-identity rejection for the second client\n"
+        + _server_log_text(server_proc)
+    )
+
+    # Only ever one successful identify -- the newcomer never got in.
+    assert _server_log_text(server_proc).count("Aircraft client identified: test1") == 1, (
+        "expected exactly one successful identify\n" + _server_log_text(server_proc)
+    )
+    # The first session was not disturbed by the rejected newcomer.
+    assert first["proc"].poll() is None, (
+        "first client process should stay alive across a rejected duplicate\n"
+        + first["log"].read_text(errors="replace")
+    )
+
+    # A command must route to the (sole) live session, never the rejected one.
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO assets_assetcommand (asset_id, command, position, altitude) "
+            "VALUES (%s, 'RTL', ST_SetSRID(ST_MakePoint(0, 0), 4326)::geography, 0)",
+            (asset_id,),
+        )
+    time.sleep(6)  # command-poller cadence
+
+    first_log = first["log"].read_text(errors="replace")
+    assert "RCVD_CMD: RTL" in first_log, (
+        "command was not delivered to the surviving session\n" + first_log
+    )
+    second_log = second["log"].read_text(errors="replace")
+    assert "RCVD_CMD: RTL" not in second_log, (
+        "command must never reach the rejected duplicate session\n" + second_log
+    )
+
+    # No telemetry interleaving: every stored position row for this asset
+    # must have landed while only one session was ever identified -- already
+    # established above (exactly one successful identify total), so a
+    # non-zero row count here is unambiguously the surviving session's.
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM assets_assetposition WHERE asset_id = %s", (asset_id,),
+        )
+        pos_count = cur.fetchone()[0]
+    assert pos_count >= 1, "surviving session should still be reporting position"

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -923,6 +923,18 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                     this->client_handler->clientDisconnected(this);
                     return;
                 }
+                /* todo/31: apply the configured duplicate-identity policy
+                 * before this session is marked identified, so a rejected
+                 * newcomer never gets far enough to receive commands or
+                 * have its telemetry stored against the shared asset_id. */
+                if (!this->client_handler->resolveDuplicateIdentity(this, asset_id))
+                {
+                    FSS_LOG_WARN("server", "Rejecting duplicate identity for asset_id "
+                                               << asset_id << " (" << client_name
+                                               << "): an existing session is already live");
+                    this->client_handler->clientDisconnected(this);
+                    return;
+                }
                 this->cached_asset_id.store(asset_id);
                 this->setPendingCommand(this->dbc->getCommand(asset_id));
                 {

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -176,6 +176,19 @@ public:
 
 class fss_client;
 
+/* Server policy when a second connection identifies as an asset that
+ * already has a live session (todo/31). mTLS proves the client cert, so a
+ * duplicate is far more likely to be a stale reconnect than a stolen-key
+ * hijack — but the default is still the conservative one, to avoid
+ * flip-flopping sessions on a genuine misconfiguration (e.g. two real
+ * assets sharing a cert). */
+enum duplicate_identity_policy {
+    /* Keep the existing session; refuse the new connection at identify. */
+    duplicate_identity_reject_newcomer,
+    /* Disconnect the existing session; the new connection proceeds. */
+    duplicate_identity_evict_oldest,
+};
+
 class fss_client_handler {
 public:
     virtual ~fss_client_handler() = default;
@@ -189,6 +202,14 @@ public:
      * giving each recipient its own independent clone before fanning delivery
      * out across separate per-client threads. */
     virtual void broadcastMsg(const std::shared_ptr<transport::fss_message> &msg, fss_client *except = nullptr) = 0;
+    /* Called from the identify path once asset_id is resolved, before
+     * `newcomer` is marked identified. Returns false if `newcomer` must be
+     * rejected outright (duplicate_identity_reject_newcomer hit an existing
+     * live session for this asset_id); true otherwise — no conflict, or the
+     * existing session was evicted (duplicate_identity_evict_oldest) and
+     * `newcomer` may proceed. Default no-op always returns true (no dedup),
+     * so existing fss_client_handler test mocks need not implement this. */
+    virtual auto resolveDuplicateIdentity(fss_client * /*newcomer*/, uint64_t /*asset_id*/) -> bool { return true; }
 };
 
 class fss_client : public transport::fss_message_cb {

--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -267,7 +267,7 @@ public:
         }
     };
     /* todo/31: called from the identify path once asset_id is resolved, before
-     * `newcomer` is marked identified. Finds any other live session already
+     * `newcomer` is marked identified. Finds any other live session(s) already
      * identified for this asset_id and applies the configured policy.
      *
      * Narrow race: two brand-new connections identifying for the same asset_id
@@ -276,16 +276,28 @@ public:
      * race snapshotClients() already documents elsewhere (a client connected
      * mid-iteration is covered by the caller's next pass). Not worth a second
      * lock ordered with client_lock to close, given how rare simultaneous
-     * identify is in practice. */
+     * identify is in practice. Because that race can leave more than one
+     * pre-existing session behind for the same asset_id, evict_oldest below
+     * evicts every match found here, not just one — otherwise a later
+     * newcomer would clear only the first (by connection order, i.e. the
+     * actual oldest) and leave the rest alive.
+     *
+     * disconnect()+clientDisconnected() runs outside `lock`, same as
+     * disconnectRevokedClients()/checkTimeouts() elsewhere in this class:
+     * clientDisconnected() takes `lock` itself and the snapshot's shared_ptr
+     * keeps `existing` alive across the call, so this is safe by the same
+     * reasoning documented on snapshotClients() above — disconnect() blocks
+     * on socket I/O and joins the recv thread, which must never happen while
+     * holding `lock`. */
     auto resolveDuplicateIdentity(flight_safety_system::server::fss_client *newcomer, uint64_t asset_id)
         -> bool override
     {
         auto snapshot = this->snapshotClients();
-        auto it = std::find_if(snapshot.begin(), snapshot.end(), [newcomer, asset_id](const auto &client) -> bool {
-            return client.get() != newcomer && client->getCachedAssetId() == asset_id;
-        });
-        std::shared_ptr<flight_safety_system::server::fss_client> existing = (it != snapshot.end()) ? *it : nullptr;
-        if (existing == nullptr)
+        bool has_existing =
+            std::any_of(snapshot.begin(), snapshot.end(), [newcomer, asset_id](const auto &client) -> bool {
+                return client.get() != newcomer && client->getCachedAssetId() == asset_id;
+            });
+        if (!has_existing)
         {
             return true;
         }
@@ -293,10 +305,19 @@ public:
         {
             return false;
         }
+        std::size_t evicted = 0;
+        for (const auto &client : snapshot)
+        {
+            if (client.get() != newcomer && client->getCachedAssetId() == asset_id)
+            {
+                client->disconnect();
+                this->clientDisconnected(client.get());
+                evicted++;
+            }
+        }
         FSS_LOG_WARN("server", "Duplicate identity for asset_id "
-                                   << asset_id << ": evicting the existing session (duplicate_identity_evict_oldest)");
-        existing->disconnect();
-        this->clientDisconnected(existing.get());
+                                   << asset_id << ": evicted " << evicted
+                                   << " existing session(s) (duplicate_identity_evict_oldest)");
         return true;
     }
     auto disconnectRevokedClients(const std::string &crl_file) -> std::size_t

--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -23,6 +23,8 @@ private:
     uint64_t position_staleness_ms{flight_safety_system::server::default_position_staleness_ms};
     uint64_t rate_capacity{100};
     uint64_t rate_refill_per_s{20};
+    flight_safety_system::server::duplicate_identity_policy duplicate_identity_policy_{
+        flight_safety_system::server::duplicate_identity_reject_newcomer};
     /* Guarded by lock. Built by the command poller thread (the only place
      * allowed to read the DB for it); broadcast by the main loop, which must
      * never perform a synchronous DB read. */
@@ -113,6 +115,10 @@ public:
     {
         this->rate_capacity = capacity;
         this->rate_refill_per_s = refill_per_s;
+    }
+    void setDuplicateIdentityPolicy(flight_safety_system::server::duplicate_identity_policy policy)
+    {
+        this->duplicate_identity_policy_ = policy;
     }
     void clientConnected(std::shared_ptr<flight_safety_system::server::fss_client> client)
     {
@@ -260,6 +266,39 @@ public:
             client->queueCommandSend();
         }
     };
+    /* todo/31: called from the identify path once asset_id is resolved, before
+     * `newcomer` is marked identified. Finds any other live session already
+     * identified for this asset_id and applies the configured policy.
+     *
+     * Narrow race: two brand-new connections identifying for the same asset_id
+     * at almost the same instant can each see the other as not-yet-identified
+     * (cached_asset_id still 0) and both proceed — the same class of benign
+     * race snapshotClients() already documents elsewhere (a client connected
+     * mid-iteration is covered by the caller's next pass). Not worth a second
+     * lock ordered with client_lock to close, given how rare simultaneous
+     * identify is in practice. */
+    auto resolveDuplicateIdentity(flight_safety_system::server::fss_client *newcomer, uint64_t asset_id)
+        -> bool override
+    {
+        auto snapshot = this->snapshotClients();
+        auto it = std::find_if(snapshot.begin(), snapshot.end(), [newcomer, asset_id](const auto &client) -> bool {
+            return client.get() != newcomer && client->getCachedAssetId() == asset_id;
+        });
+        std::shared_ptr<flight_safety_system::server::fss_client> existing = (it != snapshot.end()) ? *it : nullptr;
+        if (existing == nullptr)
+        {
+            return true;
+        }
+        if (this->duplicate_identity_policy_ == flight_safety_system::server::duplicate_identity_reject_newcomer)
+        {
+            return false;
+        }
+        FSS_LOG_WARN("server", "Duplicate identity for asset_id "
+                                   << asset_id << ": evicting the existing session (duplicate_identity_evict_oldest)");
+        existing->disconnect();
+        this->clientDisconnected(existing.get());
+        return true;
+    }
     auto disconnectRevokedClients(const std::string &crl_file) -> std::size_t
     {
         std::size_t disconnected_count = 0;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -107,6 +107,7 @@ auto main(int argc, char *argv[]) -> int
     constexpr uint64_t default_position_staleness_ms = flight_safety_system::server::default_position_staleness_ms;
     constexpr uint64_t default_rate_capacity = 100;
     constexpr uint64_t default_rate_refill_per_s = 20;
+    constexpr auto default_duplicate_identity_policy = flight_safety_system::server::duplicate_identity_reject_newcomer;
     constexpr unsigned int default_tls_handshake_timeout_ms =
         flight_safety_system::transport_ssl::default_handshake_timeout_ms;
     constexpr std::size_t default_max_concurrent_handshakes = 64;
@@ -124,6 +125,7 @@ auto main(int argc, char *argv[]) -> int
     uint64_t position_staleness_ms = default_position_staleness_ms;
     uint64_t rate_capacity = default_rate_capacity;
     uint64_t rate_refill = default_rate_refill_per_s;
+    auto duplicate_identity_policy = default_duplicate_identity_policy;
     unsigned int tls_handshake_timeout_ms = default_tls_handshake_timeout_ms;
     std::size_t max_concurrent_handshakes = default_max_concurrent_handshakes;
     std::string ca_public_key;
@@ -205,6 +207,23 @@ auto main(int argc, char *argv[]) -> int
         {
             rate_refill = config["message_rate_refill"].asUInt64();
         }
+        if (config.isMember("duplicate_identity_policy"))
+        {
+            std::string policy_str = config["duplicate_identity_policy"].asString();
+            if (policy_str == "reject_newcomer")
+            {
+                duplicate_identity_policy = flight_safety_system::server::duplicate_identity_reject_newcomer;
+            }
+            else if (policy_str == "evict_oldest")
+            {
+                duplicate_identity_policy = flight_safety_system::server::duplicate_identity_evict_oldest;
+            }
+            else
+            {
+                FSS_LOG_ERROR("server", "Invalid duplicate_identity_policy '" << policy_str
+                                                                              << "'; using default (reject_newcomer)");
+            }
+        }
         if (config.isMember("tls_handshake_timeout_ms"))
         {
             tls_handshake_timeout_ms = config["tls_handshake_timeout_ms"].asUInt();
@@ -283,6 +302,7 @@ auto main(int argc, char *argv[]) -> int
     clients->setClientIdentifyTimeoutMs(identify_timeout_sec * msec_per_sec);
     clients->setClientStalenessMs(position_staleness_ms);
     clients->setClientRateLimits(rate_capacity, rate_refill);
+    clients->setDuplicateIdentityPolicy(duplicate_identity_policy);
 
     std::shared_ptr<flight_safety_system::transport::fss_listen> listen;
     FSS_LOG_INFO("server", "Starting fss server in TLS mode");

--- a/tests/server_clients_test.cpp
+++ b/tests/server_clients_test.cpp
@@ -480,3 +480,101 @@ TEST_CASE("server_clients: disconnectRevokedClients leaves non-revoked clients")
     // Client should remain connected — cleanupRemovableClients is a no-op
     sc.cleanupRemovableClients();
 }
+
+TEST_CASE("server_clients: duplicate identity rejects the newcomer by default (todo/31)")
+{
+    /* Default policy is duplicate_identity_reject_newcomer. A second
+     * connection identifying for an asset_id that already has a live
+     * session must be disconnected before ever being marked identified —
+     * the first session is untouched. */
+    server_clients sc;
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft1"] = 42;
+
+    auto conn1 = std::make_shared<FakeConnection>();
+    conn1->cert_names.push_back("craft1");
+    auto writer1 = make_null_writer();
+    auto first = std::make_shared<fss::server::fss_client>(conn1, &mock, writer1, &sc);
+    sc.clientConnected(first);
+    first->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft1"));
+    REQUIRE(first->getCachedAssetId() == 42);
+    REQUIRE(first->isAircraft());
+
+    auto conn2 = std::make_shared<FakeConnection>();
+    conn2->cert_names.push_back("craft1");
+    auto writer2 = make_null_writer();
+    auto second = std::make_shared<fss::server::fss_client>(conn2, &mock, writer2, &sc);
+    sc.clientConnected(second);
+    second->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft1"));
+
+    // The newcomer never identifies.
+    REQUIRE(second->getCachedAssetId() == 0);
+    REQUIRE_FALSE(second->isAircraft());
+    // The first session is unaffected.
+    REQUIRE(first->getCachedAssetId() == 42);
+    REQUIRE(first->isAircraft());
+
+    // The rejected newcomer was disconnected; only the first remains live.
+    sc.cleanupRemovableClients();
+    REQUIRE(sc.getTotalClients() == 1);
+}
+
+TEST_CASE("server_clients: duplicate identity evicts the oldest session when configured (todo/31)")
+{
+    server_clients sc;
+    sc.setDuplicateIdentityPolicy(fss::server::duplicate_identity_evict_oldest);
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft1"] = 7;
+
+    auto conn1 = std::make_shared<FakeConnection>();
+    conn1->cert_names.push_back("craft1");
+    auto writer1 = make_null_writer();
+    auto first = std::make_shared<fss::server::fss_client>(conn1, &mock, writer1, &sc);
+    sc.clientConnected(first);
+    first->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft1"));
+    REQUIRE(first->getCachedAssetId() == 7);
+
+    auto conn2 = std::make_shared<FakeConnection>();
+    conn2->cert_names.push_back("craft1");
+    auto writer2 = make_null_writer();
+    auto second = std::make_shared<fss::server::fss_client>(conn2, &mock, writer2, &sc);
+    sc.clientConnected(second);
+    second->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft1"));
+
+    // The newcomer proceeds and identifies normally.
+    REQUIRE(second->getCachedAssetId() == 7);
+    REQUIRE(second->isAircraft());
+
+    // The existing session was evicted -- only the newcomer remains live.
+    REQUIRE(sc.getTotalClients() == 2);
+    sc.cleanupRemovableClients();
+    REQUIRE(sc.getTotalClients() == 1);
+}
+
+TEST_CASE("server_clients: duplicate identity check ignores distinct asset ids (todo/31)")
+{
+    /* Two different aircraft identifying concurrently must never be treated
+     * as a conflict, under either policy. */
+    server_clients sc;
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft1"] = 1;
+    mock.asset_ids["craft2"] = 2;
+
+    auto conn1 = std::make_shared<FakeConnection>();
+    conn1->cert_names.push_back("craft1");
+    auto writer1 = make_null_writer();
+    auto first = std::make_shared<fss::server::fss_client>(conn1, &mock, writer1, &sc);
+    sc.clientConnected(first);
+    first->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft1"));
+
+    auto conn2 = std::make_shared<FakeConnection>();
+    conn2->cert_names.push_back("craft2");
+    auto writer2 = make_null_writer();
+    auto second = std::make_shared<fss::server::fss_client>(conn2, &mock, writer2, &sc);
+    sc.clientConnected(second);
+    second->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft2"));
+
+    REQUIRE(first->getCachedAssetId() == 1);
+    REQUIRE(second->getCachedAssetId() == 2);
+    REQUIRE(sc.getTotalClients() == 2);
+}


### PR DESCRIPTION
## Description

Two connections presenting the same asset identity previously both became fully live sessions -- no dedup existed anywhere. Adds a server-side policy, applied at identify once asset_id is resolved but before the session is marked identified:

- duplicate_identity_reject_newcomer (default): keep the existing session, reject the new connection. Chosen as the default (over evicting the old session) to avoid flip-flopping sessions on a genuine misconfiguration, e.g. two real assets sharing a cert -- mTLS already means a "duplicate" is far more likely to be a stale reconnect than a stolen-key hijack, but a wrong guess here is safety-relevant, so the conservative default wins.
- duplicate_identity_evict_oldest: disconnect the existing session immediately so a legitimate reconnect isn't stuck behind the ~30s liveness reap.

Configurable via server.json's "duplicate_identity_policy" ("reject_newcomer" | "evict_oldest"). New fss_client_handler virtual resolveDuplicateIdentity() (default impl returns true/no-op, so existing test mocks are unaffected) implemented by server_clients: finds any other live session for the asset_id and applies the configured policy.

Only the aircraft identify path is affected -- non-aircraft clients never get an asset_id (cached_asset_id stays 0), so there's nothing to deduplicate there.

Unit tests in tests/server_clients_test.cpp cover both policies plus a distinct-asset-ids sanity case. e2e/test_duplicate_identity.py drives two fake-client processes under the same identity/cert against the real server/binary and confirms: the newcomer is rejected, the original session is undisturbed, and a command routes to the surviving session only. Extended the `fake_client` e2e fixture with an optional client_id so two launches sharing the same asset name get distinct config/log file paths (same name previously collided on one log path, silently truncating the first client's log out from under it).

## Summary by Sourcery

Introduce a configurable server policy for handling duplicate aircraft identities, defaulting to rejecting newcomer sessions while optionally evicting the existing session instead.

New Features:
- Add duplicate_identity_policy configuration in server.json to control handling of multiple connections sharing the same asset identity.
- Expose a duplicate_identity_policy enum and handler hook so fss_client can apply the chosen policy during aircraft identification.
- Extend the e2e fake_client fixture to support distinct client_id labels for per-process config and log files.

Enhancements:
- Ensure duplicate-identity resolution runs before a session is marked identified so rejected newcomers never receive commands or persist telemetry.
- Log duplicate-identity decisions on the server for observability when evicting or rejecting sessions.

Tests:
- Add unit tests validating duplicate-identity behaviour for both reject-newcomer and evict-oldest policies and for distinct asset IDs.
- Add an end-to-end test that drives two clients with the same identity to verify only one session identifies, receives commands, and reports telemetry under the default policy.