### PR TITLE
fix(transport): todo/52 close the fd only after every I/O thread is joined

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -386,26 +386,35 @@ void fss::server::fss_client::stopOutboundWorker()
 
 void fss::server::fss_client::disconnect()
 {
-    /* Order matters (todo/21): signal the worker to stop, then close the socket
-     * so a worker blocked in a send() returns, then join it — all before the
-     * base class clears the connection. The worker only ever sees a non-null
-     * connection (its sends fail fast once the fd is closed), so it can never
-     * dereference a cleared connection. */
+    /* Order matters (todo/21, todo/52): signal the worker to stop, then shut
+     * the socket down — not close it — so a worker blocked in send() returns
+     * (EPIPE) while the descriptor number stays reserved, then join the
+     * worker, and only then run the connection's disconnect(), which joins the
+     * recv thread and performs the deferred close. Closing any earlier would
+     * free the fd number for reuse while the worker may still be about to pass
+     * its stale value to send() — I/O into an unrelated session (todo/52). All
+     * of this runs before the base class clears the connection, and the worker
+     * only ever sees a non-null connection (its sends fail fast once the fd
+     * reads -1), so it can never dereference a cleared connection. */
     this->requestOutboundStop();
     auto active_conn = this->getConnection();
     if (active_conn != nullptr)
     {
-        active_conn->disconnect(); // closes the fd (unblocking a stalled worker send) and joins the recv thread
+        active_conn->shutdownSocket(); // unblocks a stalled worker send and the recv thread
     }
     this->stopOutboundWorker();
+    if (active_conn != nullptr)
+    {
+        active_conn->disconnect(); // joins the recv thread, then closes the fd
+    }
     fss_message_cb::disconnect(); // a second disconnect() on the connection here is a safe no-op
 }
 
 fss::server::fss_client::~fss_client()
 {
-    /* Single teardown entry point: disconnect() stops the worker (closing the fd
-     * first so a blocked send returns) and clears the connection. It is
-     * idempotent, so this is safe whether or not disconnect() was already
+    /* Single teardown entry point: disconnect() stops the worker (shutting the
+     * socket down first so a blocked send returns) and clears the connection.
+     * It is idempotent, so this is safe whether or not disconnect() was already
      * called. */
     fss_client::disconnect();
 }

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -272,6 +272,13 @@ class fss_connection {
     static constexpr size_t default_max_queue_size = 1000;
     std::atomic<bool> run{false};
     std::atomic<int> fd{-1};
+    /* A descriptor that has been shut down and retired from `fd` but whose
+     * close is deferred (todo/52): close() frees the fd NUMBER for reuse, so
+     * it must not run while any thread that could still pass the old number
+     * to a syscall is unjoined — a concurrently accepted connection can be
+     * handed the same number back, turning a late recv()/send() into I/O on
+     * an unrelated session. -1 when nothing is pending. */
+    std::atomic<int> pending_close_fd{-1};
     std::atomic<uint64_t> last_msg_id{0};
     fss_message_cb *handler{nullptr};
     std::queue<std::shared_ptr<fss_message>> messages{};
@@ -354,6 +361,18 @@ public:
     auto sendMsg(const std::shared_ptr<fss_message> &msg) -> bool;
     auto getMsg() -> std::shared_ptr<fss_message>;
     virtual void processMessages();
+    /* The shutdown-only half of disconnect() (todo/52): wakes any thread
+     * blocked in recv()/send() on this connection and makes every I/O loop
+     * bail fast (fd reads -1) WITHOUT releasing the descriptor number for
+     * reuse; disconnect() closes it once the recv thread is joined. Public so
+     * an owner with a sender thread of its own (the server-side fss_client
+     * outbound worker) can quiesce that thread between the shutdown and the
+     * close. Idempotent, safe to call concurrently with disconnect(). Virtual
+     * so a subclass whose blocking I/O is not fd-mediated (a test double
+     * blocking sendMsg() on its own condition variable, standing in for a
+     * black-holed peer) has the same hook disconnect() itself already relies
+     * on to release it — mirroring the existing virtual disconnect(). */
+    virtual void shutdownSocket();
     virtual void disconnect();
     virtual auto getClientNames() -> std::list<std::string>;
     virtual auto isPeerCertRevoked(const std::string &) const -> bool { return false; }

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -64,8 +64,14 @@ flight_safety_system::transport_ssl::fss_connection::~fss_connection()
      * paths capture the connection shared_ptr in the recv-thread lambda, so
      * this destructor only runs once that thread has dropped its reference —
      * i.e. after processMessages() returned (or on the recv thread itself,
-     * where recv() has likewise finished). */
-    if (this->usable.load())
+     * where recv() has likewise finished).
+     *
+     * The getFd() != -1 guard is part of todo/52: gnutls holds the raw fd
+     * NUMBER (gnutls_transport_set_int), so once a disconnect has retired the
+     * descriptor, bye() would write the close-notify into whatever that
+     * number means by now — possibly an unrelated session's socket. Skip it;
+     * it could only ever have failed with EBADF anyway. */
+    if (this->usable.load() && this->getFd() != -1)
     {
         try
         {

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -109,24 +109,54 @@ auto flight_safety_system::transport::fss_connection::getNullMsgCount() -> uint6
     return this->consecutive_null_msgs.load();
 }
 
+void flight_safety_system::transport::fss_connection::shutdownSocket()
+{
+    int orig_fd = this->fd.exchange(-1);
+    if (orig_fd == -1)
+    {
+        return;
+    }
+    /* shutdown() operates on the still-open socket, so it is what actually
+     * unblocks a peer thread stuck in recv()/send(); the I/O loops then bail
+     * on the -1 they re-load. Publish the fd for the deferred close only
+     * after the shutdown, so whoever performs the close can never observe it
+     * un-shut-down. */
+    safe_shutdown_fd(orig_fd, "transport/shutdown");
+    int prev = this->pending_close_fd.exchange(orig_fd);
+    if (prev != -1)
+    {
+        /* Only possible when this object was reconnected after a deferred
+         * close was left pending; every thread of that earlier session is
+         * past its last syscall on it, so release it rather than leak it. */
+        safe_close_fd(prev, "transport/shutdown");
+    }
+}
+
 void flight_safety_system::transport::fss_connection::disconnect()
 {
     this->run.store(false);
-    int orig_fd = this->fd.exchange(-1);
-    if (orig_fd != -1)
-    {
-        safe_shutdown_fd(orig_fd, "transport/disconnect");
-        safe_close_fd(orig_fd, "transport/disconnect");
-    }
+    /* Shut down first, close later (todo/52): close() frees the descriptor
+     * NUMBER for reuse, so it must wait until no thread that could still pass
+     * the old number to a syscall is unjoined — a setup worker accepting a
+     * new client can be handed the same number back, turning a late
+     * recv()/send() into I/O on an unrelated session. */
+    this->shutdownSocket();
+    bool recv_thread_quiesced = true;
     if (this->recv_thread.joinable())
     {
         if (this->recv_thread.get_id() == std::this_thread::get_id())
         {
-            /* Destructor called from within the recv thread itself (possible
-             * when the lambda is the last shared_ptr owner).  Detach so the
-             * thread can finish normally without trying to join itself. */
+            /* disconnect() called from within the recv thread itself (garbage
+             * threshold, oversized frame, or a destructor running there when
+             * the lambda held the last shared_ptr).  Detach so the thread can
+             * finish normally without trying to join itself. This thread
+             * issues no further I/O, but a caller-owned sender thread (the
+             * server-side fss_client outbound worker) may still be about to;
+             * leave the close pending for the owner's own disconnect() — which
+             * runs after it joined its sender — or the destructor. */
             this->recv_thread.detach();
             this->recv_thread = std::thread();
+            recv_thread_quiesced = false;
         }
         else
         {
@@ -139,11 +169,22 @@ void flight_safety_system::transport::fss_connection::disconnect()
                 /* join() failed, so the thread is still joinable; leaving it
                  * would make ~std::thread call std::terminate. Detach to avoid
                  * that (leaking the thread) — we are already in a degenerate
-                 * state where the thread could not be joined. */
+                 * state where the thread could not be joined. It may still be
+                 * running, so the fd must stay reserved as well: leave the
+                 * close pending for the destructor. */
                 FSS_LOG_ERROR("transport", "recv_thread.join() failed, detaching: " << e.what());
                 this->recv_thread.detach();
                 this->recv_thread = std::thread();
+                recv_thread_quiesced = false;
             }
+        }
+    }
+    if (recv_thread_quiesced)
+    {
+        int to_close = this->pending_close_fd.exchange(-1);
+        if (to_close != -1)
+        {
+            safe_close_fd(to_close, "transport/disconnect");
         }
     }
 }
@@ -151,6 +192,15 @@ void flight_safety_system::transport::fss_connection::disconnect()
 flight_safety_system::transport::fss_connection::~fss_connection()
 {
     fss_connection::disconnect();
+    /* Backstop for the deferred-close paths disconnect() cannot finish itself
+     * (recv-thread self-disconnect, failed join): once the last owner is
+     * destroying this object no thread can still be about to use the fd, so
+     * release the descriptor number now. */
+    int to_close = this->pending_close_fd.exchange(-1);
+    if (to_close != -1)
+    {
+        safe_close_fd(to_close, "transport/destructor");
+    }
     while (!this->messages.empty())
     {
         auto msg = this->messages.front();
@@ -365,10 +415,13 @@ auto flight_safety_system::transport::fss_connection::sendMsg(const std::shared_
 #endif
     while (sent < to_send)
     {
-        /* Re-load fd every iteration: a concurrent disconnect() does
-         * fd.exchange(-1) then closes the descriptor.  If that races with
-         * a multi-iteration send we must stop rather than write into a
-         * stale (possibly reused) descriptor. */
+        /* Re-load fd every iteration so a multi-iteration send stops promptly
+         * when a concurrent shutdownSocket()/disconnect() retires the fd.
+         * This alone does not prevent send() on a stale value (the load-vs-
+         * syscall window is unavoidable); what does is the deferred close
+         * (todo/52): the descriptor number is only released once the threads
+         * that could still send on it are joined, so until then a late send()
+         * hits the shut-down-but-open socket and fails with EPIPE. */
         current_fd = this->fd.load();
         if (current_fd == -1)
         {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -36,6 +36,7 @@ all_test_SOURCES = main.cpp messages.cpp connection.cpp client.cpp \
 	reconnect_test.cpp \
 	connection_negative_test.cpp \
 	oversized_message_test.cpp \
+	fd_lifecycle_test.cpp \
 	ssl_failure_test.cpp \
 	server_session_test.cpp \
 	async_db_write_test.cpp \

--- a/tests/fd_lifecycle_test.cpp
+++ b/tests/fd_lifecycle_test.cpp
@@ -1,0 +1,154 @@
+#ifdef HAVE_CATCH2_CATCH_ALL_HPP
+#include <catch2/catch_all.hpp>
+#elif HAVE_CATCH2_CATCH_HPP
+#include <catch2/catch.hpp>
+#elif HAVE_CATCH_CATCH_HPP
+#include <catch/catch.hpp>
+#elif HAVE_CATCH_HPP
+#include <catch.hpp>
+#else
+#error No catch header
+#endif
+
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <memory>
+#include <thread>
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "fss-transport.hpp"
+#include "test_helpers.hpp"
+
+using flight_safety_system::transport::fss_connection;
+using flight_safety_system::transport::fss_message;
+using flight_safety_system::transport::message_type_closed;
+using flight_safety_system::transport::FSS_MAX_MESSAGE_BYTES;
+
+namespace {
+
+/* Pins the todo/52 close ordering: fd-number reuse is invisible to TSan and
+ * the e2e suite (it is not a data race), so these tests assert the ordering
+ * that prevents it instead — the descriptor must still be OPEN at the moment
+ * the recv thread observes the shutdown (the point where the old code had
+ * already close()d it), and closed only once disconnect() has joined every
+ * thread that could touch it. */
+class fd_probe_connection : public fss_connection {
+public:
+    static auto create(int t_fd) -> std::shared_ptr<fd_probe_connection>
+    {
+        auto conn = std::shared_ptr<fd_probe_connection>(new fd_probe_connection(t_fd));
+        conn->startRecvThread(std::thread([conn]() -> void { conn->processMessages(); }));
+        return conn;
+    }
+    ~fd_probe_connection() override = default;
+    fd_probe_connection(const fd_probe_connection &) = delete;
+    fd_probe_connection(fd_probe_connection &&) = delete;
+    auto operator=(const fd_probe_connection &) -> fd_probe_connection & = delete;
+    auto operator=(fd_probe_connection &&) -> fd_probe_connection & = delete;
+    /* -1 until the recv thread observes teardown; then 1 if the descriptor was
+     * still open at that moment (fcntl succeeded), 0 if it was already gone. */
+    auto fdOpenAtShutdown() -> int { return this->fd_open_at_shutdown.load(); }
+protected:
+    explicit fd_probe_connection(int t_fd) : fss_connection(t_fd), raw_fd(t_fd) {}
+    auto recvBytes(void *t_bytes, size_t t_max_bytes) -> ssize_t override
+    {
+        ssize_t got = fss_connection::recvBytes(t_bytes, t_max_bytes);
+        if (got <= 0 && this->fd_open_at_shutdown.load() == -1)
+        {
+            this->fd_open_at_shutdown.store(::fcntl(this->raw_fd, F_GETFD) != -1 ? 1 : 0);
+        }
+        return got;
+    }
+private:
+    int raw_fd;
+    std::atomic<int> fd_open_at_shutdown{-1};
+};
+
+/* Wait until the connection's recv thread has delivered the closed message
+ * (no handler is attached, so it lands in the poll queue). */
+auto wait_for_closed(const std::shared_ptr<fss_connection> &conn) -> bool
+{
+    return fss_test::wait_for([&conn]() -> bool {
+        auto msg = conn->getMsg();
+        return msg != nullptr && msg->getType() == message_type_closed;
+    });
+}
+
+} // namespace
+
+TEST_CASE("transport: disconnect() closes the fd only after the recv thread is joined")
+{
+    int fds[2];
+    REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    fss_test::scoped_fd peer(fds[0]);
+    int raw_fd = fds[1];
+    auto conn = fd_probe_connection::create(raw_fd);
+
+    /* Let the recv thread reach its blocking recv() so the shutdown() wake-up
+     * path is what gets exercised; the assertion holds either way (a not-yet-
+     * blocked thread observes the retired fd and probes just the same). */
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    conn->disconnect();
+
+    /* disconnect() joined the recv thread, so the probe it recorded is
+     * visible: the descriptor had to still be open when the thread observed
+     * the teardown — the old close-before-join ordering freed the fd number
+     * for reuse at exactly that point. */
+    REQUIRE(conn->fdOpenAtShutdown() == 1);
+    /* ... and once disconnect() returns, the descriptor is really released. */
+    errno = 0;
+    REQUIRE(::fcntl(raw_fd, F_GETFD) == -1);
+    REQUIRE(errno == EBADF);
+}
+
+TEST_CASE("transport: shutdownSocket() reserves the fd number until disconnect()")
+{
+    int fds[2];
+    REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    fss_test::scoped_fd peer(fds[0]);
+    int raw_fd = fds[1];
+    auto conn = fd_probe_connection::create(raw_fd);
+
+    conn->shutdownSocket();
+    /* The recv thread unblocks and winds down, but the descriptor number must
+     * stay reserved (shut down, not closed) until disconnect() has joined it. */
+    REQUIRE(wait_for_closed(conn));
+    REQUIRE(::fcntl(raw_fd, F_GETFD) != -1);
+
+    conn->disconnect();
+    errno = 0;
+    REQUIRE(::fcntl(raw_fd, F_GETFD) == -1);
+    REQUIRE(errno == EBADF);
+}
+
+TEST_CASE("transport: a recv-thread self-disconnect leaves the close to the owner")
+{
+    /* An oversized declared length makes the recv thread call disconnect() on
+     * itself. It cannot join itself, so it must NOT close either: an owner-side
+     * sender (the server's outbound worker) may still be mid-send. The close
+     * belongs to the owner's later disconnect() (or the destructor). */
+    fss_test::capture_cerr capture; /* swallow the expected oversized-frame ERROR */
+    int fds[2];
+    REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    fss_test::scoped_fd peer(fds[0]);
+    int raw_fd = fds[1];
+    auto conn = fd_probe_connection::create(raw_fd);
+
+    uint16_t oversized = htons(FSS_MAX_MESSAGE_BYTES + 1);
+    REQUIRE(::write(peer.get(), &oversized, sizeof(oversized)) == static_cast<ssize_t>(sizeof(oversized)));
+
+    /* The closed message is queued after the self-disconnect completed, so the
+     * fd state is settled once it arrives: shut down but still open. */
+    REQUIRE(wait_for_closed(conn));
+    REQUIRE(::fcntl(raw_fd, F_GETFD) != -1);
+
+    conn->disconnect();
+    errno = 0;
+    REQUIRE(::fcntl(raw_fd, F_GETFD) == -1);
+    REQUIRE(errno == EBADF);
+}

--- a/tests/server_clients_test.cpp
+++ b/tests/server_clients_test.cpp
@@ -66,6 +66,17 @@ public:
         std::scoped_lock guard(this->sent_lock);
         return this->sent;
     }
+    /* fss_client::disconnect() (todo/52) shuts the connection down and joins
+     * its outbound worker BEFORE calling disconnect(), so shutdownSocket() is
+     * the hook that must release a blocked send here — it is not fd-mediated,
+     * so the base class's fd-shutdown alone would never wake it, and the
+     * worker join would hang forever waiting on a send this override never
+     * releases. */
+    void shutdownSocket() override
+    {
+        this->setBlocked(false);
+        fss::transport::fss_connection::shutdownSocket();
+    }
     void disconnect() override
     {
         this->disconnect_calls++;

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -104,7 +104,17 @@ public:
     }
 
     /* Releasing a blocked send is also needed when the connection is torn down,
-     * so a worker parked in sendMsg can exit and be joined. */
+     * so a worker parked in sendMsg can exit and be joined. fss_client::
+     * disconnect() (todo/52) now shuts the connection down and joins its
+     * outbound worker BEFORE calling disconnect(), so shutdownSocket() is the
+     * hook that must release the block — this send is not fd-mediated, so the
+     * base class's fd-shutdown alone would never wake it, and the worker join
+     * would hang forever waiting on a send this override never releases. */
+    void shutdownSocket() override
+    {
+        this->setBlocked(false);
+        fss::transport::fss_connection::shutdownSocket();
+    }
     void disconnect() override
     {
         this->setBlocked(false);


### PR DESCRIPTION
## Description

disconnect() used to shutdown and close the socket up front, then join the recv thread — so a recv/send that had already loaded the old fd number could, after an adversarially timed fd reuse (e.g. a concurrent accept in the TLS setup-worker pool), perform I/O on an unrelated connection.

Split teardown into shutdown-first (unblocks a stalled recv()/send(); the I/O loops bail on the retired fd) with the close deferred until the recv thread is joined. A recv-thread self-disconnect (garbage-frame threshold, oversized frame) defers its close to the owner's later disconnect() or the destructor, since it cannot join itself and a server-side outbound worker may still be mid-send. fss_client::disconnect() uses the new shutdown-only primitive to quiesce its outbound worker between shutdown and close, closing the same window for its sender thread; the TLS destructor skips the gnutls close-notify once the fd is retired, since gnutls holds the raw fd number and that write could likewise land on a reused descriptor.

Not observable by TSan or the e2e suite (fd-number reuse is not a data race); tests/fd_lifecycle_test.cpp pins the new ordering with fcntl probes instead. Whole-tree TSan run (unit suite + concurrency_tsan_test) stays at 0 races.

## Summary by Sourcery

Defer socket close until all I/O threads using the descriptor are quiesced to prevent fd reuse races, introduce a shutdown-only hook for connections, and adjust clients, SSL teardown, and tests to validate the new lifecycle.

Enhancements:
- Add a shutdown-only operation and deferred-close tracking to fss_connection to separate waking I/O from releasing the socket descriptor.
- Update server-side fss_client teardown to use the new shutdown hook before joining the outbound worker and performing the final disconnect.
- Guard SSL connection teardown to avoid gnutls writing close-notify on a retired file descriptor.
- Extend fake connection implementations to honour the new shutdown hook for non-fd-mediated blocking sends.

Tests:
- Add fd_lifecycle_test to assert the ordering of shutdown and close and the handling of self-disconnect cases.
- Update existing server session/client tests to exercise and validate the new shutdownSocket hook.