### PR TITLE
refactor(server): todo/24 getActiveServers reports a partial read by status, not exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `IDatabase::getActiveServers()` now reports a cut-short read (mid-cursor
+  error, truncated row) as an explicit `std::nullopt` status instead of
+  throwing `database_error` across the poller thread — the codebase's last
+  use of an exception as routine cross-thread control flow. Safety no longer
+  depends on every caller remembering a catch block: an unguarded future
+  caller previously meant `std::terminate` on a safety-critical service.
+  Behaviour on a failed read is unchanged (poller keeps the previous cached
+  list; identify skips the server-list send). (todo/24)
+
 ### Fixed
 - A terminal command-ack outcome (actioned/superseded/rejected/noop) is now
   final for its dispatch: a later terminal ack — from a buggy, misordered or

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -768,10 +768,18 @@ void fss::server::fss_client::sendSMMSettings()
 }
 
 namespace {
+/* nullptr when the DB read failed (partial/truncated result): the caller must
+ * skip the send or keep its cached list rather than shipping a wrong one. A
+ * genuinely empty active-server set is a non-null message with no servers. */
 auto getServersListMsg(fss::server::IDatabase *dbc) -> std::shared_ptr<fss::transport::fss_message_server_list>
 {
+    auto servers = dbc->getActiveServers();
+    if (!servers.has_value())
+    {
+        return nullptr;
+    }
     auto server_list = std::make_shared<fss::transport::fss_message_server_list>();
-    for (auto &server_details : dbc->getActiveServers())
+    for (auto &server_details : *servers)
     {
         server_list->addServer(server_details.getAddress(), server_details.getPort());
     }
@@ -974,7 +982,17 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                  * now rather than after the poller's next refresh. */
                 this->refreshSmmSettings();
                 this->sendSMMSettings();
-                active_conn->sendMsg(getServersListMsg(this->dbc));
+                /* A failed read (nullptr) skips the send; the client gets
+                 * the list from the poller's 15 s broadcast instead. */
+                if (auto server_list_msg = getServersListMsg(this->dbc))
+                {
+                    active_conn->sendMsg(server_list_msg);
+                }
+                else
+                {
+                    FSS_LOG_WARN("server", "Server-list read failed during identify of "
+                                               << this->getName() << "; relying on the periodic broadcast");
+                }
             }
         }
         else if (msg->getType() == fss::transport::message_type_identity_non_aircraft)
@@ -1288,7 +1306,9 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
 
 namespace flight_safety_system::server {
 /* Exposed so server.cpp can broadcast the server list without duplicating
- * the helper. Not in the public header — only the server binary uses it. */
+ * the helper. Not in the public header — only the server binary uses it.
+ * nullptr when the DB read failed: the poller must keep the previous cached
+ * list rather than replacing it (todo/24). */
 auto build_server_list_msg(IDatabase *dbc) -> std::shared_ptr<transport::fss_message_server_list>
 {
     return getServersListMsg(dbc);

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -230,7 +230,7 @@ auto flight_safety_system::server::db_connection::getSmmSettings(uint64_t asset_
     return res;
 }
 
-auto flight_safety_system::server::db_connection::getActiveServers() -> std::vector<fss_server_details>
+auto flight_safety_system::server::db_connection::getActiveServers() -> std::optional<std::vector<fss_server_details>>
 {
     std::vector<fss_server_details> res;
     struct fss_server_s **servers = nullptr;
@@ -251,11 +251,12 @@ auto flight_safety_system::server::db_connection::getActiveServers() -> std::vec
     }
     /* A mid-cursor failure leaves res holding only the rows read before the
      * error. Discard it: shipping a truncated list to aircraft would drop
-     * servers that are actually active. The caller's exception_guard retains
-     * the previous good cache. */
+     * servers that are actually active. nullopt tells the caller to keep its
+     * previous good list (todo/24). */
     if (fetch_error != 0)
     {
-        throw database_error("active FSS server list read failed mid-cursor; partial result discarded");
+        FSS_LOG_ERROR("db", "active FSS server list read failed mid-cursor; partial result discarded");
+        return std::nullopt;
     }
     return res;
 }

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -9,6 +9,7 @@
 #include <condition_variable>
 #include <deque>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <list>
@@ -71,10 +72,12 @@ public:
     auto isAltitudeValid() -> bool;
 };
 
-/* Thrown by a database read that could only return a partial, misleading
- * result. getActiveServers raises it when the cursor is cut short by a
- * mid-iteration error so the caller discards the truncated list rather than
- * mistaking it for the complete set of active servers. */
+/* Thrown by db_connection's write wrappers when the underlying SQL fails, so
+ * db_write_queue's worker (the only production write path) can count the
+ * failure toward the todo/34/45/47 fail-safe. Reads do not throw: a read that
+ * could only produce a partial, misleading result reports it in its return
+ * value instead (see getActiveServers), so no read caller needs a try block
+ * to stay terminate-safe (todo/24). */
 class database_error : public std::runtime_error {
 public:
     explicit database_error(const std::string &what) : std::runtime_error(what) {}
@@ -113,7 +116,13 @@ public:
     virtual void recordCommandAck(uint64_t asset_id, uint64_t dispatch_id, uint8_t ack_state, uint64_t ack_timestamp,
                                   uint8_t ack_reason) = 0;
     virtual auto getCommand(uint64_t asset_id) -> std::shared_ptr<asset_command> = 0;
-    virtual auto getActiveServers() -> std::vector<fss_server_details> = 0;
+    /* The complete set of active servers, or nullopt when the read was cut
+     * short (mid-cursor error, truncated row) and could only produce a
+     * partial, misleading list. nullopt is NOT an empty list: the caller must
+     * keep whatever list it already has rather than shipping the failure to
+     * aircraft as "no servers". An explicit status, not an exception, so the
+     * contract is visible at every call site (todo/24). */
+    virtual auto getActiveServers() -> std::optional<std::vector<fss_server_details>> = 0;
     virtual auto getSmmSettings(uint64_t asset_id) -> std::shared_ptr<smm_settings> = 0;
     virtual auto isConnected() const -> bool = 0;
     virtual void tryReconnectIfNeeded() = 0;
@@ -163,7 +172,7 @@ public:
     void recordCommandAck(uint64_t asset_id, uint64_t dispatch_id, uint8_t ack_state, uint64_t ack_timestamp,
                           uint8_t ack_reason) override;
     auto getCommand(uint64_t asset_id) -> std::shared_ptr<asset_command> override;
-    auto getActiveServers() -> std::vector<fss_server_details> override;
+    auto getActiveServers() -> std::optional<std::vector<fss_server_details>> override;
     auto getSmmSettings(uint64_t asset_id) -> std::shared_ptr<smm_settings> override;
     auto isConnected() const -> bool override;
     void tryReconnectIfNeeded() override;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -395,8 +395,15 @@ auto main(int argc, char *argv[]) -> int
                  * (counter 0) so the caches are primed at startup. */
                 if ((poll_counter % send_config_period_ticks) == 0)
                 {
-                    clients->setCachedServerList(flight_safety_system::server::build_server_list_msg(dbc.get()));
-                    clients->refreshSmmSettings();
+                    /* nullptr = the read failed (partial/truncated): keep the
+                     * previous good cache and skip this refresh round entirely
+                     * — the same both-skipped outcome the old database_error
+                     * unwind gave, but as an explicit status (todo/24). */
+                    if (auto server_list = flight_safety_system::server::build_server_list_msg(dbc.get()))
+                    {
+                        clients->setCachedServerList(std::move(server_list));
+                        clients->refreshSmmSettings();
+                    }
                 }
             });
             poll_counter++;

--- a/tests/concurrency_client_test.cpp
+++ b/tests/concurrency_client_test.cpp
@@ -16,6 +16,7 @@
 #include <list>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <queue>
 #include <string>
 #include <thread>
@@ -108,7 +109,11 @@ public:
     {
         return nullptr;
     }
-    auto getActiveServers() -> std::vector<flight_safety_system::server::fss_server_details> override { return {}; }
+    auto getActiveServers() -> std::optional<std::vector<flight_safety_system::server::fss_server_details>> override
+    {
+        /* An engaged empty vector: no servers configured, not a failed read. */
+        return std::vector<flight_safety_system::server::fss_server_details>{};
+    }
     auto getSmmSettings(uint64_t) -> std::shared_ptr<flight_safety_system::server::smm_settings> override
     {
         return nullptr;

--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -204,9 +204,10 @@ TEST_CASE("db_connection: getActiveServers returns pre-configured server")
 {
     LIVE_DB_OR_SKIP(dbc);
     auto servers = dbc->getActiveServers();
-    REQUIRE_FALSE(servers.empty());
+    REQUIRE(servers.has_value());
+    REQUIRE_FALSE(servers->empty());
     bool found = false;
-    for (auto &s : servers)
+    for (auto &s : *servers)
     {
         if (s.getAddress() == "fss.example.com" && s.getPort() == 20202)
         {
@@ -263,31 +264,19 @@ public:
 };
 } // namespace
 
-TEST_CASE("db_connection: getActiveServers throws when a server address is truncated (todo/41)")
+TEST_CASE("db_connection: getActiveServers fails the read when a server address is truncated (todo/41)")
 {
     /* A FETCH that truncates server_address ends the cursor loop with a
      * warning (sqlcode >= 0), not an error. Before todo/41's fix, getActive
      * Servers() would see fetch_error == 0 and return whatever was
      * accumulated before the bad row as the complete set -- silently
-     * dropping every server sorted after it. It must now throw
-     * database_error instead, exactly like a mid-cursor read error, so the
-     * poller's exception_guard keeps the previous good cache rather than
-     * shipping a partial list to aircraft. */
+     * dropping every server sorted after it. It must fail the read instead
+     * (nullopt, exactly like a mid-cursor read error; todo/24 turned the old
+     * database_error throw into this status return) so the poller keeps the
+     * previous good cache rather than shipping a partial list to aircraft. */
     LIVE_DB_OR_SKIP(dbc);
     scoped_truncated_server_active guard;
-    /* Assert the throw manually rather than via REQUIRE_THROWS_AS: older Catch2
-     * expands that macro to a by-value catch clause, which trips
-     * -Werror=catch-value on the polymorphic database_error type. */
-    bool threw_database_error = false;
-    try
-    {
-        dbc->getActiveServers();
-    }
-    catch (const flight_safety_system::server::database_error &)
-    {
-        threw_database_error = true;
-    }
-    REQUIRE(threw_database_error);
+    REQUIRE_FALSE(dbc->getActiveServers().has_value());
 }
 
 TEST_CASE("db_connection: tryReconnectIfNeeded returns when connection is healthy")

--- a/tests/mock_database.hpp
+++ b/tests/mock_database.hpp
@@ -5,6 +5,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -25,9 +26,8 @@ public:
     std::map<uint64_t, std::shared_ptr<flight_safety_system::server::smm_settings>> smm{};
     std::map<uint64_t, std::vector<std::shared_ptr<flight_safety_system::server::asset_command>>> commands{};
     std::vector<flight_safety_system::server::fss_server_details> active_servers{};
-    /* When set, getActiveServers throws database_error, simulating a
-     * mid-cursor read failure so tests can exercise the partial-result
-     * discard path. */
+    /* When set, getActiveServers returns nullopt, simulating a mid-cursor
+     * read failure so tests can exercise the partial-result discard path. */
     bool active_servers_fail{false};
 
     struct recorded_rtt {
@@ -165,11 +165,11 @@ public:
         return newest;
     }
 
-    auto getActiveServers() -> std::vector<flight_safety_system::server::fss_server_details> override
+    auto getActiveServers() -> std::optional<std::vector<flight_safety_system::server::fss_server_details>> override
     {
         if (active_servers_fail)
         {
-            throw flight_safety_system::server::database_error("mock mid-cursor failure");
+            return std::nullopt;
         }
         return active_servers;
     }

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -30,6 +30,13 @@
 
 namespace fss = flight_safety_system;
 
+namespace flight_safety_system::server {
+/* Defined in client_session.cpp; not in the public header. Declared here the
+ * same way server.cpp declares it, so the poller's failed-read signal
+ * (nullptr, todo/24) can be pinned at unit level. */
+auto build_server_list_msg(IDatabase *dbc) -> std::shared_ptr<transport::fss_message_server_list>;
+} // namespace flight_safety_system::server
+
 namespace {
 
 /* Stand-in for the real fss_connection used by fss_client. The default
@@ -437,16 +444,19 @@ TEST_CASE("session: server list sent on identify contains seeded servers")
     CHECK(servers[1].second == 9090);
 }
 
-TEST_CASE("session: identify surfaces a mid-cursor server-list failure instead of a partial list")
+TEST_CASE("session: identify skips the server-list send on a mid-cursor failure instead of shipping a partial list")
 {
-    /* getActiveServers throws when the cursor is cut short by a mid-iteration
-     * error. The throw must propagate out of processMessage (where production
-     * wraps it in an exception_guard) rather than a truncated server list
-     * reaching the wire. */
+    /* getActiveServers reports a cut-short cursor as nullopt (todo/24 replaced
+     * the old database_error throw). Identify must complete normally — the
+     * client still gets its command — with only the server-list send skipped;
+     * the periodic broadcast delivers the list once a read succeeds. */
     fss_test::MockDatabase mock;
-    mock.asset_ids["craft"] = 1;
+    constexpr uint64_t asset_id = 1;
+    mock.asset_ids["craft"] = asset_id;
     mock.active_servers.emplace_back("10.0.0.1", uint16_t{8080});
     mock.active_servers_fail = true;
+    mock.pushCommand(asset_id, std::make_shared<fss::server::asset_command>(
+                                   /*dbid*/ 1, /*ts*/ 100, "RTL", 0.0, 0.0, 0));
 
     auto conn = std::make_shared<FakeConnection>();
     conn->cert_names.push_back("craft");
@@ -454,22 +464,43 @@ TEST_CASE("session: identify surfaces a mid-cursor server-list failure instead o
 
     auto writer = make_mock_writer(mock);
     auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
-    /* Assert the throw manually rather than via REQUIRE_THROWS_AS: older Catch2
-     * expands that macro to a by-value catch clause, which trips
-     * -Werror=catch-value on the polymorphic database_error type. */
-    bool threw_database_error = false;
-    try
-    {
-        session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
-    }
-    catch (const fss::server::database_error &)
-    {
-        threw_database_error = true;
-    }
-    REQUIRE(threw_database_error);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
 
     /* No server list was sent: the partial result was discarded, not shipped. */
     REQUIRE(find_sent<fss::transport::fss_message_server_list>(conn->sent) == nullptr);
+    /* But identify itself completed: the pending command still went out. */
+    REQUIRE(find_sent<fss::transport::fss_message_asset_command>(conn->sent) != nullptr);
+}
+
+TEST_CASE("session: build_server_list_msg signals a failed read as nullptr, distinct from an empty list")
+{
+    /* The poller keys its cache update on this signal (todo/24): nullptr means
+     * "read failed, keep the previous cached list"; a genuinely empty active-
+     * server set is a non-null message with zero servers, which legitimately
+     * replaces the cache. */
+    fss_test::MockDatabase mock;
+
+    SECTION("failed read -> nullptr")
+    {
+        mock.active_servers.emplace_back("10.0.0.1", uint16_t{8080});
+        mock.active_servers_fail = true;
+        REQUIRE(fss::server::build_server_list_msg(&mock) == nullptr);
+    }
+
+    SECTION("empty set -> non-null message with no servers")
+    {
+        auto msg = fss::server::build_server_list_msg(&mock);
+        REQUIRE(msg != nullptr);
+        REQUIRE(msg->getServers().empty());
+    }
+
+    SECTION("populated set -> non-null message with the seeded servers")
+    {
+        mock.active_servers.emplace_back("10.0.0.1", uint16_t{8080});
+        auto msg = fss::server::build_server_list_msg(&mock);
+        REQUIRE(msg != nullptr);
+        REQUIRE(msg->getServers().size() == 1);
+    }
 }
 
 TEST_CASE("session: rapid sendCommand does not duplicate a single pending command")


### PR DESCRIPTION
## Description

getActiveServers() signalled a cut-short cursor by throwing database_error across the poller thread — the codebase's last use of an exception as routine cross-thread control flow. The pattern worked, but only because every caller happened to sit inside an exception_guard; nothing at the type level forced that, so a future unguarded caller (a new admin path, a test, a refactor moving the read) meant std::terminate on a safety-critical service.

The todo's option 1, as recommended: the IDatabase signature is now std::optional<std::vector<fss_server_details>>, nullopt meaning the read failed (mid-cursor error or todo/41 truncation) and the caller must keep whatever list it already has — nullopt is not an empty list; a genuinely empty active-server set stays a real (empty) value. getServersListMsg/ build_server_list_msg translate nullopt into a nullptr message, and both production paths preserve their old observable behaviour: the poller updates the cached list and runs refreshSmmSettings() only on a non-null build (the old throw unwound past both), and identify skips the server-list send with a WARN (the old throw was swallowed by the recv thread's exception_guard, equally skipping the send), leaving the 15 s broadcast to deliver the list once a read succeeds.

database_error itself remains: the todo/34 write wrappers still throw it into db_write_queue's catch — thread-local signalling the fail-safe counts on. Its doc comment now records that reads never throw.

Tests: the session test that asserted the throw propagated out of processMessage now asserts identify completes with only the server-list send skipped; a new unit test pins build_server_list_msg's nullptr-vs-empty-list distinction (the poller's cache-update signal); the todo/41 truncation test asserts nullopt; the mock returns nullopt instead of throwing. Full suite, check-code.sh, and the server-list/position-flow e2e tests pass.

## Summary by Sourcery

Make database server list reads report partial/truncated results via an explicit optional status instead of exceptions, and adjust server list sending logic to skip sends on failed reads while preserving existing behaviour.

Bug Fixes:
- Ensure truncated or mid-cursor server list reads no longer produce misleading partial lists, but instead signal a failed read so caches remain consistent.

Enhancements:
- Change IDatabase::getActiveServers() to return std::optional, distinguishing between a failed read, an empty set, and a populated server list.
- Update identify handling and poller refresh paths to treat failed server list reads as a skip while relying on periodic broadcasts for recovery.
- Clarify the database_error contract as write-only and document the new read failure signalling mechanism.

Documentation:
- Document the changed getActiveServers() behaviour and failure signalling in the changelog and header comments.

Tests:
- Adapt existing tests to the new optional-based getActiveServers() contract and add unit coverage for nullptr-vs-empty server list messages and failed read handling in identify and truncation scenarios.