### PR TITLE
fix(client): todo/65 retire the old connection and restart liveness on reconnect

### DIFF
--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -510,8 +510,22 @@ auto flight_safety_system::client_ssl::fss_server::reconnect() -> bool
     uint64_t ts = this->clock->now_ms();
     uint64_t elapsed_time = ts - this->last_tried;
 
-    if (this->getConnection() != nullptr)
+    /* Retire any previous connection properly (todo/65). Detach the handler
+     * FIRST so the old connection's closed event queues on the dying
+     * connection instead of reaching processMessage(), where it would be
+     * misattributed to this server object and tear down the replacement
+     * connection on the next reconnect tick. Then disconnect(), which
+     * closes the fd and joins the recv thread: dropping the reference
+     * alone leaks the connection (the recv-thread lambda holds it), and
+     * the still-open session keeps this asset's identity claimed at the
+     * server, which then rejects the re-identify as a duplicate for as
+     * long as the orphan survives. Safe to join here: reconnect() runs on
+     * the thread driving reconnection, which never holds servers_lock. */
+    auto old_conn = this->getConnection();
+    if (old_conn != nullptr)
     {
+        old_conn->setHandler(nullptr);
+        old_conn->disconnect();
         this->clearConnection();
     }
 
@@ -535,6 +549,15 @@ auto flight_safety_system::client_ssl::fss_server::reconnect() -> bool
         }
         else
         {
+            /* A fresh connection restarts liveness from the cold-connect
+             * state (todo/65): disarmed until the first message arrives on
+             * THIS connection (processMessage re-arms it). Merely
+             * refreshing the timestamp would keep measuring the previous
+             * connection's silence, so a quiet-but-healthy server would be
+             * flagged as timed out again on the very next tick, forever.
+             * Store before setHandler() so a message delivered immediately
+             * cannot have its arming overwritten by this reset. */
+            this->liveness_active.store(false, std::memory_order_relaxed);
             this->getConnection()->setHandler(this);
             /* Protocol version handshake must be the first message
              * exchanged after TLS connect, before identity. */
@@ -549,7 +572,11 @@ auto flight_safety_system::client_ssl::fss_server::reconnect() -> bool
 
 auto flight_safety_system::client_ssl::fss_server::isServerTimedOut() -> bool
 {
-    if (!this->liveness_active.load(std::memory_order_relaxed))
+    /* Acquire pairs with the release in processMessage(): once the armed
+     * flag is observed, the timestamp stored before it is visible too, so
+     * arming can never be seen with a stale/zero timestamp (which would
+     * read as an instant timeout). */
+    if (!this->liveness_active.load(std::memory_order_acquire))
     {
         return false;
     }
@@ -579,8 +606,14 @@ void flight_safety_system::client_ssl::fss_server::processMessage(
     }
     else
     {
-        this->liveness_active.store(true, std::memory_order_relaxed);
+        /* Timestamp first, then arm with release (paired with the acquire
+         * in isServerTimedOut): a reader observing the armed flag is
+         * guaranteed a timestamp at least this fresh. Arming before the
+         * timestamp allowed a window where the flag was set but the
+         * timestamp still held its previous (or zero) value — an instant
+         * spurious timeout. */
         this->last_message_received_time.store(this->clock->now_ms(), std::memory_order_relaxed);
+        this->liveness_active.store(true, std::memory_order_release);
         switch (msg->getType())
         {
             case flight_safety_system::transport::message_type_unknown:

--- a/tests/reconnect_test.cpp
+++ b/tests/reconnect_test.cpp
@@ -11,11 +11,16 @@
 #endif
 
 #include <algorithm>
+#include <array>
+#include <atomic>
 #include <chrono>
 #include <memory>
 #include <string>
 #include <thread>
 #include <vector>
+
+#include <sys/socket.h>
+#include <unistd.h>
 
 #include "fss-transport.hpp"
 #include "fss-client-ssl.hpp"
@@ -64,6 +69,62 @@ protected:
         ++attempts;
         return false;
     }
+};
+
+/* Replacement connection that "sends" successfully without any socket. */
+class NullConnection : public flight_safety_system::transport::fss_connection {
+public:
+    NullConnection() = default;
+    NullConnection(const NullConnection&) = delete;
+    NullConnection(NullConnection&&) = delete;
+    auto operator=(const NullConnection&) -> NullConnection& = delete;
+    auto operator=(NullConnection&&) -> NullConnection& = delete;
+    ~NullConnection() override = default;
+protected:
+    auto sendMsg(const std::shared_ptr<flight_safety_system::transport::buf_len>&) -> bool override { return true; }
+};
+
+/* A server that can adopt an externally built connection (standing in for
+ * the live one a liveness trip is about to replace) and whose redial always
+ * succeeds by installing a NullConnection. */
+class SwapServer : public flight_safety_system::client_ssl::fss_server {
+public:
+    using fss_server::fss_server;
+    SwapServer(const SwapServer&) = delete;
+    SwapServer(SwapServer&&) = delete;
+    auto operator=(const SwapServer&) -> SwapServer& = delete;
+    auto operator=(SwapServer&&) -> SwapServer& = delete;
+    ~SwapServer() override = default;
+    auto connected() -> bool override { return true; }
+    void adopt(const std::shared_ptr<flight_safety_system::transport::fss_connection>& t_conn)
+    {
+        this->setConnection(t_conn);
+    }
+protected:
+    auto reconnect_to() -> bool override
+    {
+        this->setConnection(std::make_shared<NullConnection>());
+        return true;
+    }
+};
+
+/* A client that counts serverRequiresReconnect calls, to detect a stale
+ * connection's closed event being misattributed to a healthy server. */
+class ObservingClient : public flight_safety_system::client_ssl::fss_client {
+public:
+    using fss_client::fss_client;
+    ObservingClient(const ObservingClient&) = delete;
+    ObservingClient(ObservingClient&&) = delete;
+    auto operator=(const ObservingClient&) -> ObservingClient& = delete;
+    auto operator=(ObservingClient&&) -> ObservingClient& = delete;
+    ~ObservingClient() override = default;
+    std::atomic<int> reconnect_requests{0};
+    void serverRequiresReconnect(flight_safety_system::client_ssl::fss_server* server) override
+    {
+        ++this->reconnect_requests;
+        fss_client::serverRequiresReconnect(server);
+    }
+    void add(const std::shared_ptr<flight_safety_system::client_ssl::fss_server>& server) { this->addServer(server); }
 };
 
 } // namespace
@@ -332,4 +393,65 @@ TEST_CASE("reconnect: multi-server failover keeps secondary reachable")
         return msg->getType() == flight_safety_system::transport::message_type_identity ||
                msg->getType() == flight_safety_system::transport::message_type_rtt_request;
     }));
+}
+
+TEST_CASE("reconnect: reconnect() retires the old connection instead of leaking it")
+{
+    /* todo/65: reconnect() used to drop its reference to the previous
+     * connection without disconnecting it. The recv-thread lambda holds the
+     * connection shared_ptr, so the "discarded" connection stayed fully
+     * alive — fd open, recv thread running — leaking a thread + fd per
+     * liveness-triggered reconnect and leaving the old session live at the
+     * server, which then rejects this asset's re-identify as a duplicate. */
+    auto client = std::make_shared<flight_safety_system::client_ssl::fss_client>();
+    auto server = std::make_shared<SwapServer>(client.get(), "127.0.0.1", static_cast<uint16_t>(20603), "", "", "");
+
+    std::array<int, 2> sv{};
+    REQUIRE(socketpair(AF_UNIX, SOCK_STREAM, 0, sv.data()) == 0);
+    auto old_conn = flight_safety_system::transport::fss_connection::create(sv[0]);
+    REQUIRE(old_conn != nullptr);
+    old_conn->setHandler(server.get());
+    server->adopt(old_conn);
+    std::weak_ptr<flight_safety_system::transport::fss_connection> retired = old_conn;
+    old_conn = nullptr;
+
+    REQUIRE(server->reconnect());
+    REQUIRE(server->connected());
+
+    /* The recv thread held the last reference; only a real disconnect (which
+     * joins that thread) lets the old connection actually die. */
+    REQUIRE(retired.expired());
+
+    close(sv[1]);
+}
+
+TEST_CASE("reconnect: a retired connection's closed event cannot tear down the replacement")
+{
+    /* todo/65: the old connection's handler used to stay wired to the
+     * fss_server across reconnect(), so when the old connection finally died
+     * its closed event hit serverRequiresReconnect() and yanked the server —
+     * with its healthy replacement connection — back into the reconnect
+     * queue, where the next tick would tear the replacement down too. */
+    auto client = std::make_shared<ObservingClient>();
+    auto server = std::make_shared<SwapServer>(client.get(), "127.0.0.1", static_cast<uint16_t>(20604), "", "", "");
+
+    std::array<int, 2> sv{};
+    REQUIRE(socketpair(AF_UNIX, SOCK_STREAM, 0, sv.data()) == 0);
+    auto old_conn = flight_safety_system::transport::fss_connection::create(sv[0]);
+    REQUIRE(old_conn != nullptr);
+    old_conn->setHandler(server.get());
+    server->adopt(old_conn);
+    old_conn = nullptr;
+    client->add(server);
+
+    REQUIRE(server->reconnect());
+    REQUIRE(client->reconnect_requests.load() == 0);
+
+    /* Sever the far end of the retired connection. Pre-fix, its still-wired
+     * recv thread delivered message_type_closed to the fss_server; with the
+     * handler detached before disconnect there is no thread left to deliver
+     * anything, so the replacement must stay untouched. */
+    close(sv[1]);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    REQUIRE(client->reconnect_requests.load() == 0);
 }

--- a/tests/timeout_test.cpp
+++ b/tests/timeout_test.cpp
@@ -233,6 +233,27 @@ protected:
     auto reconnect_to() -> bool override { return false; }
 };
 
+/* A server whose reconnect() succeeds by installing a fresh in-memory
+ * connection, for exercising post-reconnect state. */
+class ReconnectingServer : public fss::client_ssl::fss_server {
+public:
+    using fss_server::fss_server;
+    ReconnectingServer(const ReconnectingServer &) = delete;
+    ReconnectingServer(ReconnectingServer &&) = delete;
+    auto operator=(const ReconnectingServer &) -> ReconnectingServer & = delete;
+    auto operator=(ReconnectingServer &&) -> ReconnectingServer & = delete;
+    ~ReconnectingServer() override = default;
+    auto connected() -> bool override { return true; }
+    int reconnects{0};
+protected:
+    auto reconnect_to() -> bool override
+    {
+        ++reconnects;
+        this->setConnection(std::make_shared<FakeConnection>());
+        return true;
+    }
+};
+
 /* A client that exposes addServer and captures status changes. */
 class TestClient : public fss::client_ssl::fss_client {
 public:
@@ -311,4 +332,44 @@ TEST_CASE("timeout: attemptReconnect moves timed-out server to reconnect queue")
      * server moved from servers to reconnect_servers. */
     REQUIRE(client->status_changes > 0);
     REQUIRE(client->last_status == fss::client_ssl::CLIENT_CONNECTION_STATUS_DISCONNECTED);
+}
+
+TEST_CASE("timeout: successful reconnect restores cold-start liveness")
+{
+    /* todo/65: reconnect() used to leave liveness armed against the previous
+     * connection's last-received timestamp, so a reconnected server whose
+     * peer had nothing to say yet was flagged timed out again on the very
+     * next attemptReconnect() tick — tearing down a healthy connection every
+     * reconnect interval, forever. A fresh connection must restart from the
+     * cold-connect state: liveness disarmed until the first message arrives
+     * on THAT connection. */
+    auto client = std::make_shared<TestClient>();
+    auto server = std::make_shared<ReconnectingServer>(client.get(), "127.0.0.1", uint16_t{9999}, "", "", "");
+    auto clock = std::make_shared<FakeClock>();
+    server->setClock(clock);
+    client->add(server);
+
+    /* Arm liveness, then let it expire; the reconnect driver tears down and
+     * redials in the same attemptReconnect() pass. */
+    server->processMessage(std::make_shared<fss::transport::fss_message_rtt_request>());
+    clock->advance(30001);
+    REQUIRE(server->isServerTimedOut());
+
+    client->attemptReconnect();
+    REQUIRE(server->reconnects == 1);
+    REQUIRE(client->last_status == fss::client_ssl::CLIENT_CONNECTION_STATUS_CONNECTED_1_SERVER);
+
+    /* Nothing has been received on the new connection: however long it stays
+     * quiet, it must not be timed out on the old connection's stale clock. */
+    clock->advance(30001);
+    REQUIRE_FALSE(server->isServerTimedOut());
+    clock->advance(1000000);
+    REQUIRE_FALSE(server->isServerTimedOut());
+
+    /* The first message on the new connection re-arms liveness normally. */
+    server->processMessage(std::make_shared<fss::transport::fss_message_rtt_request>());
+    clock->advance(29999);
+    REQUIRE_FALSE(server->isServerTimedOut());
+    clock->advance(2);
+    REQUIRE(server->isServerTimedOut());
 }


### PR DESCRIPTION
## Description

A liveness-triggered reconnect left two traps that turned one quiet spell into a permanent 10s teardown/redial loop (reproduced by CAP Path G with two servers, both cycling in lockstep forever):

- reconnect() never touched liveness_active/last_message_received_time, so the new connection was judged against the previous connection's silence and flagged timed out again on the very next attemptReconnect() tick. A fresh connection now restarts from the cold-connect state: liveness is disarmed until the first message arrives on that connection.

- reconnect() dropped its reference to the old connection without disconnecting it. The recv-thread lambda holds the connection alive, so the "discarded" connection leaked a thread + fd, kept the old session live at the server (which then rejects the client's own re-identify as a duplicate under reject_newcomer), and its eventual closed event was delivered to the still-wired handler, yanking the healthy replacement back into the reconnect queue. The old connection is now retired properly: handler detached first (so the closed event queues on the dying connection), then disconnected (fd closed, recv thread joined), then released.

Also order the liveness arm as timestamp-then-flag with release/acquire so arming can never be observed with a stale timestamp (previously an instant spurious-timeout window).

The three new tests fail against the previous code and pass with the fix.

## Summary by Sourcery

Ensure liveness-driven reconnects create a fresh, independent connection and do not leak or misattribute events from the old connection, while tightening liveness timeout semantics.

Bug Fixes:
- Retire and fully disconnect the previous connection during reconnect to prevent thread and file-descriptor leaks and stale server sessions.
- Detach the old connection handler before disconnect so its closed event is not routed to the new connection and does not trigger spurious reconnect attempts.
- Reset liveness state on successful reconnect so the new connection is judged from a cold-start instead of the previous connection’s inactivity, avoiding permanent timeout loops.
- Strengthen the synchronization between liveness timestamp and armed flag to eliminate windows where a stale timestamp could cause an immediate spurious timeout.

Tests:
- Add reconnect tests that verify old connections are properly retired and cannot tear down replacement connections.
- Add timeout tests that verify successful reconnects restore cold-start liveness behavior and avoid repeated immediate timeouts.