### PR TITLE
docs(server): todo/59 record that broadcasts are aircraft-only by design

### DIFF
--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -219,7 +219,14 @@ public:
      * per-connection id into the message instance it is given (the C8
      * invariant), so each client must get its own instance: decode() over
      * getPacked() builds an independent clone per client rather than sharing
-     * `msg` (packed once, since the bytes don't depend on the recipient). */
+     * `msg` (packed once, since the bytes don't depend on the recipient).
+     *
+     * todo/59: the isAircraft() filter below is deliberate, not an oversight —
+     * non-aircraft clients (ADS-B feeders, config utilities) are telemetry
+     * producers and never consumers of relayed traffic, so broadcasts are
+     * aircraft-only by design. That also means the periodic 15 s server-list
+     * push intentionally skips them: they get their server list from their
+     * own config, not from discovery. */
     void broadcastMsg(const std::shared_ptr<flight_safety_system::transport::fss_message> &msg,
                       flight_safety_system::server::fss_client *except = nullptr) override
     {

--- a/tests/server_clients_test.cpp
+++ b/tests/server_clients_test.cpp
@@ -212,6 +212,11 @@ TEST_CASE("server_clients: disconnecting unknown client is a no-op")
 
 TEST_CASE("server_clients: broadcastMsg reaches aircraft clients only")
 {
+    /* todo/59: the aircraft-only filter in broadcastMsg is by design, not an
+     * accident — non-aircraft clients (ADS-B feeders, config utilities) are
+     * telemetry producers and never consumers of relayed traffic. Pin that a
+     * non-aircraft participant receives nothing from a broadcast, turning the
+     * intended behaviour into a tested contract. */
     server_clients sc;
     fss_test::MockDatabase mock;
 
@@ -228,6 +233,11 @@ TEST_CASE("server_clients: broadcastMsg reaches aircraft clients only")
     // Broadcast should not crash and should only target aircraft
     auto msg = std::make_shared<fss::transport::fss_message_rtt_request>();
     sc.broadcastMsg(msg);
+
+    // The non-aircraft client is skipped by broadcastMsg's isAircraft() filter
+    // itself (synchronously, before any per-client worker dispatch), so its
+    // connection receives nothing regardless of worker-thread timing.
+    REQUIRE(conn2->sentSnapshot().empty());
 }
 
 TEST_CASE("server_clients: broadcastMsg does not block on one black-holed client (todo/36)")


### PR DESCRIPTION
## Description

broadcastMsg()'s isAircraft() filter reads like a bug on first encounter: non-aircraft clients receive no relayed positions and no server-list broadcasts, and nothing said why. It is deliberate -- non-aircraft clients (ADS-B feeders, config utilities) are telemetry producers, never consumers of relayed traffic, and they get their server list from their own config rather than discovery. Say so in the comment block, and pin it in the existing aircraft-only broadcast test: the non-aircraft participant's connection must receive nothing.

## Summary by Sourcery

Document and codify the design choice that server broadcasts are limited to aircraft clients, ensuring non-aircraft clients do not receive relayed traffic or server-list broadcasts.

Documentation:
- Clarify in server broadcastMsg documentation comments that broadcasts and periodic server-list pushes are intentionally restricted to aircraft clients, with non-aircraft clients treated as telemetry producers only.

Tests:
- Extend the broadcastMsg aircraft-only test to assert that non-aircraft clients receive no broadcast messages, making this behavior an explicit contract.