### PR TITLE
release: prepare 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.1] - 2026-07-19
 
 ### Fixed
+- The listener's connection-setup worker now retires an accepted connection
+  that its connect callback declines (returns false) or abandons by
+  throwing. Previously the worker discarded the callback's verdict and
+  dropped its reference, while the connection's own recv thread kept the
+  connection alive — an unreachable zombie session leaking a socket and a
+  thread per declined peer. Latent rather than live: the bundled server's
+  callback never declines, but the callback's documented bool return
+  invited exactly this usage.
 - Client reconnect no longer loops forever after a liveness timeout
   (todo/65, found by CAP test-plan Path G's mixed-version interop tests).
   `fss_server::reconnect()` now retires the superseded connection properly —

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([flight-safety-system], [1.2.0], [sjp@canterburyairpatrol.org])
+AC_INIT([flight-safety-system], [1.2.1], [sjp@canterburyairpatrol.org])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign -Wno-portability])
 
 m4_include([m4/ax_cxx_compile_stdcxx.m4])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+flight-safety-system (1.2.1) stable; urgency=medium
+
+  * Stop a two-server client from tearing down and redialling both healthy
+    server connections every reconnect interval forever after a single
+    liveness timeout: a reconnect now properly retires the superseded
+    connection -- closing its socket and joining its receive thread, so the
+    server no longer rejects the client's own re-identify as a duplicate of
+    a leaked session -- and restarts the liveness timer in its cold-connect
+    state instead of judging the new connection by the old one's silence.
+  * Retire an accepted connection whose connect callback declines it (or
+    throws) instead of leaking its socket and receive thread as an
+    unreachable zombie session.
+
+ -- Scott Parlane <sjp@canterburyairpatrol.org>  Sun, 19 Jul 2026 21:56:17 +1200
+
 flight-safety-system (1.2.0) stable; urgency=medium
 
   * Add a per-server operator-action identifier to dispatched commands


### PR DESCRIPTION
## Description

CHANGELOG Unreleased becomes 1.2.1 (dated 2026-07-19) with an entry added for the accept-callback connection retirement; AC_INIT moves to 1.2.1; debian/changelog gains the 1.2.1 entry.

Patch release: implementation-only changes since 1.2.0 — no installed header differs from the 1.2.0 tag (checked per the todo/61 checklist), so -version-info stays 3:0:0, matching the 1.1.1 precedent. make distcheck passes on the 1.2.1 tarball.

## Summary by Sourcery

Prepare the 1.2.1 patch release and record the latest fixes in project metadata and changelogs.

Bug Fixes:
- Document the fix for accepted connections whose callbacks decline or throw, preventing zombie sessions and resource leaks.

Build:
- Bump the project version to 1.2.1 in Autotools configuration.

Documentation:
- Update CHANGELOG to mark the 1.2.1 release with its fix details.
- Add the 1.2.1 entry to the Debian changelog.