### PR TITLE
feat(server): todo/45,47 degraded admission gate on server_clients

### DIFF
--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -26,6 +26,16 @@ private:
     uint64_t rate_refill_per_s{20};
     flight_safety_system::server::duplicate_identity_policy duplicate_identity_policy_{
         flight_safety_system::server::duplicate_identity_reject_newcomer};
+    /* todo/45+47: while the DB fail-safe is degraded, new sessions are
+     * refused at clientConnected() so aircraft get one latched comms-loss
+     * event instead of reconnecting straight back into a server that cannot
+     * durably record telemetry or command state. Guarded by lock — the gate
+     * check shares the critical section that admits into `clients`, so with
+     * the main loop setting the gate *before* disconnectAll(), a concurrent
+     * connection either lands in the list before the gate is up (and is
+     * severed by the snapshot) or is refused; there is no interleaving that
+     * slips a live session past the fail-safe. */
+    bool degraded_{false};
     /* Which live client currently holds each asset_id (todo/44). Guarded by
      * lock. A claim is recorded in resolveDuplicateIdentity() atomically with
      * the duplicate check — i.e. before the winning client has published the
@@ -134,6 +144,15 @@ public:
     {
         this->duplicate_identity_policy_ = policy;
     }
+    /* todo/45+47: raise/lower the fail-safe admission gate (see degraded_
+     * above). The main loop sets true immediately before disconnectAll() on a
+     * fail-safe trip, and false once the db_failsafe monitor reports
+     * recovery. */
+    void setDegraded(bool degraded)
+    {
+        std::scoped_lock guard(this->lock);
+        this->degraded_ = degraded;
+    }
     void clientConnected(std::shared_ptr<flight_safety_system::server::fss_client> client)
     {
         /* Apply config before wiring the connection's message handler: the
@@ -145,10 +164,26 @@ public:
         client->setStalenessMs(this->position_staleness_ms);
         client->setRateLimits(this->rate_capacity, this->rate_refill_per_s);
         auto *raw = client.get();
+        bool refused = false;
         {
             std::scoped_lock guard(this->lock);
-            this->total_clients++;
-            this->clients.push_back(std::move(client));
+            refused = this->degraded_;
+            if (!refused)
+            {
+                this->total_clients++;
+                this->clients.push_back(std::move(client));
+            }
+        }
+        if (refused)
+        {
+            /* Sever outside the lock (disconnect() joins the recv thread —
+             * see cleanupRemovableClients). The client was never admitted or
+             * activated, so nothing else references it and it dies with
+             * `client` when this frame returns. */
+            FSS_LOG_WARN("server", "Refusing new client: DB fail-safe is degraded; "
+                                   "admission resumes once the recovery condition clears");
+            raw->disconnect();
+            return;
         }
         /* Register only after the client is in the list, so a queued message
          * flushed by activate() that triggers clientDisconnected can find it. */

--- a/tests/server_clients_test.cpp
+++ b/tests/server_clients_test.cpp
@@ -68,9 +68,14 @@ public:
     }
     void disconnect() override
     {
+        this->disconnect_calls++;
         this->setBlocked(false);
         fss::transport::fss_connection::disconnect();
     }
+    /* How many times disconnect() has run. fss_client teardown calls it
+     * again, so tests assert `> 0` at the moment of interest rather than an
+     * exact count. Atomic: disconnect can run on another thread. */
+    std::atomic<int> disconnect_calls{0};
 protected:
     auto sendMsg(const std::shared_ptr<fss::transport::buf_len> &bl) -> bool override
     {
@@ -935,4 +940,82 @@ TEST_CASE("server_clients: disconnectAll severs every live session (todo/34)")
 
     sc.cleanupRemovableClients();
     REQUIRE(sc.getTotalClients() == 0);
+}
+
+TEST_CASE("server_clients: degraded gate refuses new sessions (todo/47)")
+{
+    server_clients sc;
+    fss_test::MockDatabase mock;
+    fss_test::scoped_log_level log_guard("error");
+
+    sc.setDegraded(true);
+
+    auto conn = std::make_shared<FakeConnection>();
+    auto writer = make_null_writer();
+    auto client = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &sc);
+    sc.clientConnected(client);
+
+    /* Never admitted: no session slot, and the connection was severed. */
+    REQUIRE(sc.getTotalClients() == 0);
+    REQUIRE(conn->disconnect_calls > 0);
+}
+
+TEST_CASE("server_clients: clearing the degraded gate readmits sessions (todo/47)")
+{
+    server_clients sc;
+    fss_test::MockDatabase mock;
+    fss_test::scoped_log_level log_guard("error");
+
+    sc.setDegraded(true);
+    {
+        auto conn = std::make_shared<FakeConnection>();
+        auto writer = make_null_writer();
+        auto refused = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &sc);
+        sc.clientConnected(refused);
+        REQUIRE(sc.getTotalClients() == 0);
+    }
+
+    sc.setDegraded(false);
+    /* A full identify must succeed post-recovery, not just raw admission. */
+    auto client = make_aircraft_client("craft-recovered", mock, sc);
+    sc.clientConnected(client);
+    REQUIRE(sc.getTotalClients() == 1);
+    REQUIRE(client->isAircraft());
+}
+
+TEST_CASE("server_clients: gate-then-sever leaves no session live or admissible (todo/45+47)")
+{
+    /* The main loop's trip sequence: setDegraded(true) *then* disconnectAll().
+     * Afterwards no pre-trip session survives and no new session can enter,
+     * which is the property that turns the fail-safe from a reconnect flap
+     * into one latched comms-loss event. */
+    server_clients sc;
+    fss_test::MockDatabase mock;
+    fss_test::scoped_log_level log_guard("error");
+
+    auto craft1 = make_aircraft_client("craft1", mock, sc);
+    auto craft2 = make_aircraft_client("craft2", mock, sc);
+    sc.clientConnected(craft1);
+    sc.clientConnected(craft2);
+    REQUIRE(sc.getTotalClients() == 2);
+
+    sc.setDegraded(true);
+    REQUIRE(sc.disconnectAll() == 2);
+    sc.cleanupRemovableClients();
+    REQUIRE(sc.getTotalClients() == 0);
+
+    /* The severed aircraft's immediate reconnect attempt is refused. */
+    auto reconnect_conn = std::make_shared<FakeConnection>();
+    reconnect_conn->cert_names.push_back("craft1");
+    auto reconnect_writer = make_null_writer();
+    auto reconnecting = std::make_shared<fss::server::fss_client>(reconnect_conn, &mock, reconnect_writer, &sc);
+    sc.clientConnected(reconnecting);
+    REQUIRE(sc.getTotalClients() == 0);
+    REQUIRE(reconnect_conn->disconnect_calls > 0);
+
+    /* Recovery lifts the gate and the same asset can come back. */
+    sc.setDegraded(false);
+    auto returned = make_aircraft_client("craft1", mock, sc);
+    sc.clientConnected(returned);
+    REQUIRE(sc.getTotalClients() == 1);
 }


### PR DESCRIPTION
## Description

While the DB fail-safe is degraded, clientConnected() refuses the new session (severed outside `lock`, never admitted or activated) instead of admitting a client straight back into a server that cannot durably record telemetry or command state — the reconnect gap both todo/45 and todo/47 identify in the shipped todo/34 fail-safe.

The gate check shares the critical section that inserts into `clients`, so the trip sequence setDegraded(true) → disconnectAll() is airtight: a concurrent connection either lands in the list before the gate is up (and is caught by the severance snapshot) or is refused; no interleaving slips a live session past the fail-safe.

Not yet driven by the main loop (next commit); covered by unit tests including the full trip sequence and post-recovery readmission.

## Summary by Sourcery

Introduce a degraded admission gate in server_clients to refuse new client sessions while the DB fail-safe is degraded, ensuring no live sessions bypass the fail-safe during outage and recovery.

New Features:
- Add a degradable admission gate flag to server_clients that blocks new client sessions when the DB fail-safe is degraded.

Enhancements:
- Guard admission gating with the existing server_clients lock so the fail-safe trip sequence and concurrent connections are race-free.

Tests:
- Extend server_clients tests with coverage for degraded admission refusal, post-recovery readmission, and the full gate-then-sever trip sequence, including reconnect behavior.