### PR TITLE
fix(db): todo/48 make a terminal command-ack outcome final for its dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- A terminal command-ack outcome (actioned/superseded/rejected/noop) is now
+  final for its dispatch: a later terminal ack — from a buggy, misordered or
+  forged peer — can no longer silently rewrite a settled outcome in the
+  command audit trail. The guard previously only stopped a late "received"
+  from regressing a terminal state. Redelivery still re-acks normally:
+  recording a dispatch reopens the row's ack cycle by clearing the ack
+  columns, so the stored ack always describes the latest dispatch. (todo/48)
 - A dropped command dispatch/ack DB write now trips the fail-safe (severing
   every client) instead of only logging a counter change while the server
   kept flying aircraft on an audit trail it knew was broken. (todo/45)

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -98,13 +98,18 @@ public:
     virtual void recordSearchStatus(uint64_t asset_id, uint64_t search_id, uint64_t completed, uint64_t total) = 0;
     /* Records the dispatch id (the per-connection message id the server stamped
      * on the command) against the command row, so a later ack can be matched to
-     * this specific command. */
+     * this specific command. Also reopens the row's ack cycle (clears the ack
+     * columns): the stored ack always describes the latest dispatch, and a
+     * terminal outcome is final only within its dispatch — see recordCommandAck. */
     virtual void recordCommandDispatch(uint64_t command_dbid, uint64_t dispatch_id) = 0;
-    /* Stores a command ack against the row whose (asset_id, dispatch_id) matches;
-     * never regresses an already-terminal outcome. dispatch_id is only
-     * per-connection unique, so asset_id scopes the match to the acking asset.
-     * ack_state/ack_reason are the fss_command_ack_outcome/fss_command_ack_reason
-     * ints. */
+    /* Stores a command ack against the row whose (asset_id, dispatch_id) matches.
+     * Terminal-transition policy (todo/48): a terminal outcome (actioned/
+     * superseded/rejected/noop) is final for its dispatch — the write is refused
+     * unless the stored state is empty or received, so neither a late "received"
+     * nor a second terminal can rewrite a settled outcome; a redispatch reopens
+     * the cycle. dispatch_id is only per-connection unique, so asset_id scopes
+     * the match to the acking asset. ack_state/ack_reason are the
+     * fss_command_ack_outcome/fss_command_ack_reason ints. */
     virtual void recordCommandAck(uint64_t asset_id, uint64_t dispatch_id, uint8_t ack_state, uint64_t ack_timestamp,
                                   uint8_t ack_reason) = 0;
     virtual auto getCommand(uint64_t asset_id) -> std::shared_ptr<asset_command> = 0;

--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -191,7 +191,18 @@ int db_command_set_dispatch_id(const char *conn_arg, unsigned long long command_
     unsigned long long dispatch_id = dispatch_id_arg;
     EXEC SQL END DECLARE SECTION;
 
-    EXEC SQL AT :conn UPDATE assets_assetcommand SET dispatch_id = :dispatch_id WHERE id = :command_dbid;
+    /* Recording a dispatch also clears the ack columns: the ack columns always
+     * describe the row's LATEST dispatch, and db_command_record_ack() treats a
+     * terminal outcome as final, refusing further writes while one is stored.
+     * A redelivery (identify resends the newest command on every reconnect)
+     * must therefore reopen the ack cycle here, or the re-ack the redelivered
+     * command legitimately produces would be refused as a duplicate terminal.
+     * An ack can only match this row by carrying the new dispatch_id, which
+     * does not exist on the row until this statement lands, so no ack for the
+     * new delivery can slip in ahead of the clear. */
+    EXEC SQL AT :conn UPDATE assets_assetcommand
+        SET dispatch_id = :dispatch_id, ack_state = NULL, ack_timestamp = NULL, ack_superseded_by = NULL
+        WHERE id = :command_dbid;
 
     if (sqlca.sqlcode < 0)
     {
@@ -221,16 +232,27 @@ int db_command_record_ack(const char *conn_arg, unsigned long long asset_id_arg,
      * connection — the latest such row — so target it alone via a subselect
      * ordered by timestamp; matching all of them would let this ack rewrite a
      * long-settled historical row.
-     * Never regress an already-terminal outcome: a late "received" (state 0)
-     * must not clobber a settled actioned/superseded/rejected/noop. So skip the
-     * write when the incoming state is 0 and the stored state is already set and
-     * non-zero. ack_superseded_by is only meaningful for the superseded state. */
+     * Terminal-transition policy (todo/48): a terminal outcome is final for
+     * its dispatch. The row is writable only while unsettled — stored state
+     * NULL (no ack yet) or received (0) — so neither a late "received" nor a
+     * second terminal outcome (from a buggy, misordered or forged peer; acks
+     * are not validated in-session against a dispatched command) can rewrite
+     * a settled actioned/superseded/rejected/noop. The conforming two-phase
+     * flow (received, then exactly one terminal) is unaffected, and a
+     * REDELIVERED command still re-acks normally: db_command_set_dispatch_id()
+     * reopens the cycle by clearing the ack columns, scoping finality to the
+     * latest dispatch. A refused write matches zero rows, which is not an SQL
+     * error — a policy refusal must never look like a DB write failure to the
+     * fail-safe machinery. If a supersedable outcome is ever added (e.g.
+     * todo/17's accepted-but-not-transmitted), extend the writable set below
+     * rather than weakening finality of the true terminals.
+     * ack_superseded_by is only meaningful for the superseded state. */
     EXEC SQL AT :conn UPDATE assets_assetcommand
         SET ack_state = :ack_state, ack_timestamp = :ack_timestamp, ack_superseded_by = :ack_superseded_by
         WHERE id = (SELECT id FROM assets_assetcommand
                     WHERE asset_id = :asset_id AND dispatch_id = :dispatch_id
                     ORDER BY timestamp DESC LIMIT 1)
-          AND NOT (:ack_state = 0 AND ack_state IS NOT NULL AND ack_state <> 0);
+          AND (ack_state IS NULL OR ack_state = 0);
 
     if (sqlca.sqlcode < 0)
     {

--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -469,3 +469,92 @@ TEST_CASE("db_connection: recordCommandAck does not regress an already-terminal 
     REQUIRE(get_command_column(command_id, "ack_state") == "1");
     REQUIRE(get_command_column(command_id, "ack_timestamp") == "100");
 }
+
+TEST_CASE("db_connection: recordCommandAck refuses a second terminal outcome")
+{
+    /* todo/48: a terminal outcome is final for its dispatch. A later terminal
+     * ack (superseded/rejected/noop) from a buggy, misordered or forged peer
+     * must not rewrite a settled "actioned" in the audit record -- the
+     * query-enforced writable set is stored-state NULL or received only. */
+    LIVE_DB_OR_SKIP(dbc);
+    auto asset_id = dbc->getAssetId("test-asset");
+    REQUIRE(asset_id != 0);
+
+    const std::array<uint8_t, 3> later_terminals = {
+        static_cast<uint8_t>(flight_safety_system::transport::command_ack_superseded),
+        static_cast<uint8_t>(flight_safety_system::transport::command_ack_rejected),
+        static_cast<uint8_t>(flight_safety_system::transport::command_ack_noop),
+    };
+    uint64_t dispatch_id = 7770;
+    for (const auto later_state : later_terminals)
+    {
+        auto command_id = insert_test_command(asset_id);
+        dbc->recordCommandDispatch(command_id, dispatch_id);
+
+        dbc->recordCommandAck(asset_id, dispatch_id,
+                              static_cast<uint8_t>(flight_safety_system::transport::command_ack_actioned),
+                              uint64_t{100}, static_cast<uint8_t>(flight_safety_system::transport::supersede_none));
+        dbc->recordCommandAck(asset_id, dispatch_id, later_state, uint64_t{200},
+                              static_cast<uint8_t>(flight_safety_system::transport::supersede_low_battery));
+
+        REQUIRE(get_command_column(command_id, "ack_state") == "1");
+        REQUIRE(get_command_column(command_id, "ack_timestamp") == "100");
+        REQUIRE(get_command_column(command_id, "ack_superseded_by") == "0");
+        dispatch_id++;
+    }
+}
+
+TEST_CASE("db_connection: recordCommandAck admits the conforming received-then-terminal flow")
+{
+    /* The two-phase ack a conforming FMU sends (received, then exactly one
+     * terminal outcome) must be unaffected by the todo/48 finality guard. */
+    LIVE_DB_OR_SKIP(dbc);
+    auto asset_id = dbc->getAssetId("test-asset");
+    REQUIRE(asset_id != 0);
+    auto command_id = insert_test_command(asset_id);
+    dbc->recordCommandDispatch(command_id, uint64_t{7780});
+
+    dbc->recordCommandAck(asset_id, uint64_t{7780},
+                          static_cast<uint8_t>(flight_safety_system::transport::command_ack_received), uint64_t{100},
+                          static_cast<uint8_t>(flight_safety_system::transport::supersede_none));
+    REQUIRE(get_command_column(command_id, "ack_state") == "0");
+
+    dbc->recordCommandAck(asset_id, uint64_t{7780},
+                          static_cast<uint8_t>(flight_safety_system::transport::command_ack_actioned), uint64_t{200},
+                          static_cast<uint8_t>(flight_safety_system::transport::supersede_none));
+    REQUIRE(get_command_column(command_id, "ack_state") == "1");
+    REQUIRE(get_command_column(command_id, "ack_timestamp") == "200");
+}
+
+TEST_CASE("db_connection: recordCommandDispatch reopens the ack cycle")
+{
+    /* todo/48's finality is scoped to the latest dispatch: redelivery (identify
+     * resends the newest command on every reconnect) records a new dispatch,
+     * which clears the ack columns so the redelivered command's re-ack is
+     * admitted rather than refused as a duplicate terminal. Pinned end-to-end
+     * by test_server_restart.py's post-bounce re-ack check; this covers the
+     * same contract at the query level. */
+    LIVE_DB_OR_SKIP(dbc);
+    auto asset_id = dbc->getAssetId("test-asset");
+    REQUIRE(asset_id != 0);
+    auto command_id = insert_test_command(asset_id);
+    dbc->recordCommandDispatch(command_id, uint64_t{7790});
+    dbc->recordCommandAck(asset_id, uint64_t{7790},
+                          static_cast<uint8_t>(flight_safety_system::transport::command_ack_actioned), uint64_t{100},
+                          static_cast<uint8_t>(flight_safety_system::transport::supersede_none));
+    REQUIRE(get_command_column(command_id, "ack_state") == "1");
+
+    /* Redispatch (e.g. after a reconnect, with the new connection's id). */
+    dbc->recordCommandDispatch(command_id, uint64_t{7791});
+    REQUIRE(get_command_column(command_id, "ack_state").empty());
+    REQUIRE(get_command_column(command_id, "ack_timestamp").empty());
+    REQUIRE(get_command_column(command_id, "ack_superseded_by").empty());
+
+    /* The re-ack for the new delivery lands, terminal over the reopened row. */
+    dbc->recordCommandAck(asset_id, uint64_t{7791},
+                          static_cast<uint8_t>(flight_safety_system::transport::command_ack_superseded), uint64_t{200},
+                          static_cast<uint8_t>(flight_safety_system::transport::supersede_comms_loss));
+    REQUIRE(get_command_column(command_id, "ack_state") == "2");
+    REQUIRE(get_command_column(command_id, "ack_timestamp") == "200");
+    REQUIRE(get_command_column(command_id, "ack_superseded_by") == "2");
+}


### PR DESCRIPTION
## Description

db_command_record_ack's guard only stopped a late "received" from regressing a settled outcome; a second *terminal* ack (superseded/ rejected/noop) from a buggy, misordered or forged peer could still silently rewrite a settled outcome in the command audit trail — and an ack is not validated in-session against a command this server actually dispatched, so a spurious one is accepted.

Policy, now query-enforced: the row is writable only while unsettled (stored ack_state NULL or received), so a terminal outcome is final. Finality is scoped to the latest dispatch: recording a dispatch id also clears the ack columns, reopening the cycle, because redelivery after a reconnect legitimately re-acks (pinned by test_server_restart.py's post-bounce fresh-ack_timestamp check). An ack for the new delivery can only match the row via the new dispatch_id, which the row doesn't carry until the same statement that clears the acks lands, so nothing slips in between. A policy-refused write matches zero rows — not an SQL error — so it can never masquerade as a DB write failure and feed the todo/45/47 fail-safe.

If a supersedable outcome is ever added (todo/17's accepted-but-not- transmitted), extend the writable set rather than weakening finality.

Unit tests: a second terminal is refused for all three later outcomes, the conforming received-then-terminal flow is unaffected, and a redispatch reopens the cycle for the re-ack. The todo/32 bounce e2e and both command-ack e2e tests pass against the new guard.

## Summary by Sourcery

Enforce finality of terminal command-ack outcomes per dispatch while allowing redispatch to reopen the acknowledgement cycle for redelivered commands.

Bug Fixes:
- Prevent later terminal command acks from rewriting an already settled outcome in the command audit trail.

Enhancements:
- Clarify database interface contracts around command dispatch and ack handling, including terminal-outcome finality and redispatch behaviour.

Documentation:
- Document the new terminal command-ack finality and redispatch behaviour in the changelog.

Tests:
- Add tests verifying that a second terminal ack is refused, the received-then-terminal flow remains valid, and redispatch clears ack fields to admit a new terminal ack.