### PR TITLE
test(server): todo/60 regression coverage for the DB-read-failure identify path

### DIFF
--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -120,6 +120,18 @@ TEST_CASE("db_connection: getAssetId returns non-zero for pre-inserted asset")
     get_test_asset_id(*dbc);
 }
 
+TEST_CASE("db_connection: getAssetId returns nullopt when the read connection is down (todo/60)")
+{
+    /* Distinguishes a DB read failure from a genuinely unknown asset: before
+     * todo/60, both collapsed to 0 and the identify path could not tell a
+     * bad CN from a read outage. Force the read connection down (no
+     * reconnect) so the query is guaranteed to fail at the ECPG layer, the
+     * same technique the todo/34 write-side test uses. */
+    LIVE_DB_OR_SKIP(dbc);
+    db_disconnect(flight_safety_system::server::db_connection::read_conn_name);
+    REQUIRE_FALSE(dbc->getAssetId("test-asset").has_value());
+}
+
 TEST_CASE("db_connection: recordRtt writes a row without error")
 {
     LIVE_DB_OR_SKIP(dbc);

--- a/tests/mock_database.hpp
+++ b/tests/mock_database.hpp
@@ -29,6 +29,10 @@ public:
     /* When set, getActiveServers returns nullopt, simulating a mid-cursor
      * read failure so tests can exercise the partial-result discard path. */
     bool active_servers_fail{false};
+    /* When set, getAssetId returns nullopt regardless of name, simulating a
+     * DB read failure so tests can exercise the todo/60 split from a
+     * genuinely unknown asset (which stays a 0 lookup miss). */
+    bool asset_id_lookup_fail{false};
 
     struct recorded_rtt {
         uint64_t asset_id;
@@ -73,6 +77,10 @@ public:
 
     auto getAssetId(const std::string &name) -> std::optional<uint64_t> override
     {
+        if (asset_id_lookup_fail)
+        {
+            return std::nullopt;
+        }
         auto it = asset_ids.find(name);
         return it == asset_ids.end() ? uint64_t{0} : it->second;
     }

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -322,6 +322,31 @@ TEST_CASE("session: rejects non-aircraft identify when cert CN belongs to a know
     REQUIRE_FALSE(session->isAircraft());
 }
 
+TEST_CASE("session: rejects non-aircraft identify with a distinct log when the asset lookup itself fails (todo/60)")
+{
+    /* Can't prove this CN isn't an aircraft's when the lookup itself fails,
+     * so it must still be rejected — but logged as a read failure, not as
+     * "belongs to a known aircraft" (which would be misleading: nothing
+     * proved that). */
+    fss_test::MockDatabase mock;
+    mock.asset_id_lookup_fail = true;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("ground-station-1");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    fss_test::capture_cerr cap;
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity_non_aircraft>());
+
+    REQUIRE(handler.disconnects == 1);
+    REQUIRE_FALSE(session->isAircraft());
+    auto out = cap.str();
+    REQUIRE(out.find("DB read error") != std::string::npos);
+    REQUIRE(out.find("belongs to a known aircraft") == std::string::npos);
+}
+
 TEST_CASE("session: accepts non-aircraft identify when cert CN is not a known aircraft")
 {
     fss_test::MockDatabase mock;
@@ -408,12 +433,39 @@ TEST_CASE("session: rejects identify when asset unknown to database")
 
     REQUIRE(conn->sent.empty());
     /* The rejection must be logged with the unmatched name — a silent
-     * sever here cost a day of misdiagnosis (todo/65 re-test). The
-     * wording covers the DB-read-failure case too, which getAssetId()
-     * cannot yet distinguish (todo/60). */
+     * sever here cost a day of misdiagnosis (todo/65 re-test). */
     auto out = cap.str();
     REQUIRE(out.find("Rejecting identity 'unknownAsset'") != std::string::npos);
     REQUIRE(out.find("no matching asset") != std::string::npos);
+    REQUIRE(session->getCachedAssetId() == 0);
+}
+
+TEST_CASE("session: rejects identify with a distinct log when the asset lookup itself fails (todo/60)")
+{
+    /* getAssetId() returning nullopt (DB read error, e.g. mid-outage) must be
+     * rejected the same way as a genuinely unknown asset, but logged
+     * differently — the whole point of todo/60 is that an operator can tell
+     * "every cert CN is wrong" apart from "the DB read is down" from the log
+     * alone. */
+    fss_test::MockDatabase mock;
+    mock.asset_id_lookup_fail = true;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    fss_test::capture_cerr cap;
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    REQUIRE(handler.disconnects == 1);
+    REQUIRE(conn->sent.empty());
+    REQUIRE(session->getCachedAssetId() == 0);
+    auto out = cap.str();
+    REQUIRE(out.find("Rejecting identity 'craft'") != std::string::npos);
+    REQUIRE(out.find("DB read error") != std::string::npos);
+    REQUIRE(out.find("no matching asset") == std::string::npos);
 }
 
 TEST_CASE("session: getCommand returns newest-timestamp entry")


### PR DESCRIPTION
## Description

MockDatabase gains asset_id_lookup_fail to simulate a failed getAssetId() lookup. New session-level tests pin the distinct ERROR log and confirm no asset_id is published for both identify paths (aircraft, non-aircraft); a new db_connection_test.cpp case kills the read connection and checks the ECPG out-param surfaces as nullopt, mirroring the todo/34 write-side technique. Also drops the now-stale "cannot yet distinguish" comment from the existing unknown-asset test.

## Summary by Sourcery

Add regression coverage to distinguish DB read failures from unknown assets in identity handling.

Enhancements:
- Extend MockDatabase with a toggle to force getAssetId to return nullopt, enabling tests to simulate DB read failures.
- Clarify existing identity rejection test expectations by removing outdated comments and asserting cached asset ID is reset on rejection.

Tests:
- Add session tests for aircraft and non-aircraft identify paths that verify disconnect behaviour and distinct logging when asset ID lookup fails.
- Add db_connection test ensuring getAssetId returns nullopt when the read connection is down, separating read failures from unknown-asset cases.