### PR TITLE
fix(server): todo/60 distinguish DB read failure from unknown asset in getAssetId

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -980,18 +980,29 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                     this->client_handler->clientDisconnected(this);
                     return;
                 }
-                uint64_t asset_id = this->dbc->getAssetId(client_name);
+                auto asset_id_opt = this->dbc->getAssetId(client_name);
+                if (!asset_id_opt.has_value())
+                {
+                    /* The lookup itself failed (DB read error) -- distinct
+                     * from a genuinely unknown asset below (todo/60), so a
+                     * read outage reads as a DB incident, not a fleet of bad
+                     * CNs. A client whose identify lands here will redial and
+                     * be rejected again on every reconnect tick until the
+                     * outage clears. */
+                    FSS_LOG_ERROR("server",
+                                  "Rejecting identity '" << client_name << "': asset lookup failed (DB read error)");
+                    this->client_handler->clientDisconnected(this);
+                    return;
+                }
+                uint64_t asset_id = *asset_id_opt;
                 if (asset_id == 0)
                 {
-                    /* 0 conflates "no such asset" with "DB read failed"
-                     * (todo/60), so the wording must cover both until that
-                     * is split. A client whose identify lands here will
-                     * redial and be rejected again on every reconnect
-                     * tick, so this line recurs at that cadence — which is
-                     * the visibility we want for an unregistered asset. */
-                    FSS_LOG_WARN("server", "Rejecting identity '"
-                                               << client_name
-                                               << "': no matching asset in the database (or DB read failure)");
+                    /* The query ran fine and found no asset by this name --
+                     * an unregistered/misconfigured client, not a DB
+                     * problem. Recurs at reconnect-backoff cadence, which is
+                     * the visibility we want for this case. */
+                    FSS_LOG_WARN("server",
+                                 "Rejecting identity '" << client_name << "': no matching asset in the database");
                     this->client_handler->clientDisconnected(this);
                     return;
                 }
@@ -1050,7 +1061,18 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                 return;
             }
             const auto &client_name = possible_names.front();
-            if (this->dbc->getAssetId(client_name) != 0)
+            auto asset_id_opt = this->dbc->getAssetId(client_name);
+            if (!asset_id_opt.has_value())
+            {
+                /* Can't prove this CN isn't an aircraft's -- treat the read
+                 * failure the same as the aircraft branch above (todo/60),
+                 * not as "belongs to a known aircraft". */
+                FSS_LOG_ERROR("server", "Rejecting non-aircraft client: asset lookup failed for CN "
+                                            << client_name << " (DB read error)");
+                this->client_handler->clientDisconnected(this);
+                return;
+            }
+            if (*asset_id_opt != 0)
             {
                 FSS_LOG_ERROR("server",
                               "Rejecting non-aircraft client: CN " << client_name << " belongs to a known aircraft");

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -94,10 +94,21 @@ flight_safety_system::server::db_connection::~db_connection()
     }
 }
 
-auto flight_safety_system::server::db_connection::getAssetId(const std::string &name) -> uint64_t
+auto flight_safety_system::server::db_connection::getAssetId(const std::string &name) -> std::optional<uint64_t>
 {
-    std::scoped_lock guard(this->read_lock);
-    return db_get_asset_id(read_conn_name, name.c_str());
+    int fetch_error = 0;
+    unsigned long long asset_id = 0;
+    {
+        std::scoped_lock guard(this->read_lock);
+        asset_id = db_get_asset_id(read_conn_name, name.c_str(), &fetch_error);
+    }
+    /* nullopt tells the caller the lookup itself failed (todo/60) -- distinct
+     * from 0, which means the query ran fine and found no matching asset. */
+    if (fetch_error != 0)
+    {
+        return std::nullopt;
+    }
+    return asset_id;
 }
 
 void flight_safety_system::server::db_connection::recordRtt(uint64_t asset_id, uint64_t rtt_ms)

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -94,7 +94,12 @@ public:
     auto operator=(const IDatabase &) -> IDatabase & = delete;
     auto operator=(IDatabase &&) -> IDatabase & = delete;
     virtual ~IDatabase() = default;
-    virtual auto getAssetId(const std::string &name) -> uint64_t = 0;
+    /* nullopt means the lookup itself failed (DB read error); 0 means the
+     * query ran and found no asset by that name; anything else is the id.
+     * An explicit status, not an in-band sentinel, so a read outage isn't
+     * indistinguishable from a fleet of unregistered assets (todo/60,
+     * matches the getActiveServers() convention below). */
+    virtual auto getAssetId(const std::string &name) -> std::optional<uint64_t> = 0;
     virtual void recordPosition(uint64_t asset_id, double latitude, double longitude, uint32_t altitude) = 0;
     virtual void recordRtt(uint64_t asset_id, uint64_t rtt_ms) = 0;
     virtual void recordStatus(uint64_t asset_id, uint8_t bat_percent, uint32_t bat_mah_used, double bat_voltage) = 0;
@@ -163,7 +168,7 @@ public:
     auto operator=(db_connection &) -> db_connection & = delete;
     auto operator=(db_connection &&) -> db_connection & = delete;
     ~db_connection() override;
-    auto getAssetId(const std::string &name) -> uint64_t override;
+    auto getAssetId(const std::string &name) -> std::optional<uint64_t> override;
     void recordPosition(uint64_t asset_id, double latitude, double longitude, uint32_t altitude) override;
     void recordRtt(uint64_t asset_id, uint64_t rtt_ms) override;
     void recordStatus(uint64_t asset_id, uint8_t bat_percent, uint32_t bat_mah_used, double bat_voltage) override;

--- a/src/server-db.h
+++ b/src/server-db.h
@@ -7,7 +7,11 @@ int db_connect(const char *conn, const char *host, int port, const char *user, c
 void db_disconnect(const char *conn);
 int db_ping(const char *conn);
 
-unsigned long long db_get_asset_id(const char *conn, const char *asset_name);
+/* error_out (may be NULL) is set to 1 when the query itself failed (e.g. the
+ * connection is down), distinct from a 0 return for a genuinely unknown
+ * asset name (todo/60) -- mirrors the db_active_fss_servers_get(..., int
+ * *error_out) convention. */
+unsigned long long db_get_asset_id(const char *conn, const char *asset_name, int *error_out);
 
 /* todo/34: these six writers return 1 on success, 0 if sqlca.sqlcode < 0
  * (e.g. disk-full) -- the caller (db.cpp) throws database_error on 0 so a

--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -83,8 +83,13 @@ int db_connect(const char *conn_arg, const char *host, int port, const char *use
     return 1;
 }
 
-unsigned long long db_get_asset_id(const char *conn_arg, const char *asset_name_arg)
+unsigned long long db_get_asset_id(const char *conn_arg, const char *asset_name_arg, int *error_out)
 {
+    if (error_out != NULL)
+    {
+        *error_out = 0;
+    }
+
     EXEC SQL BEGIN DECLARE SECTION;
     const char *conn = conn_arg;
     const char *asset_name = asset_name_arg;
@@ -95,11 +100,16 @@ unsigned long long db_get_asset_id(const char *conn_arg, const char *asset_name_
 
     if (sqlca.sqlcode < 0)
     {
-        /* A query failure (connection down, etc.) returns 0 just like an
-         * unknown asset, and the caller rejects the client either way.
-         * Print the SQL error so the log tells the truth about why
-         * identification failed. */
+        /* A query failure (connection down, etc.) still returns 0 for the id
+         * like an unknown asset, but error_out lets the caller (todo/60) tell
+         * the two apart instead of treating every read outage as a fleet of
+         * unregistered assets. Print the SQL error so the log tells the truth
+         * about why identification failed. */
         sqlprint();
+        if (error_out != NULL)
+        {
+            *error_out = 1;
+        }
     }
 
     return asset_id;

--- a/tests/concurrency_client_test.cpp
+++ b/tests/concurrency_client_test.cpp
@@ -98,7 +98,10 @@ protected:
  * else. No real database is involved. */
 class stub_database : public flight_safety_system::server::IDatabase {
 public:
-    auto getAssetId(const std::string &name) -> uint64_t override { return name == "craft" ? 1 : 0; }
+    auto getAssetId(const std::string &name) -> std::optional<uint64_t> override
+    {
+        return uint64_t{name == "craft" ? 1U : 0U};
+    }
     void recordPosition(uint64_t, double, double, uint32_t) override {}
     void recordRtt(uint64_t, uint64_t) override {}
     void recordStatus(uint64_t, uint8_t, uint32_t, double) override {}

--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -15,6 +15,7 @@
 #include <cstdlib>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -70,6 +71,18 @@ auto make_live_db() -> std::unique_ptr<flight_safety_system::server::db_connecti
     return dbc;
 }
 
+/* getAssetId returns nullopt on a DB read failure, 0 for a genuinely unknown
+ * asset (todo/60). Most tests just want the "test-asset" fixture's id and
+ * should hard-fail if either variant fires, so unwrap both here rather than
+ * repeating the two checks at every call site. */
+auto get_test_asset_id(flight_safety_system::server::db_connection &dbc) -> uint64_t
+{
+    auto id = dbc.getAssetId("test-asset");
+    REQUIRE(id.has_value());
+    REQUIRE(*id != 0);
+    return *id;
+}
+
 } // namespace
 
 /* Catch2's SKIP() macro arrived in 3.3; distro packages can be older (Debian
@@ -104,46 +117,41 @@ TEST_CASE("db_connection: connects to live database")
 TEST_CASE("db_connection: getAssetId returns non-zero for pre-inserted asset")
 {
     LIVE_DB_OR_SKIP(dbc);
-    REQUIRE(dbc->getAssetId("test-asset") != 0);
+    get_test_asset_id(*dbc);
 }
 
 TEST_CASE("db_connection: recordRtt writes a row without error")
 {
     LIVE_DB_OR_SKIP(dbc);
-    auto asset_id = dbc->getAssetId("test-asset");
-    REQUIRE(asset_id != 0);
+    auto asset_id = get_test_asset_id(*dbc);
     dbc->recordRtt(asset_id, uint64_t{42});
 }
 
 TEST_CASE("db_connection: recordStatus writes a row without error")
 {
     LIVE_DB_OR_SKIP(dbc);
-    auto asset_id = dbc->getAssetId("test-asset");
-    REQUIRE(asset_id != 0);
+    auto asset_id = get_test_asset_id(*dbc);
     dbc->recordStatus(asset_id, uint8_t{80}, uint32_t{1000}, 12.4);
 }
 
 TEST_CASE("db_connection: recordSearchStatus writes a row without error")
 {
     LIVE_DB_OR_SKIP(dbc);
-    auto asset_id = dbc->getAssetId("test-asset");
-    REQUIRE(asset_id != 0);
+    auto asset_id = get_test_asset_id(*dbc);
     dbc->recordSearchStatus(asset_id, uint64_t{1}, uint64_t{50}, uint64_t{100});
 }
 
 TEST_CASE("db_connection: recordPosition with valid altitude inserts row")
 {
     LIVE_DB_OR_SKIP(dbc);
-    auto asset_id = dbc->getAssetId("test-asset");
-    REQUIRE(asset_id != 0);
+    auto asset_id = get_test_asset_id(*dbc);
     dbc->recordPosition(asset_id, -43.5, 172.6, uint32_t{100});
 }
 
 TEST_CASE("db_connection: recordPosition with overflow altitude is discarded")
 {
     LIVE_DB_OR_SKIP(dbc);
-    auto asset_id = dbc->getAssetId("test-asset");
-    REQUIRE(asset_id != 0);
+    auto asset_id = get_test_asset_id(*dbc);
     constexpr auto huge_alt = static_cast<uint32_t>(std::numeric_limits<int>::max()) + uint32_t{1};
     dbc->recordPosition(asset_id, -43.5, 172.6, huge_alt);
 }
@@ -157,8 +165,7 @@ TEST_CASE("db_connection: write methods throw database_error when the write conn
      * the write connection down (no reconnect) so the write is guaranteed to
      * fail, and require every write method surfaces it as database_error. */
     LIVE_DB_OR_SKIP(dbc);
-    auto asset_id = dbc->getAssetId("test-asset");
-    REQUIRE(asset_id != 0);
+    auto asset_id = get_test_asset_id(*dbc);
     db_disconnect(flight_safety_system::server::db_connection::write_conn_name);
 
     auto threw_database_error = [](auto &&write_call) -> bool {
@@ -185,8 +192,7 @@ TEST_CASE("db_connection: write methods throw database_error when the write conn
 TEST_CASE("db_connection: getSmmSettings returns non-null for configured asset")
 {
     LIVE_DB_OR_SKIP(dbc);
-    auto asset_id = dbc->getAssetId("test-asset");
-    REQUIRE(asset_id != 0);
+    auto asset_id = get_test_asset_id(*dbc);
     auto settings = dbc->getSmmSettings(asset_id);
     REQUIRE(settings != nullptr);
     REQUIRE_FALSE(settings->getAddress().empty());
@@ -303,8 +309,7 @@ TEST_CASE("db_connection: tryReconnectIfNeeded restores a single dropped connect
      * is lost, tryReconnectIfNeeded must restore it — and operations on that
      * connection must work again — while the other is left untouched. */
     LIVE_DB_OR_SKIP(dbc);
-    auto asset_id = dbc->getAssetId("test-asset");
-    REQUIRE(asset_id != 0);
+    auto asset_id = get_test_asset_id(*dbc);
 
     /* Drop one connection by name, recover it, then exercise both a read
      * (getAssetId) and a write (recordRtt): whichever connection was dropped
@@ -334,8 +339,7 @@ TEST_CASE("db_connection: getCommand returns non-null for asset with pending com
     /* The test fixture inserts an RTL command for test-asset before the test
      * suite runs.  getCommand() must find it and return a non-null result. */
     LIVE_DB_OR_SKIP(dbc);
-    auto asset_id = dbc->getAssetId("test-asset");
-    REQUIRE(asset_id != 0);
+    auto asset_id = get_test_asset_id(*dbc);
     auto cmd = dbc->getCommand(asset_id);
     REQUIRE(cmd != nullptr);
 }
@@ -411,8 +415,7 @@ auto get_command_column(uint64_t command_id, const std::string &column) -> std::
 TEST_CASE("db_connection: recordCommandDispatch stores the dispatch id")
 {
     LIVE_DB_OR_SKIP(dbc);
-    auto asset_id = dbc->getAssetId("test-asset");
-    REQUIRE(asset_id != 0);
+    auto asset_id = get_test_asset_id(*dbc);
     auto command_id = insert_test_command(asset_id);
 
     dbc->recordCommandDispatch(command_id, uint64_t{4242});
@@ -423,8 +426,7 @@ TEST_CASE("db_connection: recordCommandDispatch stores the dispatch id")
 TEST_CASE("db_connection: recordCommandAck stores ack_state, ack_timestamp and ack_superseded_by")
 {
     LIVE_DB_OR_SKIP(dbc);
-    auto asset_id = dbc->getAssetId("test-asset");
-    REQUIRE(asset_id != 0);
+    auto asset_id = get_test_asset_id(*dbc);
     auto command_id = insert_test_command(asset_id);
     dbc->recordCommandDispatch(command_id, uint64_t{5555});
 
@@ -443,8 +445,7 @@ TEST_CASE("db_connection: recordCommandAck does not regress an already-terminal 
      * the comment above the UPDATE in db_command_record_ack(). Simulate an
      * out-of-order ack arrival: actioned first, then a stale "received". */
     LIVE_DB_OR_SKIP(dbc);
-    auto asset_id = dbc->getAssetId("test-asset");
-    REQUIRE(asset_id != 0);
+    auto asset_id = get_test_asset_id(*dbc);
     auto command_id = insert_test_command(asset_id);
     dbc->recordCommandDispatch(command_id, uint64_t{6666});
 
@@ -466,8 +467,7 @@ TEST_CASE("db_connection: recordCommandAck refuses a second terminal outcome")
      * must not rewrite a settled "actioned" in the audit record -- the
      * query-enforced writable set is stored-state NULL or received only. */
     LIVE_DB_OR_SKIP(dbc);
-    auto asset_id = dbc->getAssetId("test-asset");
-    REQUIRE(asset_id != 0);
+    auto asset_id = get_test_asset_id(*dbc);
 
     const std::array<uint8_t, 3> later_terminals = {
         static_cast<uint8_t>(flight_safety_system::transport::command_ack_superseded),
@@ -498,8 +498,7 @@ TEST_CASE("db_connection: recordCommandAck admits the conforming received-then-t
     /* The two-phase ack a conforming FMU sends (received, then exactly one
      * terminal outcome) must be unaffected by the todo/48 finality guard. */
     LIVE_DB_OR_SKIP(dbc);
-    auto asset_id = dbc->getAssetId("test-asset");
-    REQUIRE(asset_id != 0);
+    auto asset_id = get_test_asset_id(*dbc);
     auto command_id = insert_test_command(asset_id);
     dbc->recordCommandDispatch(command_id, uint64_t{7780});
 
@@ -524,8 +523,7 @@ TEST_CASE("db_connection: recordCommandDispatch reopens the ack cycle")
      * by test_server_restart.py's post-bounce re-ack check; this covers the
      * same contract at the query level. */
     LIVE_DB_OR_SKIP(dbc);
-    auto asset_id = dbc->getAssetId("test-asset");
-    REQUIRE(asset_id != 0);
+    auto asset_id = get_test_asset_id(*dbc);
     auto command_id = insert_test_command(asset_id);
     dbc->recordCommandDispatch(command_id, uint64_t{7790});
     dbc->recordCommandAck(asset_id, uint64_t{7790},

--- a/tests/mock_database.hpp
+++ b/tests/mock_database.hpp
@@ -71,10 +71,10 @@ public:
     auto operator=(MockDatabase &&) -> MockDatabase & = delete;
     ~MockDatabase() override = default;
 
-    auto getAssetId(const std::string &name) -> uint64_t override
+    auto getAssetId(const std::string &name) -> std::optional<uint64_t> override
     {
         auto it = asset_ids.find(name);
-        return it == asset_ids.end() ? 0 : it->second;
+        return it == asset_ids.end() ? uint64_t{0} : it->second;
     }
 
     void recordPosition(uint64_t asset_id, double latitude, double longitude, uint32_t altitude) override


### PR DESCRIPTION
## Description

db_get_asset_id() returned 0 for both a genuinely unknown asset name and a failed query (connection down mid-outage), so a DB read outage during identify was indistinguishable from a fleet of bad certificate CNs.

IDatabase::getAssetId() now returns std::optional<uint64_t> (nullopt = read failed, 0 = definitively unknown), matching the getActiveServers() explicit- status convention. The ECPG layer gains an error_out param mirroring db_active_fss_servers_get(). Both identify call sites (aircraft, and the non-aircraft known-aircraft check) now log a distinct ERROR for a failed lookup instead of folding it into the "no matching asset" wording.

## Summary by Sourcery

Distinguish database read failures from unknown assets when resolving asset IDs and update callers, interfaces, and tests to use an explicit status via std::optional.

Bug Fixes:
- Treat database read outages during client identification as DB incidents rather than as unregistered assets by propagating lookup failures explicitly.

Enhancements:
- Change IDatabase::getAssetId and db_connection::getAssetId to return std::optional<uint64_t>, with nullopt indicating a read failure and 0 indicating a definitively unknown asset.
- Extend the ECPG db_get_asset_id interface with an error_out parameter to report query-level failures separately from unknown asset results.
- Update client_session identity handling to log distinct messages and disconnect behaviour for DB read errors versus genuinely unknown assets.
- Refactor tests to handle the new optional asset ID contract and centralise retrieval of the test asset ID via a helper.
- Adjust stub and mock database implementations to conform to the new optional-return getAssetId interface.

Tests:
- Update db_connection and concurrency client tests to use the new optional asset ID semantics and shared helper for the test asset fixture.