### PR TITLE
fix(server): todo/50 guard zero-valued timeout and rate-limit config

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -190,9 +190,31 @@ auto main(int argc, char *argv[]) -> int
         {
             client_timeout_sec = config["client_timeout"].asUInt64();
         }
+        if (client_timeout_sec == 0)
+        {
+            /* isTimedOut() severs an identified client
+             * client_timeout_ms after its last RTT response; 0 makes that
+             * deadline expire one tick after identify, so checkTimeouts() severs
+             * every identified aircraft on every 1 s sweep -- a fleet-wide
+             * disconnect/reconnect loop. */
+            FSS_LOG_WARN("server", "client_timeout must be > 0 (0 disconnects every identified client almost "
+                                   "immediately); using default "
+                                       << default_client_timeout_sec);
+            client_timeout_sec = default_client_timeout_sec;
+        }
         if (config.isMember("identify_timeout"))
         {
             identify_timeout_sec = config["identify_timeout"].asUInt64();
+        }
+        if (identify_timeout_sec == 0)
+        {
+            /* isTimedOut() prunes an unidentified client identify_timeout_ms
+             * after activation; 0 prunes it before it can ever complete the
+             * identify handshake, so no client can ever connect. */
+            FSS_LOG_WARN("server",
+                         "identify_timeout must be > 0 (0 prunes every client before it can identify); using default "
+                             << default_identify_timeout_sec);
+            identify_timeout_sec = default_identify_timeout_sec;
         }
         if (config.isMember("position_staleness_ms"))
         {
@@ -202,9 +224,34 @@ auto main(int argc, char *argv[]) -> int
         {
             rate_capacity = config["message_rate_capacity"].asUInt64();
         }
+        if (rate_capacity == 0)
+        {
+            /* rate_limiter's token bucket saturates at max_tokens == 0
+             * (rate-limiter.hpp), so it can never grant a token -- every
+             * rate-limited message from every client is dropped forever. This is
+             * silent at the liveness layer: rtt_response is exempt from rate
+             * limiting (todo/37), so the aircraft still looks healthily
+             * connected while zero positions/status/search reports get through. */
+            FSS_LOG_WARN("server", "message_rate_capacity must be > 0 (0 drops every rate-limited message forever); "
+                                   "using default "
+                                       << default_rate_capacity);
+            rate_capacity = default_rate_capacity;
+        }
         if (config.isMember("message_rate_refill"))
         {
             rate_refill = config["message_rate_refill"].asUInt64();
+        }
+        if (rate_refill == 0)
+        {
+            /* The refill_per_s > 0 branch in rate_limiter::consume() never runs
+             * (rate-limiter.hpp), so once the initial bucket drains, all
+             * rate-limited traffic is dropped forever -- the same silent hazard
+             * as message_rate_capacity == 0, just delayed until the burst
+             * capacity is used up. */
+            FSS_LOG_WARN("server", "message_rate_refill must be > 0 (0 permanently drains the rate-limit bucket "
+                                   "once it empties); using default "
+                                       << default_rate_refill_per_s);
+            rate_refill = default_rate_refill_per_s;
         }
         if (config.isMember("duplicate_identity_policy"))
         {

--- a/tests/rate_limiter_test.cpp
+++ b/tests/rate_limiter_test.cpp
@@ -124,6 +124,30 @@ TEST_CASE("rate_limiter: refill rate above 1000/s does not stall the clock")
     REQUIRE(!rl.consume(2));
 }
 
+TEST_CASE("rate_limiter: zero capacity never grants a token (todo/50)")
+{
+    // Pins the config-validation hazard todo/50 guards against:
+    // message_rate_capacity == 0 means max_tokens == 0, so tokens saturates
+    // at 0 and consume() can never succeed, no matter how much time passes.
+    fss::rate_limiter rl(0, 5);
+    REQUIRE(!rl.consume(0));
+    REQUIRE(!rl.consume(1000));
+    REQUIRE(!rl.consume(1000000000));
+}
+
+TEST_CASE("rate_limiter: zero refill grants exactly the initial capacity, then never again (todo/50)")
+{
+    // Pins the other half of the todo/50 hazard: message_rate_refill == 0
+    // means the refill_per_s > 0 branch never runs, so the bucket drains once
+    // and stays empty forever, even after a very long elapsed time.
+    fss::rate_limiter rl(3, 0);
+    REQUIRE(rl.consume(0));
+    REQUIRE(rl.consume(0));
+    REQUIRE(rl.consume(0));
+    REQUIRE(!rl.consume(0));
+    REQUIRE(!rl.consume(1000000000));
+}
+
 TEST_CASE("rate_limiter: huge elapsed at a high refill rate does not overflow")
 {
     // elapsed * refill_per_s is computed in uint64_t. With refill_per_s = 2^32


### PR DESCRIPTION
## Description

client_timeout, identify_timeout, message_rate_capacity and message_rate_refill accepted 0, and each 0 is operationally destructive: zero timeouts sever/prune every client on the next 1s sweep, and a zero rate-limit capacity (or refill, once the bucket drains) drops every rate-limited message forever -- silently at the liveness layer, because rtt_response is exempt from rate limiting (todo/37), so aircraft still look healthily connected while no telemetry gets through. Each field now warns and substitutes its default, the same pattern the tls_handshake_timeout_ms and max_concurrent_handshakes guards already use. New rate_limiter unit tests pin both zero-value hazards the guards protect against.

## Summary by Sourcery

Guard server timeout and rate-limit configuration against zero values that would break client connectivity and message flow, and add tests to pin the rate limiter’s behavior in these edge cases.

Bug Fixes:
- Prevent zero-valued client and identify timeouts from immediately disconnecting or permanently blocking client connections by falling back to default values.
- Prevent zero-valued rate-limit capacity and refill settings from dropping all rate-limited messages indefinitely by substituting safe defaults.

Tests:
- Add unit tests verifying that a zero-capacity rate limiter never grants tokens and a zero-refill rate limiter only allows the initial burst before permanently exhausting tokens.