### PR TITLE
build: todo/61 bump library sonames to .so.3 for the 1.1.x-era ABI breaks

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,8 +21,8 @@ lib_LTLIBRARIES = libfss.la libfss-transport.la
 include_HEADERS = fss.hpp fss-log.hpp
 pkgconfig_DATA = fss.pc
 
-libfss_la_LDFLAGS = -version-info 2:0:0
-libfss_transport_la_LDFLAGS = -version-info 2:0:0
+libfss_la_LDFLAGS = -version-info 3:0:0
+libfss_transport_la_LDFLAGS = -version-info 3:0:0
 
 libfss_la_SOURCES = fss-main.cpp fss.hpp
 
@@ -32,7 +32,7 @@ libfss_transport_la_SOURCES = transport.cpp transport-helpers.cpp transport-mess
 libfss_transport_la_LIBADD = $(pthread_LIBS)
 
 lib_LTLIBRARIES += libfss-transport-ssl.la
-libfss_transport_ssl_la_LDFLAGS = -version-info 2:0:0
+libfss_transport_ssl_la_LDFLAGS = -version-info 3:0:0
 libfss_transport_ssl_la_SOURCES = transport-ssl.cpp
 libfss_transport_ssl_la_CXXFLAGS = $(AM_CXXFLAGS) $(GNUTLS_CFLAGS)
 libfss_transport_ssl_la_LIBADD = $(GNUTLS_LIBS) -L. libfss-transport.la
@@ -40,7 +40,7 @@ include_HEADERS += fss-transport-ssl.hpp
 pkgconfig_DATA += fss-transport-ssl.pc
 
 lib_LTLIBRARIES += libfss-client-ssl.la
-libfss_client_ssl_la_LDFLAGS = -version-info 2:0:0
+libfss_client_ssl_la_LDFLAGS = -version-info 3:0:0
 libfss_client_ssl_la_SOURCES = client-ssl.cpp
 libfss_client_ssl_la_CXXFLAGS = $(AM_CXXFLAGS) $(JSONCPP_CFLAGS)
 libfss_client_ssl_la_LIBADD = $(GNUTLS_LIBS) $(JSONCPP_LIBS) -L. libfss.la libfss-transport.la libfss-transport-ssl.la


### PR DESCRIPTION
## Description

All four libs move -version-info 2:0:0 -> 3:0:0. Since the 1.1.x line the installed fss-transport.hpp changed object layout (fss_connection gained tcp_user_timeout_ms, todo/26) and vtable shape (fss_message_asset_command gained getServerCommandId(), todo/49), and fss-client-ssl.hpp grew members too. A same-soname mix of old library and new header (or vice versa) would silently corrupt derived-class layouts across the library boundary rather than fail to link, so the soname must move before 1.2.0 ships. The debian libfss*.install globs wildcard the version suffix, so they need no change.

## Summary by Sourcery

Build:
- Update libfss, libfss-transport, libfss-transport-ssl, and libfss-client-ssl libtool version-info from 2:0:0 to 3:0:0.