### PR TITLE
fix(server): todo/44 make duplicate-identity resolution atomic with a claim map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Duplicate-identity resolution is now atomic: `server_clients` records an
+  asset-id claim under its lock at identify time (released on disconnect),
+  where it previously checked a snapshot of already-published ids and let
+  the caller publish later — two connections identifying the same asset at
+  the same instant could each miss the other's unpublished claim and both go
+  live, violating both `duplicate_identity_policy` contracts (commands
+  delivered to two sessions presenting the same aircraft identity, telemetry
+  from two sources stored under one asset). (todo/44)
+
 ## [1.1.1] - 2026-07-06
 
 ### Fixed

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -926,7 +926,10 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                 /* todo/31: apply the configured duplicate-identity policy
                  * before this session is marked identified, so a rejected
                  * newcomer never gets far enough to receive commands or
-                 * have its telemetry stored against the shared asset_id. */
+                 * have its telemetry stored against the shared asset_id.
+                 * The handler reserves asset_id for this client atomically
+                 * with the check (todo/44); the store below publishes the
+                 * id for the poller and telemetry paths. */
                 if (!this->client_handler->resolveDuplicateIdentity(this, asset_id))
                 {
                     FSS_LOG_WARN("server", "Rejecting duplicate identity for asset_id "

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -207,8 +207,13 @@ public:
      * rejected outright (duplicate_identity_reject_newcomer hit an existing
      * live session for this asset_id); true otherwise — no conflict, or the
      * existing session was evicted (duplicate_identity_evict_oldest) and
-     * `newcomer` may proceed. Default no-op always returns true (no dedup),
-     * so existing fss_client_handler test mocks need not implement this. */
+     * `newcomer` may proceed. The caller publishes into cached_asset_id only
+     * after a true return, so an implementation must make the duplicate
+     * check atomic with an internal reservation of asset_id for `newcomer`
+     * (todo/44) — a check against published ids alone races a concurrent
+     * identify for the same asset — and release the reservation when the
+     * client disconnects. Default no-op always returns true (no dedup), so
+     * existing fss_client_handler test mocks need not implement this. */
     virtual auto resolveDuplicateIdentity(fss_client * /*newcomer*/, uint64_t /*asset_id*/) -> bool { return true; }
 };
 

--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -65,6 +65,11 @@ public:
         std::list<std::shared_ptr<flight_safety_system::server::fss_client>> doomed;
         {
             std::scoped_lock guard(this->lock);
+            /* Claims die with the client list, so a straggling identify on a
+             * recv thread not yet joined below sees a consistently empty map
+             * rather than owners that are no longer in `clients` (which
+             * resolveDuplicateIdentity would report as an invariant breach). */
+            this->asset_owners.clear();
             doomed.splice(doomed.end(), this->clients);
             while (!this->disconnected.empty())
             {
@@ -306,29 +311,57 @@ public:
         -> bool override
     {
         std::shared_ptr<flight_safety_system::server::fss_client> evictee{};
+        bool reject = false;
+        bool stale_owner = false;
         {
             std::scoped_lock guard(this->lock);
             auto owner = this->asset_owners.find(asset_id);
             if (owner != this->asset_owners.end() && owner->second != newcomer)
             {
+                /* Invariant: a recorded owner is always still in `clients`.
+                 * clientDisconnected() erases the claim in the same critical
+                 * section that removes the client, and ~server_clients clears
+                 * the map alongside the list, so a miss here means some
+                 * removal path failed to release its claim. That breach must
+                 * not stay silent: under reject_newcomer the asset would be
+                 * refused forever; under evict_oldest the "eviction" severs
+                 * nobody while resolve still reports success. Behaviour is
+                 * unchanged either way (reject still rejects; evict_oldest
+                 * transfers the claim with nobody to disconnect) — the ERROR
+                 * below (logged outside the lock, like every other nontrivial
+                 * action in this class) is what makes the breach visible. */
+                auto it = std::find_if(this->clients.begin(), this->clients.end(),
+                                       [&owner](const auto &c) -> bool { return c.get() == owner->second; });
+                stale_owner = it == this->clients.end();
                 if (this->duplicate_identity_policy_ ==
                     flight_safety_system::server::duplicate_identity_reject_newcomer)
                 {
-                    return false;
+                    reject = true;
                 }
-                /* evict_oldest: dethrone the recorded owner. It may already
-                 * have left `clients` (concurrent teardown won the race to
-                 * clientDisconnected, which erases the claim under this same
-                 * lock — so this window is tiny); then there is nobody left
-                 * to disconnect and the claim simply transfers. */
-                auto it = std::find_if(this->clients.begin(), this->clients.end(),
-                                       [&owner](const auto &c) -> bool { return c.get() == owner->second; });
-                if (it != this->clients.end())
+                else
                 {
-                    evictee = *it;
+                    if (!stale_owner)
+                    {
+                        evictee = *it;
+                    }
+                    this->asset_owners[asset_id] = newcomer;
                 }
             }
-            this->asset_owners[asset_id] = newcomer;
+            else
+            {
+                this->asset_owners[asset_id] = newcomer;
+            }
+        }
+        if (stale_owner)
+        {
+            FSS_LOG_ERROR("server", "Duplicate identity for asset_id "
+                                        << asset_id
+                                        << ": recorded claim owner is not in the live client list — a client-removal "
+                                           "path failed to release its claim (invariant breach)");
+        }
+        if (reject)
+        {
+            return false;
         }
         if (evictee != nullptr)
         {

--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <atomic>
 #include <list>
+#include <map>
 #include <mutex>
 #include <queue>
 #include <utility>
@@ -25,6 +26,14 @@ private:
     uint64_t rate_refill_per_s{20};
     flight_safety_system::server::duplicate_identity_policy duplicate_identity_policy_{
         flight_safety_system::server::duplicate_identity_reject_newcomer};
+    /* Which live client currently holds each asset_id (todo/44). Guarded by
+     * lock. A claim is recorded in resolveDuplicateIdentity() atomically with
+     * the duplicate check — i.e. before the winning client has published the
+     * id into its cached_asset_id — and released in clientDisconnected(), so
+     * two connections identifying the same asset_id at the same instant
+     * serialise on the claim and at most one live session can ever hold a
+     * given asset_id. */
+    std::map<uint64_t, flight_safety_system::server::fss_client *> asset_owners{};
     /* Guarded by lock. Built by the command poller thread (the only place
      * allowed to read the DB for it); broadcast by the main loop, which must
      * never perform a synchronous DB read. */
@@ -145,6 +154,15 @@ public:
         std::scoped_lock guard(this->lock);
         if (this->shutting_down)
             return;
+        /* Release any asset-id claim this client holds (todo/44). Scan by
+         * owner rather than looking up client->getCachedAssetId(): a claim
+         * whose publication never completed (the client timed out or was
+         * evicted while its identify was still in flight) must still be
+         * released, or the asset_id would stay unclaimable until restart. */
+        for (auto owner_it = this->asset_owners.begin(); owner_it != this->asset_owners.end();)
+        {
+            owner_it = (owner_it->second == client) ? this->asset_owners.erase(owner_it) : std::next(owner_it);
+        }
         auto it = std::find_if(this->clients.begin(), this->clients.end(),
                                [client](const auto &c) -> auto { return c.get() == client; });
         if (it != this->clients.end())
@@ -266,58 +284,60 @@ public:
             client->queueCommandSend();
         }
     };
-    /* todo/31: called from the identify path once asset_id is resolved, before
-     * `newcomer` is marked identified. Finds any other live session(s) already
-     * identified for this asset_id and applies the configured policy.
+    /* todo/31, reworked for todo/44: called from the identify path once
+     * asset_id is resolved, before `newcomer` is marked identified. The
+     * duplicate check and the claim are one critical section over
+     * asset_owners: the first claimant records itself under `lock`, so a
+     * second connection identifying the same asset_id serialises here and
+     * sees the claim even though the winner has not yet published the id
+     * into its cached_asset_id. (The previous implementation checked a
+     * snapshot of *published* ids and left publication to the caller; two
+     * concurrent identifies could each miss the other's unpublished claim
+     * and both proceed — the todo/44 race.) Because claims are unique per
+     * asset_id, evict_oldest has exactly one owner to dethrone.
      *
-     * Narrow race: two brand-new connections identifying for the same asset_id
-     * at almost the same instant can each see the other as not-yet-identified
-     * (cached_asset_id still 0) and both proceed — the same class of benign
-     * race snapshotClients() already documents elsewhere (a client connected
-     * mid-iteration is covered by the caller's next pass). Not worth a second
-     * lock ordered with client_lock to close, given how rare simultaneous
-     * identify is in practice. Because that race can leave more than one
-     * pre-existing session behind for the same asset_id, evict_oldest below
-     * evicts every match found here, not just one — otherwise a later
-     * newcomer would clear only the first (by connection order, i.e. the
-     * actual oldest) and leave the rest alive.
-     *
-     * disconnect()+clientDisconnected() runs outside `lock`, same as
-     * disconnectRevokedClients()/checkTimeouts() elsewhere in this class:
-     * clientDisconnected() takes `lock` itself and the snapshot's shared_ptr
-     * keeps `existing` alive across the call, so this is safe by the same
-     * reasoning documented on snapshotClients() above — disconnect() blocks
-     * on socket I/O and joins the recv thread, which must never happen while
-     * holding `lock`. */
+     * The evictee's disconnect()+clientDisconnected() runs outside `lock`,
+     * same as disconnectRevokedClients()/checkTimeouts() elsewhere in this
+     * class: clientDisconnected() takes `lock` itself and the shared_ptr
+     * grabbed under the lock keeps the evictee alive across the call —
+     * disconnect() blocks on socket I/O and joins the recv thread, which
+     * must never happen while holding `lock`. */
     auto resolveDuplicateIdentity(flight_safety_system::server::fss_client *newcomer, uint64_t asset_id)
         -> bool override
     {
-        auto snapshot = this->snapshotClients();
-        bool has_existing =
-            std::any_of(snapshot.begin(), snapshot.end(), [newcomer, asset_id](const auto &client) -> bool {
-                return client.get() != newcomer && client->getCachedAssetId() == asset_id;
-            });
-        if (!has_existing)
+        std::shared_ptr<flight_safety_system::server::fss_client> evictee{};
         {
-            return true;
-        }
-        if (this->duplicate_identity_policy_ == flight_safety_system::server::duplicate_identity_reject_newcomer)
-        {
-            return false;
-        }
-        std::size_t evicted = 0;
-        for (const auto &client : snapshot)
-        {
-            if (client.get() != newcomer && client->getCachedAssetId() == asset_id)
+            std::scoped_lock guard(this->lock);
+            auto owner = this->asset_owners.find(asset_id);
+            if (owner != this->asset_owners.end() && owner->second != newcomer)
             {
-                client->disconnect();
-                this->clientDisconnected(client.get());
-                evicted++;
+                if (this->duplicate_identity_policy_ ==
+                    flight_safety_system::server::duplicate_identity_reject_newcomer)
+                {
+                    return false;
+                }
+                /* evict_oldest: dethrone the recorded owner. It may already
+                 * have left `clients` (concurrent teardown won the race to
+                 * clientDisconnected, which erases the claim under this same
+                 * lock — so this window is tiny); then there is nobody left
+                 * to disconnect and the claim simply transfers. */
+                auto it = std::find_if(this->clients.begin(), this->clients.end(),
+                                       [&owner](const auto &c) -> bool { return c.get() == owner->second; });
+                if (it != this->clients.end())
+                {
+                    evictee = *it;
+                }
             }
+            this->asset_owners[asset_id] = newcomer;
         }
-        FSS_LOG_WARN("server", "Duplicate identity for asset_id "
-                                   << asset_id << ": evicted " << evicted
-                                   << " existing session(s) (duplicate_identity_evict_oldest)");
+        if (evictee != nullptr)
+        {
+            evictee->disconnect();
+            this->clientDisconnected(evictee.get());
+            FSS_LOG_WARN("server", "Duplicate identity for asset_id "
+                                       << asset_id
+                                       << ": evicted the existing session (duplicate_identity_evict_oldest)");
+        }
         return true;
     }
     auto disconnectRevokedClients(const std::string &crl_file) -> std::size_t

--- a/tests/mock_database.hpp
+++ b/tests/mock_database.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -181,8 +182,11 @@ public:
     }
 
     /* Number of getSmmSettings calls — lets tests assert that send paths
-     * use the cache rather than re-reading the database. */
-    int smm_reads{0};
+     * use the cache rather than re-reading the database. Atomic because
+     * concurrent-identify tests (todo/44) drive refreshSmmSettings() from
+     * two threads at once; the smm map itself stays unguarded like the other
+     * read-side maps (set up before any threads run, const find() after). */
+    std::atomic<int> smm_reads{0};
 
     auto isConnected() const -> bool override { return true; }
     void tryReconnectIfNeeded() override {}

--- a/tests/server_clients_test.cpp
+++ b/tests/server_clients_test.cpp
@@ -850,6 +850,65 @@ TEST_CASE("server_clients: a claim that never published is still released on dis
     REQUIRE(sc.resolveDuplicateIdentity(second.get(), 42));
 }
 
+TEST_CASE("server_clients: a stale claim owner is reported loudly under evict_oldest (todo/44, PR #328 review)")
+{
+    /* Claim-map invariant: a recorded owner is always still in `clients`
+     * (clientDisconnected releases claims in the same critical section that
+     * removes the client). Violate it deliberately — claim via a client never
+     * registered through clientConnected() — and require the breach to
+     * surface as an ERROR while behaviour stays unchanged: evict_oldest still
+     * admits the newcomer, with nobody to evict, and transfers the claim. */
+    server_clients sc;
+    sc.setDuplicateIdentityPolicy(fss::server::duplicate_identity_evict_oldest);
+    fss_test::MockDatabase mock;
+
+    auto conn1 = std::make_shared<FakeConnection>();
+    auto writer1 = make_null_writer();
+    /* Deliberately NOT clientConnected: the claim's owner is unknown to the
+     * client list, modelling a removal path that forgot to release it. */
+    auto stale = std::make_shared<fss::server::fss_client>(conn1, &mock, writer1, &sc);
+    REQUIRE(sc.resolveDuplicateIdentity(stale.get(), 42));
+
+    auto conn2 = std::make_shared<FakeConnection>();
+    auto writer2 = make_null_writer();
+    auto newcomer = std::make_shared<fss::server::fss_client>(conn2, &mock, writer2, &sc);
+    sc.clientConnected(newcomer);
+
+    fss_test::capture_cerr capture;
+    REQUIRE(sc.resolveDuplicateIdentity(newcomer.get(), 42));
+    REQUIRE(capture.str().find("invariant breach") != std::string::npos);
+
+    /* Nobody was evicted — the registered newcomer is the only live session,
+     * and it now owns the claim (a third resolve for the same id must see a
+     * conflict again). */
+    sc.cleanupRemovableClients();
+    REQUIRE(sc.getTotalClients() == 1);
+}
+
+TEST_CASE("server_clients: a stale claim owner is reported loudly under reject_newcomer (todo/44, PR #328 review)")
+{
+    /* Same deliberate breach under the default policy: the newcomer is still
+     * refused (the conservative outcome — a stale claim must not silently
+     * hand the identity over), but the breach is visible as an ERROR rather
+     * than looking like an ordinary duplicate rejection. */
+    server_clients sc;
+    fss_test::MockDatabase mock;
+
+    auto conn1 = std::make_shared<FakeConnection>();
+    auto writer1 = make_null_writer();
+    auto stale = std::make_shared<fss::server::fss_client>(conn1, &mock, writer1, &sc);
+    REQUIRE(sc.resolveDuplicateIdentity(stale.get(), 42));
+
+    auto conn2 = std::make_shared<FakeConnection>();
+    auto writer2 = make_null_writer();
+    auto newcomer = std::make_shared<fss::server::fss_client>(conn2, &mock, writer2, &sc);
+    sc.clientConnected(newcomer);
+
+    fss_test::capture_cerr capture;
+    REQUIRE_FALSE(sc.resolveDuplicateIdentity(newcomer.get(), 42));
+    REQUIRE(capture.str().find("invariant breach") != std::string::npos);
+}
+
 TEST_CASE("server_clients: disconnectAll severs every live session (todo/34)")
 {
     /* Unconditional counterpart of disconnectRevokedClients, used by the

--- a/tests/server_clients_test.cpp
+++ b/tests/server_clients_test.cpp
@@ -10,12 +10,14 @@
 #error No catch header
 #endif
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <list>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <sys/socket.h>
@@ -577,6 +579,275 @@ TEST_CASE("server_clients: duplicate identity check ignores distinct asset ids (
     REQUIRE(first->getCachedAssetId() == 1);
     REQUIRE(second->getCachedAssetId() == 2);
     REQUIRE(sc.getTotalClients() == 2);
+}
+
+TEST_CASE("server_clients: duplicate check is atomic with the claim, not the published id (todo/44)")
+{
+    /* The todo/44 race distilled: resolveDuplicateIdentity() used to check a
+     * snapshot of *published* cached_asset_ids while publication happened
+     * later in the caller, so a second identify running between the first's
+     * check and its publish saw no conflict and both sessions went live.
+     * Model exactly that interleaving: resolve for two clients back-to-back
+     * without letting either publish. The claim recorded by the first call
+     * must reject the second even though nothing is published yet. */
+    server_clients sc;
+    fss_test::MockDatabase mock;
+
+    auto conn1 = std::make_shared<FakeConnection>();
+    auto writer1 = make_null_writer();
+    auto first = std::make_shared<fss::server::fss_client>(conn1, &mock, writer1, &sc);
+    sc.clientConnected(first);
+
+    auto conn2 = std::make_shared<FakeConnection>();
+    auto writer2 = make_null_writer();
+    auto second = std::make_shared<fss::server::fss_client>(conn2, &mock, writer2, &sc);
+    sc.clientConnected(second);
+
+    REQUIRE(sc.resolveDuplicateIdentity(first.get(), 42));
+    /* Nothing is published yet — exactly the state a concurrent identify
+     * that has not reached its cached_asset_id store is in. */
+    REQUIRE(first->getCachedAssetId() == 0);
+    REQUIRE_FALSE(sc.resolveDuplicateIdentity(second.get(), 42));
+}
+
+TEST_CASE("server_clients: eviction keys on the claim, not the published id (todo/44)")
+{
+    /* Same interleaving as above under duplicate_identity_evict_oldest: the
+     * second resolve must find and evict the first claimant even though the
+     * first has not yet published its asset id. Pre-todo/44 the snapshot
+     * check saw no published match, evicted nobody, and both sessions went
+     * live. */
+    server_clients sc;
+    sc.setDuplicateIdentityPolicy(fss::server::duplicate_identity_evict_oldest);
+    fss_test::MockDatabase mock;
+
+    auto conn1 = std::make_shared<FakeConnection>();
+    auto writer1 = make_null_writer();
+    auto first = std::make_shared<fss::server::fss_client>(conn1, &mock, writer1, &sc);
+    sc.clientConnected(first);
+
+    auto conn2 = std::make_shared<FakeConnection>();
+    auto writer2 = make_null_writer();
+    auto second = std::make_shared<fss::server::fss_client>(conn2, &mock, writer2, &sc);
+    sc.clientConnected(second);
+
+    REQUIRE(sc.resolveDuplicateIdentity(first.get(), 7));
+    REQUIRE(sc.resolveDuplicateIdentity(second.get(), 7));
+
+    /* The first claimant was evicted; only the second remains live. */
+    REQUIRE(sc.getTotalClients() == 2);
+    sc.cleanupRemovableClients();
+    REQUIRE(sc.getTotalClients() == 1);
+}
+
+TEST_CASE("server_clients: concurrent identifies for one asset admit exactly one session (todo/44)")
+{
+    /* todo/44's acceptance criterion driven through the real identify path:
+     * release two identification handlers together on separate threads and
+     * require that exactly one publishes the shared asset id and becomes an
+     * aircraft under reject_newcomer. Repeated so a regression back to
+     * check-then-publish gets many chances to interleave badly, and so TSan
+     * sees the claim map under real contention. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft1"] = 42;
+
+    constexpr int rounds = 20;
+    for (int round = 0; round < rounds; ++round)
+    {
+        server_clients sc;
+
+        auto conn1 = std::make_shared<FakeConnection>();
+        conn1->cert_names.push_back("craft1");
+        auto writer1 = make_null_writer();
+        auto first = std::make_shared<fss::server::fss_client>(conn1, &mock, writer1, &sc);
+        sc.clientConnected(first);
+
+        auto conn2 = std::make_shared<FakeConnection>();
+        conn2->cert_names.push_back("craft1");
+        auto writer2 = make_null_writer();
+        auto second = std::make_shared<fss::server::fss_client>(conn2, &mock, writer2, &sc);
+        sc.clientConnected(second);
+
+        std::atomic<bool> go{false};
+        auto identify = [&go](const std::shared_ptr<fss::server::fss_client> &client) -> void {
+            while (!go.load())
+            {
+                std::this_thread::yield();
+            }
+            client->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft1"));
+        };
+        std::thread t1(identify, first);
+        std::thread t2(identify, second);
+        go.store(true);
+        t1.join();
+        t2.join();
+
+        bool first_won = first->getCachedAssetId() == 42 && first->isAircraft();
+        bool second_won = second->getCachedAssetId() == 42 && second->isAircraft();
+        REQUIRE(first_won != second_won);
+        sc.cleanupRemovableClients();
+        REQUIRE(sc.getTotalClients() == 1);
+    }
+}
+
+TEST_CASE("server_clients: concurrent identifies under evict_oldest leave exactly one live session (todo/44)")
+{
+    /* Under evict_oldest both concurrent identifies return true (the later
+     * claimant dethrones the earlier one), so the invariant is at the session
+     * level: exactly one live session may remain, whichever thread won. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft1"] = 7;
+
+    server_clients sc;
+    sc.setDuplicateIdentityPolicy(fss::server::duplicate_identity_evict_oldest);
+
+    auto conn1 = std::make_shared<FakeConnection>();
+    conn1->cert_names.push_back("craft1");
+    auto writer1 = make_null_writer();
+    auto first = std::make_shared<fss::server::fss_client>(conn1, &mock, writer1, &sc);
+    sc.clientConnected(first);
+
+    auto conn2 = std::make_shared<FakeConnection>();
+    conn2->cert_names.push_back("craft1");
+    auto writer2 = make_null_writer();
+    auto second = std::make_shared<fss::server::fss_client>(conn2, &mock, writer2, &sc);
+    sc.clientConnected(second);
+
+    std::atomic<bool> go{false};
+    auto identify = [&go](const std::shared_ptr<fss::server::fss_client> &client) -> void {
+        while (!go.load())
+        {
+            std::this_thread::yield();
+        }
+        client->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft1"));
+    };
+    std::thread t1(identify, first);
+    std::thread t2(identify, second);
+    go.store(true);
+    t1.join();
+    t2.join();
+
+    sc.cleanupRemovableClients();
+    REQUIRE(sc.getTotalClients() == 1);
+
+    /* The claim followed the survivor: a third session identifying the same
+     * asset must find exactly one owner to evict and become the sole live
+     * session itself. */
+    auto conn3 = std::make_shared<FakeConnection>();
+    conn3->cert_names.push_back("craft1");
+    auto writer3 = make_null_writer();
+    auto third = std::make_shared<fss::server::fss_client>(conn3, &mock, writer3, &sc);
+    sc.clientConnected(third);
+    third->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft1"));
+
+    REQUIRE(third->getCachedAssetId() == 7);
+    REQUIRE(third->isAircraft());
+    sc.cleanupRemovableClients();
+    REQUIRE(sc.getTotalClients() == 1);
+}
+
+TEST_CASE("server_clients: distinct asset ids still identify concurrently (todo/44)")
+{
+    /* Closing the duplicate race must not serialise or reject unrelated
+     * identifies: two different aircraft released together must both go
+     * live. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft1"] = 1;
+    mock.asset_ids["craft2"] = 2;
+
+    server_clients sc;
+
+    auto conn1 = std::make_shared<FakeConnection>();
+    conn1->cert_names.push_back("craft1");
+    auto writer1 = make_null_writer();
+    auto first = std::make_shared<fss::server::fss_client>(conn1, &mock, writer1, &sc);
+    sc.clientConnected(first);
+
+    auto conn2 = std::make_shared<FakeConnection>();
+    conn2->cert_names.push_back("craft2");
+    auto writer2 = make_null_writer();
+    auto second = std::make_shared<fss::server::fss_client>(conn2, &mock, writer2, &sc);
+    sc.clientConnected(second);
+
+    std::atomic<bool> go{false};
+    auto identify = [&go](const std::shared_ptr<fss::server::fss_client> &client, const std::string &name) -> void {
+        while (!go.load())
+        {
+            std::this_thread::yield();
+        }
+        client->processMessage(std::make_shared<fss::transport::fss_message_identity>(name));
+    };
+    std::thread t1(identify, first, "craft1");
+    std::thread t2(identify, second, "craft2");
+    go.store(true);
+    t1.join();
+    t2.join();
+
+    REQUIRE(first->getCachedAssetId() == 1);
+    REQUIRE(first->isAircraft());
+    REQUIRE(second->getCachedAssetId() == 2);
+    REQUIRE(second->isAircraft());
+    sc.cleanupRemovableClients();
+    REQUIRE(sc.getTotalClients() == 2);
+}
+
+TEST_CASE("server_clients: a disconnected session's asset id can be claimed again (todo/44)")
+{
+    /* The claim must be released when its owner disconnects, or under
+     * reject_newcomer every reconnect after a timeout/network drop would be
+     * refused until server restart. */
+    server_clients sc;
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft1"] = 42;
+
+    auto conn1 = std::make_shared<FakeConnection>();
+    conn1->cert_names.push_back("craft1");
+    auto writer1 = make_null_writer();
+    auto first = std::make_shared<fss::server::fss_client>(conn1, &mock, writer1, &sc);
+    sc.clientConnected(first);
+    first->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft1"));
+    REQUIRE(first->getCachedAssetId() == 42);
+
+    sc.clientDisconnected(first.get());
+    sc.cleanupRemovableClients();
+
+    auto conn2 = std::make_shared<FakeConnection>();
+    conn2->cert_names.push_back("craft1");
+    auto writer2 = make_null_writer();
+    auto second = std::make_shared<fss::server::fss_client>(conn2, &mock, writer2, &sc);
+    sc.clientConnected(second);
+    second->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft1"));
+
+    REQUIRE(second->getCachedAssetId() == 42);
+    REQUIRE(second->isAircraft());
+    REQUIRE(sc.getTotalClients() == 1);
+}
+
+TEST_CASE("server_clients: a claim that never published is still released on disconnect (todo/44)")
+{
+    /* Releases scan by owner, not by the client's published id: a client that
+     * claimed an asset id but disconnected before its identify stored
+     * cached_asset_id (timed out or evicted mid-identify) must not leave the
+     * id unclaimable until restart. */
+    server_clients sc;
+    fss_test::MockDatabase mock;
+
+    auto conn1 = std::make_shared<FakeConnection>();
+    auto writer1 = make_null_writer();
+    auto first = std::make_shared<fss::server::fss_client>(conn1, &mock, writer1, &sc);
+    sc.clientConnected(first);
+
+    auto conn2 = std::make_shared<FakeConnection>();
+    auto writer2 = make_null_writer();
+    auto second = std::make_shared<fss::server::fss_client>(conn2, &mock, writer2, &sc);
+    sc.clientConnected(second);
+
+    REQUIRE(sc.resolveDuplicateIdentity(first.get(), 42));
+    REQUIRE(first->getCachedAssetId() == 0); // claimed, never published
+    sc.clientDisconnected(first.get());
+    sc.cleanupRemovableClients();
+
+    REQUIRE(sc.resolveDuplicateIdentity(second.get(), 42));
 }
 
 TEST_CASE("server_clients: disconnectAll severs every live session (todo/34)")


### PR DESCRIPTION
## Description

resolveDuplicateIdentity() checked a snapshot of *published* cached_asset_ids while publication happened later in the caller, so two connections identifying the same asset at the same instant could each miss the other's unpublished claim and both go live -- violating both duplicate_identity_policy contracts (commands delivered to two sessions presenting the same aircraft identity, telemetry from two sources stored under one asset). The header itself documented the race as accepted; todo/44 (High) reclassified it.

server_clients now owns an asset_owners claim map guarded by its existing lock: the duplicate check and the claim are one critical section (first claimant wins; reject_newcomer refuses the loser, evict_oldest dethrones the single recorded owner -- exactly one, since claims are unique per asset_id). Claims are released in clientDisconnected() by scanning for the client as *owner* rather than by its published id, so a claim whose identify never completed publication (timed out or evicted mid-identify) cannot leave the asset_id unclaimable until restart. The evictee's blocking disconnect() stays outside the lock, preserving the established lock-ordering rule. Claim-only atomicity is sufficient -- the check now reads the map, not cached_asset_id, so publication timing no longer matters and no fss_client API change was needed.

Regression tests land with the fix (so untagged, per the house rule): the two distilled interleavings -- resolve-then-resolve with publication withheld, one per policy -- were verified to fail deterministically against a genuinely pre-fix build (which required force-recompiling the test objects: this tree is configured with --disable-dependency-tracking, so a header revert alone relinks stale objects that still contain the fix). Plus: concurrent identifies through the real processMessage path (exactly-one-winner x20 rounds; evict_oldest exactly-one-survivor with a claim-transfer follow-up), concurrent distinct-id identifies stay admissible, and release-on-disconnect for both a published and a never-published claim.

Verified: clean-rebuild make check, e2e test_duplicate_identity.py against the real server/TLS/PostGIS stack, and check-code.sh all pass.

## Summary by Sourcery

Make duplicate-identity resolution use an internal asset ownership map so that claiming an asset ID is atomic and tied to client lifecycle, preventing multiple live sessions from sharing the same aircraft identity.

Bug Fixes:
- Ensure duplicate-identity checks use an atomic asset-id claim rather than a snapshot of published IDs, so simultaneous identifies for the same asset cannot both succeed.
- Release asset-id claims when a client disconnects, including sessions that never finished publishing their asset ID, so reconnects are admitted correctly.

Enhancements:
- Document the atomic reservation requirement for duplicate-identity handling in the fss_client_handler interface and clarify the identify path comments.
- Add a per-asset owner map to server_clients to track which live client holds each asset ID and support deterministic eviction under duplicate_identity_evict_oldest.

Documentation:
- Update the changelog to describe the fixed race in duplicate-identity handling and the new atomic claim behavior.

Tests:
- Add regression and concurrency tests covering atomic duplicate-identity resolution, eviction semantics, concurrent identifies for same and distinct asset IDs, and claim release on disconnect.