### PR TITLE
fix(server): todo/45,47 main loop drives the unified DB fail-safe

### DIFF
--- a/e2e/test_db_disk_full.py
+++ b/e2e/test_db_disk_full.py
@@ -263,9 +263,11 @@ def test_disk_full_fails_visibly_and_a_fresh_instance_recovers(certs_dir, tmp_pa
         # stay a silently-kept-alive one -- give the streak/incident guard
         # its own window (db_write_failure_disconnect_ticks, default 5s,
         # plus margin) *after* the first failure was already observed
-        # above, rather than checking instantly.
+        # above, rather than checking instantly. (todo/45+47 unified the
+        # severance into the "DB fail-safe tripped ... severed N
+        # connection(s)" message.)
         def severed() -> bool:
-            return "severing" in server["log"].read_text(errors="replace")
+            return "DB fail-safe tripped" in server["log"].read_text(errors="replace")
 
         assert _wait_for(severed, timeout=30.0), (
             "server logged write failures but never severed the session\n"

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -526,7 +526,11 @@ void fss::server::fss_client::sendCommand()
         this->last_command_dbid = dbid;
     } // client_lock released before the blocking send
 
-    if (!this->getConnection()->sendMsg(msg))
+    /* Null-safe base-class sendMsg: sendCommand() is called from the identify
+     * path, which can lose its connection to a concurrent evict_oldest
+     * teardown (see the pinned-connection note in processMessage); a cleared
+     * connection reads as a failed send, taking the retry branch below. */
+    if (!this->sendMsg(msg))
     {
         /* The socket write failed, so the command never reached the aircraft.
          * Undo the claim above so the command is retried on the next send tick
@@ -757,7 +761,9 @@ void fss::server::fss_client::sendSMMSettings()
     {
         auto settings_msg = std::make_shared<fss::transport::fss_message_smm_settings>(
             smm->getAddress(), smm->getUsername(), smm->getPassword());
-        this->getConnection()->sendMsg(settings_msg);
+        /* Null-safe base-class sendMsg: also reached from the identify path,
+         * same concurrent-teardown hazard as sendCommand(). */
+        this->sendMsg(settings_msg);
     }
 }
 
@@ -790,6 +796,19 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                                        << " client disconnected: " << this->getName());
         }
         this->client_handler->clientDisconnected(this);
+        return;
+    }
+    /* Pin the connection for the remainder of this message (PR #332 TSan
+     * crash): a concurrent teardown — e.g. duplicate_identity_evict_oldest
+     * severing this client while its identify is still in flight — clears
+     * the base class's pointer, and the only production protection is the
+     * recv-thread join inside disconnect(), which callers off the recv
+     * thread do not get. The local shared_ptr keeps the connection alive
+     * and non-null for the whole call; after teardown its fd is closed, so
+     * sends simply fail, exactly like any mid-message disconnect. */
+    auto active_conn = this->getConnection();
+    if (active_conn == nullptr)
+    {
         return;
     }
     if (msg->getType() == fss::transport::message_type_version)
@@ -835,8 +854,8 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                 return;
             }
             uint16_t negotiated = std::min(peer_version, fss::transport::FSS_PROTOCOL_VERSION);
-            this->getConnection()->setNegotiatedVersion(negotiated);
-            this->getConnection()->setNegotiatedFeatureFlags(
+            active_conn->setNegotiatedVersion(negotiated);
+            active_conn->setNegotiatedFeatureFlags(
                 fss::transport::negotiateFeatureFlags(version_msg->getFeatureFlags()));
             this->version_received = true;
             if (negotiated >= 2)
@@ -844,7 +863,7 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                 this->expected_seq.store(msg->getId() + 1);
             }
             auto resp = std::make_shared<fss::transport::fss_message_version>();
-            this->getConnection()->sendMsg(resp);
+            active_conn->sendMsg(resp);
         }
         return;
     }
@@ -855,7 +874,7 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
      * replay defence. Under its security assumptions TLS already provides
      * replay and reorder protection at the record layer, so this check is not
      * relied upon to stop an attacker. */
-    if (this->getConnection()->getNegotiatedVersion() >= 2)
+    if (active_conn->getNegotiatedVersion() >= 2)
     {
         uint64_t wanted = this->expected_seq.load();
         if (wanted != 0)
@@ -901,7 +920,7 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
             if (identity_msg != nullptr)
             {
                 auto client_name = identity_msg->getName();
-                auto possible_names = this->getConnection()->getClientNames();
+                auto possible_names = active_conn->getClientNames();
                 bool name_valid = false;
                 if (possible_names.empty())
                 {
@@ -955,12 +974,12 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                  * now rather than after the poller's next refresh. */
                 this->refreshSmmSettings();
                 this->sendSMMSettings();
-                this->getConnection()->sendMsg(getServersListMsg(this->dbc));
+                active_conn->sendMsg(getServersListMsg(this->dbc));
             }
         }
         else if (msg->getType() == fss::transport::message_type_identity_non_aircraft)
         {
-            auto possible_names = this->getConnection()->getClientNames();
+            auto possible_names = active_conn->getClientNames();
             if (possible_names.empty())
             {
                 FSS_LOG_ERROR("server", "Rejecting non-aircraft client: no CN found in certificate");
@@ -1074,7 +1093,7 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
             case fss::transport::message_type_version: break;
             case fss::transport::message_type_rtt_request: {
                 auto reply_msg = std::make_shared<fss::transport::fss_message_rtt_response>(msg->getId());
-                this->getConnection()->sendMsg(reply_msg);
+                active_conn->sendMsg(reply_msg);
             }
             break;
             case fss::transport::message_type_rtt_response: {
@@ -1131,8 +1150,7 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                     /* RTT clock-offset (todo/17 item 3): only when the peer
                      * negotiated the capability — otherwise any trailing
                      * timestamp is not part of the agreed dialect and is ignored. */
-                    if ((this->getConnection()->getNegotiatedFeatureFlags() & fss::transport::FSS_FEATURE_RTT_OFFSET) !=
-                        0)
+                    if ((active_conn->getNegotiatedFeatureFlags() & fss::transport::FSS_FEATURE_RTT_OFFSET) != 0)
                     {
                         this->updateClockOffset(rtt_resp_msg->getClientTimestamp(), rtt_ms, recv_wall);
                     }
@@ -1233,7 +1251,7 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                  * Only honour it when the peer negotiated the capability — a
                  * conforming client never sends one otherwise, so an ack without
                  * the flag is from a misbehaving/forged peer and is dropped. */
-                if ((this->getConnection()->getNegotiatedFeatureFlags() & fss::transport::FSS_FEATURE_COMMAND_ACK) == 0)
+                if ((active_conn->getNegotiatedFeatureFlags() & fss::transport::FSS_FEATURE_COMMAND_ACK) == 0)
                 {
                     break;
                 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -4,6 +4,7 @@
 #include "fss.hpp"
 #include "fss-server.hpp"
 #include "server-clients.hpp"
+#include "server-failsafe.hpp"
 
 #include <algorithm>
 #include <chrono>
@@ -50,58 +51,6 @@ auto read_tcp_port(const Json::Value &node, const char *path, int &out) -> bool
     out = port;
     return true;
 }
-
-/* todo/34 (PR #327 review): tracks a *wall-clock* DB-write-failure incident
- * for the main loop's sustained-failure guard, not a per-tick consecutive-
- * growth counter -- real write traffic (position/status/search) only lands
- * every position_interval (5s default), so failures arrive in bursts with
- * quiet once-per-second checks in between; a counter reset by any quiet
- * tick could never reach its threshold under normal telemetry cadence.
- * tick() is called once per second (elapsed_secs is this tracker's own
- * count, so it is directly in seconds, unlike tick_counter which advances
- * every command_poll_ms). */
-class db_write_failure_incident_tracker {
-private:
-    uint64_t elapsed_secs{0};
-    uint64_t incident_start_secs{0}; // 0 = no active incident
-    uint64_t last_new_failure_secs{0};
-    uint64_t recovery_grace_secs;
-public:
-    explicit db_write_failure_incident_tracker(uint64_t t_recovery_grace_secs)
-        : recovery_grace_secs(t_recovery_grace_secs)
-    {
-    }
-    /* Advances one second. If new_failure is set, registers it as (still)
-     * part of the current incident, starting one if none is active.
-     * Otherwise, a quiet tick clears a stale incident once it has gone
-     * recovery_grace_secs without a new failure -- comfortably longer than
-     * any realistic telemetry cadence, so a future failure starts a fresh
-     * incident rather than inheriting this one's age. Returns the active
-     * incident's age in seconds, or 0 if none is active. */
-    auto tick(bool new_failure) -> uint64_t
-    {
-        elapsed_secs++;
-        if (new_failure)
-        {
-            if (incident_start_secs == 0)
-            {
-                incident_start_secs = elapsed_secs;
-            }
-            last_new_failure_secs = elapsed_secs;
-        }
-        else if (incident_start_secs != 0 && (elapsed_secs - last_new_failure_secs) > recovery_grace_secs)
-        {
-            incident_start_secs = 0;
-        }
-        return incident_start_secs == 0 ? 0 : elapsed_secs - incident_start_secs;
-    }
-    /* Distinct from "age() == 0": age() also reads 0 while an incident is
-     * merely one tick old, so a disconnect-ticks threshold of 0 must not be
-     * indistinguishable from "no incident at all" -- callers gate on this
-     * first. */
-    [[nodiscard]] auto active() const -> bool { return incident_start_secs != 0; }
-    void reset() { incident_start_secs = 0; }
-};
 
 } // namespace
 
@@ -161,17 +110,19 @@ auto main(int argc, char *argv[]) -> int
     constexpr uint64_t default_rate_refill_per_s = 20;
     constexpr auto default_duplicate_identity_policy = flight_safety_system::server::duplicate_identity_reject_newcomer;
     /* todo/34: default 5s age for a sustained DB-write-failure incident
-     * (see db_write_failure_incident_tracker above) before severing every
-     * connected client. A single transient failure never trips this -- the
-     * incident only persists while failures keep recurring within
-     * default_db_write_failure_recovery_grace_secs of each other; only
-     * sustained failure -- what disk-full looks like -- reaches the age
-     * threshold. */
+     * (see server-failsafe.hpp) before the fail-safe trips: every connected
+     * client is severed and new sessions are refused (todo/45+47). A single
+     * transient failure never trips this -- the trip requires a new failure
+     * arriving once the incident spans the threshold, so only sustained
+     * failure -- what disk-full looks like -- can fire it. Command
+     * dispatch/ack drops trip unconditionally, with no threshold (todo/45). */
     constexpr uint64_t default_db_write_failure_disconnect_ticks = 5;
-    /* How long a DB-write-failure incident stays "active" with no new
-     * failure before being considered recovered (PR #327 review: this was
-     * hardcoded; now configurable like the threshold above, for
-     * deployments whose telemetry cadence differs from the 5s default). */
+    /* Two roles (same meaning: how long with no new failure before the
+     * incident is considered over). Outside a trip: how long failures may
+     * pause and still chain into one incident (PR #327 review: configurable
+     * for deployments whose telemetry cadence differs from the 5s default).
+     * While degraded: the quiet window that, once the write queue has also
+     * drained, ends the degraded state and readmits sessions (todo/47). */
     constexpr uint64_t default_db_write_failure_recovery_grace_secs = 15;
     constexpr unsigned int default_tls_handshake_timeout_ms =
         flight_safety_system::transport_ssl::default_handshake_timeout_ms;
@@ -472,30 +423,55 @@ auto main(int argc, char *argv[]) -> int
                 clients->cleanupRemovableClients();
                 clients->checkTimeouts();
                 clients->sendRTTRequest();
+                using flight_safety_system::server::db_failsafe;
                 static uint64_t last_failure_count = 0;
-                static db_write_failure_incident_tracker db_incident(db_write_failure_recovery_grace_secs);
+                static uint64_t last_command_dropped = 0;
+                static db_failsafe failsafe(db_write_failure_disconnect_ticks, db_write_failure_recovery_grace_secs);
                 uint64_t current_failures = writer->write_failure_count();
-                bool new_failure = current_failures != last_failure_count;
-                if (new_failure)
+                if (current_failures != last_failure_count)
                 {
-                    FSS_LOG_ERROR("server", "DB write failures since start: " << current_failures);
+                    FSS_LOG_ERROR("server", "DB write failures since start: " << current_failures << " (was "
+                                                                              << last_failure_count << ")");
                     last_failure_count = current_failures;
                 }
-                uint64_t incident_age_secs = db_incident.tick(new_failure);
-                if (db_incident.active() && incident_age_secs >= db_write_failure_disconnect_ticks)
-                {
-                    auto severed = clients->disconnectAll();
-                    FSS_LOG_ERROR("server", "DB writes have been failing for "
-                                                << incident_age_secs << "s; severing " << severed
-                                                << " connection(s) rather than silently discarding telemetry");
-                    db_incident.reset();
-                }
-                static uint64_t last_command_dropped = 0;
                 uint64_t current_command_dropped = writer->command_dropped_count();
                 if (current_command_dropped != last_command_dropped)
                 {
-                    FSS_LOG_ERROR("server", "command DB writes dropped since start: " << current_command_dropped);
+                    FSS_LOG_ERROR("server", "command DB writes dropped since start: "
+                                                << current_command_dropped << " (was " << last_command_dropped << ")");
                     last_command_dropped = current_command_dropped;
+                }
+                /* todo/45+47: one fail-safe for both triggers. On a trip the
+                 * gate goes up *before* the severance so no connection can
+                 * slip between the snapshot and the gate (see
+                 * server_clients::degraded_); it stays up until the write
+                 * queue has drained and been quiet for the recovery grace,
+                 * so aircraft get one latched comms-loss event instead of a
+                 * disconnect/reconnect flap into the same unhealthy server.
+                 * Recovery logs at ERROR like the trip: supervision watching
+                 * for the fail-safe must see both edges at one level. */
+                switch (failsafe.tick(current_failures, current_command_dropped, writer->pending_count()))
+                {
+                    case db_failsafe::event::tripped: {
+                        clients->setDegraded(true);
+                        auto severed = clients->disconnectAll();
+                        FSS_LOG_ERROR("server", "DB fail-safe tripped ("
+                                                    << (failsafe.reason() == db_failsafe::trip_reason::command_drop
+                                                            ? "a command dispatch/ack DB write was dropped — audit "
+                                                              "state destroyed"
+                                                            : "sustained DB write failures")
+                                                    << "); severed " << severed
+                                                    << " connection(s) and refusing new sessions until the write "
+                                                       "queue drains and stays quiet");
+                        break;
+                    }
+                    case db_failsafe::event::recovered:
+                        clients->setDegraded(false);
+                        FSS_LOG_ERROR("server", "DB fail-safe recovered: write queue drained and quiet for "
+                                                    << db_write_failure_recovery_grace_secs
+                                                    << "s; accepting sessions again");
+                        break;
+                    case db_failsafe::event::none: break;
                 }
                 dbc->tryReconnectIfNeeded();
             }

--- a/tests/server_clients_test.cpp
+++ b/tests/server_clients_test.cpp
@@ -751,6 +751,32 @@ TEST_CASE("server_clients: concurrent identifies under evict_oldest leave exactl
     REQUIRE(sc.getTotalClients() == 1);
 }
 
+TEST_CASE("server_clients: a message processed after teardown is a no-op, not a crash")
+{
+    /* Distilled from a TSan CI crash (PR #332): under evict_oldest, the
+     * evictor's disconnect() clears the victim's connection while the
+     * victim's identify is still in flight, and the identify tail called
+     * getConnection()->sendMsg() with no null guard. In production the
+     * recv-thread join inside disconnect() serialises the two, but the
+     * contract is subtle enough to pin: processMessage on a torn-down
+     * client must complete harmlessly. */
+    server_clients sc;
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft1"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft1");
+    auto writer = make_null_writer();
+    auto client = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &sc);
+    sc.clientConnected(client);
+
+    client->disconnect(); // clears the connection out from under later calls
+
+    client->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft1"));
+    REQUIRE(!client->isAircraft());
+    REQUIRE(client->getCachedAssetId() == 0);
+}
+
 TEST_CASE("server_clients: distinct asset ids still identify concurrently (todo/44)")
 {
     /* Closing the duplicate race must not serialise or reject unrelated


### PR DESCRIPTION
## Description

Replace the per-second tick's incident tracker + log-only command-drop check with the db_failsafe monitor:

- a command dispatch/ack drop now trips the fail-safe instead of only logging a counter change (todo/45's High finding: the server knew audit state was destroyed and kept flying aircraft on it);
- a trip raises the server_clients admission gate *before* disconnectAll(), and the gate stays up until the write queue has drained and stayed quiet for db_write_failure_recovery_grace_secs — closing todo/47's reconnect flap (severed aircraft could previously re-identify immediately into the same failing server and be severed again every db_write_failure_disconnect_ticks);
- both counter logs now include the previous count, and trip/recovery log at ERROR so supervision sees both edges at one level.

No new config: the existing disconnect-ticks/recovery-grace values drive the unified monitor. Exiting non-zero (both todos' "consider") was not taken: drain-plus-quiet defines a recovery that does not require a restart, and readmitted traffic is the health probe — a persistent fault re-latches on the incident timescale.

## Summary by Sourcery

Unify database write failure and command drop handling behind a central DB fail-safe in the main server loop, severing and gating clients on trips and reopening admission on sustained recovery.

Bug Fixes:
- Trigger client severing and connection admission gating on both sustained DB write failures and command dispatch/ack drops instead of only logging these incidents, preventing continued operation on destroyed audit state.
- Keep the server in a degraded, no-new-sessions state until the DB write queue has drained and remained quiet for the configured grace period, avoiding repeated disconnect/reconnect flapping into an unhealthy server.

Enhancements:
- Log DB write failure and command drop counters with both current and previous values, and emit fail-safe trip and recovery transitions at error level for clearer operational visibility.