### PR TITLE
fix(certs): todo/63 keep every revoked cert on the CRL, not just the newest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the process. Both surfaced by the CRL-revocation e2e test. (todo/29)
 
 ### Security
+- `certs/revoke-client.sh` no longer silently un-revokes earlier
+  revocations: certtool's `--generate-crl` honours only the last
+  `--load-certificate` flag (observed with certtool 3.8.13), so revoking a
+  second client produced a CRL containing only that client — and a server
+  reloading the CRL (SIGHUP, or a fresh listener) would accept every
+  previously revoked certificate again. The script now concatenates all
+  revoked certs into one PEM and passes it once, a form every certtool
+  version honours; regression-tested by revoking two clients and asserting
+  both serials stay on the CRL. (todo/63)
 - Two `secure_string` scrubbing gaps closed: the recv-side frame and the
   packed send buffer of `smm_settings` messages (SMM credentials in flight)
   are now wiped after use, and the PostgreSQL password is held in

--- a/certs/revoke-client.sh
+++ b/certs/revoke-client.sh
@@ -34,24 +34,27 @@ fi
 mkdir -p "${REVOKED_DIR}"
 cp "${CLIENT_PUBLIC_PEM}" "${REVOKED_DIR}/${1}.public.pem"
 
-LOAD_CERT_ARGS=()
-for cert in "${REVOKED_DIR}"/*.public.pem; do
-    LOAD_CERT_ARGS+=("--load-certificate" "${cert}")
-done
-
 # Without --template, certtool prompts interactively for "next CRL update in
 # (days)"; run non-interactively (as any script or test harness invoking this
 # does) and it hangs forever reading EOF from a closed stdin. crl_number must
 # increase on every regeneration or some TLS stacks treat the new CRL as
 # stale; a Unix timestamp is a simple monotonic source across repeated runs.
 CRL_TMPL=$(mktemp)
-trap 'rm -f "${CRL_TMPL}"' EXIT
+ALL_REVOKED_PEM=$(mktemp)
+trap 'rm -f "${CRL_TMPL}" "${ALL_REVOKED_PEM}"' EXIT
 printf 'crl_next_update = 3650\ncrl_number = %s\n' "$(date +%s)" > "${CRL_TMPL}"
+
+# certtool --generate-crl does not accumulate repeated --load-certificate
+# flags: only the last one lands in the CRL (observed with certtool 3.8.13),
+# so one flag per revoked cert silently un-revoked everything but the newest
+# revocation (todo/63). Concatenate every revoked cert into one PEM and pass
+# it once — that form is honoured on every certtool version.
+cat "${REVOKED_DIR}"/*.public.pem > "${ALL_REVOKED_PEM}"
 
 certtool --generate-crl \
     --load-ca-privkey "${CA_PRIVATE_PEM}" \
     --load-ca-certificate "${CA_PUBLIC_PEM}" \
-    "${LOAD_CERT_ARGS[@]}" \
+    --load-certificate "${ALL_REVOKED_PEM}" \
     --template "${CRL_TMPL}" \
     --outfile "${CRL_FILE}"
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -48,6 +48,10 @@ flight-safety-system (1.2.0) stable; urgency=medium
     password in secure_string.
   * Fix certs/revoke-client.sh hanging forever when run non-interactively,
     and stop the example fake_client dying on SIGPIPE after a peer reset.
+  * Fix certs/revoke-client.sh silently dropping every earlier revocation
+    from the CRL when revoking another client (certtool honours only the
+    last --load-certificate flag), which let a server reloading the CRL
+    re-admit previously revoked certificates.
   * Document the optional-trailing-wire-field extension rule in
     fss-transport.hpp so the next capability author does not have to
     re-derive it.
@@ -58,7 +62,7 @@ flight-safety-system (1.2.0) stable; urgency=medium
     fss-transport.hpp changed object layout and vtable shape since the 1.1.x
     line; consumers must rebuild.
 
- -- Scott Parlane <sjp@canterburyairpatrol.org>  Sat, 18 Jul 2026 17:41:31 +1200
+ -- Scott Parlane <sjp@canterburyairpatrol.org>  Sat, 18 Jul 2026 21:11:11 +1200
 
 flight-safety-system (1.1.1) stable; urgency=medium
 

--- a/e2e/test_crl_revocation.py
+++ b/e2e/test_crl_revocation.py
@@ -71,6 +71,31 @@ def crl_certs_dir(tmp_path_factory: pytest.TempPathFactory, certs_dir: Path) -> 
     return target
 
 
+def test_second_revocation_keeps_the_first_on_the_crl(crl_certs_dir: Path) -> None:
+    """Revoking a second client must not silently un-revoke the first.
+
+    todo/63: certtool --generate-crl honours only the last --load-certificate
+    flag (observed with certtool 3.8.13), so the script's old
+    one-flag-per-revoked-cert form produced a CRL holding only the newest
+    revocation -- a server reloading it (SIGHUP, or a fresh listener) would
+    re-admit every client revoked earlier. No server needed here: the defect
+    is in the CRL contents themselves.
+    """
+    for name in ("test1", "test2"):
+        subprocess.check_call(
+            ["./revoke-client.sh", name],
+            cwd=str(crl_certs_dir),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+    info = subprocess.check_output(
+        ["certtool", "--crl-info", "--infile", "crl.pem"],
+        cwd=str(crl_certs_dir), stdin=subprocess.DEVNULL, text=True,
+    )
+    assert "Revoked certificates (2):" in info, info
+    assert info.count("Serial Number") == 2, info
+
+
 @pytest.mark.requires_docker
 @pytest.mark.slow
 def test_revocation_disconnects_and_blocks_reconnect_but_not_others(


### PR DESCRIPTION
## Description

certtool --generate-crl does not accumulate repeated --load-certificate flags (observed with certtool 3.8.13: only the last one lands in the CRL), so revoke-client.sh's one-flag-per-revoked-cert loop silently un-revoked every earlier certificate on each new revocation — a server reloading the CRL (SIGHUP, or a fresh listener) would accept previously revoked clients again. Reproduced against the unmodified script before fixing. Every revoked cert is now concatenated into one PEM passed via a single --load-certificate, a form every certtool version honours; re-revoking an already-revoked client stays idempotent (the copy into revoked/ overwrites the same file).

Regression test (server-free, in e2e/test_crl_revocation.py): revoke two clients, assert both serials stay on the CRL — verified failing against the pre-fix script. CHANGELOG.md (Security) and debian/changelog entries added to the still-untagged 1.2.0.

## Summary by Sourcery

Ensure all previously revoked client certificates remain listed in the generated CRL when new revocations are added.

Bug Fixes:
- Fix CRL generation to include all revoked client certificates instead of only the most recently revoked one.

Enhancements:
- Add an end-to-end test to verify multiple client revocations remain present in the CRL contents.

Documentation:
- Document the CRL revocation behaviour and fix in the changelog, including the security impact.