### PR TITLE
test(e2e): todo/49 pin server-command-id delivery, retry, and redelivery

### DIFF
--- a/e2e/test_command_identity.py
+++ b/e2e/test_command_identity.py
@@ -1,0 +1,80 @@
+"""e2e: dispatched commands carry the server's command row id (todo/49).
+
+fss_message_asset_command gains an optional server_command_id, negotiated
+via FSS_FEATURE_SERVER_COMMAND_ID: the dispatching server's DB row id for
+the operator action. Within one connection the id identifies the action --
+a redelivery reuses it (pinned across a server bounce in
+test_server_restart), while a deliberate operator retry (a NEW row with
+identical command/payload) arrives with a fresh id. That per-server
+identity is what lets an FMU connected to redundant servers (cap-fmu
+todo/86) tell a genuine retry apart from another server's delivery of the
+same push. Ids are unique per server only and must never be compared
+across connections.
+"""
+from __future__ import annotations
+
+import re
+import time
+from pathlib import Path
+
+import pytest
+
+CMD_ID_RE = re.compile(r"RCVD_CMD: RTL cmd_id=(\d+)")
+
+
+def _delivered_ids(log_path: Path) -> list[int]:
+    return [int(m) for m in CMD_ID_RE.findall(log_path.read_text(errors="replace"))]
+
+
+def _wait_for_id(log_path: Path, expected_id: int, timeout: float = 15.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if expected_id in _delivered_ids(log_path):
+            return True
+        time.sleep(0.1)
+    return False
+
+
+@pytest.mark.requires_docker
+def test_command_id_matches_row_and_retry_gets_fresh_id(db_conn, fake_client, server_proc):
+    """The wire id equals the inserted row's id, and an operator retry --
+    a second row identical in command and payload -- is delivered with the
+    new row's id, not swallowed as a duplicate of the first."""
+    with db_conn.cursor() as cur:
+        cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
+        asset_id = cur.fetchone()[0]
+
+    client = fake_client("test1")
+    log = client["log"]
+
+    def insert_rtl() -> int:
+        with db_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO assets_assetcommand (asset_id, command, position, altitude) "
+                "VALUES (%s, 'RTL', ST_SetSRID(ST_MakePoint(0, 0), 4326)::geography, 0) "
+                "RETURNING id",
+                (asset_id,),
+            )
+            return cur.fetchone()[0]
+
+    first_id = insert_rtl()
+    assert _wait_for_id(log, first_id), (
+        f"command row {first_id} was not delivered with its own id as cmd_id\n"
+        + log.read_text(errors="replace")
+    )
+
+    # The retry: a new row, byte-identical command/payload/altitude. Only the
+    # row id (and its DB timestamp) differ -- exactly the delivery cap-fmu's
+    # dedup window used to swallow. It must arrive under the fresh id.
+    second_id = insert_rtl()
+    assert second_id != first_id
+    assert _wait_for_id(log, second_id), (
+        f"identical-payload retry row {second_id} was not delivered with a fresh cmd_id "
+        f"(first row was {first_id})\n" + log.read_text(errors="replace")
+    )
+
+    # Every delivery carried a real id from the rows we created: never 0
+    # (unreported -- both binaries are this build, so the capability is
+    # always negotiated) and never a value we did not insert.
+    ids = _delivered_ids(log)
+    assert set(ids) <= {first_id, second_id}, f"unexpected cmd_id values delivered: {ids}"

--- a/e2e/test_server_restart.py
+++ b/e2e/test_server_restart.py
@@ -5,6 +5,7 @@ ack bookkeeping settles rather than getting stuck."""
 from __future__ import annotations
 
 import os
+import re
 import signal
 import socket
 import subprocess
@@ -250,6 +251,19 @@ def test_client_reconnects_after_server_bounce(
         assert redelivered, (
             "command was not redelivered after reconnect\n"
             + client_log.read_text(errors="replace")
+        )
+        # todo/49: a redelivery is the SAME operator action, so every RTL
+        # delivery -- pre-bounce and redelivered -- carried this one row's id
+        # as its server command id (a fresh id would falsely signal a new
+        # operator action to an FMU deduping on it).
+        delivered_cmd_ids = {
+            int(m) for m in re.findall(
+                r"RCVD_CMD: RTL cmd_id=(\d+)", client_log.read_text(errors="replace"),
+            )
+        }
+        assert delivered_cmd_ids == {command_dbid}, (
+            f"redelivery changed (or dropped) the server command id: "
+            f"expected only {command_dbid}, saw {sorted(delivered_cmd_ids)}"
         )
         with conn.cursor() as cur:
             cur.execute(

--- a/examples/fake_client.cpp
+++ b/examples/fake_client.cpp
@@ -62,7 +62,11 @@ public:
     void handleCommandFrom(const std::shared_ptr<fss::transport::fss_message_asset_command> &msg,
                            fss::client_ssl::fss_server *origin) override
     {
-        std::cout << "RCVD_CMD: " << commandName(msg->getCommand()) << std::endl;
+        /* cmd_id is this server's DB row id for the operator action (todo/49);
+         * 0 = unreported (capability not negotiated). e2e asserts it matches
+         * the inserted row and that an identical-payload retry gets a new id. */
+        std::cout << "RCVD_CMD: " << commandName(msg->getCommand()) << " cmd_id=" << msg->getServerCommandId()
+                  << std::endl;
         /* When the server negotiated command-ack, reply on the originating
          * connection with the two-phase ack (received, then actioned) so the
          * server's routing+storage path is exercised end to end. A real FMU


### PR DESCRIPTION
## Description

fake_client's RCVD_CMD line gains cmd_id= (existing matchers are substring checks on the prefix, all still pass). New test_command_identity.py drives the property the field exists for: the delivered id equals the inserted command row's id, and an operator retry -- a second row identical in command/payload -- arrives under the new row's fresh id instead of being indistinguishable from a redelivery. test_server_restart's todo/32 redelivery check now also asserts the bounce redelivery reuses the SAME id (same action), never a fresh one.

## Summary by Sourcery

Validate server command identity for dispatched RTL commands, ensuring redeliveries reuse the original command row id while operator retries receive a fresh id.

New Features:
- Expose server command row id on the wire via fake_client logging, including cmd_id in RCVD_CMD output.
- Add an end-to-end test that asserts delivered RTL commands carry the originating DB row id and that identical-payload retries are delivered under a new id.

Bug Fixes:
- Prevent operator retries with identical command and payload from being indistinguishable from redeliveries by enforcing distinct server command ids.

Enhancements:
- Extend the server restart e2e test to verify that redelivered RTL commands after a bounce retain the same server command id instead of getting a new one.

Tests:
- Introduce test_command_identity e2e coverage for server command id delivery, retry behavior, and constraints on delivered cmd_id values.