### PR TITLE
feat(docker): honor optional CRL_FILE env var in start-server.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or every client during a DB read outage — was indistinguishable from
   network flapping at every layer's logs (this cost a day of misdiagnosis in
   the todo/65 re-test).
+- `docker/start-server.sh` now accepts an optional `CRL_FILE` env var and,
+  when set, adds it as `ssl.crl_file` in the generated `server.json`
+  (todo/62). Previously the entrypoint's generated config had no way to
+  reach `crl_file` at all — the server and `transport-ssl.cpp` have
+  supported it (and its SIGHUP reload) since todo/29, but a container built
+  from this image could only get CRL support by bind-mounting a
+  hand-written `server.json` over the entrypoint's DB/port wiring entirely.
+  Omitting `CRL_FILE` reproduces the previous config byte-for-byte.
 
 ## [1.2.1] - 2026-07-19
 

--- a/docker/start-server.sh
+++ b/docker/start-server.sh
@@ -7,12 +7,13 @@ jq -n \
     --arg ca "/certs/ca.public.pem" \
     --arg priv "/certs/${NAME}.private.pem" \
     --arg pub "/certs/${NAME}.public.pem" \
+    --arg crl "${CRL_FILE:-}" \
     --arg host "${DB_HOST}" \
     --argjson db_port "${DB_PORT:-5432}" \
     --arg user "${DB_USER}" \
     --arg db "${DB_NAME}" \
     --arg pass "${DB_PASS}" \
-    '{port: ($port|tonumber), ssl: {ca_public_key: $ca, server_private_key: $priv, server_public_key: $pub}, postgres: {host: $host, port: $db_port, user: $user, db: $db, pass: $pass}}' \
+    '{port: ($port|tonumber), ssl: ({ca_public_key: $ca, server_private_key: $priv, server_public_key: $pub} + (if $crl != "" then {crl_file: $crl} else {} end)), postgres: {host: $host, port: $db_port, user: $user, db: $db, pass: $pass}}' \
     > "${CONFIG_FILE}"
 
 cat /etc/fss/server.json


### PR DESCRIPTION
## Description

todo/62: the entrypoint's generated server.json had no way to set ssl.crl_file, so a container could only get CRL support by bind-mounting a hand-written config over the entrypoint's DB/port wiring. Omitting CRL_FILE reproduces the previous config exactly; verified both cases by running the shipped script inside an actual built trixie image.

## Summary by Sourcery

Add optional CRL_FILE support to Docker start-server entrypoint to propagate certificate revocation list configuration into generated server.json without changing behavior when unset.

Enhancements:
- Extend docker/start-server.sh to include ssl.crl_file in generated server.json when CRL_FILE is provided, while preserving previous configuration when it is not.

Documentation:
- Document CRL_FILE support for docker/start-server.sh in the changelog, including its behavior when omitted.