### PR TITLE
feat(transport): todo/26 per-connection configurable TCP_USER_TIMEOUT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Per-connection configurable `TCP_USER_TIMEOUT`: a flight-safety client
+  (e.g. cap-fmu) can now bound how long a blocking send into a half-dead
+  server can stall — `tcp_user_timeout_ms` in the client JSON config, a
+  protected `fss_client::setTcpUserTimeoutMs()` for programmatic use, and
+  `fss_connection::setTcpUserTimeoutMs()` /
+  `fss_connection_client::create(..., t_tcp_user_timeout_ms)` at the
+  transport layer. The default stays the established 30 s everywhere, and
+  server-accepted sockets are unaffected. (todo/26)
+
 ### Changed
 - `IDatabase::getActiveServers()` now reports a cut-short read (mid-cursor
   error, truncated row) as an explicit `std::nullopt` status instead of

--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -63,6 +63,10 @@ flight_safety_system::client_ssl::fss_client::fss_client(const std::string &t_fi
         {
             this->setClockOffsetMs(config["clock_offset_ms"].asInt64());
         }
+        if (config.isMember("tcp_user_timeout_ms"))
+        {
+            this->setTcpUserTimeoutMs(config["tcp_user_timeout_ms"].asUInt());
+        }
 
         this->ca_file = config["ssl"]["ca_public_key"].asString();
         this->private_key_file = config["ssl"]["client_private_key"].asString();
@@ -163,6 +167,15 @@ void flight_safety_system::client_ssl::fss_client::setClockOffsetMs(int64_t t_of
     /* Set once during configuration, before concurrent use (same as
      * setAssetName above) -- no lock needed. */
     this->clock_offset_ms = t_offset_ms;
+}
+
+void flight_safety_system::client_ssl::fss_client::setTcpUserTimeoutMs(unsigned int t_timeout_ms)
+{
+    /* Set once during configuration, before concurrent use (same as
+     * setAssetName above) -- no lock needed. fss_server::reconnect_to()
+     * reads it at every (re)connect, so it also applies to servers learned
+     * later from a server-list update, not just config-file entries. */
+    this->tcp_user_timeout_ms = t_timeout_ms;
 }
 
 auto flight_safety_system::client_ssl::fss_client::getSkewedTimestamp() const -> uint64_t
@@ -470,8 +483,14 @@ void flight_safety_system::client_ssl::fss_server::sendVersion()
 
 auto flight_safety_system::client_ssl::fss_server::reconnect_to() -> bool
 {
+    /* Read the client's requested send bound at every (re)connect rather
+     * than capturing it at construction, so it uniformly covers config-file
+     * servers, programmatic connectTo, and servers learned from a
+     * server-list update (todo/26). Null client (some tests): default. */
+    auto timeout_ms = this->client != nullptr ? this->client->getTcpUserTimeoutMs()
+                                              : flight_safety_system::transport::default_tcp_user_timeout_ms;
     auto new_conn = flight_safety_system::transport_ssl::fss_connection_client::create(
-        this->ca_file, this->private_key_file, this->public_key_file, this->getAddress(), this->getPort());
+        this->ca_file, this->private_key_file, this->public_key_file, this->getAddress(), this->getPort(), timeout_ms);
     if (new_conn == nullptr)
     {
         return false;

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -34,6 +34,13 @@ private:
      * e2e test drive a client with a deliberately skewed clock without
      * needing root/faketime. Positive = client clock ahead of real time. */
     int64_t clock_offset_ms{0};
+    /* TCP_USER_TIMEOUT requested for every server connection this client
+     * makes (todo/26): the bound on how long a blocking send() can stall
+     * into a half-dead server before the kernel errors the connection out.
+     * A flight-safety client (e.g. cap-fmu) can set this well below the
+     * 30 s default so a wedged send worker recovers on its own clock.
+     * Config field "tcp_user_timeout_ms"; consulted at (re)connect time. */
+    unsigned int tcp_user_timeout_ms{flight_safety_system::transport::default_tcp_user_timeout_ms};
     std::string ca_file{""};
     std::string private_key_file{""};
     std::string public_key_file{""};
@@ -56,6 +63,9 @@ protected:
     void setAssetName(std::string t_asset_name);
     void setNonAircraft(bool t_non_aircraft);
     void setClockOffsetMs(int64_t t_offset_ms);
+    /* Call before connecting (configuration state, like the setters above);
+     * an already-established connection keeps the bound it connected with. */
+    void setTcpUserTimeoutMs(unsigned int t_timeout_ms);
     void addServer(const std::shared_ptr<fss_server> &server);
 public:
     explicit fss_client(const std::string &config_file);
@@ -73,6 +83,7 @@ public:
     virtual auto getAssetName() -> std::string;
     virtual auto isNonAircraft() const -> bool { return this->non_aircraft; }
     virtual auto getClockOffsetMs() const -> int64_t { return this->clock_offset_ms; }
+    virtual auto getTcpUserTimeoutMs() const -> unsigned int { return this->tcp_user_timeout_ms; }
     /* fss_current_timestamp() + clock_offset_ms (todo/33): the single
      * source of truth for "what time does this client think it is", used
      * both for the RTT response's reported client clock and for any

--- a/src/fss-transport-ssl.hpp
+++ b/src/fss-transport-ssl.hpp
@@ -80,8 +80,13 @@ public:
     auto operator=(fss_connection_client&&) -> fss_connection& = delete;
     ~fss_connection_client() override;
     auto connectTo(const std::string& address, uint16_t port) -> bool override;
-    static auto create(std::string t_ca, std::string t_private_key, std::string t_public_key,
-                       const std::string& address, uint16_t port) -> std::shared_ptr<fss_connection_client>;
+    /* t_tcp_user_timeout_ms: per-connection TCP_USER_TIMEOUT applied at
+     * connect (todo/26); the default keeps the established 30 s bound. */
+    static auto
+    create(std::string t_ca, std::string t_private_key, std::string t_public_key, const std::string& address,
+           uint16_t port,
+           unsigned int t_tcp_user_timeout_ms = flight_safety_system::transport::default_tcp_user_timeout_ms)
+        -> std::shared_ptr<fss_connection_client>;
 };
 
 

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -64,6 +64,15 @@ inline auto negotiateFeatureFlags(uint32_t peer_flags) -> uint32_t
  * largest legitimate message (server_list with many entries) with headroom. */
 static constexpr uint16_t FSS_MAX_MESSAGE_BYTES = 8192;
 
+/* Default TCP_USER_TIMEOUT (ms) applied to every connection: how long
+ * transmitted data may stay unacknowledged before the kernel errors the
+ * connection out, which is what bounds a blocking send() into a half-dead
+ * peer. 30 s matches the server's application-layer liveness timeout
+ * (default client_timeout) and is the right bound for the server; a
+ * flight-safety *client* (e.g. cap-fmu's FSS send worker) can request a
+ * tighter bound per connection via setTcpUserTimeoutMs (todo/26). */
+static constexpr unsigned int default_tcp_user_timeout_ms = 30000;
+
 class fss_connection;
 class fss_listen;
 class fss_message;
@@ -260,6 +269,11 @@ class fss_connection {
      * advertised feature_flags, masked by FSS_SUPPORTED_FEATURES). 0 until the
      * version handshake negotiates it; a legacy peer leaves it 0. */
     std::atomic<uint32_t> negotiated_feature_flags{0};
+    /* TCP_USER_TIMEOUT this connection requests at connect time (todo/26).
+     * Only consulted by the connectTo() paths (plain and TLS); a
+     * server-accepted socket already had the default applied at accept and
+     * is not affected by this member. */
+    unsigned int tcp_user_timeout_ms{default_tcp_user_timeout_ms};
 protected:
     auto recvMsg() -> std::shared_ptr<fss_message>;
     auto getMessageId() -> uint64_t;
@@ -284,6 +298,15 @@ public:
     auto operator=(fss_connection &&) -> fss_connection & = delete;
     virtual ~fss_connection();
     void setHandler(fss_message_cb *cb);
+    /* Request a tighter (or looser) TCP_USER_TIMEOUT than the 30 s default
+     * for this connection (todo/26): the bound on how long a blocking send()
+     * can stall into a half-dead peer before the kernel errors the connection
+     * out. Must be called BEFORE connectTo() — it is applied to the socket at
+     * connect time and has no effect afterwards, nor on a server-accepted
+     * connection. 0 means the kernel default (no user timeout); per tcp(7)
+     * values are milliseconds. */
+    void setTcpUserTimeoutMs(unsigned int ms) { this->tcp_user_timeout_ms = ms; }
+    auto getTcpUserTimeoutMs() const -> unsigned int { return this->tcp_user_timeout_ms; }
     virtual auto connectTo(const std::string &address, uint16_t port) -> bool;
     auto getNegotiatedVersion() -> uint16_t { return this->negotiated_version.load(); }
     void setNegotiatedVersion(uint16_t v) { this->negotiated_version.store(v); }

--- a/src/transport-helpers.cpp
+++ b/src/transport-helpers.cpp
@@ -67,7 +67,7 @@ auto convert_str_to_sa(const std::string &addr, uint16_t port, struct sockaddr_s
     return family != AF_UNSPEC;
 }
 
-void set_tcp_keepalive(int fd)
+void set_tcp_keepalive(int fd, unsigned int tcp_user_timeout_ms) // NOLINT(bugprone-easily-swappable-parameters)
 {
     int val = 1;
     if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &val, sizeof(val)) < 0)
@@ -95,12 +95,13 @@ void set_tcp_keepalive(int fd)
      * (~15 minutes), so a blocking send() into a black-holed peer can stall
      * a sender thread for that long. TCP_USER_TIMEOUT bounds how long
      * transmitted data may stay unacknowledged before the kernel errors the
-     * connection out, matching the 30 s liveness timeout the server already
-     * applies at the application layer (default client_timeout). */
+     * connection out. The default (default_tcp_user_timeout_ms, 30 s) matches
+     * the liveness timeout the server applies at the application layer
+     * (default client_timeout); a flight-safety client can pass a tighter
+     * per-connection bound (todo/26). */
     /* tcp(7): TCP_USER_TIMEOUT takes an unsigned int (milliseconds). The
-     * regression test pins this value with a literal on purpose - changing
+     * regression test pins the default with a literal on purpose - changing
      * it must consciously break the test. */
-    constexpr unsigned int tcp_user_timeout_ms = 30000;
     unsigned int user_timeout_ms = tcp_user_timeout_ms;
     if (setsockopt(fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &user_timeout_ms, sizeof(user_timeout_ms)) < 0)
     {

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -171,7 +171,7 @@ auto flight_safety_system::transport_ssl::fss_connection_client::connectTo(const
         return false;
     }
 
-    set_tcp_keepalive(this->getFd());
+    set_tcp_keepalive(this->getFd(), this->getTcpUserTimeoutMs());
 
     this->usable.store(this->setupSSL());
 
@@ -181,12 +181,15 @@ auto flight_safety_system::transport_ssl::fss_connection_client::connectTo(const
 // NOLINTBEGIN(bugprone-easily-swappable-parameters)
 auto flight_safety_system::transport_ssl::fss_connection_client::create(std::string t_ca, std::string t_private_key,
                                                                         std::string t_public_key,
-                                                                        const std::string &address, uint16_t port)
+                                                                        const std::string &address, uint16_t port,
+                                                                        unsigned int t_tcp_user_timeout_ms)
     -> std::shared_ptr<fss_connection_client>
 // NOLINTEND(bugprone-easily-swappable-parameters)
 {
     auto conn =
         std::make_shared<fss_connection_client>(std::move(t_ca), std::move(t_private_key), std::move(t_public_key));
+    /* Before connectTo: the option is applied to the socket at connect time. */
+    conn->setTcpUserTimeoutMs(t_tcp_user_timeout_ms);
     if (!conn->connectTo(address, port))
     {
         return nullptr;

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -298,7 +298,7 @@ auto flight_safety_system::transport::fss_connection::connectTo(const std::strin
         return false;
     }
 
-    set_tcp_keepalive(current_fd);
+    set_tcp_keepalive(current_fd, this->getTcpUserTimeoutMs());
 
     this->startRecvThread(std::thread([this]() -> void { this->processMessages(); }));
 
@@ -606,7 +606,9 @@ void flight_safety_system::transport::fss_listen::processMessages()
         inet_ntop_stor(&sa, addr_str, INET6_ADDRSTRLEN, &client_port);
         std::cout << "New client from " << addr_str << ":" << client_port << " as " << newfd << std::endl;
 #endif
-        set_tcp_keepalive(newfd);
+        /* Server-accepted sockets always get the default bound; only a
+         * client's outbound connection can request a tighter one (todo/26). */
+        set_tcp_keepalive(newfd, flight_safety_system::transport::default_tcp_user_timeout_ms);
         if (this->cb == nullptr)
         {
             /* Thanks for your call, unfortunately we don't know how to deal with it */

--- a/src/transport.hpp
+++ b/src/transport.hpp
@@ -4,7 +4,11 @@
 #include <netinet/in.h>
 
 auto convert_str_to_sa(const std::string &addr, uint16_t port, struct sockaddr_storage *sa) -> bool;
-void set_tcp_keepalive(int fd);
+/* tcp_user_timeout_ms is the TCP_USER_TIMEOUT to apply (todo/26); pass
+ * flight_safety_system::transport::default_tcp_user_timeout_ms unless the
+ * connection requested its own bound. No default parameter on purpose —
+ * every call site states which bound it is applying. */
+void set_tcp_keepalive(int fd, unsigned int tcp_user_timeout_ms); // NOLINT(bugprone-easily-swappable-parameters)
 /* close()/shutdown() with EINTR retry and failure logging; context names the
  * call site in the log. shutdown treats ENOTCONN as success. */
 auto safe_close_fd(int fd, const char *context) -> int;

--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -351,6 +351,40 @@ TEST_CASE("client: JSON config with server entry parses name and creates reconne
     std::remove(tmppath);
 }
 
+TEST_CASE("client: JSON config tcp_user_timeout_ms sets the per-connection send bound (todo/26)")
+{
+    /* A flight-safety client (cap-fmu) requests a tighter TCP_USER_TIMEOUT
+     * than the 30 s default via its config; every server (re)connect reads
+     * it through getTcpUserTimeoutMs(). Absent, the default must hold. */
+    const char *tmppath = "/tmp/fss_test_client_send_timeout.json";
+
+    SECTION("configured value is exposed")
+    {
+        {
+            std::ofstream f(tmppath);
+            f << R"({"name":"test-asset","tcp_user_timeout_ms":5000,)"
+              << R"("ssl":{"ca_public_key":"ca.pem","client_private_key":"key.pem","client_public_key":"cert.pem"},)"
+              << R"("servers":[{"address":"127.0.0.1","port":9999}]})";
+        }
+        fss::client_ssl::fss_client client(tmppath);
+        REQUIRE(client.getTcpUserTimeoutMs() == 5000);
+    }
+
+    SECTION("absent field keeps the 30s default")
+    {
+        {
+            std::ofstream f(tmppath);
+            f << R"({"name":"test-asset",)"
+              << R"("ssl":{"ca_public_key":"ca.pem","client_private_key":"key.pem","client_public_key":"cert.pem"},)"
+              << R"("servers":[{"address":"127.0.0.1","port":9999}]})";
+        }
+        fss::client_ssl::fss_client client(tmppath);
+        REQUIRE(client.getTcpUserTimeoutMs() == fss::transport::default_tcp_user_timeout_ms);
+    }
+
+    std::remove(tmppath);
+}
+
 TEST_CASE("client: disconnect closes all active server connections")
 {
     /* connectTo with connect=true adds a server to the connected list.

--- a/tests/connection-ssl.cpp
+++ b/tests/connection-ssl.cpp
@@ -13,6 +13,9 @@
 #error No catch header
 #endif
 
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
 #include <unistd.h>
 
 #include "fss-transport-ssl.hpp"
@@ -88,6 +91,46 @@ TEST_CASE("SSL - Listen Socket")
     REQUIRE(msg == nullptr);
 
     client_handoff.reset();
+}
+
+namespace {
+/* Exposes the protected fd so the todo/26 test can pin the socket option the
+ * TLS connect path applied (the plain-TCP twin lives in connection.cpp). */
+class fd_visible_connection_client : public flight_safety_system::transport_ssl::fss_connection_client {
+public:
+    fd_visible_connection_client(std::string t_ca, std::string t_private_key, std::string t_public_key)
+        : fss_connection_client(std::move(t_ca), std::move(t_private_key), std::move(t_public_key))
+    {
+    }
+    auto testGetFd() -> int { return this->getFd(); }
+};
+} // namespace
+
+TEST_CASE("SSL - client connectTo applies the requested TCP_USER_TIMEOUT (todo/26)")
+{
+#ifdef TCP_USER_TIMEOUT
+    /* The TLS client connect path is the one a flight-safety client
+     * (cap-fmu) actually uses; pin that its socket gets the per-connection
+     * bound requested before connectTo(), through a full handshake. */
+    client_handoff.reset();
+    const uint16_t listen_port = fss_test::pick_port();
+    REQUIRE(listen_port != 0);
+    auto listen = std::make_shared<flight_safety_system::transport_ssl::fss_listen>(
+        listen_port, client_handoff.callback(), CA_PUBLIC_FILE, SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
+    REQUIRE(listen != nullptr);
+
+    auto conn = std::make_shared<fd_visible_connection_client>(CA_PUBLIC_FILE, CLIENT_PRIVATE_FILE, CLIENT_PUBLIC_FILE);
+    conn->setTcpUserTimeoutMs(7000);
+    REQUIRE(conn->connectTo("localhost", listen_port));
+
+    unsigned int val = 0;
+    socklen_t len = sizeof(val);
+    REQUIRE(::getsockopt(conn->testGetFd(), IPPROTO_TCP, TCP_USER_TIMEOUT, &val, &len) == 0);
+    REQUIRE(val == 7000);
+
+    REQUIRE(client_handoff.wait() != nullptr);
+    client_handoff.reset();
+#endif
 }
 
 TEST_CASE("SSL - Listen - Callback")

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -283,6 +283,12 @@ TEST_CASE("fss_connection: connectTo applies the connection's requested TCP_USER
         REQUIRE(conn->connectTo("127.0.0.1", listen_port));
         REQUIRE(::getsockopt(conn->testGetFd(), IPPROTO_TCP, TCP_USER_TIMEOUT, &val, &len) == 0);
         REQUIRE(val == flight_safety_system::transport::default_tcp_user_timeout_ms);
+        /* Join the recv thread connectTo() started before this derived test
+         * object is destroyed: destroying it mid-recv rewrites the vptr under
+         * the recv thread's virtual dispatch (TSan: race on vptr). Production
+         * code destroys connections only through the base class or after
+         * disconnect, so this is a test-shape hazard, not a library one. */
+        conn->disconnect();
     }
 
     SECTION("a tighter per-connection bound is honoured")
@@ -292,6 +298,7 @@ TEST_CASE("fss_connection: connectTo applies the connection's requested TCP_USER
         REQUIRE(conn->connectTo("127.0.0.1", listen_port));
         REQUIRE(::getsockopt(conn->testGetFd(), IPPROTO_TCP, TCP_USER_TIMEOUT, &val, &len) == 0);
         REQUIRE(val == 5000);
+        conn->disconnect(); /* same vptr-race avoidance as above */
     }
 
     client_handoff.reset();

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -233,11 +233,68 @@ TEST_CASE("set_tcp_keepalive bounds unacked data with TCP_USER_TIMEOUT")
     int sock = ::socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
     REQUIRE(sock >= 0);
     fss_test::scoped_fd guard(sock);
-    set_tcp_keepalive(sock);
     unsigned int val = 0;
     socklen_t len = sizeof(val);
-    REQUIRE(::getsockopt(sock, IPPROTO_TCP, TCP_USER_TIMEOUT, &val, &len) == 0);
-    REQUIRE(val == 30000);
+
+    SECTION("the default bound is 30s (pinned by literal on purpose)")
+    {
+        set_tcp_keepalive(sock, flight_safety_system::transport::default_tcp_user_timeout_ms);
+        REQUIRE(::getsockopt(sock, IPPROTO_TCP, TCP_USER_TIMEOUT, &val, &len) == 0);
+        REQUIRE(val == 30000);
+    }
+
+    SECTION("a caller-supplied bound is applied verbatim (todo/26)")
+    {
+        set_tcp_keepalive(sock, 5000);
+        REQUIRE(::getsockopt(sock, IPPROTO_TCP, TCP_USER_TIMEOUT, &val, &len) == 0);
+        REQUIRE(val == 5000);
+    }
+#endif
+}
+
+namespace {
+/* Exposes the protected fd so a test can pin the socket option a connect
+ * applied (todo/26); same pattern as fd_visible_listen below. */
+class fd_visible_connection : public flight_safety_system::transport::fss_connection {
+public:
+    auto testGetFd() -> int { return this->getFd(); }
+};
+} // namespace
+
+TEST_CASE("fss_connection: connectTo applies the connection's requested TCP_USER_TIMEOUT (todo/26)")
+{
+#ifdef TCP_USER_TIMEOUT
+    /* A flight-safety client must be able to pick a send bound tighter than
+     * the 30 s default (a wedged send worker recovers on its own clock, not
+     * the server's liveness clock). Pin that setTcpUserTimeoutMs() before
+     * connectTo() lands on the socket, and that a connection which never
+     * asked keeps the default. */
+    client_handoff.reset();
+    const uint16_t listen_port = fss_test::pick_port();
+    REQUIRE(listen_port != 0);
+    auto listen = std::make_shared<flight_safety_system::transport::fss_listen>(listen_port, client_handoff.callback());
+
+    unsigned int val = 0;
+    socklen_t len = sizeof(val);
+
+    SECTION("default: never asked, gets 30s")
+    {
+        auto conn = std::make_shared<fd_visible_connection>();
+        REQUIRE(conn->connectTo("127.0.0.1", listen_port));
+        REQUIRE(::getsockopt(conn->testGetFd(), IPPROTO_TCP, TCP_USER_TIMEOUT, &val, &len) == 0);
+        REQUIRE(val == flight_safety_system::transport::default_tcp_user_timeout_ms);
+    }
+
+    SECTION("a tighter per-connection bound is honoured")
+    {
+        auto conn = std::make_shared<fd_visible_connection>();
+        conn->setTcpUserTimeoutMs(5000);
+        REQUIRE(conn->connectTo("127.0.0.1", listen_port));
+        REQUIRE(::getsockopt(conn->testGetFd(), IPPROTO_TCP, TCP_USER_TIMEOUT, &val, &len) == 0);
+        REQUIRE(val == 5000);
+    }
+
+    client_handoff.reset();
 #endif
 }
 


### PR DESCRIPTION
## Description

A client's blocking send() into a half-dead peer was bounded only by the compile-time 30 s TCP_USER_TIMEOUT in set_tcp_keepalive(). 30 s is the right bound for the server (it matches the application-layer liveness timeout), but a flight-safety client like cap-fmu — whose dedicated FSS send worker can still wedge on a single in-flight send for the full 30 s — had no way to ask for anything tighter.

The knob, threaded through every layer a consumer might hold:
- fss_connection::setTcpUserTimeoutMs() (before connectTo), applied by both the plain-TCP and TLS connect paths;
- an optional trailing arg on fss_connection_client::create();
- fss_client: "tcp_user_timeout_ms" in the JSON config plus a protected programmatic setter, read by fss_server::reconnect_to() at every (re)connect so it also covers servers learned from a server-list update.

set_tcp_keepalive(fd, ms) takes the bound explicitly — no default parameter, so every call site states which bound it applies. The server accept path passes default_tcp_user_timeout_ms and is unchanged, as is the 30 s default everywhere a consumer doesn't ask.

The todo's option B (SO_SNDTIMEO) was deliberately not taken: a timed-out send() can return after a partial write, leaving a torn frame on a stream that is unrecoverable anyway — exactly the outcome TCP_USER_TIMEOUT delivers without breaking the blocking-socket invariant both sendMsg() loops rely on. On Linux TCP_USER_TIMEOUT also bounds the zero-window stall (peer ACKing probes but not reading), so SO_SNDTIMEO adds no coverage this lacks.

Tests: the existing 30 s pin gains a verbatim-application section; new plain-TCP and TLS tests pin that the requested bound lands on the connected socket (fd-exposing subclasses, full TLS handshake on the SSL path); config parsing covered for both present and absent field. The cap-fmu-side change (setting the field) is tracked in that repo.

## Summary by Sourcery

Add per-connection configuration of TCP_USER_TIMEOUT while preserving the existing 30s default, allowing flight-safety clients to tighten send stall bounds without affecting server-accepted sockets.

New Features:
- Allow fss_connection instances to request a custom TCP_USER_TIMEOUT value applied at connect time.
- Expose TCP_USER_TIMEOUT configuration to TLS clients via fss_connection_client::create with an optional timeout parameter.
- Add tcp_user_timeout_ms to the JSON config and programmatic API of fss_client so clients can set a global per-server send timeout bound.

Enhancements:
- Refine set_tcp_keepalive to take an explicit TCP_USER_TIMEOUT value, making timeout selection explicit at all call sites.
- Ensure server-side accept paths consistently apply the default TCP_USER_TIMEOUT rather than per-client overrides.

Documentation:
- Document the new configurable TCP_USER_TIMEOUT behavior and client JSON field in CHANGELOG.md.

Tests:
- Extend transport and SSL tests to verify that default and caller-specified TCP_USER_TIMEOUT values are applied to connected sockets.
- Add client configuration tests to confirm tcp_user_timeout_ms is parsed when present and defaults correctly when absent.