### PR TITLE
release: prepare 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.0] - 2026-07-18
 
 ### Added
 - Dispatched commands now carry a per-server operator-action identifier:
@@ -37,6 +37,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   caller previously meant `std::terminate` on a safety-critical service.
   Behaviour on a failed read is unchanged (poller keeps the previous cached
   list; identify skips the server-list send). (todo/24)
+- ABI: all four library sonames bump `.so.2` → `.so.3`
+  (`-version-info 3:0:0` for `libfss`, `libfss-transport`,
+  `libfss-transport-ssl`, `libfss-client-ssl`). The installed
+  `fss-transport.hpp` changed object layout (`fss_connection` gained
+  `tcp_user_timeout_ms`, todo/26) and vtable shape
+  (`fss_message_asset_command` gained `getServerCommandId()`, todo/49) since
+  the 1.1.x line; a same-soname mix of an old library with the new header
+  (or vice versa) would silently corrupt derived-class layouts rather than
+  fail to link. Consumers must rebuild. (todo/61)
+- The optional-trailing-wire-field extension rule is now documented in
+  `fss-transport.hpp`, next to the `FSS_FEATURE` flag block: any future
+  optional trailing field on an already-extended message must be
+  prefix-closed with the earlier ones (emitted together, 0-filled if unset)
+  so length alone still decodes it unambiguously. No wire or code change —
+  the two fields this already governs (`rtt_response.client_timestamp`,
+  `asset_command.server_command_id`) are unaffected. (todo/51)
 
 ### Fixed
 - A terminal command-ack outcome (actioned/superseded/rejected/noop) is now
@@ -71,6 +87,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   live, violating both `duplicate_identity_policy` contracts (commands
   delivered to two sessions presenting the same aircraft identity, telemetry
   from two sources stored under one asset). (todo/44)
+- Four config fields that silently produce a live-looking but data-dead (or
+  flapping) server at 0 now warn and substitute a safe default, matching the
+  existing `tls_handshake_timeout_ms`/`max_concurrent_handshakes` guards:
+  `client_timeout` and `identify_timeout` (0 would sever/prune every client
+  on the very next tick) and `message_rate_capacity`/`message_rate_refill` (0
+  silently drops all rate-limited telemetry forever while the aircraft still
+  looks healthily connected, since `rtt_response` is exempt from rate
+  limiting — todo/37). (todo/50)
+- `sendRTTRequest()` now sends through the null-safe base-class `sendMsg()`,
+  closing the one remaining unguarded `getConnection()` dereference among the
+  three per-client send paths. Not reachable as a crash today — safe only
+  because of a call-graph ordering invariant documented nowhere near the call
+  site — but this hardens it the same way `sendCommand()` and
+  `sendSMMSettings()` already were. (todo/53)
 
 ## [1.1.1] - 2026-07-06
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([flight-safety-system], [1.1.1], [sjp@canterburyairpatrol.org])
+AC_INIT([flight-safety-system], [1.2.0], [sjp@canterburyairpatrol.org])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign -Wno-portability])
 
 m4_include([m4/ax_cxx_compile_stdcxx.m4])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,44 @@
+flight-safety-system (1.2.0) stable; urgency=medium
+
+  * Add a per-server operator-action identifier to dispatched commands
+    (fss_message_asset_command.server_command_id) via the new
+    FSS_FEATURE_SERVER_COMMAND_ID capability, so an FMU connected to
+    redundant servers can tell a genuine operator retry apart from another
+    server's delivery of the same push.
+  * Add a per-connection configurable TCP_USER_TIMEOUT so a flight-safety
+    client can bound how long a blocking send into a half-dead server may
+    stall.
+  * Report a cut-short active-server read as an explicit failure status
+    instead of throwing an exception across the poller thread.
+  * Make a terminal command-ack outcome final for its dispatch, so a later,
+    misordered or forged ack can no longer rewrite a settled outcome in the
+    command audit trail.
+  * Trip the DB fail-safe on a dropped command dispatch/ack write, not just a
+    logged counter change.
+  * Latch the DB fail-safe behind an admission gate, so a write-only DB
+    failure no longer flaps every aircraft in and out of comms-loss RTL.
+  * Require a DB write-failure incident to genuinely span
+    db_write_failure_disconnect_ticks before tripping the fail-safe, instead
+    of tripping under the default configuration regardless.
+  * Make duplicate-identity resolution atomic with the asset-id claim, so two
+    connections identifying the same asset at the same instant can no longer
+    both go live.
+  * Warn and substitute a safe default for client_timeout, identify_timeout,
+    message_rate_capacity, and message_rate_refill when configured as 0,
+    matching the existing tls_handshake_timeout_ms guard -- a zero rate-limit
+    value previously dropped all telemetry silently while the aircraft still
+    looked healthily connected.
+  * Harden sendRTTRequest() to use the null-safe base-class sendMsg(), the
+    same guard sendCommand()/sendSMMSettings() already had.
+  * Document the optional-trailing-wire-field extension rule in
+    fss-transport.hpp so the next capability author does not have to
+    re-derive it.
+  * Bump library sonames .so.2 -> .so.3 (-version-info 3:0:0): the installed
+    fss-transport.hpp changed object layout and vtable shape since the 1.1.x
+    line; consumers must rebuild.
+
+ -- Scott Parlane <sjp@canterburyairpatrol.org>  Sat, 18 Jul 2026 11:30:46 +1200
+
 flight-safety-system (1.1.1) stable; urgency=medium
 
   * Release client_lock before the blocking send in sendCommand/sendRTTRequest


### PR DESCRIPTION
## Description

CHANGELOG Unreleased becomes 1.2.0 (dated 2026-07-18) with entries added for the todo/50 config guards, the todo/53 sendRTTRequest hardening, the todo/51 wire-extension rule, and the todo/61 soname bump; AC_INIT moves to 1.2.0; debian/changelog gains the 1.2.0 entry.

## Summary by Sourcery

Prepare the 1.2.0 release, including version/ABI bumps and documenting recently completed work.

Bug Fixes:
- Harden configuration handling by guarding zero-valued timeouts and rate-limit fields with warnings and safe defaults.
- Make RTT request sending null-safe by routing it through the guarded base send path.

Enhancements:
- Bump all library sonames to .so.3 to reflect ABI changes and require consumers to rebuild.
- Clarify and formalize the optional trailing wire-field extension rule in the public transport header.

Build:
- Update project version to 1.2.0 in build metadata and Debian packaging.