### PR TITLE
fix(db): todo/46 bound in-flight libpq stalls with PGTCPUSERTIMEOUT

### DIFF
--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -19,14 +19,23 @@
 
 int db_connect(const char *conn_arg, const char *host, int port, const char *user, const char *pass, const char *db)
 {
-    /* Set connect_timeout and TCP keepalives via environment variables.
-     * setenv is not thread-safe, and reconnects call db_connect with other
-     * threads live, so guard it to run only on the first call - which
-     * happens in the db_connection constructor before any threads exist.
-     * overwrite=0 preserves operator overrides from the real environment.
-     * keepalives_idle=10 / interval=5 / count=3 means the kernel declares
-     * the connection dead after 10 + 5*3 = 25 s of silence, replacing the
-     * OS default retransmit timeout of ~127 s. */
+    /* Set connect_timeout, TCP keepalives and the in-flight TCP timeout via
+     * environment variables. setenv is not thread-safe, and reconnects call
+     * db_connect with other threads live, so guard it to run only on the
+     * first call - which happens in the db_connection constructor before any
+     * threads exist. overwrite=0 preserves operator overrides from the real
+     * environment.
+     * keepalives_idle=10 / interval=5 / count=3 means the kernel declares an
+     * *idle* connection dead after 10 + 5*3 = 25 s of silence, replacing the
+     * OS default retransmit timeout of ~127 s. Keepalives do not govern a
+     * connection with data in flight: a query already sent to a black-holed
+     * peer sits in TCP retransmission for the kernel's ~15 min default.
+     * PGTCPUSERTIMEOUT (libpq tcp_user_timeout, in ms; PG 12+, Linux-only)
+     * bounds that case to the same 25 s clock (todo/46). statement_timeout
+     * is deliberately NOT set: it is enforced by the backend, so it bounds
+     * neither a frozen host nor a partition, and it would turn legitimate
+     * lock waits (e.g. a long EXCLUSIVE table lock the async writer is
+     * expected to ride out) into write failures feeding the DB fail-safe. */
     static int env_configured = 0;
     if (!env_configured)
     {
@@ -36,6 +45,7 @@ int db_connect(const char *conn_arg, const char *host, int port, const char *use
         setenv("PGKEEPALIVESIDLE",   "10", 0);
         setenv("PGKEEPALIVEINTERVAL","5",  0);
         setenv("PGKEEPALIVESCOUNT",  "3",  0);
+        setenv("PGTCPUSERTIMEOUT",   "25000", 0);
     }
 
     /* ECPG connection target: dbname@host:port */

--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -33,6 +33,19 @@ TEST_CASE("db_connection: invalid host reports not connected")
     REQUIRE_FALSE(dbc.isConnected());
 }
 
+TEST_CASE("db_connection: construction bounds in-flight TCP stalls via PGTCPUSERTIMEOUT")
+{
+    /* db_connect()'s run-once env block must set PGTCPUSERTIMEOUT so a
+     * black-holed connection with a query in flight fails on the keepalive
+     * clock instead of the kernel's retransmission timeout (todo/46). Any
+     * construction latches the env block, connected or not. Only presence is
+     * asserted: overwrite=0 means an operator override must win, so the
+     * value may legitimately differ from the built-in default. */
+    flight_safety_system::server::db_connection dbc(
+        "db.invalid", 5432, "user", flight_safety_system::secure_string(std::string_view{"pass"}), "db");
+    REQUIRE(std::getenv("PGTCPUSERTIMEOUT") != nullptr);
+}
+
 namespace {
 
 /* Build a db_connection from the TEST_DB_* env vars and REQUIRE it has


### PR DESCRIPTION
## Description

The PGKEEPALIVES* settings only govern idle connections: a query already in flight to a black-holed peer (partition, silently dropping firewall) sits in TCP retransmission for the kernel's ~15 min default, wedging whichever thread holds that connection's mutex. Set PGTCPUSERTIMEOUT (libpq tcp_user_timeout) to 25000 ms so in-flight death is declared on the same 25 s clock as idle death. overwrite=0 keeps operator overrides winning, as with the existing PG* vars.

statement_timeout is deliberately not set: it is enforced by the backend, so it bounds neither a frozen host nor a partition, and it would turn legitimate lock waits (e.g. the EXCLUSIVE table lock the async writer rides out in e2e/test_slow_db_does_not_stall.py) into write failures feeding the DB fail-safe.

## Summary by Sourcery

Configure database connections to fail in-flight TCP stalls on the same timeout as idle connections and add coverage to ensure the configuration is applied at construction time.

Bug Fixes:
- Ensure in-flight PostgreSQL client connections to unresponsive peers are bounded by a 25s TCP user timeout instead of relying on long kernel retransmission defaults.

Tests:
- Add a db_connection test verifying that PGTCPUSERTIMEOUT is set during construction so TCP stalls are bounded consistently.