### PR TITLE
test(e2e): todo/28 ADS-B forwarding, non-aircraft client-library hook

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -419,6 +419,8 @@ def fake_client(
         name: str = "test1",
         ca_override: Path | None = None,
         client_id: str | None = None,
+        non_aircraft: bool = False,
+        extra_args: list[str] | None = None,
     ) -> dict[str, object]:
         # client_id labels this launch's config/log file paths; defaults to
         # `name` (existing behaviour for every caller with one client per
@@ -429,8 +431,9 @@ def fake_client(
         label = client_id if client_id is not None else name
         config_path = tmp_path / f"client-{label}.json"
         log_path = tmp_path / f"client-{label}.log"
+        template = "client-non-aircraft.json.tmpl" if non_aircraft else "client.json.tmpl"
         _render_template(
-            E2E_ROOT / "fixtures" / "client.json.tmpl",
+            E2E_ROOT / "fixtures" / template,
             config_path,
             CLIENT_NAME=name,
             CERTS_DIR=str(ca_override if ca_override else certs_dir),
@@ -441,7 +444,7 @@ def fake_client(
         log_fp = log_path.open("wb")
         # sourcery skip: dangerous-subprocess-use-audit
         proc = subprocess.Popen(
-            [str(FAKE_CLIENT_BIN), str(config_path)],
+            [str(FAKE_CLIENT_BIN), str(config_path), *(extra_args or [])],
             cwd=str(REPO_ROOT),
             env=env,
             stdout=log_fp,

--- a/e2e/fixtures/client-non-aircraft.json.tmpl
+++ b/e2e/fixtures/client-non-aircraft.json.tmpl
@@ -1,0 +1,15 @@
+{
+    "name": "${CLIENT_NAME}",
+    "non_aircraft": true,
+    "ssl": {
+        "ca_public_key": "${CERTS_DIR}/ca.public.pem",
+        "client_private_key": "${CERTS_DIR}/${CLIENT_NAME}.private.pem",
+        "client_public_key": "${CERTS_DIR}/${CLIENT_NAME}.public.pem"
+    },
+    "servers": [
+        {
+            "address": "localhost",
+            "port": ${SERVER_PORT}
+        }
+    ]
+}

--- a/e2e/test_adsb_forwarding.py
+++ b/e2e/test_adsb_forwarding.py
@@ -1,0 +1,121 @@
+"""e2e ADS-B forwarding to aircraft clients (TC-SRV-002 + Path C server share).
+
+Covers todo/28: the server forwards position reports from non-aircraft
+clients (e.g. an fss-adsb feeder) and from other aircraft to connected
+aircraft clients, with no echo back to the reporting client. Rate limiting
+in this codebase is a single per-connection token bucket (src/rate-
+limiter.hpp), not per-ICAO as originally assumed when this todo was filed --
+test 4 is scoped to what actually exists: N updates/sec from one feeder
+connection are capped by that connection's own bucket.
+
+MAVLink-side delivery (ADSB_VEHICLE into the autopilot) stays in Tier 3 Path
+C/E -- out of scope here.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+
+def _log_text(client: dict) -> str:
+    return client["log"].read_text(errors="replace")
+
+
+def _wait_for_rcvd_pos(client: dict, icao_hex: str, timeout: float = 20.0) -> bool:
+    needle = f"RCVD_POS: icao={icao_hex}"
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if needle in _log_text(client):
+            return True
+        time.sleep(0.1)
+    return False
+
+
+@pytest.mark.satisfies("TC-SRV-002")
+@pytest.mark.requires_docker
+def test_adsb_forwarded_to_aircraft(db_conn, fake_client):
+    """A non-aircraft client's position report for an arbitrary ICAO reaches
+    a connected aircraft client."""
+    with db_conn.cursor() as cur:
+        cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
+
+    aircraft = fake_client("test1")
+    # test3's cert is not enrolled as an asset -- required for non-aircraft
+    # identify (the server rejects a non-aircraft CN that IS a known
+    # aircraft).
+    feeder = fake_client(
+        "test3", non_aircraft=True,
+        extra_args=["--icao=0xabc123", "--callsign=FEEDER", "--position-interval-ms=500"],
+    )
+
+    assert _wait_for_rcvd_pos(aircraft, "abc123"), (
+        "aircraft client never received the feeder's position report\n" + _log_text(aircraft)
+    )
+    # The feeder itself must never see its own report relayed back (also
+    # covered explicitly by test_no_echo below) or any aircraft position.
+    assert "RCVD_POS" not in _log_text(feeder), (
+        "non-aircraft feeder must never receive relayed position reports\n" + _log_text(feeder)
+    )
+
+
+@pytest.mark.requires_docker
+def test_aircraft_to_aircraft_forwarding(db_conn, fake_client):
+    """Positions from one aircraft are relayed to another (Path C c01)."""
+    with db_conn.cursor() as cur:
+        cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
+        cur.execute("INSERT INTO assets_asset (name) VALUES ('test2') RETURNING id")
+
+    first = fake_client("test1", extra_args=["--icao=0x1111", "--position-interval-ms=1000"])
+    second = fake_client("test2", extra_args=["--icao=0x2222", "--position-interval-ms=1000"])
+
+    assert _wait_for_rcvd_pos(second, "1111"), (
+        "second aircraft never received first aircraft's position\n" + _log_text(second)
+    )
+    assert _wait_for_rcvd_pos(first, "2222"), (
+        "first aircraft never received second aircraft's position\n" + _log_text(first)
+    )
+
+
+@pytest.mark.requires_docker
+def test_no_echo(db_conn, fake_client):
+    """A client's own position reports are never relayed back to it (Path C
+    c03) -- the sole connected client here has nothing else to receive."""
+    with db_conn.cursor() as cur:
+        cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
+
+    solo = fake_client("test1", extra_args=["--position-interval-ms=1000"])
+    time.sleep(8)  # several send cycles
+
+    assert "RCVD_POS" not in _log_text(solo), (
+        "client must never receive its own relayed position report\n" + _log_text(solo)
+    )
+
+
+@pytest.mark.requires_docker
+@pytest.mark.slow
+def test_rate_limited_per_connection(db_conn, fake_client):
+    """N updates/sec from one feeder connection are capped by that
+    connection's per-connection token bucket (default capacity 100, refill
+    20/s -- src/rate-limiter.hpp), not delivered 1:1 to the receiver."""
+    with db_conn.cursor() as cur:
+        cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
+
+    aircraft = fake_client("test1")
+    fake_client(
+        "test3", non_aircraft=True,
+        extra_args=["--icao=0xfeed01", "--callsign=BURST", "--position-interval-ms=10"],
+    )
+
+    # ~2s at a 10ms interval is ~200 send attempts -- well over the default
+    # bucket capacity (100) plus refill (20/s) for this window. The feeder
+    # keeps running past this snapshot (stopped by the fixture's teardown);
+    # reading the log now just takes a point-in-time count.
+    time.sleep(2.5)
+
+    received = _log_text(aircraft).count("RCVD_POS: icao=feed01")
+    assert received > 0, "no bursted position reports were forwarded at all\n" + _log_text(aircraft)
+    assert received < 150, (
+        f"expected the per-connection rate limiter to cap delivery well under "
+        f"the ~200 attempted sends, got {received}\n" + _log_text(aircraft)
+    )

--- a/examples/fake_client.cpp
+++ b/examples/fake_client.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <csignal>
 #include <iostream>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -82,7 +83,50 @@ struct cli_options {
     int position_interval_ms{5000};
 };
 
-auto parse_args(int argc, char *argv[]) -> cli_options
+/* Parses `text` as a base-10 integer via strtoul/strtol, requiring the
+ * *entire* string to be consumed (no trailing junk, no empty string) so a
+ * malformed --flag=value fails loudly instead of silently becoming 0 --
+ * a bad e2e test invocation should error out, not run with nonsense
+ * defaults. */
+auto parse_uint_arg(std::string_view flag, std::string_view text, uint32_t &out) -> bool
+{
+    if (text.empty())
+    {
+        std::cout << "Invalid value for " << flag << ": empty" << std::endl;
+        return false;
+    }
+    std::string text_owned(text);
+    char *end = nullptr;
+    unsigned long value = std::strtoul(text_owned.c_str(), &end, 0);
+    if (end != text_owned.c_str() + text_owned.size())
+    {
+        std::cout << "Invalid value for " << flag << ": '" << text << "'" << std::endl;
+        return false;
+    }
+    out = static_cast<uint32_t>(value);
+    return true;
+}
+
+auto parse_int_arg(std::string_view flag, std::string_view text, int &out) -> bool
+{
+    if (text.empty())
+    {
+        std::cout << "Invalid value for " << flag << ": empty" << std::endl;
+        return false;
+    }
+    std::string text_owned(text);
+    char *end = nullptr;
+    long value = std::strtol(text_owned.c_str(), &end, 10);
+    if (end != text_owned.c_str() + text_owned.size())
+    {
+        std::cout << "Invalid value for " << flag << ": '" << text << "'" << std::endl;
+        return false;
+    }
+    out = static_cast<int>(value);
+    return true;
+}
+
+auto parse_args(int argc, char *argv[]) -> std::optional<cli_options>
 {
     cli_options opts;
     constexpr std::string_view icao_prefix = "--icao=";
@@ -93,8 +137,10 @@ auto parse_args(int argc, char *argv[]) -> cli_options
         std::string_view arg = argv[i];
         if (arg.substr(0, icao_prefix.size()) == icao_prefix)
         {
-            opts.icao_address =
-                static_cast<uint32_t>(std::strtoul(std::string(arg.substr(icao_prefix.size())).c_str(), nullptr, 0));
+            if (!parse_uint_arg(icao_prefix, arg.substr(icao_prefix.size()), opts.icao_address))
+            {
+                return std::nullopt;
+            }
         }
         else if (arg.substr(0, callsign_prefix.size()) == callsign_prefix)
         {
@@ -102,7 +148,10 @@ auto parse_args(int argc, char *argv[]) -> cli_options
         }
         else if (arg.substr(0, interval_prefix.size()) == interval_prefix)
         {
-            opts.position_interval_ms = std::atoi(std::string(arg.substr(interval_prefix.size())).c_str());
+            if (!parse_int_arg(interval_prefix, arg.substr(interval_prefix.size()), opts.position_interval_ms))
+            {
+                return std::nullopt;
+            }
         }
         else
         {
@@ -129,7 +178,12 @@ auto main(int argc, char *argv[]) -> int
     signal(SIGPIPE, SIG_IGN);
 
     auto client = std::make_shared<logging_client>(argv[1]);
-    auto opts = parse_args(argc, argv);
+    auto parsed_opts = parse_args(argc, argv);
+    if (!parsed_opts.has_value())
+    {
+        return -1;
+    }
+    auto opts = *parsed_opts;
 
     /* Connect to each server */
     /* Send reports:
@@ -151,20 +205,32 @@ auto main(int argc, char *argv[]) -> int
      * rate-limit testing (todo/28 wants well over 20/s to exceed the
      * default token-bucket capacity within a short test), while
      * status/search keep their original fixed 5s cadence regardless of the
-     * position interval. */
+     * position interval.
+     *
+     * Deadline-based (next_*_ms), not modulo-on-elapsed_ms: elapsed_ms only
+     * ever takes multiples of tick_ms, so `elapsed_ms % interval_ms == 0`
+     * only fires on schedule when interval_ms happens to be a multiple of
+     * tick_ms -- any other value (e.g. --position-interval-ms=1234) fires
+     * at LCM(tick_ms, interval_ms) instead, silently far slower than
+     * requested. Each next_*_ms is incremented by its own interval after
+     * firing, so drift never accumulates and any positive interval works. */
     constexpr int tick_ms = 10;
     constexpr int reconnect_check_ms = 1000;
     constexpr int status_search_interval_ms = 5000;
     int elapsed_ms = 0;
+    int next_reconnect_ms = reconnect_check_ms;
+    int next_status_search_ms = status_search_interval_ms;
+    int next_position_ms = opts.position_interval_ms;
     while (running == 1)
     {
         usleep(tick_ms * 1000);
         elapsed_ms += tick_ms;
-        if ((elapsed_ms % reconnect_check_ms) == 0)
+        if (elapsed_ms >= next_reconnect_ms)
         {
             client->attemptReconnect();
+            next_reconnect_ms += reconnect_check_ms;
         }
-        if ((elapsed_ms % status_search_interval_ms) == 0)
+        if (elapsed_ms >= next_status_search_ms)
         {
             constexpr int bat_remaining = 75;
             constexpr int bat_mah_used = 1000;
@@ -178,8 +244,9 @@ auto main(int argc, char *argv[]) -> int
                 search_number, search_current_point, search_total_points);
             client->sendMsgAll(msg_status);
             client->sendMsgAll(msg_search);
+            next_status_search_ms += status_search_interval_ms;
         }
-        if (opts.position_interval_ms > 0 && (elapsed_ms % opts.position_interval_ms) == 0)
+        if (opts.position_interval_ms > 0 && elapsed_ms >= next_position_ms)
         {
             constexpr double lat = -43.5;
             constexpr double lng = 172.5;
@@ -196,6 +263,7 @@ auto main(int argc, char *argv[]) -> int
                 lat, lng, alt, heading_cdeg, hor_vel, vert_vel, opts.icao_address, opts.callsign, squawk_code,
                 time_since_last_contact, flags, alt_type, emitter_type, fss::fss_current_timestamp());
             client->sendMsgAll(msg_pos);
+            next_position_ms += opts.position_interval_ms;
         }
     }
     client->disconnect();

--- a/examples/fake_client.cpp
+++ b/examples/fake_client.cpp
@@ -1,8 +1,11 @@
 #include "fss-client-ssl.hpp"
 
+#include <cstdlib>
 #include <csignal>
 #include <iostream>
+#include <sstream>
 #include <string>
+#include <string_view>
 
 #include <unistd.h>
 
@@ -34,6 +37,16 @@ static auto commandName(fss::transport::fss_asset_command cmd) -> std::string
 class logging_client : public fss::client_ssl::fss_client {
 public:
     using fss::client_ssl::fss_client::fss_client;
+    /* Logged in the same grep-able style as RCVD_CMD/SENT_ACK below, so e2e
+     * tests can assert a client actually received a relayed position report
+     * (todo/28) by scanning its stdout log rather than the DB. */
+    void handlePositionReport(const std::shared_ptr<fss::transport::fss_message_position_report> &msg) override
+    {
+        std::ostringstream icao_hex;
+        icao_hex << std::hex << msg->getICAOAddress();
+        std::cout << "RCVD_POS: icao=" << icao_hex.str() << " callsign=" << msg->getCallSign()
+                  << " lat=" << msg->getLatitude() << " lng=" << msg->getLongitude() << std::endl;
+    }
     void handleCommandFrom(const std::shared_ptr<fss::transport::fss_message_asset_command> &msg,
                            fss::client_ssl::fss_server *origin) override
     {
@@ -58,6 +71,49 @@ public:
     }
 };
 
+namespace {
+
+/* CLI-overridable knobs for driving an ADS-B-style feeder (todo/28). Every
+ * default reproduces this example's original fixed behaviour exactly, so
+ * existing callers that only pass a config path are unaffected. */
+struct cli_options {
+    uint32_t icao_address{0};
+    std::string callsign{"example"};
+    int position_interval_ms{5000};
+};
+
+auto parse_args(int argc, char *argv[]) -> cli_options
+{
+    cli_options opts;
+    constexpr std::string_view icao_prefix = "--icao=";
+    constexpr std::string_view callsign_prefix = "--callsign=";
+    constexpr std::string_view interval_prefix = "--position-interval-ms=";
+    for (int i = 2; i < argc; i++)
+    {
+        std::string_view arg = argv[i];
+        if (arg.substr(0, icao_prefix.size()) == icao_prefix)
+        {
+            opts.icao_address =
+                static_cast<uint32_t>(std::strtoul(std::string(arg.substr(icao_prefix.size())).c_str(), nullptr, 0));
+        }
+        else if (arg.substr(0, callsign_prefix.size()) == callsign_prefix)
+        {
+            opts.callsign = std::string(arg.substr(callsign_prefix.size()));
+        }
+        else if (arg.substr(0, interval_prefix.size()) == interval_prefix)
+        {
+            opts.position_interval_ms = std::atoi(std::string(arg.substr(interval_prefix.size())).c_str());
+        }
+        else
+        {
+            std::cout << "Unknown argument: " << arg << std::endl;
+        }
+    }
+    return opts;
+}
+
+} // namespace
+
 auto main(int argc, char *argv[]) -> int
 {
     if (argc < 2)
@@ -73,6 +129,7 @@ auto main(int argc, char *argv[]) -> int
     signal(SIGPIPE, SIG_IGN);
 
     auto client = std::make_shared<logging_client>(argv[1]);
+    auto opts = parse_args(argc, argv);
 
     /* Connect to each server */
     /* Send reports:
@@ -90,14 +147,24 @@ auto main(int argc, char *argv[]) -> int
        - Server reset
      */
 
-    constexpr int send_interval = 5;
-    int counter = 0;
+    /* Base tick fine-grained enough to drive a fast position-interval for
+     * rate-limit testing (todo/28 wants well over 20/s to exceed the
+     * default token-bucket capacity within a short test), while
+     * status/search keep their original fixed 5s cadence regardless of the
+     * position interval. */
+    constexpr int tick_ms = 10;
+    constexpr int reconnect_check_ms = 1000;
+    constexpr int status_search_interval_ms = 5000;
+    int elapsed_ms = 0;
     while (running == 1)
     {
-        sleep(1);
-        client->attemptReconnect();
-        counter++;
-        if (counter % send_interval == 0)
+        usleep(tick_ms * 1000);
+        elapsed_ms += tick_ms;
+        if ((elapsed_ms % reconnect_check_ms) == 0)
+        {
+            client->attemptReconnect();
+        }
+        if ((elapsed_ms % status_search_interval_ms) == 0)
         {
             constexpr int bat_remaining = 75;
             constexpr int bat_mah_used = 1000;
@@ -109,24 +176,25 @@ auto main(int argc, char *argv[]) -> int
             constexpr int search_total_points = 100;
             auto msg_search = std::make_shared<fss::transport::fss_message_search_status>(
                 search_number, search_current_point, search_total_points);
+            client->sendMsgAll(msg_status);
+            client->sendMsgAll(msg_search);
+        }
+        if (opts.position_interval_ms > 0 && (elapsed_ms % opts.position_interval_ms) == 0)
+        {
             constexpr double lat = -43.5;
             constexpr double lng = 172.5;
             constexpr int alt = 300;
             constexpr int heading_cdeg = 1800;
             constexpr int hor_vel = 200;
             constexpr int vert_vel = 0;
-            constexpr int icao_address = 0;
-            constexpr const char *callsign = "example";
             constexpr int squawk_code = 01200;
             constexpr int time_since_last_contact = 0;
             constexpr int flags = 1 | 2 | 4 | 8 | 16 | 32;
             constexpr int alt_type = 1;
             constexpr int emitter_type = 14;
             auto msg_pos = std::make_shared<fss::transport::fss_message_position_report>(
-                lat, lng, alt, heading_cdeg, hor_vel, vert_vel, icao_address, callsign, squawk_code,
+                lat, lng, alt, heading_cdeg, hor_vel, vert_vel, opts.icao_address, opts.callsign, squawk_code,
                 time_since_last_contact, flags, alt_type, emitter_type, fss::fss_current_timestamp());
-            client->sendMsgAll(msg_status);
-            client->sendMsgAll(msg_search);
             client->sendMsgAll(msg_pos);
         }
     }

--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -55,6 +55,10 @@ flight_safety_system::client_ssl::fss_client::fss_client(const std::string &t_fi
         configfile >> config;
 
         this->setAssetName(config["name"].asString());
+        if (config.isMember("non_aircraft"))
+        {
+            this->setNonAircraft(config["non_aircraft"].asBool());
+        }
 
         this->ca_file = config["ssl"]["ca_public_key"].asString();
         this->private_key_file = config["ssl"]["client_private_key"].asString();
@@ -141,6 +145,13 @@ void flight_safety_system::client_ssl::fss_client::setAssetName(std::string t_as
      * reads it unlocked). Recompute the configured flag afterwards. */
     this->asset_name = std::move(t_asset_name);
     this->updateConfigured();
+}
+
+void flight_safety_system::client_ssl::fss_client::setNonAircraft(bool t_non_aircraft)
+{
+    /* Set once during configuration, before concurrent use (same as
+     * setAssetName above) -- no lock needed. */
+    this->non_aircraft = t_non_aircraft;
 }
 
 void flight_safety_system::client_ssl::fss_client::connectTo(const std::string &t_address, uint16_t t_port,
@@ -414,6 +425,14 @@ auto flight_safety_system::client_ssl::fss_server::getClient() -> fss_client *
 
 void flight_safety_system::client_ssl::fss_server::sendIdentify()
 {
+    if (this->client->isNonAircraft())
+    {
+        /* The server derives the identity from the peer cert's CN on this
+         * path (todo/28), not from a message field. */
+        this->getConnection()->sendMsg(
+            std::make_shared<flight_safety_system::transport::fss_message_identity_non_aircraft>());
+        return;
+    }
     auto ident_msg =
         std::make_shared<flight_safety_system::transport::fss_message_identity>(this->client->getAssetName());
     this->getConnection()->sendMsg(ident_msg);

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -24,6 +24,11 @@ enum connection_status {
 class fss_client {
 private:
     std::string asset_name{""};
+    /* When true, sendIdentify() sends message_type_identity_non_aircraft
+     * instead of the aircraft identity (todo/28). The server derives the
+     * asset name from the peer cert's CN in that path, not from a message
+     * field, so there is no non-aircraft counterpart to asset_name. */
+    bool non_aircraft{false};
     std::string ca_file{""};
     std::string private_key_file{""};
     std::string public_key_file{""};
@@ -44,6 +49,7 @@ private:
     virtual void connectionStatusChange(flight_safety_system::client_ssl::connection_status status);
 protected:
     void setAssetName(std::string t_asset_name);
+    void setNonAircraft(bool t_non_aircraft);
     void addServer(const std::shared_ptr<fss_server> &server);
 public:
     explicit fss_client(const std::string &config_file);
@@ -59,6 +65,7 @@ public:
     virtual void disconnect();
     virtual void sendMsgAll(const std::shared_ptr<flight_safety_system::transport::fss_message> &msg);
     virtual auto getAssetName() -> std::string;
+    virtual auto isNonAircraft() const -> bool { return this->non_aircraft; }
     virtual auto isConfigured() const -> bool;
     virtual void serverRequiresReconnect(fss_server *server);
     virtual void updateServers(const std::shared_ptr<flight_safety_system::transport::fss_message_server_list> &msg);


### PR DESCRIPTION
## Description

fake_client.cpp had no way to identify as non-aircraft or drive arbitrary ICAO/callsign/rate, and nothing logged received position reports -- all needed to exercise the server's forwarding path end to end.

Library change (src/fss-client-ssl.hpp, src/client-ssl.cpp): fss_client gains a non_aircraft flag (config field "non_aircraft", default false) and sendIdentify() sends message_type_identity_non_aircraft instead of the aircraft identity when set. fss_server was always constructed as the concrete type, so a fake_client.cpp subclass had no way to override sendIdentify() itself -- this is the smallest change that unblocks non-aircraft mode without a virtual-factory refactor.

examples/fake_client.cpp: CLI overrides --icao=, --callsign=, --position-interval-ms= (all defaulting to the original hardcoded values/cadence, so every existing caller is unaffected); a handlePositionReport override logging "RCVD_POS: icao=... callsign=... lat=... lng=..." in the same grep-able style as RCVD_CMD/SENT_ACK. The send loop moved from a 1s-granular counter to a 10ms tick so --position-interval-ms can drive a fast-enough burst to actually exceed the per-connection rate limiter's default capacity within a short test window.

e2e/test_adsb_forwarding.py (TC-SRV-002 + Path C server share): non- aircraft-to-aircraft forwarding, aircraft-to-aircraft forwarding, no-echo, and a rate-limit case scoped to what the rate limiter actually is -- src/rate-limiter.hpp is a single per-connection token bucket, not per-ICAO as the todo assumed when filed; the test asserts a burst well over capacity+refill is capped, not delivered 1:1.

## Summary by Sourcery

Add support for non-aircraft client identification and enhance the fake client to drive configurable ADS-B-style traffic, enabling new end-to-end tests for server forwarding and rate limiting.

New Features:
- Allow clients to be marked as non-aircraft via configuration so the server sends a non-aircraft identity message.
- Extend the fake client example with CLI options for ICAO address, callsign, and position report interval, plus logging of received position reports for test assertions.

Enhancements:
- Adjust the fake client’s send loop to a fine-grained tick so it can generate high-rate position bursts while keeping status/search messages at a fixed cadence.
- Update the e2e client launcher to support non-aircraft configs and pass through extra CLI arguments to the fake client.

Documentation:
- Add a non-aircraft client configuration template fixture describing the new JSON field used in tests.

Tests:
- Introduce e2e ADS-B forwarding tests that cover non-aircraft-to-aircraft and aircraft-to-aircraft forwarding, ensure clients do not receive their own echoed positions, and verify per-connection rate limiting behavior.