### PR TITLE
feat(transport): todo/49 optional server command id on asset_command

### DIFF
--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -44,10 +44,12 @@ static constexpr uint16_t FSS_PROTOCOL_MIN_VERSION = 1;
  * cannot force on a capability we do not implement: the AND with
  * FSS_SUPPORTED_FEATURES masks any bit we have not enabled. Each bit is added
  * to FSS_SUPPORTED_FEATURES only once this build actually implements it. */
-static constexpr uint32_t FSS_FEATURE_RTT_OFFSET = 0x1U;    /* todo/17 item 3 */
-static constexpr uint32_t FSS_FEATURE_COMMAND_ACK = 0x2U;   /* todo/17 item 1 */
-static constexpr uint32_t FSS_FEATURE_SYSTEM_HEALTH = 0x4U; /* todo/17 item 2 */
-static constexpr uint32_t FSS_SUPPORTED_FEATURES = FSS_FEATURE_RTT_OFFSET | FSS_FEATURE_COMMAND_ACK;
+static constexpr uint32_t FSS_FEATURE_RTT_OFFSET = 0x1U;        /* todo/17 item 3 */
+static constexpr uint32_t FSS_FEATURE_COMMAND_ACK = 0x2U;       /* todo/17 item 1 */
+static constexpr uint32_t FSS_FEATURE_SYSTEM_HEALTH = 0x4U;     /* todo/17 item 2 */
+static constexpr uint32_t FSS_FEATURE_SERVER_COMMAND_ID = 0x8U; /* todo/49 */
+static constexpr uint32_t FSS_SUPPORTED_FEATURES =
+    FSS_FEATURE_RTT_OFFSET | FSS_FEATURE_COMMAND_ACK | FSS_FEATURE_SERVER_COMMAND_ID;
 
 /* The capability set to adopt for a peer that advertised peer_flags: the
  * intersection with what this build implements, so a peer can never enable a
@@ -556,6 +558,28 @@ private:
     double longitude;
     uint32_t altitude;
     uint64_t timestamp;
+    /* The dispatching server's identifier for the operator action this command
+     * carries — its command DB row id (todo/49). Contract the receiver may
+     * rely on:
+     *   - Within one connection, this id identifies the operator action: the
+     *     same id means the same action (a redelivery — resend window,
+     *     reconnect identify, server bounce), a new id means a new operator
+     *     action, even when command/payload/timestamp are unchanged. This is
+     *     what lets a client on redundant servers tell a deliberate operator
+     *     retry (fresh id on every server) from another server's delivery of
+     *     the action it already has.
+     *   - Ids are unique PER SERVER only: each server assigns from its own DB
+     *     sequence, so one operator action arrives with a DIFFERENT id on each
+     *     connection, and ids must never be compared across connections.
+     *   - 0 means "not reported" — a legacy peer, or the
+     *     FSS_FEATURE_SERVER_COMMAND_ID capability was not negotiated. Carried
+     *     as an optional trailing wire field, omitted when 0, like
+     *     rtt_response's client_timestamp (todo/17 item 3).
+     * This is NOT the per-connection header id used for command-ack
+     * correlation (dispatch_id): that one is scoped to a single delivery and
+     * stable across resends of it; this one is scoped to the operator action
+     * and survives reconnects. */
+    uint64_t server_command_id{0};
 protected:
     void unpackData(const std::shared_ptr<buf_len> &bl);
     void packData(std::shared_ptr<buf_len> bl) override;
@@ -569,6 +593,11 @@ public:
     auto getLongitude() -> double override;
     auto getAltitude() -> uint32_t override;
     auto getTimeStamp() -> uint64_t override;
+    /* Stamped by the server at dispatch, only when the connection negotiated
+     * FSS_FEATURE_SERVER_COMMAND_ID; left 0 otherwise so the wire bytes stay
+     * identical to a legacy command. */
+    void setServerCommandId(uint64_t t_server_command_id) { this->server_command_id = t_server_command_id; }
+    virtual auto getServerCommandId() -> uint64_t;
 };
 
 class fss_message_smm_settings : public fss_message {

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -1032,6 +1032,14 @@ void flight_safety_system::transport::fss_message_asset_command::packData(std::s
     bl->addData(&lng, sizeof(int32_t));
     bl->addData(&alt, sizeof(uint32_t));
     bl->addData(&cmd, sizeof(uint8_t));
+    /* The server command id is an optional trailing field: omitting it when 0
+     * keeps the wire bytes identical to a legacy command, so a peer that never
+     * negotiated FSS_FEATURE_SERVER_COMMAND_ID is unaffected. */
+    if (this->server_command_id != 0)
+    {
+        uint64_t scid = fss_htobe64(this->server_command_id);
+        bl->addData(&scid, sizeof(uint64_t));
+    }
 }
 
 void flight_safety_system::transport::fss_message_asset_command::unpackData(const std::shared_ptr<buf_len> &bl)
@@ -1050,7 +1058,16 @@ void flight_safety_system::transport::fss_message_asset_command::unpackData(cons
     {
         this->command = decode_asset_command(cmd);
     }
+    /* Coordinates are assigned before the optional trailing read below: a
+     * failed optional read latches the reader not-ok, and assign_coordinates
+     * must judge "was the frame truncated" on the mandatory fields only —
+     * otherwise every legacy (id-less) GOTO would decode to NaN coordinates. */
     assign_coordinates(reader, lat, lng, this->latitude, this->longitude);
+    /* Optional trailing field; left at 0 when absent (legacy command). */
+    if (!reader.readUint64(this->server_command_id))
+    {
+        this->server_command_id = 0;
+    }
 }
 
 auto flight_safety_system::transport::fss_message_asset_command::getCommand() -> fss_asset_command
@@ -1072,6 +1089,10 @@ auto flight_safety_system::transport::fss_message_asset_command::getAltitude() -
 auto flight_safety_system::transport::fss_message_asset_command::getTimeStamp() -> uint64_t
 {
     return this->timestamp;
+}
+auto flight_safety_system::transport::fss_message_asset_command::getServerCommandId() -> uint64_t
+{
+    return this->server_command_id;
 }
 
 // NOLINTBEGIN(bugprone-easily-swappable-parameters)

--- a/tests/messages.cpp
+++ b/tests/messages.cpp
@@ -459,6 +459,91 @@ TEST_CASE("Asset Command Message Check - Altitude", "[TC-FSS-002]")
     REQUIRE(decoded_generic->getAltitude() == altitude);
 }
 
+TEST_CASE("Asset Command carries an optional server command id", "[TC-FSS-002]")
+{
+    auto msg_id = static_cast<uint64_t>(random());
+    auto timestamp = static_cast<uint64_t>(random());
+    constexpr uint64_t server_command_id = 0x1122334455667788ULL;
+
+    auto msg = std::make_shared<flight_safety_system::transport::fss_message_asset_command>(
+        flight_safety_system::transport::asset_command_rtl, timestamp);
+    /* Not stamped yet: defaults to "not reported". */
+    REQUIRE(msg->getServerCommandId() == 0);
+    msg->setServerCommandId(server_command_id);
+    REQUIRE(msg->getServerCommandId() == server_command_id);
+
+    msg->setId(msg_id);
+    auto bl = msg->getPacked();
+    REQUIRE(bl != nullptr);
+
+    auto decoded = std::make_shared<flight_safety_system::transport::fss_message_asset_command>(msg_id, bl);
+    REQUIRE(decoded->getCommand() == flight_safety_system::transport::asset_command_rtl);
+    REQUIRE(decoded->getTimeStamp() == timestamp);
+    REQUIRE(decoded->getServerCommandId() == server_command_id);
+
+    auto decoded_generic = std::dynamic_pointer_cast<flight_safety_system::transport::fss_message_asset_command>(
+        flight_safety_system::transport::fss_message::decode(bl));
+    REQUIRE(decoded_generic != nullptr);
+    REQUIRE(decoded_generic->getServerCommandId() == server_command_id);
+}
+
+TEST_CASE("Asset Command with position keeps its server command id", "[TC-FSS-002]")
+{
+    /* The goto variant is the one whose payload trails coordinates — pin that
+     * the optional trailing id and the coordinates do not corrupt each other. */
+    auto msg_id = static_cast<uint64_t>(random());
+    auto timestamp = static_cast<uint64_t>(random());
+    constexpr double goto_lat = -43.5;
+    constexpr double goto_lng = 172.0;
+    constexpr uint64_t server_command_id = 987654321ULL;
+
+    auto msg = std::make_shared<flight_safety_system::transport::fss_message_asset_command>(
+        flight_safety_system::transport::asset_command_goto, timestamp, goto_lat, goto_lng);
+    msg->setServerCommandId(server_command_id);
+    msg->setId(msg_id);
+    auto bl = msg->getPacked();
+    REQUIRE(bl != nullptr);
+
+    auto decoded = std::make_shared<flight_safety_system::transport::fss_message_asset_command>(msg_id, bl);
+    REQUIRE(decoded->getCommand() == flight_safety_system::transport::asset_command_goto);
+    REQUIRE(decoded->getLatitude() == goto_lat);
+    REQUIRE(decoded->getLongitude() == goto_lng);
+    REQUIRE(decoded->getServerCommandId() == server_command_id);
+}
+
+TEST_CASE("Asset Command without a server command id is byte-identical to a legacy command", "[TC-FSS-002]")
+{
+    /* Backward compatibility: a command whose server command id is 0 (not
+     * reported) must pack to exactly the same bytes as before the optional
+     * field existed — no trailing 8 bytes — so a legacy peer sees an
+     * unchanged wire format, and a legacy frame decodes with the id at 0. */
+    auto timestamp = static_cast<uint64_t>(random());
+    auto without = std::make_shared<flight_safety_system::transport::fss_message_asset_command>(
+        flight_safety_system::transport::asset_command_rtl, timestamp);
+    auto with_zero = std::make_shared<flight_safety_system::transport::fss_message_asset_command>(
+        flight_safety_system::transport::asset_command_rtl, timestamp);
+    with_zero->setServerCommandId(0);
+    without->setId(7);
+    with_zero->setId(7);
+    auto bl_without = without->getPacked();
+    auto bl_with_zero = with_zero->getPacked();
+    REQUIRE(bl_without->getLength() == bl_with_zero->getLength());
+    REQUIRE(std::string(bl_without->getData(), bl_without->getLength()) ==
+            std::string(bl_with_zero->getData(), bl_with_zero->getLength()));
+
+    /* A legacy frame (packed without the field) decodes to "not reported". */
+    auto decoded = std::make_shared<flight_safety_system::transport::fss_message_asset_command>(7, bl_without);
+    REQUIRE(decoded->getServerCommandId() == 0);
+
+    /* And a command that does report an id is exactly 8 bytes longer. */
+    auto with_id = std::make_shared<flight_safety_system::transport::fss_message_asset_command>(
+        flight_safety_system::transport::asset_command_rtl, timestamp);
+    with_id->setServerCommandId(42);
+    with_id->setId(7);
+    auto bl_with_id = with_id->getPacked();
+    REQUIRE(bl_with_id->getLength() == bl_without->getLength() + sizeof(uint64_t));
+}
+
 TEST_CASE("Command Ack Message Check - Actioned")
 {
     auto msg_id = static_cast<uint64_t>(random());


### PR DESCRIPTION
## Description

Give the FMU a way to tell a deliberate operator retry apart from a redundant cross-server delivery: fss_message_asset_command gains an optional trailing server_command_id (the dispatching server's command DB row id), gated by the new FSS_FEATURE_SERVER_COMMAND_ID capability. Omitted when 0, so the wire bytes stay identical to a legacy command; a legacy frame decodes with the id at 0 ("not reported").

The id is unique per SERVER, not across servers: each server assigns from its own DB sequence, so one operator action arrives with a different id on every connection and ids must never be compared across connections. Within one connection, same id = same action (redelivery), new id = new operator action — a retry inserts a new row in every server's DB, so it shows up as a fresh id everywhere, which is the property cap-fmu's CommandAckGroup needs (their todo/86).

Coordinates are assigned before the optional trailing read: a failed optional read latches the BufferReader not-ok, and assign_coordinates must judge truncation on the mandatory fields only — otherwise every legacy GOTO would decode to NaN coordinates.

## Summary by Sourcery

Add an optional server command identifier to asset command messages while preserving backward-compatible wire format and capability negotiation.

New Features:
- Introduce FSS_FEATURE_SERVER_COMMAND_ID capability flag to advertise support for server command identifiers on asset commands.
- Extend asset command messages with a server-scoped server_command_id field that can be stamped and read by peers when negotiated.

Enhancements:
- Ensure asset command packing/unpacking treats the server command id as an optional trailing field that does not affect coordinates decoding or legacy peers.
- Update asset command tests to cover server command id behavior, including coordinate payloads and backward-compatible framing.