### PR TITLE
fix(server): todo/34 surface DB write failures instead of discarding them

### DIFF
--- a/e2e/test_db_disk_full.py
+++ b/e2e/test_db_disk_full.py
@@ -1,0 +1,318 @@
+"""e2e: database disk exhaustion fails visibly, not silently (Path M m05
+server share, todo/34).
+
+Two confirmed defects, both fixed alongside this test:
+
+1. The deeper one: src/server-db.pgc's six write functions
+   (db_position_create_entry and siblings) executed their EXEC SQL
+   INSERT/UPDATE and returned void unconditionally -- never checking
+   sqlca.sqlcode. A failed write just got ECPG's default sqlprint() (a bare
+   stderr line, no exception), while db.cpp's C++ wrapper returned
+   normally as if it had succeeded. db_write_queue::run()'s catch block
+   (the mechanism this todo originally assumed was the whole story) can
+   only count a failure that throws -- and nothing ever did, so
+   write_failure_count() stayed at 0 through an entire live run against a
+   genuinely full disk. Confirmed live via a temporary debug print before
+   fixing it. Fix: the six functions now return 1/0 on success/failure;
+   db.cpp's wrappers throw database_error on 0, the same idiom
+   getActiveServers() already used for read failures.
+2. With (1) fixed, db_write_queue's catch block does fire -- but
+   src/server.cpp's per-second tick originally reset its failure streak on
+   any tick with no *new* failure. Real telemetry only lands every
+   position_interval (5s by default), so failures arrive in bursts with
+   quiet once-per-second checks in between, and a counter reset by any
+   quiet tick could never reach its threshold. Fixed by tracking a
+   wall-clock failure *incident* (started at the first new failure, only
+   cleared after a 15s quiet recovery window) instead of a per-tick streak;
+   once the incident has lasted db_write_failure_disconnect_ticks (default
+   5s), every connected client is severed via
+   server_clients::disconnectAll() -- matching Tier-3 Path M m05's
+   expectation that the server "sever connections cleanly ... rather than
+   hanging while accepting traffic it cannot store."
+
+Investigating the real failure mode (a size-capped tmpfs data directory,
+see _start_disk_limited_container below) also found that Postgres does not
+degrade gracefully once free space drops below roughly one WAL segment
+(16MB by default): it PANICs on the WAL write, and because its own crash
+*recovery* also needs to write WAL, the whole instance exits rather than
+restarting -- this reproduced identically at multiple insert-batch sizes,
+so it is a property of Postgres's WAL durability guarantee, not a fixable
+test artifact. That matches Tier-3 Path M's own framing of this as a
+sever-connections-or-worse event, not a "keeps humming along" one. Given
+that, recovery here is demonstrated the way the todo explicitly allows
+("either resumes storing or a restart restores service"): a fresh
+container + fresh server/client, not resuscitating the dead instance.
+"""
+from __future__ import annotations
+
+import os
+import signal
+import socket
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+import psycopg2
+import pytest
+
+from conftest import (
+    E2E_ROOT,
+    FAKE_CLIENT_BIN,
+    POSTGIS_IMAGE,
+    REPO_ROOT,
+    SCHEMA_DIR,
+    SERVER_BIN,
+    _pick_port,
+    _render_template,
+    _wait_for,
+)
+
+
+def _start_disk_limited_container(size: str) -> dict[str, object]:
+    container = f"fss-e2e-pg-disk-{uuid.uuid4().hex[:8]}"
+    password = "e2e"  # noqa: S105 - throwaway password for an ephemeral local test container
+    port = _pick_port()
+    subprocess.check_call([
+        "docker", "run", "--rm", "-d",
+        "--name", container,
+        "-e", f"POSTGRES_PASSWORD={password}",
+        "--tmpfs", f"/var/lib/postgresql:rw,size={size}",
+        "-p", f"{port}:5432",
+        POSTGIS_IMAGE,
+    ], stdout=subprocess.DEVNULL)
+
+    def ready() -> bool:
+        try:
+            c = psycopg2.connect(
+                host="127.0.0.1", port=port, user="postgres", password=password,
+                dbname="postgres", connect_timeout=2,
+            )
+            c.close()
+            return True
+        except psycopg2.Error:
+            return False
+
+    if not _wait_for(ready, 60.0, poll=0.5):
+        raise RuntimeError(f"disk-limited postgres container {container} did not become ready in 60s")
+    return {
+        "host": "127.0.0.1", "port": port, "user": "postgres",
+        "password": password, "dbname": "postgres", "container": container,
+    }
+
+
+def _stop_container(container: str) -> None:
+    subprocess.run(["docker", "stop", container], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def _migrate(conn_params: dict[str, object]) -> None:
+    conn = psycopg2.connect(
+        host=conn_params["host"], port=conn_params["port"],
+        user=conn_params["user"], password=conn_params["password"],
+        dbname=conn_params["dbname"],
+    )
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cur:
+            for sql_file in sorted(SCHEMA_DIR.glob("*.sql")):
+                cur.execute(sql_file.read_text())
+    finally:
+        conn.close()
+
+
+def _spawn_server(conn_params: dict[str, object], certs_dir: Path, tmp_path: Path, name: str) -> dict[str, object]:
+    port = _pick_port()
+    config_path = tmp_path / f"server-{name}.json"
+    log_path = tmp_path / f"server-{name}.log"
+    _render_template(
+        E2E_ROOT / "fixtures" / "server.json.tmpl",
+        config_path,
+        SERVER_PORT=str(port),
+        DB_HOST=conn_params["host"],
+        DB_PORT=str(conn_params["port"]),
+        DB_USER=conn_params["user"],
+        DB_PASS=conn_params["password"],
+        DB_NAME=conn_params["dbname"],
+        CERTS_DIR=str(certs_dir),
+    )
+    env = os.environ.copy()
+    env["LD_LIBRARY_PATH"] = str(REPO_ROOT / "src" / ".libs")
+    env["PGPORT"] = str(conn_params["port"])
+    env["PGPASSWORD"] = str(conn_params["password"])
+    log_fp = log_path.open("wb")
+    # sourcery skip: dangerous-subprocess-use-audit
+    proc = subprocess.Popen(
+        [str(SERVER_BIN), str(config_path)],
+        cwd=str(REPO_ROOT), env=env, stdout=log_fp, stderr=subprocess.STDOUT,
+    )
+
+    def listening() -> bool:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.settimeout(0.2)
+            try:
+                s.connect(("127.0.0.1", port))
+                return True
+            except OSError:
+                return False
+
+    if not _wait_for(listening, timeout=10.0):
+        proc.terminate()
+        raise RuntimeError(f"server-{name} never bound:\n{log_path.read_text(errors='replace')}")
+    time.sleep(0.5)
+    return {"proc": proc, "port": port, "log": log_path, "log_fp": log_fp, "env": env}
+
+
+def _stop_proc(proc: subprocess.Popen) -> None:
+    if proc.poll() is None:
+        proc.send_signal(signal.SIGINT)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+
+
+def _spawn_client(server: dict[str, object], certs_dir: Path, tmp_path: Path, name: str) -> dict[str, object]:
+    client_cfg = tmp_path / f"client-{name}.json"
+    client_log = tmp_path / f"client-{name}.log"
+    _render_template(
+        E2E_ROOT / "fixtures" / "client.json.tmpl",
+        client_cfg,
+        CLIENT_NAME="test1",
+        CERTS_DIR=str(certs_dir),
+        SERVER_PORT=str(server["port"]),
+    )
+    log_fp = client_log.open("wb")
+    # sourcery skip: dangerous-subprocess-use-audit
+    proc = subprocess.Popen(
+        [str(FAKE_CLIENT_BIN), str(client_cfg)],
+        cwd=str(REPO_ROOT), env=server["env"], stdout=log_fp, stderr=subprocess.STDOUT,
+    )
+    return {"proc": proc, "log": client_log, "log_fp": log_fp}
+
+
+@pytest.mark.requires_docker
+@pytest.mark.slow
+@pytest.mark.timeout(180)
+def test_disk_full_fails_visibly_and_a_fresh_instance_recovers(certs_dir, tmp_path):
+    """Fill a real, disk-limited Postgres via ongoing INSERT traffic on an
+    already-connected server; assert the failure is visible (write-failure
+    count logged, clients severed) rather than silently discarded, then
+    show a fresh instance (container + server + client) is unaffected --
+    "a restart restores service", the todo's explicitly-sanctioned recovery
+    path once the underlying Postgres instance itself is gone."""
+    db = _start_disk_limited_container("130m")
+    server = None
+    client = None
+    flood_conn = None
+    fresh_container = None
+    fresh_server = None
+    fresh_client = None
+    try:
+        _migrate(db)
+        setup_conn = psycopg2.connect(
+            host=db["host"], port=db["port"], user=db["user"], password=db["password"], dbname=db["dbname"],
+        )
+        setup_conn.autocommit = True
+        with setup_conn.cursor() as cur:
+            cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
+            asset_id = cur.fetchone()[0]
+
+        server = _spawn_server(db, certs_dir, tmp_path, "flood")
+        client = _spawn_client(server, certs_dir, tmp_path, "flood")
+
+        def first_row() -> bool:
+            with setup_conn.cursor() as cur:
+                cur.execute("SELECT COUNT(*) FROM assets_assetposition WHERE asset_id = %s", (asset_id,))
+                return cur.fetchone()[0] > 0
+
+        assert _wait_for(first_row, timeout=25.0), (
+            "no baseline position row before flooding the disk\n"
+            f"-- server log --\n{server['log'].read_text(errors='replace')}\n"
+            f"-- client log --\n{client['log'].read_text(errors='replace')}"
+        )
+
+        # Flood via a separate connection while the server's own connection
+        # stays open, so its *established* session is the one that
+        # experiences the write failure -- not a fresh-connect failure.
+        flood_conn = psycopg2.connect(
+            host=db["host"], port=db["port"], user=db["user"], password=db["password"], dbname=db["dbname"],
+        )
+        flood_conn.autocommit = True
+        with flood_conn.cursor() as flood_cur:
+            for _ in range(2000):
+                try:
+                    flood_cur.execute(
+                        "INSERT INTO assets_assetposition (asset_id, position, altitude) "
+                        "SELECT %s, ST_SetSRID(ST_MakePoint(172.6, -43.6), 4326)::geometry, 500 "
+                        "FROM generate_series(1, 2000)",
+                        (asset_id,),
+                    )
+                except psycopg2.Error:
+                    break
+
+        def failure_logged() -> bool:
+            return "DB write failures since start" in server["log"].read_text(errors="replace")
+
+        assert _wait_for(failure_logged, timeout=60.0), (
+            "server never logged a DB write failure after the disk filled\n"
+            + server["log"].read_text(errors="replace")
+        )
+
+        # The failure must escalate to visibly severing the session, not
+        # stay a silently-kept-alive one -- give the streak/incident guard
+        # its own window (db_write_failure_disconnect_ticks, default 5s,
+        # plus margin) *after* the first failure was already observed
+        # above, rather than checking instantly.
+        def severed() -> bool:
+            return "severing" in server["log"].read_text(errors="replace")
+
+        assert _wait_for(severed, timeout=30.0), (
+            "server logged write failures but never severed the session\n"
+            + server["log"].read_text(errors="replace")
+        )
+
+        # Fresh instance: a restart restores service (explicitly sanctioned
+        # by the todo as an acceptable recovery path once the flooded
+        # instance itself cannot recover in place -- see module docstring).
+        fresh_container = _start_disk_limited_container("130m")
+        _migrate(fresh_container)
+        fresh_setup_conn = psycopg2.connect(
+            host=fresh_container["host"], port=fresh_container["port"],
+            user=fresh_container["user"], password=fresh_container["password"], dbname=fresh_container["dbname"],
+        )
+        fresh_setup_conn.autocommit = True
+        with fresh_setup_conn.cursor() as cur:
+            cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
+            fresh_asset_id = cur.fetchone()[0]
+
+        fresh_server = _spawn_server(fresh_container, certs_dir, tmp_path, "fresh")
+        fresh_client = _spawn_client(fresh_server, certs_dir, tmp_path, "fresh")
+
+        def fresh_row() -> bool:
+            with fresh_setup_conn.cursor() as cur:
+                cur.execute(
+                    "SELECT COUNT(*) FROM assets_assetposition WHERE asset_id = %s", (fresh_asset_id,),
+                )
+                return cur.fetchone()[0] > 0
+
+        assert _wait_for(fresh_row, timeout=25.0), (
+            "fresh instance never resumed storing telemetry\n"
+            f"-- server log --\n{fresh_server['log'].read_text(errors='replace')}\n"
+            f"-- client log --\n{fresh_client['log'].read_text(errors='replace')}"
+        )
+        fresh_setup_conn.close()
+    finally:
+        for proc_dict in (client, fresh_client):
+            if proc_dict is not None:
+                _stop_proc(proc_dict["proc"])
+                proc_dict["log_fp"].close()
+        for srv_dict in (server, fresh_server):
+            if srv_dict is not None:
+                _stop_proc(srv_dict["proc"])
+                srv_dict["log_fp"].close()
+        if flood_conn is not None:
+            flood_conn.close()
+        if fresh_container is not None:
+            _stop_container(str(fresh_container["container"]))
+        _stop_container(str(db["container"]))

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -103,27 +103,39 @@ auto flight_safety_system::server::db_connection::getAssetId(const std::string &
 void flight_safety_system::server::db_connection::recordRtt(uint64_t asset_id, uint64_t rtt_ms)
 {
     std::scoped_lock guard(this->write_lock);
-    db_rtt_create_entry(write_conn_name, asset_id, rtt_ms);
+    if (db_rtt_create_entry(write_conn_name, asset_id, rtt_ms) == 0)
+    {
+        throw database_error("rtt write failed for asset " + std::to_string(asset_id));
+    }
 }
 
 void flight_safety_system::server::db_connection::recordStatus(uint64_t asset_id, uint8_t bat_percent,
                                                                uint32_t bat_mah_used, double bat_voltage)
 {
     std::scoped_lock guard(this->write_lock);
-    db_status_create_entry(write_conn_name, asset_id, bat_percent, bat_mah_used, bat_voltage);
+    if (db_status_create_entry(write_conn_name, asset_id, bat_percent, bat_mah_used, bat_voltage) == 0)
+    {
+        throw database_error("status write failed for asset " + std::to_string(asset_id));
+    }
 }
 
 void flight_safety_system::server::db_connection::recordSearchStatus(uint64_t asset_id, uint64_t search_id,
                                                                      uint64_t completed, uint64_t total)
 {
     std::scoped_lock guard(this->write_lock);
-    db_search_status_create_entry(write_conn_name, asset_id, search_id, completed, total);
+    if (db_search_status_create_entry(write_conn_name, asset_id, search_id, completed, total) == 0)
+    {
+        throw database_error("search status write failed for asset " + std::to_string(asset_id));
+    }
 }
 
 void flight_safety_system::server::db_connection::recordCommandDispatch(uint64_t command_dbid, uint64_t dispatch_id)
 {
     std::scoped_lock guard(this->write_lock);
-    db_command_set_dispatch_id(write_conn_name, command_dbid, dispatch_id);
+    if (db_command_set_dispatch_id(write_conn_name, command_dbid, dispatch_id) == 0)
+    {
+        throw database_error("command dispatch-id write failed for command " + std::to_string(command_dbid));
+    }
 }
 
 void flight_safety_system::server::db_connection::recordCommandAck(uint64_t asset_id, uint64_t dispatch_id,
@@ -131,8 +143,11 @@ void flight_safety_system::server::db_connection::recordCommandAck(uint64_t asse
                                                                    uint8_t ack_reason)
 {
     std::scoped_lock guard(this->write_lock);
-    db_command_record_ack(write_conn_name, asset_id, dispatch_id, static_cast<int>(ack_state), ack_timestamp,
-                          static_cast<int>(ack_reason));
+    if (db_command_record_ack(write_conn_name, asset_id, dispatch_id, static_cast<int>(ack_state), ack_timestamp,
+                              static_cast<int>(ack_reason)) == 0)
+    {
+        throw database_error("command ack write failed for asset " + std::to_string(asset_id));
+    }
 }
 
 void flight_safety_system::server::db_connection::recordPosition(uint64_t asset_id, double latitude, double longitude,
@@ -145,7 +160,10 @@ void flight_safety_system::server::db_connection::recordPosition(uint64_t asset_
                                         << asset_id);
         return;
     }
-    db_position_create_entry(write_conn_name, asset_id, latitude, longitude, static_cast<int>(altitude));
+    if (db_position_create_entry(write_conn_name, asset_id, latitude, longitude, static_cast<int>(altitude)) == 0)
+    {
+        throw database_error("position write failed for asset " + std::to_string(asset_id));
+    }
 }
 
 auto flight_safety_system::server::db_connection::getCommand(uint64_t asset_id) -> std::shared_ptr<asset_command>

--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -340,7 +340,15 @@ public:
      * the main loop's sustained-DB-write-failure guard — every currently
      * live session gets severed (Tier-3 Path M m05 expects this to trigger
      * aircraft comms-loss RTL) rather than the server silently continuing
-     * to accept telemetry it cannot store. */
+     * to accept telemetry it cannot store.
+     *
+     * Same disconnect()+clientDisconnected() pattern as
+     * disconnectRevokedClients() above, so it is safe by the same reasoning:
+     * both calls are idempotent (fss_client::disconnect() documents a second
+     * call as a safe no-op; clientDisconnected() only acts if the client is
+     * still in `clients`, erasing it on the first call), so a client racing
+     * its own concurrent teardown mid-snapshot is handled harmlessly rather
+     * than double-freed or double-erased. */
     auto disconnectAll() -> std::size_t
     {
         std::size_t disconnected_count = 0;

--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -336,4 +336,20 @@ public:
         }
         return disconnected_count;
     };
+    /* todo/34: unconditional version of disconnectRevokedClients above, for
+     * the main loop's sustained-DB-write-failure guard — every currently
+     * live session gets severed (Tier-3 Path M m05 expects this to trigger
+     * aircraft comms-loss RTL) rather than the server silently continuing
+     * to accept telemetry it cannot store. */
+    auto disconnectAll() -> std::size_t
+    {
+        std::size_t disconnected_count = 0;
+        for (const auto &client : this->snapshotClients())
+        {
+            client->disconnect();
+            this->clientDisconnected(client.get());
+            disconnected_count++;
+        }
+        return disconnected_count;
+    };
 };

--- a/src/server-db.h
+++ b/src/server-db.h
@@ -8,19 +8,24 @@ void db_disconnect(const char *conn);
 int db_ping(const char *conn);
 
 unsigned long long db_get_asset_id(const char *conn, const char *asset_name);
-void db_rtt_create_entry(const char *conn, unsigned long long asset_id, unsigned long long delta);
-void db_status_create_entry(const char *conn, unsigned long long asset_id, unsigned short bat_percent,
-                            unsigned int bat_mah_used, double bat_voltage);
-void db_search_status_create_entry(const char *conn, unsigned long long asset_id, unsigned long long search_id,
-                                   unsigned long long search_completed, unsigned long long search_total);
-void db_position_create_entry(const char *conn, unsigned long long asset_id, double latitude, double longitude,
-                              int altitude);
+
+/* todo/34: these six writers return 1 on success, 0 if sqlca.sqlcode < 0
+ * (e.g. disk-full) -- the caller (db.cpp) throws database_error on 0 so a
+ * silent per-INSERT failure isn't indistinguishable from a successful
+ * write to db_write_queue's caller. */
+int db_rtt_create_entry(const char *conn, unsigned long long asset_id, unsigned long long delta);
+int db_status_create_entry(const char *conn, unsigned long long asset_id, unsigned short bat_percent,
+                           unsigned int bat_mah_used, double bat_voltage);
+int db_search_status_create_entry(const char *conn, unsigned long long asset_id, unsigned long long search_id,
+                                  unsigned long long search_completed, unsigned long long search_total);
+int db_position_create_entry(const char *conn, unsigned long long asset_id, double latitude, double longitude,
+                             int altitude);
 
 /* Records the per-connection message id the server stamped onto the dispatched
  * command, on the assets_assetcommand row identified by its primary key
  * (command_dbid). Lets a later command-ack be matched back to this specific
  * command via dispatch_id == acked_command_id. */
-void db_command_set_dispatch_id(const char *conn, unsigned long long command_dbid, unsigned long long dispatch_id);
+int db_command_set_dispatch_id(const char *conn, unsigned long long command_dbid, unsigned long long dispatch_id);
 
 /* Updates the ack fields on the assets_assetcommand row whose (asset_id,
  * dispatch_id) matches the acking asset and the acked id. dispatch_id is only
@@ -29,8 +34,8 @@ void db_command_set_dispatch_id(const char *conn, unsigned long long command_dbi
  * ack_superseded_by the fss_command_ack_reason int, ack_timestamp the FMU
  * wall-clock ms. The update never lowers an already-terminal ack_state back to a
  * non-terminal one (a late "received" cannot clobber a settled outcome). */
-void db_command_record_ack(const char *conn, unsigned long long asset_id, unsigned long long dispatch_id, int ack_state,
-                           unsigned long long ack_timestamp, int ack_superseded_by);
+int db_command_record_ack(const char *conn, unsigned long long asset_id, unsigned long long dispatch_id, int ack_state,
+                          unsigned long long ack_timestamp, int ack_superseded_by);
 
 struct asset_command_s {
     char *command;

--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -95,7 +95,7 @@ unsigned long long db_get_asset_id(const char *conn_arg, const char *asset_name_
     return asset_id;
 }
 
-void db_rtt_create_entry(const char *conn_arg, unsigned long long asset_id_arg, unsigned long long delta)
+int db_rtt_create_entry(const char *conn_arg, unsigned long long asset_id_arg, unsigned long long delta)
 {
     EXEC SQL BEGIN DECLARE SECTION;
     const char *conn = conn_arg;
@@ -104,9 +104,16 @@ void db_rtt_create_entry(const char *conn_arg, unsigned long long asset_id_arg, 
     EXEC SQL END DECLARE SECTION;
 
     EXEC SQL AT :conn INSERT INTO assets_assetrtt (asset_id, rtt, timestamp) VALUES (:asset_id, :rtt, NOW());
+
+    if (sqlca.sqlcode < 0)
+    {
+        sqlprint();
+        return 0;
+    }
+    return 1;
 }
 
-void db_status_create_entry(const char *conn_arg, unsigned long long asset_id_arg, unsigned short bat_percent, unsigned int bat_mah_used, double bat_voltage)
+int db_status_create_entry(const char *conn_arg, unsigned long long asset_id_arg, unsigned short bat_percent, unsigned int bat_mah_used, double bat_voltage)
 {
     EXEC SQL BEGIN DECLARE SECTION;
     const char *conn = conn_arg;
@@ -117,9 +124,16 @@ void db_status_create_entry(const char *conn_arg, unsigned long long asset_id_ar
     EXEC SQL END DECLARE SECTION;
 
     EXEC SQL AT :conn INSERT INTO assets_assetstatus (asset_id, bat_percent, bat_used_mah, bat_volt, timestamp) VALUES (:asset_id, :bp, :bu, :voltage, NOW());
+
+    if (sqlca.sqlcode < 0)
+    {
+        sqlprint();
+        return 0;
+    }
+    return 1;
 }
 
-void db_search_status_create_entry(const char *conn_arg, unsigned long long asset_id_arg, unsigned long long search_id, unsigned long long search_completed, unsigned long long search_total)
+int db_search_status_create_entry(const char *conn_arg, unsigned long long asset_id_arg, unsigned long long search_id, unsigned long long search_completed, unsigned long long search_total)
 {
     EXEC SQL BEGIN DECLARE SECTION;
     const char *conn = conn_arg;
@@ -130,9 +144,16 @@ void db_search_status_create_entry(const char *conn_arg, unsigned long long asse
     EXEC SQL END DECLARE SECTION;
 
     EXEC SQL AT :conn INSERT INTO assets_assetsearchprogress (asset_id, search, search_progress, search_progress_of, timestamp) VALUES (:asset_id, :s, :sp, :spo, NOW());
+
+    if (sqlca.sqlcode < 0)
+    {
+        sqlprint();
+        return 0;
+    }
+    return 1;
 }
 
-void db_position_create_entry(const char *conn_arg, unsigned long long asset_id_arg, double latitude, double longitude, int altitude)
+int db_position_create_entry(const char *conn_arg, unsigned long long asset_id_arg, double latitude, double longitude, int altitude)
 {
     EXEC SQL BEGIN DECLARE SECTION;
     const char *conn = conn_arg;
@@ -143,9 +164,16 @@ void db_position_create_entry(const char *conn_arg, unsigned long long asset_id_
     EXEC SQL END DECLARE SECTION;
 
     EXEC SQL AT :conn INSERT INTO assets_assetposition (asset_id, position, altitude, timestamp) VALUES (:asset_id, ST_SetSRID(ST_MakePoint(:lng, :lat), 4326), :alt, NOW());
+
+    if (sqlca.sqlcode < 0)
+    {
+        sqlprint();
+        return 0;
+    }
+    return 1;
 }
 
-void db_command_set_dispatch_id(const char *conn_arg, unsigned long long command_dbid_arg, unsigned long long dispatch_id_arg)
+int db_command_set_dispatch_id(const char *conn_arg, unsigned long long command_dbid_arg, unsigned long long dispatch_id_arg)
 {
     EXEC SQL BEGIN DECLARE SECTION;
     const char *conn = conn_arg;
@@ -154,9 +182,16 @@ void db_command_set_dispatch_id(const char *conn_arg, unsigned long long command
     EXEC SQL END DECLARE SECTION;
 
     EXEC SQL AT :conn UPDATE assets_assetcommand SET dispatch_id = :dispatch_id WHERE id = :command_dbid;
+
+    if (sqlca.sqlcode < 0)
+    {
+        sqlprint();
+        return 0;
+    }
+    return 1;
 }
 
-void db_command_record_ack(const char *conn_arg, unsigned long long asset_id_arg, unsigned long long dispatch_id_arg, int ack_state_arg, unsigned long long ack_timestamp_arg, int ack_superseded_by_arg)
+int db_command_record_ack(const char *conn_arg, unsigned long long asset_id_arg, unsigned long long dispatch_id_arg, int ack_state_arg, unsigned long long ack_timestamp_arg, int ack_superseded_by_arg)
 {
     EXEC SQL BEGIN DECLARE SECTION;
     const char *conn = conn_arg;
@@ -186,6 +221,13 @@ void db_command_record_ack(const char *conn_arg, unsigned long long asset_id_arg
                     WHERE asset_id = :asset_id AND dispatch_id = :dispatch_id
                     ORDER BY timestamp DESC LIMIT 1)
           AND NOT (:ack_state = 0 AND ack_state IS NOT NULL AND ack_state <> 0);
+
+    if (sqlca.sqlcode < 0)
+    {
+        sqlprint();
+        return 0;
+    }
+    return 1;
 }
 
 struct asset_command_s *

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -108,6 +108,12 @@ auto main(int argc, char *argv[]) -> int
     constexpr uint64_t default_rate_capacity = 100;
     constexpr uint64_t default_rate_refill_per_s = 20;
     constexpr auto default_duplicate_identity_policy = flight_safety_system::server::duplicate_identity_reject_newcomer;
+    /* todo/34: default 5 consecutive per-second ticks (~5s) of a growing DB
+     * write-failure count before severing every connected client. A single
+     * transient failure never trips this (the streak resets whenever a tick
+     * passes with no new failures); only sustained failure -- what disk-full
+     * looks like -- does. */
+    constexpr uint64_t default_db_write_failure_disconnect_ticks = 5;
     constexpr unsigned int default_tls_handshake_timeout_ms =
         flight_safety_system::transport_ssl::default_handshake_timeout_ms;
     constexpr std::size_t default_max_concurrent_handshakes = 64;
@@ -126,6 +132,7 @@ auto main(int argc, char *argv[]) -> int
     uint64_t rate_capacity = default_rate_capacity;
     uint64_t rate_refill = default_rate_refill_per_s;
     auto duplicate_identity_policy = default_duplicate_identity_policy;
+    uint64_t db_write_failure_disconnect_ticks = default_db_write_failure_disconnect_ticks;
     unsigned int tls_handshake_timeout_ms = default_tls_handshake_timeout_ms;
     std::size_t max_concurrent_handshakes = default_max_concurrent_handshakes;
     std::string ca_public_key;
@@ -223,6 +230,10 @@ auto main(int argc, char *argv[]) -> int
                 FSS_LOG_ERROR("server", "Invalid duplicate_identity_policy '" << policy_str
                                                                               << "'; using default (reject_newcomer)");
             }
+        }
+        if (config.isMember("db_write_failure_disconnect_ticks"))
+        {
+            db_write_failure_disconnect_ticks = config["db_write_failure_disconnect_ticks"].asUInt64();
         }
         if (config.isMember("tls_handshake_timeout_ms"))
         {
@@ -398,11 +409,48 @@ auto main(int argc, char *argv[]) -> int
                 clients->checkTimeouts();
                 clients->sendRTTRequest();
                 static uint64_t last_failure_count = 0;
+                /* todo/34: tracks a *wall-clock* failure incident, not a
+                 * per-tick consecutive-growth counter -- real write traffic
+                 * (position/status/search) only lands every position_
+                 * interval (5s by default), so failures arrive in bursts
+                 * with quiet once-per-second checks in between. A counter
+                 * that reset on any quiet tick could never reach its
+                 * threshold under normal telemetry cadence. Elapsed_secs
+                 * below is this per-second block's own execution count
+                 * (not tick_counter, which advances every command_poll_ms),
+                 * so it is directly in seconds. */
+                static uint64_t elapsed_secs = 0;
+                static uint64_t incident_start_secs = 0; // 0 = no active incident
+                static uint64_t last_new_failure_secs = 0;
+                elapsed_secs++;
                 uint64_t current_failures = writer->write_failure_count();
                 if (current_failures != last_failure_count)
                 {
                     FSS_LOG_ERROR("server", "DB write failures since start: " << current_failures);
                     last_failure_count = current_failures;
+                    if (incident_start_secs == 0)
+                    {
+                        incident_start_secs = elapsed_secs;
+                    }
+                    last_new_failure_secs = elapsed_secs;
+                }
+                /* Recovery: no new failure for a grace window comfortably
+                 * longer than any realistic telemetry cadence -- the
+                 * incident is over, so a future failure starts a fresh one
+                 * rather than inheriting this one's age. */
+                constexpr uint64_t recovery_grace_secs = 15;
+                if (incident_start_secs != 0 && (elapsed_secs - last_new_failure_secs) > recovery_grace_secs)
+                {
+                    incident_start_secs = 0;
+                }
+                if (incident_start_secs != 0 &&
+                    (elapsed_secs - incident_start_secs) >= db_write_failure_disconnect_ticks)
+                {
+                    auto severed = clients->disconnectAll();
+                    FSS_LOG_ERROR("server", "DB writes have been failing for "
+                                                << (elapsed_secs - incident_start_secs) << "s; severing " << severed
+                                                << " connection(s) rather than silently discarding telemetry");
+                    incident_start_secs = 0;
                 }
                 static uint64_t last_command_dropped = 0;
                 uint64_t current_command_dropped = writer->command_dropped_count();

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -51,6 +51,58 @@ auto read_tcp_port(const Json::Value &node, const char *path, int &out) -> bool
     return true;
 }
 
+/* todo/34 (PR #327 review): tracks a *wall-clock* DB-write-failure incident
+ * for the main loop's sustained-failure guard, not a per-tick consecutive-
+ * growth counter -- real write traffic (position/status/search) only lands
+ * every position_interval (5s default), so failures arrive in bursts with
+ * quiet once-per-second checks in between; a counter reset by any quiet
+ * tick could never reach its threshold under normal telemetry cadence.
+ * tick() is called once per second (elapsed_secs is this tracker's own
+ * count, so it is directly in seconds, unlike tick_counter which advances
+ * every command_poll_ms). */
+class db_write_failure_incident_tracker {
+private:
+    uint64_t elapsed_secs{0};
+    uint64_t incident_start_secs{0}; // 0 = no active incident
+    uint64_t last_new_failure_secs{0};
+    uint64_t recovery_grace_secs;
+public:
+    explicit db_write_failure_incident_tracker(uint64_t t_recovery_grace_secs)
+        : recovery_grace_secs(t_recovery_grace_secs)
+    {
+    }
+    /* Advances one second. If new_failure is set, registers it as (still)
+     * part of the current incident, starting one if none is active.
+     * Otherwise, a quiet tick clears a stale incident once it has gone
+     * recovery_grace_secs without a new failure -- comfortably longer than
+     * any realistic telemetry cadence, so a future failure starts a fresh
+     * incident rather than inheriting this one's age. Returns the active
+     * incident's age in seconds, or 0 if none is active. */
+    auto tick(bool new_failure) -> uint64_t
+    {
+        elapsed_secs++;
+        if (new_failure)
+        {
+            if (incident_start_secs == 0)
+            {
+                incident_start_secs = elapsed_secs;
+            }
+            last_new_failure_secs = elapsed_secs;
+        }
+        else if (incident_start_secs != 0 && (elapsed_secs - last_new_failure_secs) > recovery_grace_secs)
+        {
+            incident_start_secs = 0;
+        }
+        return incident_start_secs == 0 ? 0 : elapsed_secs - incident_start_secs;
+    }
+    /* Distinct from "age() == 0": age() also reads 0 while an incident is
+     * merely one tick old, so a disconnect-ticks threshold of 0 must not be
+     * indistinguishable from "no incident at all" -- callers gate on this
+     * first. */
+    [[nodiscard]] auto active() const -> bool { return incident_start_secs != 0; }
+    void reset() { incident_start_secs = 0; }
+};
+
 } // namespace
 
 volatile sig_atomic_t running = 1;
@@ -108,12 +160,19 @@ auto main(int argc, char *argv[]) -> int
     constexpr uint64_t default_rate_capacity = 100;
     constexpr uint64_t default_rate_refill_per_s = 20;
     constexpr auto default_duplicate_identity_policy = flight_safety_system::server::duplicate_identity_reject_newcomer;
-    /* todo/34: default 5 consecutive per-second ticks (~5s) of a growing DB
-     * write-failure count before severing every connected client. A single
-     * transient failure never trips this (the streak resets whenever a tick
-     * passes with no new failures); only sustained failure -- what disk-full
-     * looks like -- does. */
+    /* todo/34: default 5s age for a sustained DB-write-failure incident
+     * (see db_write_failure_incident_tracker above) before severing every
+     * connected client. A single transient failure never trips this -- the
+     * incident only persists while failures keep recurring within
+     * default_db_write_failure_recovery_grace_secs of each other; only
+     * sustained failure -- what disk-full looks like -- reaches the age
+     * threshold. */
     constexpr uint64_t default_db_write_failure_disconnect_ticks = 5;
+    /* How long a DB-write-failure incident stays "active" with no new
+     * failure before being considered recovered (PR #327 review: this was
+     * hardcoded; now configurable like the threshold above, for
+     * deployments whose telemetry cadence differs from the 5s default). */
+    constexpr uint64_t default_db_write_failure_recovery_grace_secs = 15;
     constexpr unsigned int default_tls_handshake_timeout_ms =
         flight_safety_system::transport_ssl::default_handshake_timeout_ms;
     constexpr std::size_t default_max_concurrent_handshakes = 64;
@@ -133,6 +192,7 @@ auto main(int argc, char *argv[]) -> int
     uint64_t rate_refill = default_rate_refill_per_s;
     auto duplicate_identity_policy = default_duplicate_identity_policy;
     uint64_t db_write_failure_disconnect_ticks = default_db_write_failure_disconnect_ticks;
+    uint64_t db_write_failure_recovery_grace_secs = default_db_write_failure_recovery_grace_secs;
     unsigned int tls_handshake_timeout_ms = default_tls_handshake_timeout_ms;
     std::size_t max_concurrent_handshakes = default_max_concurrent_handshakes;
     std::string ca_public_key;
@@ -234,6 +294,10 @@ auto main(int argc, char *argv[]) -> int
         if (config.isMember("db_write_failure_disconnect_ticks"))
         {
             db_write_failure_disconnect_ticks = config["db_write_failure_disconnect_ticks"].asUInt64();
+        }
+        if (config.isMember("db_write_failure_recovery_grace_secs"))
+        {
+            db_write_failure_recovery_grace_secs = config["db_write_failure_recovery_grace_secs"].asUInt64();
         }
         if (config.isMember("tls_handshake_timeout_ms"))
         {
@@ -409,48 +473,22 @@ auto main(int argc, char *argv[]) -> int
                 clients->checkTimeouts();
                 clients->sendRTTRequest();
                 static uint64_t last_failure_count = 0;
-                /* todo/34: tracks a *wall-clock* failure incident, not a
-                 * per-tick consecutive-growth counter -- real write traffic
-                 * (position/status/search) only lands every position_
-                 * interval (5s by default), so failures arrive in bursts
-                 * with quiet once-per-second checks in between. A counter
-                 * that reset on any quiet tick could never reach its
-                 * threshold under normal telemetry cadence. Elapsed_secs
-                 * below is this per-second block's own execution count
-                 * (not tick_counter, which advances every command_poll_ms),
-                 * so it is directly in seconds. */
-                static uint64_t elapsed_secs = 0;
-                static uint64_t incident_start_secs = 0; // 0 = no active incident
-                static uint64_t last_new_failure_secs = 0;
-                elapsed_secs++;
+                static db_write_failure_incident_tracker db_incident(db_write_failure_recovery_grace_secs);
                 uint64_t current_failures = writer->write_failure_count();
-                if (current_failures != last_failure_count)
+                bool new_failure = current_failures != last_failure_count;
+                if (new_failure)
                 {
                     FSS_LOG_ERROR("server", "DB write failures since start: " << current_failures);
                     last_failure_count = current_failures;
-                    if (incident_start_secs == 0)
-                    {
-                        incident_start_secs = elapsed_secs;
-                    }
-                    last_new_failure_secs = elapsed_secs;
                 }
-                /* Recovery: no new failure for a grace window comfortably
-                 * longer than any realistic telemetry cadence -- the
-                 * incident is over, so a future failure starts a fresh one
-                 * rather than inheriting this one's age. */
-                constexpr uint64_t recovery_grace_secs = 15;
-                if (incident_start_secs != 0 && (elapsed_secs - last_new_failure_secs) > recovery_grace_secs)
-                {
-                    incident_start_secs = 0;
-                }
-                if (incident_start_secs != 0 &&
-                    (elapsed_secs - incident_start_secs) >= db_write_failure_disconnect_ticks)
+                uint64_t incident_age_secs = db_incident.tick(new_failure);
+                if (db_incident.active() && incident_age_secs >= db_write_failure_disconnect_ticks)
                 {
                     auto severed = clients->disconnectAll();
                     FSS_LOG_ERROR("server", "DB writes have been failing for "
-                                                << (elapsed_secs - incident_start_secs) << "s; severing " << severed
+                                                << incident_age_secs << "s; severing " << severed
                                                 << " connection(s) rather than silently discarding telemetry");
-                    incident_start_secs = 0;
+                    db_incident.reset();
                 }
                 static uint64_t last_command_dropped = 0;
                 uint64_t current_command_dropped = writer->command_dropped_count();

--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -135,6 +135,40 @@ TEST_CASE("db_connection: recordPosition with overflow altitude is discarded")
     dbc->recordPosition(asset_id, -43.5, 172.6, huge_alt);
 }
 
+TEST_CASE("db_connection: write methods throw database_error when the write connection is down (todo/34)")
+{
+    /* Before todo/34's fix, db_position_create_entry et al. (server-db.pgc)
+     * checked nothing after EXEC SQL -- a failed INSERT/UPDATE just printed
+     * via sqlprint() and the C++ wrapper returned normally, so db_write_queue
+     * never saw an exception and write_failure_count() never moved. Force
+     * the write connection down (no reconnect) so the write is guaranteed to
+     * fail, and require every write method surfaces it as database_error. */
+    LIVE_DB_OR_SKIP(dbc);
+    auto asset_id = dbc->getAssetId("test-asset");
+    REQUIRE(asset_id != 0);
+    db_disconnect(flight_safety_system::server::db_connection::write_conn_name);
+
+    auto threw_database_error = [](auto &&write_call) -> bool {
+        try
+        {
+            write_call();
+        }
+        catch (const flight_safety_system::server::database_error &)
+        {
+            return true;
+        }
+        return false;
+    };
+
+    REQUIRE(threw_database_error([&] { dbc->recordPosition(asset_id, -43.5, 172.6, uint32_t{100}); }));
+    REQUIRE(threw_database_error([&] { dbc->recordRtt(asset_id, uint64_t{42}); }));
+    REQUIRE(threw_database_error([&] { dbc->recordStatus(asset_id, uint8_t{80}, uint32_t{1000}, 12.4); }));
+    REQUIRE(threw_database_error([&] { dbc->recordSearchStatus(asset_id, uint64_t{1}, uint64_t{50}, uint64_t{100}); }));
+    REQUIRE(threw_database_error([&] { dbc->recordCommandDispatch(uint64_t{1}, uint64_t{1}); }));
+    REQUIRE(threw_database_error(
+        [&] { dbc->recordCommandAck(asset_id, uint64_t{1}, uint8_t{1}, uint64_t{1}, uint8_t{0}); }));
+}
+
 TEST_CASE("db_connection: getSmmSettings returns non-null for configured asset")
 {
     LIVE_DB_OR_SKIP(dbc);

--- a/tests/server_clients_test.cpp
+++ b/tests/server_clients_test.cpp
@@ -578,3 +578,31 @@ TEST_CASE("server_clients: duplicate identity check ignores distinct asset ids (
     REQUIRE(second->getCachedAssetId() == 2);
     REQUIRE(sc.getTotalClients() == 2);
 }
+
+TEST_CASE("server_clients: disconnectAll severs every live session (todo/34)")
+{
+    /* Unconditional counterpart of disconnectRevokedClients, used by the
+     * main loop's sustained-DB-write-failure guard: every connected client
+     * must be severed, revoked or not. */
+    server_clients sc;
+    fss_test::MockDatabase mock;
+
+    auto conn1 = std::make_shared<FakeConnection>();
+    conn1->revoked = false;
+    auto writer1 = make_null_writer();
+    auto client1 = std::make_shared<fss::server::fss_client>(conn1, &mock, writer1, &sc);
+    sc.clientConnected(client1);
+
+    auto conn2 = std::make_shared<FakeConnection>();
+    conn2->revoked = false;
+    auto writer2 = make_null_writer();
+    auto client2 = std::make_shared<fss::server::fss_client>(conn2, &mock, writer2, &sc);
+    sc.clientConnected(client2);
+
+    REQUIRE(sc.getTotalClients() == 2);
+    auto severed = sc.disconnectAll();
+    REQUIRE(severed == 2);
+
+    sc.cleanupRemovableClients();
+    REQUIRE(sc.getTotalClients() == 0);
+}


### PR DESCRIPTION
## Description

Two layered defects, both confirmed live against a genuinely disk-full Postgres before fixing:

1. The deeper one: src/server-db.pgc's six write functions (db_position_create_entry and siblings: rtt/status/search/dispatch/ack) ran their EXEC SQL INSERT/UPDATE and returned void unconditionally -- never checking sqlca.sqlcode. A failed write got ECPG's default sqlprint() (a bare stderr line) while the C++ wrapper returned normally as if it had succeeded. db_write_queue::run()'s catch block -- the mechanism this todo originally assumed was the whole story -- can only count a failure that throws, and nothing ever did: write_failure_count() stayed at 0 through an entire run against a full disk. Fixed by having the six functions return 1/0 on success/failure and db.cpp's wrappers throw database_error on 0, the same idiom getActiveServers() already uses for read failures. No IDatabase interface change needed -- void methods can throw without changing their signature, so MockDatabase is unaffected.
2. With (1) fixed, the main loop's per-second tick (server.cpp) still needed rework: it originally reset its failure streak on any tick with no *new* failure, but real telemetry only lands every position_interval (5s by default), so failures arrive in bursts with quiet ticks between -- a counter reset by any quiet tick could never reach its threshold. Replaced with a wall-clock failure *incident* (starts at the first new failure, only clears after a 15s quiet recovery window); once the incident has lasted db_write_failure_disconnect_ticks (default 5s), every connected client is severed via the new server_clients::disconnectAll(), matching Tier-3 Path M m05's expectation that the server "sever connections cleanly ... rather than hanging while accepting traffic it cannot store."

tests/db_connection_test.cpp: new live-DB regression forcing the write connection down and requiring every one of the six write methods to throw database_error (previously they'd have returned silently). Validated against a manual local Postgres container since TEST_DB_HOST isn't set in this environment.

e2e/test_db_disk_full.py: a real disk-limited Postgres container (size- capped tmpfs) filled via ongoing traffic on an already-connected server. Found along the way that Postgres does not degrade gracefully once free space drops below roughly one WAL segment (16MB) -- it PANICs, and because its own crash *recovery* also needs to write WAL, the whole instance exits rather than restarting. That's a property of Postgres's WAL durability guarantee, not a fixable test artifact, and it matches Tier-3 Path M's own framing as a sever-connections-or-worse event. Given that, the test demonstrates recovery the way the todo explicitly allows ("either resumes storing or a restart restores service"): a fresh container + fresh server/client, not resuscitating the dead instance.

## Summary by Sourcery

Surface database write failures and sever client connections when writes are persistently failing, ensuring telemetry is not silently discarded under disk-full conditions.

Bug Fixes:
- Ensure all database write operations report failures via exceptions instead of silently succeeding when the write connection or disk is unavailable.
- Adjust the server’s DB write failure tracking so sustained write errors are detected despite sparse telemetry cadence, triggering appropriate client disconnection.

Enhancements:
- Add a configurable threshold for sustained DB write failures before disconnecting all clients.
- Introduce an unconditional server_clients disconnectAll operation used to cleanly sever all active sessions on DB write failure incidents.

Tests:
- Add unit tests verifying that all DB write methods throw database_error when the write connection is down.
- Add unit tests covering server_clients disconnectAll behaviour.
- Introduce an end-to-end test that fills a disk-limited Postgres instance, validates visible DB write failures and client severing, and confirms a fresh instance can resume storing telemetry.