### PR TITLE
test(e2e): todo/33 clock-skew handling, client-side skewed-timestamp hook

### DIFF
--- a/e2e/test_clock_skew.py
+++ b/e2e/test_clock_skew.py
@@ -1,0 +1,89 @@
+"""e2e: skewed client timestamps handled sanely (Path J server share, todo/33).
+
+The server's skew-aware position-staleness gate (client_session.cpp's
+position_report handler) compares each report's client-stamped timestamp
+against the server clock, corrected by client_clock_offset_ms -- measured
+from RTT responses that carry the client's clock (todo/17 item 3), smoothed
+via EWMA, updated roughly every 10s (the RTT request cadence). Until that
+offset is learned, a skewed client's reports read as stale and are
+discarded; once learned, storage should resume.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from conftest import wait_for_row
+
+
+@pytest.mark.satisfies("TC-MAV-017")
+@pytest.mark.requires_docker
+@pytest.mark.slow
+@pytest.mark.parametrize("offset_ms", [300_000, -300_000], ids=["ahead", "behind"])
+def test_moderate_skew_still_stores_and_commands_work(db_conn, fake_client, server_proc, offset_ms):
+    """+-5 min skew: TLS connects, telemetry is eventually stored once the
+    RTT clock-offset is learned, and a command round-trip still works."""
+    with db_conn.cursor() as cur:
+        cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
+        asset_id = cur.fetchone()[0]
+
+    client = fake_client("test1", extra_args=[f"--clock-offset-ms={offset_ms}"])
+
+    row = wait_for_row(
+        db_conn,
+        "SELECT id FROM assets_assetposition WHERE asset_id = %s ORDER BY id LIMIT 1",
+        params=(asset_id,),
+        timeout=30.0,
+    )
+    assert row is not None, (
+        f"no position row stored within 30s for offset_ms={offset_ms}\n"
+        + client["log"].read_text(errors="replace")
+    )
+    assert client["proc"].poll() is None, "client process should stay connected under moderate skew"
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO assets_assetcommand (asset_id, command, position, altitude) "
+            "VALUES (%s, 'RTL', ST_SetSRID(ST_MakePoint(0, 0), 4326)::geography, 0)",
+            (asset_id,),
+        )
+    time.sleep(6)
+    log_content = client["log"].read_text(errors="replace")
+    assert "RCVD_CMD: RTL" in log_content, (
+        f"command round-trip broken under offset_ms={offset_ms}\n" + log_content
+    )
+
+
+@pytest.mark.requires_docker
+@pytest.mark.slow
+def test_extreme_skew_one_hour(db_conn, fake_client, server_proc):
+    """1h skew: pin whatever the current policy actually does rather than
+    assume a clamp/reject that doesn't exist -- max_rtt_for_clock_offset_ms
+    gates RTT *sample quality*, not the size of the reported skew, so a
+    clean RTT round-trip should still let the offset be learned same as a
+    moderate skew, just with a larger correction."""
+    with db_conn.cursor() as cur:
+        cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
+        asset_id = cur.fetchone()[0]
+
+    client = fake_client("test1", extra_args=["--clock-offset-ms=3600000"])
+
+    row = wait_for_row(
+        db_conn,
+        "SELECT id FROM assets_assetposition WHERE asset_id = %s ORDER BY id LIMIT 1",
+        params=(asset_id,),
+        timeout=30.0,
+    )
+    assert row is not None, (
+        "no position row stored within 30s for a 1h clock skew\n"
+        + client["log"].read_text(errors="replace")
+    )
+    assert client["proc"].poll() is None, "client process should stay connected under extreme skew"
+    # No corrupted ordering: once storage resumes, rows keep accumulating
+    # rather than getting stuck after the first.
+    time.sleep(6)
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM assets_assetposition WHERE asset_id = %s", (asset_id,))
+        count = cur.fetchone()[0]
+    assert count >= 1

--- a/examples/fake_client.cpp
+++ b/examples/fake_client.cpp
@@ -38,6 +38,9 @@ static auto commandName(fss::transport::fss_asset_command cmd) -> std::string
 class logging_client : public fss::client_ssl::fss_client {
 public:
     using fss::client_ssl::fss_client::fss_client;
+    /* Exposes the protected setter for --clock-offset-ms (todo/33): a CLI
+     * flag is "less magic" than faketime and works on any runner. */
+    void applyClockOffsetMs(int64_t offset_ms) { this->setClockOffsetMs(offset_ms); }
     /* Logged in the same grep-able style as RCVD_CMD/SENT_ACK below, so e2e
      * tests can assert a client actually received a relayed position report
      * (todo/28) by scanning its stdout log rather than the DB. */
@@ -81,6 +84,7 @@ struct cli_options {
     uint32_t icao_address{0};
     std::string callsign{"example"};
     int position_interval_ms{5000};
+    int64_t clock_offset_ms{0};
 };
 
 /* Parses `text` as a base-10 integer via strtoul/strtol, requiring the
@@ -132,6 +136,7 @@ auto parse_args(int argc, char *argv[]) -> std::optional<cli_options>
     constexpr std::string_view icao_prefix = "--icao=";
     constexpr std::string_view callsign_prefix = "--callsign=";
     constexpr std::string_view interval_prefix = "--position-interval-ms=";
+    constexpr std::string_view clock_offset_prefix = "--clock-offset-ms=";
     for (int i = 2; i < argc; i++)
     {
         std::string_view arg = argv[i];
@@ -152,6 +157,11 @@ auto parse_args(int argc, char *argv[]) -> std::optional<cli_options>
             {
                 return std::nullopt;
             }
+        }
+        else if (arg.substr(0, clock_offset_prefix.size()) == clock_offset_prefix)
+        {
+            opts.clock_offset_ms =
+                std::strtoll(std::string(arg.substr(clock_offset_prefix.size())).c_str(), nullptr, 10);
         }
         else
         {
@@ -184,6 +194,10 @@ auto main(int argc, char *argv[]) -> int
         return -1;
     }
     auto opts = *parsed_opts;
+    if (opts.clock_offset_ms != 0)
+    {
+        client->applyClockOffsetMs(opts.clock_offset_ms);
+    }
 
     /* Connect to each server */
     /* Send reports:
@@ -259,9 +273,13 @@ auto main(int argc, char *argv[]) -> int
             constexpr int flags = 1 | 2 | 4 | 8 | 16 | 32;
             constexpr int alt_type = 1;
             constexpr int emitter_type = 14;
+            /* getSkewedTimestamp() (todo/33) rather than fss_current_timestamp()
+             * directly: a genuinely clock-skewed client stamps everything with
+             * its wrong clock, not just RTT responses -- defaults to the real
+             * clock when --clock-offset-ms was never given. */
             auto msg_pos = std::make_shared<fss::transport::fss_message_position_report>(
                 lat, lng, alt, heading_cdeg, hor_vel, vert_vel, opts.icao_address, opts.callsign, squawk_code,
-                time_since_last_contact, flags, alt_type, emitter_type, fss::fss_current_timestamp());
+                time_since_last_contact, flags, alt_type, emitter_type, client->getSkewedTimestamp());
             client->sendMsgAll(msg_pos);
             next_position_ms += opts.position_interval_ms;
         }

--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -59,6 +59,10 @@ flight_safety_system::client_ssl::fss_client::fss_client(const std::string &t_fi
         {
             this->setNonAircraft(config["non_aircraft"].asBool());
         }
+        if (config.isMember("clock_offset_ms"))
+        {
+            this->setClockOffsetMs(config["clock_offset_ms"].asInt64());
+        }
 
         this->ca_file = config["ssl"]["ca_public_key"].asString();
         this->private_key_file = config["ssl"]["client_private_key"].asString();
@@ -152,6 +156,21 @@ void flight_safety_system::client_ssl::fss_client::setNonAircraft(bool t_non_air
     /* Set once during configuration, before concurrent use (same as
      * setAssetName above) -- no lock needed. */
     this->non_aircraft = t_non_aircraft;
+}
+
+void flight_safety_system::client_ssl::fss_client::setClockOffsetMs(int64_t t_offset_ms)
+{
+    /* Set once during configuration, before concurrent use (same as
+     * setAssetName above) -- no lock needed. */
+    this->clock_offset_ms = t_offset_ms;
+}
+
+auto flight_safety_system::client_ssl::fss_client::getSkewedTimestamp() const -> uint64_t
+{
+    /* The timestamp is well below 2^63, so the signed round trip cannot
+     * overflow for any offset an e2e test would configure. */
+    return static_cast<uint64_t>(static_cast<int64_t>(flight_safety_system::fss_current_timestamp()) +
+                                 this->clock_offset_ms);
 }
 
 void flight_safety_system::client_ssl::fss_client::connectTo(const std::string &t_address, uint16_t t_port,
@@ -601,10 +620,11 @@ void flight_safety_system::client_ssl::fss_server::processMessage(
                 bool report_clock =
                     active_conn != nullptr && (active_conn->getNegotiatedFeatureFlags() &
                                                flight_safety_system::transport::FSS_FEATURE_RTT_OFFSET) != 0;
+                auto skewed_timestamp = this->getClient()->getSkewedTimestamp();
                 auto reply_msg =
                     report_clock
-                        ? std::make_shared<flight_safety_system::transport::fss_message_rtt_response>(
-                              msg->getId(), flight_safety_system::fss_current_timestamp())
+                        ? std::make_shared<flight_safety_system::transport::fss_message_rtt_response>(msg->getId(),
+                                                                                                      skewed_timestamp)
                         : std::make_shared<flight_safety_system::transport::fss_message_rtt_response>(msg->getId());
                 this->sendMsg(reply_msg);
             }

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -29,6 +29,11 @@ private:
      * asset name from the peer cert's CN in that path, not from a message
      * field, so there is no non-aircraft counterpart to asset_name. */
     bool non_aircraft{false};
+    /* Added to the wall-clock timestamp reported in an RTT response, when
+     * the server negotiated the clock-offset capability (todo/33). Lets an
+     * e2e test drive a client with a deliberately skewed clock without
+     * needing root/faketime. Positive = client clock ahead of real time. */
+    int64_t clock_offset_ms{0};
     std::string ca_file{""};
     std::string private_key_file{""};
     std::string public_key_file{""};
@@ -50,6 +55,7 @@ private:
 protected:
     void setAssetName(std::string t_asset_name);
     void setNonAircraft(bool t_non_aircraft);
+    void setClockOffsetMs(int64_t t_offset_ms);
     void addServer(const std::shared_ptr<fss_server> &server);
 public:
     explicit fss_client(const std::string &config_file);
@@ -66,6 +72,15 @@ public:
     virtual void sendMsgAll(const std::shared_ptr<flight_safety_system::transport::fss_message> &msg);
     virtual auto getAssetName() -> std::string;
     virtual auto isNonAircraft() const -> bool { return this->non_aircraft; }
+    virtual auto getClockOffsetMs() const -> int64_t { return this->clock_offset_ms; }
+    /* fss_current_timestamp() + clock_offset_ms (todo/33): the single
+     * source of truth for "what time does this client think it is", used
+     * both for the RTT response's reported client clock and for any
+     * message timestamp a skewed-clock test wants to be consistent with
+     * it (e.g. a position report) -- a client whose clock is genuinely
+     * wrong stamps everything with that wrong clock, not just RTT
+     * responses. */
+    virtual auto getSkewedTimestamp() const -> uint64_t;
     virtual auto isConfigured() const -> bool;
     virtual void serverRequiresReconnect(fss_server *server);
     virtual void updateServers(const std::shared_ptr<flight_safety_system::transport::fss_message_server_list> &msg);


### PR DESCRIPTION
## Description

fss_client gains a clock_offset_ms (config field, default 0) and a getSkewedTimestamp() = fss_current_timestamp() + clock_offset_ms, used for the RTT response's reported client clock. fake_client.cpp exposes it via --clock-offset-ms= (a CLI flag is "less magic" than faketime and works on any runner) and a public applyClockOffsetMs() wrapper.

Debugging the first e2e attempt (which never saw storage resume even after the RTT clock-offset was measured, per DEBUGTMP prints added and removed during the investigation) found the actual bug: fake_client.cpp's position_report message still stamped fss_current_timestamp() directly, not the skewed clock. A genuinely clock-skewed client stamps *every* message with its wrong clock, not just RTT responses -- with an unskewed position timestamp, the staleness gate's offset correction was "correcting" a report that was never actually skewed, manufacturing a fake discrepancy equal to the offset every time. Routing the position report's timestamp through the same getSkewedTimestamp() fixed it: storage now resumes once the RTT-based offset is learned (~1-2s in, given this build's RTT cadence), exactly as the skew-aware staleness gate (todo/08) intends.

e2e/test_clock_skew.py (Path J server share, TC-MAV-017): +-5 min skew still stores telemetry and commands round-trip once the offset is learned; a 1h skew behaves the same way (max_rtt_for_clock_offset_ms gates RTT sample quality, not the size of the reported skew, so there is no clamp/reject to assume here -- pinned the actually-observed behaviour per plan).

## Summary by Sourcery

Add configurable client-side clock offset support and verify skew-aware timestamp handling via new end-to-end tests.

New Features:
- Introduce a configurable client clock offset field and accessor that exposes the client’s perceived time via a skew-aware timestamp helper.
- Add a --clock-offset-ms CLI option to the fake client to simulate skewed clocks in end-to-end scenarios.

Bug Fixes:
- Ensure RTT responses and position reports use the same skewed client timestamp so clock-offset correction no longer manufactures false staleness.

Tests:
- Add e2e tests that validate telemetry storage and command round-trips under moderate (+-5 minutes) and extreme (1 hour) client clock skew.