### PR TITLE
feat(server): todo/45,47 unified DB fail-safe monitor with latched degraded state

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -58,7 +58,7 @@ CLEANFILES = server-db.c
 if SERVER
 sbin_PROGRAMS += fss-server
 
-fss_server_SOURCES = server.cpp client_session.cpp fss-server.hpp rate-limiter.hpp server-clients.hpp db.cpp server-db.pgc server-db.h db-write-queue.cpp db-write-queue.hpp
+fss_server_SOURCES = server.cpp client_session.cpp fss-server.hpp rate-limiter.hpp server-clients.hpp server-failsafe.hpp db.cpp server-db.pgc server-db.h db-write-queue.cpp db-write-queue.hpp
 fss_server_CXXFLAGS = $(AM_CXXFLAGS) $(JSONCPP_CFLAGS)
 fss_server_CFLAGS = $(AM_CFLAGS) $(ECPG_CFLAGS)
 fss_server_LDADD = libfss.la libfss-transport.la $(JSONCPP_LIBS) $(ECPG_LIBS)

--- a/src/server-failsafe.hpp
+++ b/src/server-failsafe.hpp
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace flight_safety_system {
+namespace server {
+
+/* Unified DB fail-safe monitor for the main loop's per-second tick (todo/34,
+ * todo/45, todo/47). Watches the db_write_queue's failure counters and owns
+ * the decision to degrade:
+ *
+ * - A *sustained* write-failure incident (todo/34): failures recurring within
+ *   recovery_grace_secs of each other form one incident; the trip requires a
+ *   new failure arriving once the incident is at least disconnect_age_secs
+ *   old, i.e. failures genuinely spanning the window. A single transient
+ *   failure ages out quietly and never trips (the pre-todo/47 tracker let a
+ *   lone failure trip at the age threshold purely by staying "active" through
+ *   the grace period, despite documenting the opposite).
+ *
+ * - Any command dispatch/ack drop (todo/45): trips immediately on the first
+ *   counter increase. A dropped command write is known-destroyed audit state
+ *   (the command/ack link, or the aircraft's reported outcome), so there is
+ *   no threshold to age through.
+ *
+ * A trip latches the degraded state (todo/47): the caller severs every client
+ * *and* gates new admissions (server_clients::setDegraded) so aircraft get one
+ * clean comms-loss event instead of a disconnect/reconnect flap into the same
+ * unhealthy server. Recovery requires the write queue fully drained AND more
+ * than recovery_grace_secs with no new failure or drop; readmitted traffic is
+ * then the health probe — if the fault persists, the next incident latches
+ * again rather than flapping on the tick period.
+ *
+ * Not thread-safe: main-loop tick only, like the tracker it replaces. */
+class db_failsafe {
+public:
+    /* State transition reported by tick(); the caller performs the actual
+     * severance/gating and logging, keeping I/O out of this class. */
+    enum class event {
+        none,
+        tripped,
+        recovered,
+    };
+    enum class trip_reason {
+        none,
+        write_failure,
+        command_drop,
+    };
+private:
+    uint64_t disconnect_age_secs;
+    uint64_t recovery_grace_secs;
+    uint64_t elapsed_secs{0};
+    uint64_t incident_start_secs{0}; // 0 = no active write-failure incident
+    uint64_t last_event_secs{0};     // last tick a new failure or drop arrived
+    uint64_t last_write_failures{0};
+    uint64_t last_command_drops{0};
+    bool degraded_{false};
+    trip_reason reason_{trip_reason::none};
+public:
+    db_failsafe(uint64_t t_disconnect_age_secs, uint64_t t_recovery_grace_secs)
+        : disconnect_age_secs(t_disconnect_age_secs), recovery_grace_secs(t_recovery_grace_secs)
+    {
+    }
+    /* Advance one second with the queue's current cumulative counters and
+     * backlog depth. Counters are cumulative (never reset), so a change since
+     * the previous tick is a new failure/drop in the last second. */
+    auto tick(uint64_t write_failures, uint64_t command_drops, std::size_t pending_writes) -> event
+    {
+        this->elapsed_secs++;
+        bool new_write_failure = write_failures != this->last_write_failures;
+        bool new_command_drop = command_drops != this->last_command_drops;
+        this->last_write_failures = write_failures;
+        this->last_command_drops = command_drops;
+        if (new_write_failure || new_command_drop)
+        {
+            this->last_event_secs = this->elapsed_secs;
+        }
+        if (this->degraded_)
+        {
+            /* The backlog must be gone before the quiet window means
+             * anything: while tasks are still draining against a broken sink
+             * they keep producing failures, and a nonempty-but-quiet queue
+             * (e.g. a wedged sink) is not health either. */
+            bool quiet = !new_write_failure && !new_command_drop &&
+                         (this->elapsed_secs - this->last_event_secs) > this->recovery_grace_secs;
+            if (pending_writes == 0 && quiet)
+            {
+                this->degraded_ = false;
+                this->reason_ = trip_reason::none;
+                this->incident_start_secs = 0;
+                return event::recovered;
+            }
+            return event::none;
+        }
+        if (new_command_drop)
+        {
+            this->degraded_ = true;
+            this->reason_ = trip_reason::command_drop;
+            this->incident_start_secs = 0;
+            return event::tripped;
+        }
+        if (new_write_failure)
+        {
+            if (this->incident_start_secs == 0)
+            {
+                this->incident_start_secs = this->elapsed_secs;
+            }
+            /* Not `else`: a disconnect_age_secs of 0 means "sever on any
+             * failure", so the incident's first failure must satisfy the age
+             * check on its own tick. */
+            if ((this->elapsed_secs - this->incident_start_secs) >= this->disconnect_age_secs)
+            {
+                this->degraded_ = true;
+                this->reason_ = trip_reason::write_failure;
+                this->incident_start_secs = 0;
+                return event::tripped;
+            }
+        }
+        else if (this->incident_start_secs != 0 &&
+                 (this->elapsed_secs - this->last_event_secs) > this->recovery_grace_secs)
+        {
+            this->incident_start_secs = 0;
+        }
+        return event::none;
+    }
+    [[nodiscard]] auto degraded() const -> bool { return this->degraded_; }
+    [[nodiscard]] auto reason() const -> trip_reason { return this->reason_; }
+    /* The active write-failure incident's age in seconds (0 if none), for the
+     * caller's trip log. */
+    [[nodiscard]] auto incidentAgeSecs() const -> uint64_t
+    {
+        return this->incident_start_secs == 0 ? 0 : this->elapsed_secs - this->incident_start_secs;
+    }
+};
+
+} // namespace server
+} // namespace flight_safety_system

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -38,6 +38,7 @@ all_test_SOURCES = main.cpp messages.cpp connection.cpp client.cpp \
 	secure_string_test.cpp \
 	rate_limiter_test.cpp \
 	server_clients_test.cpp \
+	server_failsafe_test.cpp \
 	exception_isolation_test.cpp \
 	../src/client_session.cpp \
 	../src/db-write-queue.cpp \

--- a/tests/server_failsafe_test.cpp
+++ b/tests/server_failsafe_test.cpp
@@ -1,0 +1,251 @@
+#ifdef HAVE_CATCH2_CATCH_ALL_HPP
+#include <catch2/catch_all.hpp>
+#elif HAVE_CATCH2_CATCH_HPP
+#include <catch2/catch.hpp>
+#elif HAVE_CATCH_CATCH_HPP
+#include <catch/catch.hpp>
+#elif HAVE_CATCH_HPP
+#include <catch.hpp>
+#else
+#error No catch header
+#endif
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+
+#include "db-write-queue.hpp"
+#include "server-failsafe.hpp"
+#include "test_helpers.hpp"
+
+namespace fss = flight_safety_system;
+
+using fss::server::db_failsafe;
+
+/* Unit tests for the unified DB fail-safe monitor (todo/45 + todo/47): the
+ * write-failure incident semantics carried over from todo/34's tracker, the
+ * immediate command-drop trip, and the latched degraded state with its
+ * drain-plus-quiet-window recovery rule. */
+
+TEST_CASE("db_failsafe: a single transient write failure never trips")
+{
+    /* Pins the documented todo/34 intent ("A single transient failure never
+     * trips this"). The pre-todo/47 tracker violated it whenever the recovery
+     * grace exceeded the disconnect threshold — the default configuration —
+     * because a lone failure kept the incident 'active' through the grace
+     * period and the age check then fired with no further failure. */
+    db_failsafe f(5, 15);
+    REQUIRE(f.tick(1, 0, 0) == db_failsafe::event::none);
+    for (int i = 0; i < 30; i++)
+    {
+        REQUIRE(f.tick(1, 0, 0) == db_failsafe::event::none);
+        REQUIRE(!f.degraded());
+    }
+}
+
+TEST_CASE("db_failsafe: sustained write failures trip once they span the age threshold")
+{
+    db_failsafe f(5, 15);
+    uint64_t failures = 0;
+    /* Failures every tick: the incident starts at the first one; the trip
+     * needs a new failure arriving at age >= 5, i.e. the sixth tick. */
+    for (int age = 0; age < 5; age++)
+    {
+        REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::none);
+        REQUIRE(!f.degraded());
+    }
+    REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::tripped);
+    REQUIRE(f.degraded());
+    REQUIRE(f.reason() == db_failsafe::trip_reason::write_failure);
+}
+
+TEST_CASE("db_failsafe: failures recurring within the grace window chain into one incident")
+{
+    /* Real telemetry lands every ~5s, so failures arrive in bursts with quiet
+     * ticks between: gaps shorter than the recovery grace must not restart
+     * the incident age (the reason todo/34 replaced a consecutive-tick
+     * counter with a wall-clock incident). */
+    db_failsafe f(4, 15);
+    REQUIRE(f.tick(1, 0, 0) == db_failsafe::event::none); // incident starts
+    for (int i = 0; i < 3; i++)
+    {
+        REQUIRE(f.tick(1, 0, 0) == db_failsafe::event::none); // quiet gap < grace
+    }
+    /* A new failure at age 4 >= threshold 4: same incident, trips. */
+    REQUIRE(f.tick(2, 0, 0) == db_failsafe::event::tripped);
+    REQUIRE(f.reason() == db_failsafe::trip_reason::write_failure);
+}
+
+TEST_CASE("db_failsafe: a gap longer than the grace window starts a fresh incident")
+{
+    db_failsafe f(5, 3);
+    REQUIRE(f.tick(1, 0, 0) == db_failsafe::event::none);
+    for (int i = 0; i < 6; i++)
+    {
+        REQUIRE(f.tick(1, 0, 0) == db_failsafe::event::none); // ages out after grace
+    }
+    /* Next failure is a fresh incident at age 0, despite the total span since
+     * the first failure being well past the threshold. */
+    REQUIRE(f.tick(2, 0, 0) == db_failsafe::event::none);
+    REQUIRE(!f.degraded());
+}
+
+TEST_CASE("db_failsafe: a disconnect threshold of 0 trips on the first failure")
+{
+    db_failsafe f(0, 15);
+    REQUIRE(f.tick(1, 0, 0) == db_failsafe::event::tripped);
+    REQUIRE(f.degraded());
+    REQUIRE(f.reason() == db_failsafe::trip_reason::write_failure);
+}
+
+TEST_CASE("db_failsafe: any command drop trips immediately")
+{
+    /* todo/45: a dropped command dispatch/ack write is known-destroyed audit
+     * state; there is no threshold to age through. */
+    db_failsafe f(5, 15);
+    REQUIRE(f.tick(0, 0, 0) == db_failsafe::event::none);
+    REQUIRE(f.tick(0, 1, 0) == db_failsafe::event::tripped);
+    REQUIRE(f.degraded());
+    REQUIRE(f.reason() == db_failsafe::trip_reason::command_drop);
+}
+
+TEST_CASE("db_failsafe: no recovery while the write queue still holds a backlog")
+{
+    db_failsafe f(0, 2);
+    REQUIRE(f.tick(1, 0, 5) == db_failsafe::event::tripped);
+    /* Quiet, but the backlog never drains: stays degraded no matter how long
+     * the quiet window grows (a wedged-but-silent sink is not health). */
+    for (int i = 0; i < 10; i++)
+    {
+        REQUIRE(f.tick(1, 0, 5) == db_failsafe::event::none);
+        REQUIRE(f.degraded());
+    }
+    /* Drain completes and the quiet window is already satisfied: recovered. */
+    REQUIRE(f.tick(1, 0, 0) == db_failsafe::event::recovered);
+    REQUIRE(!f.degraded());
+    REQUIRE(f.reason() == db_failsafe::trip_reason::none);
+}
+
+TEST_CASE("db_failsafe: recovery requires the full quiet window after the last failure")
+{
+    db_failsafe f(0, 3);
+    REQUIRE(f.tick(1, 0, 0) == db_failsafe::event::tripped);
+    /* Quiet, drained ticks: the window must strictly exceed the grace. */
+    REQUIRE(f.tick(1, 0, 0) == db_failsafe::event::none); // 1s quiet
+    REQUIRE(f.tick(1, 0, 0) == db_failsafe::event::none); // 2s quiet
+    REQUIRE(f.tick(1, 0, 0) == db_failsafe::event::none); // 3s quiet
+    REQUIRE(f.tick(1, 0, 0) == db_failsafe::event::recovered);
+    REQUIRE(!f.degraded());
+}
+
+TEST_CASE("db_failsafe: failures during the degraded drain push recovery out")
+{
+    /* After the trip severs everything, the queue's backlog keeps draining
+     * against the broken sink and keeps producing failures; each one restarts
+     * the quiet window, so recovery only follows genuine silence. */
+    db_failsafe f(0, 3);
+    REQUIRE(f.tick(1, 0, 3) == db_failsafe::event::tripped);
+    REQUIRE(f.tick(2, 0, 2) == db_failsafe::event::none); // drain failure
+    REQUIRE(f.tick(2, 0, 1) == db_failsafe::event::none); // quiet 1s
+    REQUIRE(f.tick(3, 0, 1) == db_failsafe::event::none); // drain failure again
+    REQUIRE(f.tick(3, 0, 0) == db_failsafe::event::none); // quiet 1s, drained
+    REQUIRE(f.tick(3, 0, 0) == db_failsafe::event::none); // 2s
+    REQUIRE(f.tick(3, 0, 0) == db_failsafe::event::none); // 3s
+    REQUIRE(f.tick(3, 0, 0) == db_failsafe::event::recovered);
+}
+
+TEST_CASE("db_failsafe: a command drop while already degraded does not re-trip")
+{
+    db_failsafe f(0, 2);
+    REQUIRE(f.tick(1, 0, 0) == db_failsafe::event::tripped);
+    /* Already degraded: the drop extends the quiet window but reports no new
+     * transition (the caller has already severed and gated). */
+    REQUIRE(f.tick(1, 1, 1) == db_failsafe::event::none);
+    REQUIRE(f.degraded());
+    REQUIRE(f.tick(1, 1, 0) == db_failsafe::event::none); // 1s quiet
+    REQUIRE(f.tick(1, 1, 0) == db_failsafe::event::none); // 2s quiet
+    REQUIRE(f.tick(1, 1, 0) == db_failsafe::event::recovered);
+}
+
+TEST_CASE("db_failsafe: a fresh incident after recovery trips again")
+{
+    /* The latched degraded state ends when the queue is drained and quiet;
+     * readmitted traffic is the health probe. If the fault persists, the next
+     * incident must latch again (one clean severance per incident, on the
+     * incident timescale — not a per-tick flap). */
+    db_failsafe f(2, 3);
+    uint64_t failures = 0;
+    REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::none);
+    REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::none);
+    REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::tripped);
+    for (int i = 0; i < 3; i++)
+    {
+        REQUIRE(f.tick(failures, 0, 0) == db_failsafe::event::none);
+    }
+    REQUIRE(f.tick(failures, 0, 0) == db_failsafe::event::recovered);
+    /* Same fault re-manifests once clients reconnect and write again. */
+    REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::none);
+    REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::none);
+    REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::tripped);
+    REQUIRE(f.degraded());
+}
+
+TEST_CASE("db_failsafe: telemetry-only drops from a real queue never trip the fail-safe")
+{
+    /* Drive the monitor from a real db_write_queue held at capacity by
+     * protected command writes: incoming telemetry is rejected (the generic
+     * dropped counter), which must not feed the command-integrity fail-safe —
+     * telemetry stays loss-tolerant (todo/20). A subsequent genuine command
+     * drop then trips it, pinning that the two counters reach the monitor on
+     * distinct paths. */
+    std::mutex gate_lock;
+    std::condition_variable gate_cv;
+    bool gate_open = false;
+    std::atomic<int> entered{0};
+    auto sink = [&](const fss::server::db_write_task & /*task*/) -> void {
+        entered++;
+        std::unique_lock<std::mutex> lock(gate_lock);
+        gate_cv.wait(lock, [&]() -> bool { return gate_open; });
+    };
+
+    constexpr std::size_t depth = 3;
+    fss::server::db_write_queue q(depth, sink);
+    /* Park the worker on a first command so the queue fills predictably. */
+    q.enqueue(fss::server::command_dispatch_write{1, 1});
+    REQUIRE(fss_test::wait_for([&]() -> bool { return entered.load() >= 1; }));
+    for (uint64_t i = 2; i <= depth + 1; i++)
+    {
+        q.enqueue(fss::server::command_dispatch_write{i, i});
+    }
+    REQUIRE(q.pending_count() == depth);
+
+    /* Telemetry arrives with nothing to evict: rejected on the generic drop
+     * path, no command dropped. */
+    q.enqueue(fss::server::rtt_write{99, 0});
+    REQUIRE(q.dropped_count() == 1);
+    REQUIRE(q.command_dropped_count() == 0);
+
+    db_failsafe f(5, 15);
+    for (int i = 0; i < 20; i++)
+    {
+        REQUIRE(f.tick(q.write_failure_count(), q.command_dropped_count(), q.pending_count()) ==
+                db_failsafe::event::none);
+        REQUIRE(!f.degraded());
+    }
+
+    /* One more command overflows the all-command queue: the distinct
+     * command-drop counter moves and the monitor trips on its next tick. */
+    q.enqueue(fss::server::command_dispatch_write{50, 50});
+    REQUIRE(q.command_dropped_count() == 1);
+    REQUIRE(f.tick(q.write_failure_count(), q.command_dropped_count(), q.pending_count()) ==
+            db_failsafe::event::tripped);
+    REQUIRE(f.reason() == db_failsafe::trip_reason::command_drop);
+
+    {
+        std::scoped_lock guard(gate_lock);
+        gate_open = true;
+    }
+    gate_cv.notify_all();
+    q.stop();
+}


### PR DESCRIPTION
## Description

Extract todo/34's db_write_failure_incident_tracker out of server.cpp into src/server-failsafe.hpp as db_failsafe, unifying the two fail-safe triggers todo/45 and todo/47 call for and adding the latched degraded state both need:

- any command_dropped_count() increase trips immediately (todo/45): a dropped command dispatch/ack write is known-destroyed audit state, so there is no threshold to age through;
- a trip latches `degraded`; recovery requires the write queue drained to zero AND more than the recovery grace with no new failure or drop (todo/47's suggested rule), so readmitted traffic becomes the health probe and a persistent fault re-latches on the incident timescale instead of flapping every disconnect_ticks;
- the write-failure trip now requires a new failure arriving once the incident spans the age threshold. The previous tracker tripped on a single transient failure whenever the recovery grace exceeded the threshold (the default config: one blipped INSERT severed the fleet 5s later), contradicting its own "A single transient failure never trips this" comment; with the todo/47 gate raising the cost of a spurious trip to severance plus a reconnect lockout, that misfire would have become operationally worse.

Standalone and unit-tested in this commit; wiring into the main loop and the server_clients admission gate follow separately. The queue- boundary regression todo/45 asks for already exists (async_db_write_test.cpp "command overload drops on a distinct command-specific path").

## Summary by Sourcery

Introduce a unified database fail-safe monitor with latched degraded state and validate its behavior with unit tests.

New Features:
- Add db_failsafe monitor to centralize database write failure and command-drop detection with configurable disconnect and recovery thresholds.

Enhancements:
- Refine degraded-state handling to require both an empty write queue and a quiet window before recovery, preventing flapping on intermittent failures.

Tests:
- Add server_failsafe_test suite to cover write-failure incidents, immediate command-drop trips, recovery behavior, and interaction with a real db_write_queue.