### PR TITLE
refactor(transport): todo/52 dedupe the pending-close exchange-and-close pattern

### DIFF
--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -62,6 +62,20 @@ auto safe_shutdown_fd(int fd, const char *context) -> int
     }
 }
 
+/* Atomically take whatever fd is parked in `slot` (if any) and close it.
+ * Shared by every todo/52 deferred-close consumer (shutdownSocket()'s
+ * stale-pending rollover, disconnect()'s quiesced-thread close, and the
+ * destructor's backstop) so the exchange-then-close pattern lives in one
+ * place. */
+static void close_pending_fd(std::atomic<int> &slot, const char *context)
+{
+    int fd = slot.exchange(-1);
+    if (fd != -1)
+    {
+        safe_close_fd(fd, context);
+    }
+}
+
 #ifdef DEBUG
 /* Run inet_ntop on a sockaddr_storage object */
 const char *inet_ntop_stor(struct sockaddr_storage *src, char *dst, size_t dstlen, uint16_t *port)
@@ -127,7 +141,11 @@ void flight_safety_system::transport::fss_connection::shutdownSocket()
     {
         /* Only possible when this object was reconnected after a deferred
          * close was left pending; every thread of that earlier session is
-         * past its last syscall on it, so release it rather than leak it. */
+         * past its last syscall on it, so release it rather than leak it.
+         * prev is already taken out of pending_close_fd above (the exchange
+         * that just stored orig_fd), so close it directly rather than
+         * through close_pending_fd (which would re-exchange a slot that no
+         * longer holds it). */
         safe_close_fd(prev, "transport/shutdown");
     }
 }
@@ -181,11 +199,7 @@ void flight_safety_system::transport::fss_connection::disconnect()
     }
     if (recv_thread_quiesced)
     {
-        int to_close = this->pending_close_fd.exchange(-1);
-        if (to_close != -1)
-        {
-            safe_close_fd(to_close, "transport/disconnect");
-        }
+        close_pending_fd(this->pending_close_fd, "transport/disconnect");
     }
 }
 
@@ -196,11 +210,7 @@ flight_safety_system::transport::fss_connection::~fss_connection()
      * (recv-thread self-disconnect, failed join): once the last owner is
      * destroying this object no thread can still be about to use the fd, so
      * release the descriptor number now. */
-    int to_close = this->pending_close_fd.exchange(-1);
-    if (to_close != -1)
-    {
-        safe_close_fd(to_close, "transport/destructor");
-    }
+    close_pending_fd(this->pending_close_fd, "transport/destructor");
     while (!this->messages.empty())
     {
         auto msg = this->messages.front();

--- a/tests/fd_lifecycle_test.cpp
+++ b/tests/fd_lifecycle_test.cpp
@@ -53,6 +53,11 @@ public:
     /* -1 until the recv thread observes teardown; then 1 if the descriptor was
      * still open at that moment (fcntl succeeded), 0 if it was already gone. */
     auto fdOpenAtShutdown() -> int { return this->fd_open_at_shutdown.load(); }
+    /* Simulates the object-reuse reconnect pattern fss_connection::connectTo()
+     * itself uses on this base class (fd == -1 check, then a fresh socket on
+     * the SAME instance) — exposes the protected setFd() so a test can set up
+     * the reuse-with-a-stale-pending-close scenario. */
+    void reuseFd(int new_fd) { this->setFd(new_fd); }
 protected:
     explicit fd_probe_connection(int t_fd) : fss_connection(t_fd), raw_fd(t_fd) {}
     auto recvBytes(void *t_bytes, size_t t_max_bytes) -> ssize_t override
@@ -123,6 +128,47 @@ TEST_CASE("transport: shutdownSocket() reserves the fd number until disconnect()
     conn->disconnect();
     errno = 0;
     REQUIRE(::fcntl(raw_fd, F_GETFD) == -1);
+    REQUIRE(errno == EBADF);
+}
+
+TEST_CASE("transport: shutdownSocket() closes a stale pending fd when the object is reused")
+{
+    /* fss_connection::connectTo() reuses the same object for a reconnect (an
+     * fd == -1 check, then a fresh socket) rather than allocating a new
+     * fss_connection. If an earlier session's disconnect() left its close
+     * pending (self-disconnect or a failed join — see the previous test), the
+     * next shutdownSocket() on the reused object must roll that stale
+     * descriptor over into a real close rather than leaking it. */
+    int fds_a[2];
+    REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds_a) == 0);
+    fss_test::scoped_fd peer_a(fds_a[0]);
+    int raw_fd_a = fds_a[1];
+    auto conn = fd_probe_connection::create(raw_fd_a);
+
+    conn->shutdownSocket();
+    REQUIRE(wait_for_closed(conn));
+    /* Session A's fd is shut down but deliberately left open — the state a
+     * self-disconnect or failed join leaves behind, with nobody left to call
+     * disconnect() for that session again. */
+    REQUIRE(::fcntl(raw_fd_a, F_GETFD) != -1);
+
+    int fds_b[2];
+    REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds_b) == 0);
+    fss_test::scoped_fd peer_b(fds_b[0]);
+    int raw_fd_b = fds_b[1];
+    conn->reuseFd(raw_fd_b);
+
+    conn->shutdownSocket();
+    errno = 0;
+    REQUIRE(::fcntl(raw_fd_a, F_GETFD) == -1);
+    REQUIRE(errno == EBADF);
+    /* B's own fd is shut down but not yet closed — same deferred-close
+     * contract as every other session. */
+    REQUIRE(::fcntl(raw_fd_b, F_GETFD) != -1);
+
+    conn->disconnect();
+    errno = 0;
+    REQUIRE(::fcntl(raw_fd_b, F_GETFD) == -1);
     REQUIRE(errno == EBADF);
 }
 


### PR DESCRIPTION
## Description

Sourcery review on PR #359: shutdownSocket()'s stale-pending rollover, disconnect()'s quiesced-thread close, and the destructor's backstop all repeated the same "exchange(-1); close if present" sequence. Factor it into a file-local close_pending_fd() helper. Kept out of the header (unlike the earlier shutdownSocket() change) so there's no vtable-layout risk this time.

Also adds the missing test coverage the same review asked for: a connection reused for a fresh fd (the pattern fss_connection::connectTo() itself uses) while an earlier session's close is still pending must roll that stale descriptor into a real close rather than leaking it.

## Summary by Sourcery

Deduplicate the deferred file-descriptor close logic in the transport layer and add coverage to ensure stale pending descriptors are correctly closed when a connection object is reused.

Bug Fixes:
- Ensure a stale pending file descriptor from a previous session is properly closed when a connection is reused and shutdown again, preventing descriptor leaks.

Enhancements:
- Introduce a shared helper to atomically take and close a pending file descriptor, used by shutdown, disconnect, and the connection destructor to centralize deferred-close handling.

Tests:
- Extend fd lifecycle tests to cover the reconnect-with-stale-pending-close scenario using a reusable connection instance and verify that both old and new descriptors are closed as expected.