### PR TITLE
feat(server): todo/49 stamp the command DB row id on dispatched commands

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -512,6 +512,17 @@ void fss::server::fss_client::sendCommand()
                 msg = std::make_shared<fss::transport::fss_message_asset_command>(command, ac->getTimeStamp());
                 break;
         }
+        /* Stamp this server's identity for the operator action — the command
+         * DB row id (todo/49) — only when the peer negotiated the capability;
+         * otherwise the trailing field is not part of the agreed dialect and
+         * the message keeps its legacy wire form. getConnection() only takes
+         * its own leaf conn_lock, so holding client_lock here is safe. */
+        auto command_conn = this->getConnection();
+        if (command_conn != nullptr &&
+            (command_conn->getNegotiatedFeatureFlags() & fss::transport::FSS_FEATURE_SERVER_COMMAND_ID) != 0)
+        {
+            msg->setServerCommandId(dbid);
+        }
         /* Claim the resend window now, atomically with the check above, not
          * after the send returns: the recv thread can also call sendCommand()
          * directly (identify handling) while this outbound-worker call is

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -612,6 +612,49 @@ TEST_CASE("session: a successful command send records exactly one dispatch and s
     REQUIRE(mock.getDispatches().front().command_dbid == 88);
 }
 
+TEST_CASE("session: dispatched command carries the server command id only when negotiated (todo/49)")
+{
+    /* The dispatched wire message identifies the operator action by this
+     * server's command DB row id — but only as part of the negotiated dialect
+     * (FSS_FEATURE_SERVER_COMMAND_ID); a legacy peer gets the unchanged wire
+     * form with the id unreported (0). */
+    fss_test::MockDatabase mock;
+    constexpr uint64_t asset_id = 13;
+    mock.asset_ids["craft"] = asset_id;
+    constexpr uint64_t command_dbid = 91;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+    auto clock = std::make_shared<FakeClock>();
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->setClock(clock);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    SECTION("negotiated: the id rides the message")
+    {
+        conn->setNegotiatedFeatureFlags(fss::transport::FSS_FEATURE_SERVER_COMMAND_ID);
+        session->setPendingCommand(
+            std::make_shared<fss::server::asset_command>(command_dbid, /*ts*/ 500, "RTL", 0.0, 0.0, 0));
+        session->sendCommand();
+        auto cmd = find_sent<fss::transport::fss_message_asset_command>(conn->sent);
+        REQUIRE(cmd != nullptr);
+        REQUIRE(cmd->getServerCommandId() == command_dbid);
+    }
+
+    SECTION("not negotiated: the id stays unreported")
+    {
+        session->setPendingCommand(
+            std::make_shared<fss::server::asset_command>(command_dbid, /*ts*/ 500, "RTL", 0.0, 0.0, 0));
+        session->sendCommand();
+        auto cmd = find_sent<fss::transport::fss_message_asset_command>(conn->sent);
+        REQUIRE(cmd != nullptr);
+        REQUIRE(cmd->getServerCommandId() == 0);
+    }
+}
+
 TEST_CASE("session: queueCommandSend dispatches a command on the outbound worker thread")
 {
     /* todo/21: the server main loop schedules a command via queueCommandSend()


### PR DESCRIPTION
## Description

sendCommand() sets the new server_command_id wire field to the command row's dbid — the value it already keys the resend window and dispatch recording on — when the connection negotiated
FSS_FEATURE_SERVER_COMMAND_ID; a legacy peer keeps the unchanged wire form. The stamp happens under client_lock where dbid is read; getConnection() only takes its own leaf conn_lock, so no lock-order edge is added.

Session tests pin both dialects: negotiated delivers id == dbid, unnegotiated delivers 0 (unreported).

## Summary by Sourcery

Stamp dispatched commands with the server command DB row id when the server-command-id feature is negotiated, and validate both negotiated and legacy behaviors in session tests.

New Features:
- Include the server command DB row id in dispatched asset command messages when the peer negotiates the server-command-id capability.

Tests:
- Add session tests to verify that negotiated peers receive the stamped server command id while non-negotiated peers see the id as unreported (0).