### PR TITLE
docs: complete the 1.2.0 changelog with the six omitted notable changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `fss_connection_client::create(..., t_tcp_user_timeout_ms)` at the
   transport layer. The default stays the established 30 s everywhere, and
   server-accepted sockets are unaffected. (todo/26)
+- Configurable duplicate-identity handling: a second connection identifying
+  as an already-connected asset is now resolved by policy instead of both
+  sessions going live. `duplicate_identity_policy` in `server.json` selects
+  `reject_newcomer` (default: keep the established session and refuse the
+  newcomer, avoiding flip-flop on a genuine misconfiguration) or
+  `evict_oldest` (favour a fast reconnect). Applied at identify, aircraft
+  connections only — non-aircraft clients never claim an asset id. (todo/31)
+- Client-library hooks added for the e2e harness, usable by any consumer: a
+  `non_aircraft` config flag so `sendIdentify()` sends
+  `identity_non_aircraft`, and `clock_offset_ms` (config field) +
+  `getSkewedTimestamp()` so a client reports a deliberately skewed clock.
+  (todo/28, todo/33)
 
 ### Changed
 - `IDatabase::getActiveServers()` now reports a cut-short read (mid-cursor
@@ -55,6 +67,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `asset_command.server_command_id`) are unaffected. (todo/51)
 
 ### Fixed
+- Failed telemetry/command DB writes are now detected at all: the six ECPG
+  write functions (position/RTT/status/search/dispatch/ack) ran their SQL
+  and returned unconditionally, never checking `sqlca.sqlcode`, so a failing
+  write — e.g. a full disk — was silent audit loss that the fail-safe
+  machinery never saw (`write_failure_count()` stayed 0 through an entire
+  disk-full run). They now report failure, and the `db.cpp` wrappers raise
+  it into the write queue's failure accounting — the signal that arms the
+  todo/45/47 fail-safe entries below. (todo/34)
+- The main loop no longer makes blocking DB calls: the per-connection
+  reconnect health probe (a live `SELECT 1` per tick) moved onto the
+  command poller, which already owns every DB read, so a frozen or
+  black-holed Postgres now degrades to "caches go stale" instead of
+  "command dispatch stops fleet-wide". Defence in depth:
+  `PGTCPUSERTIMEOUT=25000` bounds in-flight libpq stalls on the same 25 s
+  clock as the keepalive envelope, so a sustained partition fails writes —
+  tripping the fail-safe — instead of hanging the writer forever. (todo/46)
 - A terminal command-ack outcome (actioned/superseded/rejected/noop) is now
   final for its dispatch: a later terminal ack — from a buggy, misordered or
   forged peer — can no longer silently rewrite a settled outcome in the
@@ -101,6 +129,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   because of a call-graph ordering invariant documented nowhere near the call
   site — but this hardens it the same way `sendCommand()` and
   `sendSMMSettings()` already were. (todo/53)
+- `processMessage()` now captures the connection `shared_ptr` once, up
+  front, and bails if teardown has already cleared it; the local reference
+  keeps the connection alive and non-null for the whole call, so a
+  mid-message teardown reads as failed sends on a closed fd. Previously
+  several handler sites dereferenced `getConnection()` unguarded — safe in
+  production only via the recv-thread join inside `disconnect()`, and a
+  concurrent teardown (evict_oldest severing a client mid-identify) crashed
+  the unit harness under TSan through exactly that window. (PR #332)
+- `certs/revoke-client.sh` no longer hangs forever when run
+  non-interactively — `certtool --generate-crl` had no `--template`, so any
+  scripted invocation sat at an interactive prompt — and the example
+  `fake_client` now ignores SIGPIPE the way the server does, so a send
+  after the peer resets the connection fails the send instead of killing
+  the process. Both surfaced by the CRL-revocation e2e test. (todo/29)
+
+### Security
+- Two `secure_string` scrubbing gaps closed: the recv-side frame and the
+  packed send buffer of `smm_settings` messages (SMM credentials in flight)
+  are now wiped after use, and the PostgreSQL password is held in
+  `secure_string` end-to-end (`pg_pass` and `db_connection`'s copy), with a
+  by-value nul-terminated accessor for ECPG rather than a cached mutable
+  buffer the two reconnecting DB threads could race on. (todo/43)
+
+### Packaging
+- The release tarball now ships `LICENSE.md` and `CHANGELOG.md`, and always
+  includes `tests/tsan.supp` and the test support headers — automake only
+  distributes conditional `EXTRA_DIST` entries when the condition is true
+  in the tree that runs `make dist`, so tarballs rolled without
+  `--enable-tsan` silently dropped the TSan suppression file. The dist-hook
+  now also strips `e2e/.ruff_cache` and the generated `e2e/traceability.json`.
 
 ## [1.1.1] - 2026-07-06
 
@@ -487,6 +545,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.12.3] - 2025-11-07
 
+[1.2.0]: https://github.com/canterbury-air-patrol/flight-safety-system/compare/1.1.1...1.2.0
+[1.1.1]: https://github.com/canterbury-air-patrol/flight-safety-system/compare/1.1.0...1.1.1
+[1.1.0]: https://github.com/canterbury-air-patrol/flight-safety-system/compare/1.0.3...1.1.0
+[1.0.3]: https://github.com/canterbury-air-patrol/flight-safety-system/compare/1.0.2...1.0.3
+[1.0.2]: https://github.com/canterbury-air-patrol/flight-safety-system/compare/1.0.1...1.0.2
 [1.0.1]: https://github.com/canterbury-air-patrol/flight-safety-system/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/canterbury-air-patrol/flight-safety-system/compare/0.12.3...1.0.0
 [0.12.3]: https://github.com/canterbury-air-patrol/flight-safety-system/releases/tag/0.12.3

--- a/debian/changelog
+++ b/debian/changelog
@@ -8,11 +8,18 @@ flight-safety-system (1.2.0) stable; urgency=medium
   * Add a per-connection configurable TCP_USER_TIMEOUT so a flight-safety
     client can bound how long a blocking send into a half-dead server may
     stall.
+  * Add a configurable duplicate-identity policy, applied when a second
+    connection identifies as an already-connected asset:
+    reject_newcomer (default, keep the established session) or
+    evict_oldest.
   * Report a cut-short active-server read as an explicit failure status
     instead of throwing an exception across the poller thread.
   * Make a terminal command-ack outcome final for its dispatch, so a later,
     misordered or forged ack can no longer rewrite a settled outcome in the
     command audit trail.
+  * Detect failed telemetry/command DB writes at all: the ECPG write
+    functions never checked sqlca.sqlcode, so a failing write (e.g. a full
+    disk) was silent audit loss the fail-safe machinery never saw.
   * Trip the DB fail-safe on a dropped command dispatch/ack write, not just a
     logged counter change.
   * Latch the DB fail-safe behind an admission gate, so a write-only DB
@@ -20,6 +27,10 @@ flight-safety-system (1.2.0) stable; urgency=medium
   * Require a DB write-failure incident to genuinely span
     db_write_failure_disconnect_ticks before tripping the fail-safe, instead
     of tripping under the default configuration regardless.
+  * Move the per-connection DB reconnect health probe off the main loop onto
+    the command poller, and bound in-flight libpq stalls with
+    PGTCPUSERTIMEOUT, so a frozen or partitioned database degrades to stale
+    caches instead of freezing command dispatch fleet-wide.
   * Make duplicate-identity resolution atomic with the asset-id claim, so two
     connections identifying the same asset at the same instant can no longer
     both go live.
@@ -30,14 +41,24 @@ flight-safety-system (1.2.0) stable; urgency=medium
     looked healthily connected.
   * Harden sendRTTRequest() to use the null-safe base-class sendMsg(), the
     same guard sendCommand()/sendSMMSettings() already had.
+  * Pin the connection across processMessage so a concurrent teardown can
+    no longer leave message handlers dereferencing a cleared connection
+    pointer.
+  * Wipe SMM credential wire frames after use and hold the PostgreSQL
+    password in secure_string.
+  * Fix certs/revoke-client.sh hanging forever when run non-interactively,
+    and stop the example fake_client dying on SIGPIPE after a peer reset.
   * Document the optional-trailing-wire-field extension rule in
     fss-transport.hpp so the next capability author does not have to
     re-derive it.
+  * Ship LICENSE.md, CHANGELOG.md and tests/tsan.supp in the release
+    tarball, and stop developer-local caches and generated test reports
+    leaking into it.
   * Bump library sonames .so.2 -> .so.3 (-version-info 3:0:0): the installed
     fss-transport.hpp changed object layout and vtable shape since the 1.1.x
     line; consumers must rebuild.
 
- -- Scott Parlane <sjp@canterburyairpatrol.org>  Sat, 18 Jul 2026 11:30:46 +1200
+ -- Scott Parlane <sjp@canterburyairpatrol.org>  Sat, 18 Jul 2026 17:41:31 +1200
 
 flight-safety-system (1.1.1) stable; urgency=medium
 


### PR DESCRIPTION
## Description

The release-readiness review found the 1.2.0 changelog omitted several notable changes shipped since 1.1.1: the todo/34 detection of silently dropped DB writes (arguably the release's most safety-significant fix — the existing 45/47 entries cite it but never state it), the todo/46 main-loop blocking-DB-call fix with the PGTCPUSERTIMEOUT stall bound, the todo/31 duplicate_identity_policy feature (previously mentioned only parenthetically inside todo/44's entry), the todo/43 secure_string scrubbing gaps, the PR #332 processMessage teardown pinning, and the todo/29 revoke-client.sh non-interactive hang / fake_client SIGPIPE fixes. All added to both CHANGELOG.md and debian/changelog, plus the client-library non_aircraft/clock_offset_ms hooks (todo/28, todo/33) and a Packaging entry for the tarball fixes just landed. The CHANGELOG's compare-link definitions now cover 1.0.2 through 1.2.0 — they had stopped at 1.0.1.

## Summary by Sourcery

Document additional notable changes for the 1.2.0 release and update changelog compare links.

Documentation:
- Extend the 1.2.0 changelog with previously omitted fixes and features around DB write detection, main-loop DB usage, duplicate identity handling, secure string scrubbing, connection teardown robustness, client revocation tooling, and client-library hooks.
- Add a Packaging section describing release tarball contents and TSan-related distribution fixes.
- Update changelog GitHub compare-link references to cover versions 1.0.2 through 1.2.0.