### PR TITLE
fix(build): ship LICENSE, CHANGELOG and tsan.supp in the tarball; stop leaking e2e caches

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 AUTOMAKE_OPTIONS = foreign
 ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = src examples tests
-EXTRA_DIST = debian e2e .clang-format certs
+EXTRA_DIST = debian e2e .clang-format certs LICENSE.md CHANGELOG.md
 
 # `make distcheck` must build everything the release ships — the server,
 # the tests, and the example client — so a header missing from the tarball
@@ -21,7 +21,9 @@ e2e-test:
 	cd $(srcdir)/e2e && pytest
 
 # EXTRA_DIST copies the e2e/ tree recursively; strip developer-local Python
-# cruft (virtualenvs, caches) so it never lands in the release tarball.
+# cruft (virtualenvs, caches) and generated test reports so they never land
+# in the release tarball.
 dist-hook:
-	rm -rf $(distdir)/e2e/.venv $(distdir)/e2e/.pytest_cache
+	rm -rf $(distdir)/e2e/.venv $(distdir)/e2e/.pytest_cache $(distdir)/e2e/.ruff_cache
+	rm -f $(distdir)/e2e/traceability.json
 	find $(distdir)/e2e -name __pycache__ -type d -prune -exec rm -rf {} +

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -7,6 +7,13 @@ AM_CXXFLAGS = -pthread -fPIC -std=c++17 -I. -Werror -Wall -Wshadow -Wunused -Wnu
 AM_CXXFLAGS += $(TSAN_CXXFLAGS)
 AM_LDFLAGS = $(TSAN_LDFLAGS)
 
+# EXTRA_DIST must stay outside every conditional: automake only distributes
+# conditional EXTRA_DIST entries when the condition was true in the tree that
+# ran `make dist`, and the release tarball must carry these files regardless
+# of that tree's configure flags (tsan.supp was silently dropped from the
+# 1.2.0 tarball this way).
+EXTRA_DIST = test_helpers.hpp mock_database.hpp tsan.supp
+
 if ENABLE_TSAN
 # Under --enable-tsan the whole suite runs instrumented, so `make check` needs
 # the suppression file in the environment or the documented kernel-synchronised
@@ -55,8 +62,6 @@ all_test_LDADD = ../src/libfss-transport.la ../src/libfss-client-ssl.la ../src/l
 
 all_test_SOURCES += connection-ssl.cpp
 all_test_LDADD += ../src/libfss-transport-ssl.la $(GNUTLS_LIBS) $(CATCH2_LIBS)
-
-EXTRA_DIST = test_helpers.hpp mock_database.hpp
 
 BUILT_SOURCES += certs certs-alt certs/expired certs/ghost certs/client.crl.pem certs/empty.crl.pem
 
@@ -129,8 +134,6 @@ concurrency_tsan_test_SOURCES = main.cpp \
 	../src/fss-main.cpp
 concurrency_tsan_test_CXXFLAGS = $(AM_CXXFLAGS)
 concurrency_tsan_test_LDADD = $(CATCH2_LIBS) $(pthread_LIBS)
-
-EXTRA_DIST += tsan.supp
 
 # Run the full unit suite *and* the concurrency stress binary under TSan in one
 # command. `make check` already runs all_test under TSan (TESTS +


### PR DESCRIPTION
## Description

The release tarball shipped with no license text or release notes: LICENSE.md and CHANGELOG.md are outside automake's auto-distributed set and were never in EXTRA_DIST. tests/ kept its whole EXTRA_DIST inside the ENABLE_TESTS/ENABLE_TSAN conditionals, and automake only distributes conditional EXTRA_DIST entries when the condition is true in the tree that runs `make dist` — so tsan.supp was silently dropped from the 1.2.0 tarball (and a --disable-tests tree would drop the test support headers too). The dist-hook also let e2e/.ruff_cache — recreated by every check-code.sh run, so bound to recur — and a generated e2e/traceability.json leak into the tarball, regressing the 1.0.0 clean-release-tarball guarantee.

Found during the 1.2.0 release-readiness review.

## Summary by Sourcery

Ensure release tarballs include required metadata and test support files while excluding local caches and generated artifacts.

Build:
- Include LICENSE.md and CHANGELOG.md in the distributed release tarball.
- Always distribute test helper headers and tsan.supp regardless of configure-time test/TSAN flags.
- Exclude e2e virtualenvs, Python caches, Ruff caches, and generated traceability reports from the release tarball to keep it clean.