### PR TITLE
feat(server): log the reason for every rejected aircraft identify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- The server now logs every silently-rejected aircraft identify: an ERROR
+  naming both sides of a certificate-CN/identity mismatch, and a WARN
+  naming an identity with no matching asset in the database (wording also
+  covers a DB read failure, which getAssetId() cannot yet distinguish —
+  todo/60). Previously both paths severed the connection without a single
+  log line, so a permanently rejected client — e.g. an unregistered asset
+  name — was indistinguishable from network flapping at every layer's logs
+  (this cost a day of misdiagnosis in the todo/65 re-test).
+
 ## [1.2.1] - 2026-07-19
 
 ### Fixed

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -957,12 +957,32 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                 }
                 if (!name_valid)
                 {
+                    if (!possible_names.empty())
+                    {
+                        /* The empty-CN case logged above; this is the
+                         * cert-present-but-name-differs case — a
+                         * misconfigured client at best, an impersonation
+                         * attempt at worst. Name both sides so the
+                         * mismatch is diagnosable from this line alone. */
+                        FSS_LOG_ERROR("server", "Rejecting identity '" << client_name
+                                                                       << "': does not match certificate CN '"
+                                                                       << possible_names.front() << "'");
+                    }
                     this->client_handler->clientDisconnected(this);
                     return;
                 }
                 uint64_t asset_id = this->dbc->getAssetId(client_name);
                 if (asset_id == 0)
                 {
+                    /* 0 conflates "no such asset" with "DB read failed"
+                     * (todo/60), so the wording must cover both until that
+                     * is split. A client whose identify lands here will
+                     * redial and be rejected again on every reconnect
+                     * tick, so this line recurs at that cadence — which is
+                     * the visibility we want for an unregistered asset. */
+                    FSS_LOG_WARN("server", "Rejecting identity '"
+                                               << client_name
+                                               << "': no matching asset in the database (or DB read failure)");
                     this->client_handler->clientDisconnected(this);
                     return;
                 }

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -242,9 +242,15 @@ TEST_CASE("session: rejects identify when claimed name does not match cert CN")
 
     auto writer = make_mock_writer(mock);
     auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    fss_test::capture_cerr cap;
     session->processMessage(std::make_shared<fss::transport::fss_message_identity>("imposter"));
 
     REQUIRE(handler.disconnects > 0);
+    /* The rejection must be logged, naming both sides of the mismatch —
+     * a silent sever here cost a day of misdiagnosis (todo/65 re-test). */
+    auto out = cap.str();
+    REQUIRE(out.find("Rejecting identity 'imposter'") != std::string::npos);
+    REQUIRE(out.find("certificate CN 'craft'") != std::string::npos);
     /* No server-list / command messages should leak out before disconnect. */
     for (const auto &m : conn->sent)
     {
@@ -386,10 +392,18 @@ TEST_CASE("session: rejects identify when asset unknown to database")
 
     auto writer = make_mock_writer(mock);
     auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    fss_test::capture_cerr cap;
     auto identify = std::make_shared<fss::transport::fss_message_identity>("unknownAsset");
     session->processMessage(identify);
 
     REQUIRE(conn->sent.empty());
+    /* The rejection must be logged with the unmatched name — a silent
+     * sever here cost a day of misdiagnosis (todo/65 re-test). The
+     * wording covers the DB-read-failure case too, which getAssetId()
+     * cannot yet distinguish (todo/60). */
+    auto out = cap.str();
+    REQUIRE(out.find("Rejecting identity 'unknownAsset'") != std::string::npos);
+    REQUIRE(out.find("no matching asset") != std::string::npos);
 }
 
 TEST_CASE("session: getCommand returns newest-timestamp entry")


### PR DESCRIPTION
## Description

Both silent rejection branches in the identify path now say why the session is being severed: a CN-present-but-mismatched identity logs an ERROR naming the claimed identity and the certificate CN (misconfigured client at best, impersonation attempt at worst), and an identity with no matching asset logs a WARN naming it (wording covers the DB-read-failure case getAssetId() cannot yet distinguish — todo/60).

Previously both paths disconnected without any log line. The todo/65 re-test showed why that matters: a test-harness asset-name mismatch (asset registered as 'pathg' while the vehicle identified as 'pathg-vehicle') produced an endless reject/redial cycle that was indistinguishable in every log from the reconnect bug 1.2.1 had just fixed, and cost a day of misdiagnosis. A rejected client redials every reconnect tick, so the WARN recurs at that cadence — deliberate visibility for an unregistered asset.

The extended tests pin both log lines via capture_cerr.

## Summary by Sourcery

Add explicit logging for all aircraft identity rejections and extend tests and documentation to ensure these cases are visible and diagnosable rather than silently severing sessions.

New Features:
- Log an ERROR with both claimed identity and certificate CN when an aircraft identify is rejected due to a CN mismatch.
- Log a WARN with the rejected identity when no matching asset exists in the database or a DB read failure occurs during identify handling.

Documentation:
- Update the changelog with an Unreleased entry describing the new identify rejection logging behavior and its rationale.

Tests:
- Extend server session tests to capture stderr and assert that both rejection scenarios emit the expected log lines, preventing silent disconnects.