### PR TITLE
fix(transport): retire a connection the accept callback does not adopt

### DIFF
--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -662,9 +662,31 @@ void flight_safety_system::transport::fss_listen::startSetupWorker(int t_newfd)
         flight_safety_system::exception_guard setup_guard("transport", "new connection setup");
         setup_guard.run([&]() -> void {
             auto conn = this->newConnection(t_newfd);
-            if (conn != nullptr && this->cb != nullptr)
+            if (conn == nullptr)
             {
-                this->cb(conn);
+                return;
+            }
+            /* The callback only takes ownership by returning true. On every
+             * other outcome — false (declined), no callback, or a throw —
+             * the connection must be actively retired: its recv thread holds
+             * a shared_ptr to it (the create() lambda capture), so merely
+             * dropping ours here would leave it alive forever — fd open,
+             * thread running, messages queueing — with nobody able to reach
+             * it again. Same leaked-zombie mechanism the client reconnect
+             * path had (todo/65). */
+            bool adopted = false;
+            try
+            {
+                adopted = this->cb != nullptr && this->cb(conn);
+            }
+            catch (...)
+            {
+                conn->disconnect();
+                throw; // setup_guard logs it
+            }
+            if (!adopted)
+            {
+                conn->disconnect();
             }
         });
         this->releaseSetupSlot();

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -14,6 +14,8 @@
 
 #include <atomic>
 #include <csignal>
+#include <mutex>
+#include <stdexcept>
 #include <thread>
 
 #include <netinet/in.h>
@@ -402,4 +404,94 @@ TEST_CASE("Listen - Callback")
     REQUIRE(!cb->connected());
 
     client_handoff.reset();
+}
+
+TEST_CASE("Listen - declined connection is retired, not leaked")
+{
+    /* The connect callback only adopts a connection by returning true
+     * (todo/65 family): the connection's recv thread holds a shared_ptr to
+     * it, so if the setup worker merely dropped its own reference on a
+     * false return, the declined connection would stay alive forever — fd
+     * open, recv thread running — invisible to the application. */
+    constexpr uint16_t listen_port = 20220;
+    std::mutex sync;
+    bool callback_ran = false;
+    std::weak_ptr<flight_safety_system::transport::fss_connection> accepted;
+    flight_safety_system::transport::fss_connect_cb decline =
+        [&](std::shared_ptr<flight_safety_system::transport::fss_connection> c) -> bool {
+        const std::scoped_lock guard(sync);
+        callback_ran = true;
+        accepted = c;
+        return false;
+    };
+    auto listen = std::make_shared<flight_safety_system::transport::fss_listen>(listen_port, decline);
+    REQUIRE(listen != nullptr);
+
+    auto conn = std::make_shared<flight_safety_system::transport::fss_connection>();
+    REQUIRE(conn->connectTo("localhost", listen_port));
+
+    REQUIRE(fss_test::wait_for([&]() {
+        const std::scoped_lock guard(sync);
+        return callback_ran;
+    }));
+
+    /* The worker must actively disconnect the declined connection so the
+     * recv thread exits and releases the last reference. */
+    REQUIRE(fss_test::wait_for([&]() {
+        const std::scoped_lock guard(sync);
+        return accepted.expired();
+    }));
+
+    /* The peer observes a close rather than a silent zombie. */
+    std::shared_ptr<flight_safety_system::transport::fss_message> msg;
+    REQUIRE(fss_test::wait_for([&]() {
+        msg = conn->getMsg();
+        return msg != nullptr;
+    }));
+    REQUIRE(msg->getType() == flight_safety_system::transport::message_type_closed);
+
+    conn->disconnect();
+}
+
+TEST_CASE("Listen - throwing connect callback retires the connection")
+{
+    /* Same guarantee on the exception path: a callback that throws has not
+     * taken ownership, so the worker must retire the connection before the
+     * exception guard swallows and logs the error. */
+    constexpr uint16_t listen_port = 20221;
+    std::mutex sync;
+    bool callback_ran = false;
+    std::weak_ptr<flight_safety_system::transport::fss_connection> accepted;
+    flight_safety_system::transport::fss_connect_cb thrower =
+        [&](std::shared_ptr<flight_safety_system::transport::fss_connection> c) -> bool {
+        {
+            const std::scoped_lock guard(sync);
+            callback_ran = true;
+            accepted = c;
+        }
+        throw std::runtime_error("declined loudly");
+    };
+    auto listen = std::make_shared<flight_safety_system::transport::fss_listen>(listen_port, thrower);
+    REQUIRE(listen != nullptr);
+
+    auto conn = std::make_shared<flight_safety_system::transport::fss_connection>();
+    REQUIRE(conn->connectTo("localhost", listen_port));
+
+    REQUIRE(fss_test::wait_for([&]() {
+        const std::scoped_lock guard(sync);
+        return callback_ran;
+    }));
+    REQUIRE(fss_test::wait_for([&]() {
+        const std::scoped_lock guard(sync);
+        return accepted.expired();
+    }));
+
+    std::shared_ptr<flight_safety_system::transport::fss_message> msg;
+    REQUIRE(fss_test::wait_for([&]() {
+        msg = conn->getMsg();
+        return msg != nullptr;
+    }));
+    REQUIRE(msg->getType() == flight_safety_system::transport::message_type_closed);
+
+    conn->disconnect();
 }


### PR DESCRIPTION
## Description

fss_connect_cb returns bool precisely so a callback can decline a connection, but the setup worker discarded the verdict: on a false return (or a throw, which the exception guard contains) the worker just dropped its shared_ptr while the connection's own recv thread — which holds a shared_ptr via the create() lambda capture — kept it alive forever: fd open, thread running, messages queueing, unreachable by the application. Same leaked-zombie mechanism as the todo/65 client reconnect fix.

Latent today (the server's callback always returns true and delegates refusal to clientConnected(), which disconnects properly), but it is the natural way to write "decline this peer" and would have leaked a thread and fd per declined connection. The worker now disconnects the connection on every non-adoption path: declined, no callback, or callback throw.

Both new tests verified failing against the previous code.

## Summary by Sourcery

Ensure declined or exception-throwing server connection callbacks actively retire the connection instead of leaking it.

Bug Fixes:
- Prevent leaked connections when the server connect callback returns false, is absent, or throws by explicitly disconnecting the new connection in those cases.

Tests:
- Add regression tests verifying declined and exception-throwing connect callbacks cause the connection to be closed and retired rather than left as a zombie.