### PR TITLE
fix(server): todo/53 null-safe send in sendRTTRequest

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -637,7 +637,12 @@ void fss::server::fss_client::sendRTTRequest(const std::shared_ptr<fss::transpor
      * sendMsg, under its own send_lock, before the blocking write), so the
      * real id is not known until the call returns. The entry is therefore
      * pushed immediately after a successful send (todo/22: only a request
-     * that actually went out is tracked), not before it. */
+     * that actually went out is tracked), not before it.
+     *
+     * todo/53: the send below now goes through the null-safe base-class
+     * sendMsg(), like sendCommand() and sendSMMSettings() — a connection
+     * cleared by a concurrent teardown reads as a failed send (handled below
+     * by reaping via clientDisconnected) instead of a null-pointer crash. */
     bool timed_out = false;
     {
         std::scoped_lock guard(this->client_lock);
@@ -660,7 +665,7 @@ void fss::server::fss_client::sendRTTRequest(const std::shared_ptr<fss::transpor
         return;
     }
     uint64_t now = this->clock->now_ms();
-    if (!this->getConnection()->sendMsg(rtt_req))
+    if (!this->sendMsg(rtt_req))
     {
         /* The socket write failed, so the connection is broken. Reap the client
          * now rather than waiting out the liveness timeout against a peer that

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -2618,6 +2618,34 @@ TEST_CASE("session: a failed RTT send creates no outstanding request and is not 
     REQUIRE(conn->send_attempts.size() == attempts_before + 2);
 }
 
+TEST_CASE("session: sendRTTRequest on a cleared connection reaps via the handler instead of crashing (todo/53)")
+{
+    /* todo/53: sendRTTRequest() used to dereference getConnection() with no
+     * null guard, unlike its siblings sendCommand()/sendSMMSettings(). It was
+     * safe only because production calls it exclusively from the outbound
+     * worker, which never observes a null connection. Pin the fix directly:
+     * clear the connection (disconnect() already run, as a concurrent
+     * teardown would leave it) and confirm the call is a harmless failed-send
+     * that reaps the client through the handler, not a null-pointer crash. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    session->disconnect();             // clears the connection out from under sendRTTRequest below
+    REQUIRE(handler.disconnects == 0); // baseline: disconnect() itself does not call clientDisconnected
+
+    auto rtt_req = std::make_shared<fss::transport::fss_message_rtt_request>();
+    session->sendRTTRequest(rtt_req); // must not crash
+
+    REQUIRE(handler.disconnects > 0);
+}
+
 TEST_CASE("asset_command: altitude above uint16_t max survives pack/decode round-trip")
 {
     /* Regression: altitude was stored as uint16_t, silently truncating any


### PR DESCRIPTION
## Description

sendRTTRequest() was the one per-client send path still dereferencing getConnection() unguarded. It could not crash in the current call graph -- production only calls it from the outbound worker, which fss_client's teardown joins before the base class clears the connection -- but that safety argument is an ordering invariant documented nowhere near the call site, and the next caller from the recv thread (as the identify path already does for sendCommand) would have inherited a null deref. Route it through the null-safe base-class sendMsg() like sendCommand() and sendSMMSettings(): a cleared connection now reads as a failed send and takes the existing reap-via-clientDisconnected path. The post-send rtt_req->getId() bookkeeping is unaffected -- the id is stamped into the message before the send regardless of wrapper. New session test pins the cleared-connection call directly.

## Summary by Sourcery

Route RTT request sending through the null-safe base-class send path and add coverage for cleared-connection behavior to prevent crashes when the client connection is torn down.

Bug Fixes:
- Prevent a potential null-pointer dereference in sendRTTRequest when the underlying client connection has been cleared.

Tests:
- Add a session test ensuring sendRTTRequest on a cleared connection results in a handled failed send and client reap instead of a crash.