### PR TITLE
refactor: todo/58 one shared JSON TCP-port validator

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -41,7 +41,7 @@ pkgconfig_DATA += fss-transport-ssl.pc
 
 lib_LTLIBRARIES += libfss-client-ssl.la
 libfss_client_ssl_la_LDFLAGS = -version-info 3:0:0
-libfss_client_ssl_la_SOURCES = client-ssl.cpp
+libfss_client_ssl_la_SOURCES = client-ssl.cpp json-config.hpp
 libfss_client_ssl_la_CXXFLAGS = $(AM_CXXFLAGS) $(JSONCPP_CFLAGS)
 libfss_client_ssl_la_LIBADD = $(GNUTLS_LIBS) $(JSONCPP_LIBS) -L. libfss.la libfss-transport.la libfss-transport-ssl.la
 include_HEADERS += fss-client-ssl.hpp
@@ -58,7 +58,7 @@ CLEANFILES = server-db.c
 if SERVER
 sbin_PROGRAMS += fss-server
 
-fss_server_SOURCES = server.cpp client_session.cpp fss-server.hpp rate-limiter.hpp server-clients.hpp server-failsafe.hpp db.cpp server-db.pgc server-db.h db-write-queue.cpp db-write-queue.hpp
+fss_server_SOURCES = server.cpp client_session.cpp fss-server.hpp rate-limiter.hpp server-clients.hpp server-failsafe.hpp json-config.hpp db.cpp server-db.pgc server-db.h db-write-queue.cpp db-write-queue.hpp
 fss_server_CXXFLAGS = $(AM_CXXFLAGS) $(JSONCPP_CFLAGS)
 fss_server_CFLAGS = $(AM_CFLAGS) $(ECPG_CFLAGS)
 fss_server_LDADD = libfss.la libfss-transport.la $(JSONCPP_LIBS) $(ECPG_LIBS)

--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -1,5 +1,6 @@
 #include <fss-client-ssl.hpp>
 #include "fss-log.hpp"
+#include "json-config.hpp"
 
 #include <algorithm>
 #include <iostream>
@@ -11,30 +12,6 @@
 #pragma GCC diagnostic ignored "-Weffc++"
 #include <json/json.h>
 #pragma GCC diagnostic pop
-
-namespace {
-
-constexpr int min_tcp_port = 1;
-constexpr int max_tcp_port = 65535;
-
-auto read_server_port(const Json::Value &server, unsigned int idx, uint16_t &out) -> bool
-{
-    if (!server.isMember("port") || !server["port"].isInt())
-    {
-        FSS_LOG_ERROR("client", "Invalid server config at index " << idx << ": port must be an integer TCP port");
-        return false;
-    }
-    int port = server["port"].asInt();
-    if (port < min_tcp_port || port > max_tcp_port)
-    {
-        FSS_LOG_ERROR("client", "Invalid server config at index " << idx << ": port " << port << " is outside 1-65535");
-        return false;
-    }
-    out = static_cast<uint16_t>(port);
-    return true;
-}
-
-} // namespace
 
 flight_safety_system::client_ssl::fss_client::fss_client(const std::string &t_fileName)
 {
@@ -76,7 +53,8 @@ flight_safety_system::client_ssl::fss_client::fss_client(const std::string &t_fi
         for (unsigned int idx = 0; idx < config["servers"].size(); idx++)
         {
             uint16_t port = 0;
-            if (!read_server_port(config["servers"][idx], idx, port))
+            if (!read_json_tcp_port(config["servers"][idx]["port"], "client",
+                                    "server config at index " + std::to_string(idx), port))
             {
                 continue;
             }

--- a/src/json-config.hpp
+++ b/src/json-config.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+/* Internal helper, not installed (like transport.hpp): a jsoncpp dependency in
+ * an installed header would leak into the public API surface, and the .pc
+ * files deliberately don't require jsoncpp for transport consumers. */
+
+#include <cstdint>
+#include <string>
+
+#include "fss-log.hpp"
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weffc++"
+#include <json/json.h>
+#pragma GCC diagnostic pop
+
+/* Shared TCP-port validator for a jsoncpp config node (todo/58): server.cpp's
+ * `port`/`postgres.port` and client-ssl.cpp's per-server `servers[].port` used
+ * to each carry their own copy of this isInt()/range check. `what` names the
+ * field for the log message (e.g. "config field port" or "server config at
+ * index 3"), so each call site keeps its own informative, distinct wording;
+ * `component` is the FSS_LOG tag ("server"/"client") so log lines still read
+ * as coming from the caller's subsystem. A missing member reaches here as
+ * jsoncpp's null Json::Value (operator[] on a non-existent key), whose
+ * isInt() is false, so the caller's missing-field path (log + skip/fail) is
+ * unaffected without needing its own isMember() check. */
+inline auto read_json_tcp_port(const Json::Value &node, const char *component, const std::string &what, uint16_t &out)
+    -> bool
+{
+    constexpr int min_tcp_port = 1;
+    constexpr int max_tcp_port = 65535;
+    if (!node.isInt())
+    {
+        FSS_LOG_ERROR(component, "Invalid " << what << ": must be an integer TCP port");
+        return false;
+    }
+    int port = node.asInt();
+    if (port < min_tcp_port || port > max_tcp_port)
+    {
+        FSS_LOG_ERROR(component, "Invalid " << what << ": " << port << " is outside 1-65535");
+        return false;
+    }
+    out = static_cast<uint16_t>(port);
+    return true;
+}

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -5,6 +5,7 @@
 #include "fss-server.hpp"
 #include "server-clients.hpp"
 #include "server-failsafe.hpp"
+#include "json-config.hpp"
 
 #include <algorithm>
 #include <chrono>
@@ -29,30 +30,6 @@ namespace flight_safety_system::server {
  * of the active server list can reuse the helper. */
 auto build_server_list_msg(IDatabase *dbc) -> std::shared_ptr<transport::fss_message_server_list>;
 } // namespace flight_safety_system::server
-
-namespace {
-
-constexpr int min_tcp_port = 1;
-constexpr int max_tcp_port = 65535;
-
-auto read_tcp_port(const Json::Value &node, const char *path, int &out) -> bool
-{
-    if (!node.isInt())
-    {
-        FSS_LOG_ERROR("server", "Invalid config field " << path << ": must be an integer TCP port");
-        return false;
-    }
-    int port = node.asInt();
-    if (port < min_tcp_port || port > max_tcp_port)
-    {
-        FSS_LOG_ERROR("server", "Invalid config field " << path << ": " << port << " is outside 1-65535");
-        return false;
-    }
-    out = port;
-    return true;
-}
-
-} // namespace
 
 volatile sig_atomic_t running = 1;
 volatile sig_atomic_t reload_crl = 0;
@@ -186,16 +163,20 @@ auto main(int argc, char *argv[]) -> int
             return 1;
         }
 
-        if (!read_tcp_port(config["port"], "port", listen_port))
+        uint16_t listen_port_u16 = 0;
+        if (!read_json_tcp_port(config["port"], "server", "config field port", listen_port_u16))
         {
             return 1;
         }
+        listen_port = listen_port_u16;
         if (config["postgres"].isMember("port"))
         {
-            if (!read_tcp_port(config["postgres"]["port"], "postgres.port", pg_port))
+            uint16_t pg_port_u16 = 0;
+            if (!read_json_tcp_port(config["postgres"]["port"], "server", "config field postgres.port", pg_port_u16))
             {
                 return 1;
             }
+            pg_port = pg_port_u16;
         }
         pg_host = config["postgres"]["host"].asString();
         pg_user = config["postgres"]["user"].asString();


### PR DESCRIPTION
## Description

server.cpp's read_tcp_port and client-ssl.cpp's read_server_port were the same isInt()/range check twice, each in its own anonymous namespace -- drift-in-waiting for a fix that only reaches one copy. Both call sites now use read_json_tcp_port() in the new internal json-config.hpp (not installed, like transport.hpp: a jsoncpp dependency in an installed header would leak into the public API surface). The caller supplies the log tag and the field description, so both sites keep their own informative wording; the client's missing-port-member path still logs and skips, since a missing key reaches the helper as jsoncpp's null value whose isInt() is false.

## Summary by Sourcery

Introduce a shared internal helper for validating TCP port values in JSON configuration and update server and client code to use it.

Enhancements:
- Deduplicate TCP port validation logic for JSON-based configuration into a shared internal json-config.hpp helper used by both server and SSL client components.

Build:
- Include json-config.hpp in the server and client-ssl build targets so the shared JSON configuration helper is compiled.