### PR TITLE
feat(db): todo/23 IDatabase::getCommands batched read

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -211,6 +211,9 @@ auto flight_safety_system::server::db_connection::getCommands(const std::vector<
     {
         return res;
     }
+    /* At most one entry per requested asset (fewer when some have no pending
+     * command); reserve up front so this per-tick poll path never rehashes. */
+    res.reserve(asset_ids.size());
     /* db_asset_commands_get takes the C asset-id type (unsigned long long) used
      * throughout server-db.h; copy into it because uint64_t may be a distinct
      * type (unsigned long here) whose pointer will not implicitly convert. */

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -203,6 +203,50 @@ auto flight_safety_system::server::db_connection::getCommand(uint64_t asset_id) 
     return res;
 }
 
+auto flight_safety_system::server::db_connection::getCommands(const std::vector<uint64_t> &asset_ids)
+    -> std::unordered_map<uint64_t, std::shared_ptr<asset_command>>
+{
+    std::unordered_map<uint64_t, std::shared_ptr<asset_command>> res;
+    if (asset_ids.empty())
+    {
+        return res;
+    }
+    /* db_asset_commands_get takes the C asset-id type (unsigned long long) used
+     * throughout server-db.h; copy into it because uint64_t may be a distinct
+     * type (unsigned long here) whose pointer will not implicitly convert. */
+    std::vector<unsigned long long> ids(asset_ids.begin(), asset_ids.end());
+    struct asset_command_row_s **rows = nullptr;
+    int fetch_error = 0;
+    {
+        std::scoped_lock guard(this->read_lock);
+        rows = db_asset_commands_get(read_conn_name, ids.data(), ids.size(), &fetch_error);
+    }
+    if (rows)
+    {
+        for (size_t i = 0; rows[i] != nullptr; i++)
+        {
+            struct asset_command_row_s *row = rows[i];
+            res[row->asset_id] =
+                std::make_shared<asset_command>(row->dbid, row->timestamp, std::string(row->command), row->latitude,
+                                                row->longitude, row->altitude, row->altitude_null == 0);
+            free(row->command);
+            free(row);
+        }
+        db_free_asset_commands(rows);
+    }
+    /* A mid-cursor failure leaves res holding only the assets read before the
+     * error; the rest are absent (treated as "no pending command"). This is the
+     * same outcome the per-asset getCommand path already produces when the read
+     * connection is down — both serialise on the one read connection, so a drop
+     * fails them all — so the poller's next tick simply retries. No discard. */
+    if (fetch_error != 0)
+    {
+        FSS_LOG_ERROR("db",
+                      "batched command read failed mid-cursor; " << res.size() << " asset(s) read before the error");
+    }
+    return res;
+}
+
 auto flight_safety_system::server::db_connection::getSmmSettings(uint64_t asset_id) -> std::shared_ptr<smm_settings>
 {
     std::shared_ptr<smm_settings> res = nullptr;

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -15,6 +15,7 @@
 #include <list>
 #include <mutex>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
 namespace flight_safety_system {
@@ -121,6 +122,15 @@ public:
     virtual void recordCommandAck(uint64_t asset_id, uint64_t dispatch_id, uint8_t ack_state, uint64_t ack_timestamp,
                                   uint8_t ack_reason) = 0;
     virtual auto getCommand(uint64_t asset_id) -> std::shared_ptr<asset_command> = 0;
+    /* Batched getCommand: the newest command for each id in asset_ids, keyed by
+     * asset_id. Assets with no pending command are simply absent from the map,
+     * so callers treat "absent" exactly as getCommand's nullptr. Lets the
+     * command poller issue one query per tick instead of one per client
+     * (todo/23). A mid-read error yields a partial map — the same envelope as
+     * getCommand returning nullptr per asset when the read connection is down,
+     * since both share the one read connection. */
+    virtual auto getCommands(const std::vector<uint64_t> &asset_ids)
+        -> std::unordered_map<uint64_t, std::shared_ptr<asset_command>> = 0;
     /* The complete set of active servers, or nullopt when the read was cut
      * short (mid-cursor error, truncated row) and could only produce a
      * partial, misleading list. nullopt is NOT an empty list: the caller must
@@ -177,6 +187,8 @@ public:
     void recordCommandAck(uint64_t asset_id, uint64_t dispatch_id, uint8_t ack_state, uint64_t ack_timestamp,
                           uint8_t ack_reason) override;
     auto getCommand(uint64_t asset_id) -> std::shared_ptr<asset_command> override;
+    auto getCommands(const std::vector<uint64_t> &asset_ids)
+        -> std::unordered_map<uint64_t, std::shared_ptr<asset_command>> override;
     auto getActiveServers() -> std::optional<std::vector<fss_server_details>> override;
     auto getSmmSettings(uint64_t asset_id) -> std::shared_ptr<smm_settings> override;
     auto isConnected() const -> bool override;

--- a/tests/concurrency_client_test.cpp
+++ b/tests/concurrency_client_test.cpp
@@ -112,6 +112,11 @@ public:
     {
         return nullptr;
     }
+    auto getCommands(const std::vector<uint64_t> &)
+        -> std::unordered_map<uint64_t, std::shared_ptr<flight_safety_system::server::asset_command>> override
+    {
+        return {};
+    }
     auto getActiveServers() -> std::optional<std::vector<flight_safety_system::server::fss_server_details>> override
     {
         /* An engaged empty vector: no servers configured, not a failed read. */

--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -47,6 +47,17 @@ TEST_CASE("db_connection: construction bounds in-flight TCP stalls via PGTCPUSER
     REQUIRE(std::getenv("PGTCPUSERTIMEOUT") != nullptr);
 }
 
+TEST_CASE("db_connection: getCommands short-circuits empty input without a round-trip")
+{
+    /* An empty asset set returns before any DB access (it would also build an
+     * invalid "IN ()" clause), so it must succeed even against a connection
+     * that never came up -- the poller relies on this when no client is yet
+     * identified. */
+    flight_safety_system::server::db_connection dbc(
+        "db.invalid", 5432, "user", flight_safety_system::secure_string(std::string_view{"pass"}), "db");
+    REQUIRE(dbc.getCommands({}).empty());
+}
+
 namespace {
 
 /* Build a db_connection from the TEST_DB_* env vars and REQUIRE it has
@@ -423,6 +434,40 @@ auto get_command_column(uint64_t command_id, const std::string &column) -> std::
 }
 
 } // namespace
+
+TEST_CASE("db_connection: getCommands returns the newest command per asset and omits absent ones")
+{
+    /* Exercises the batched read end-to-end: DISTINCT ON must pick the newest
+     * command for the asset, the IN-list must filter to only the requested
+     * asset, and an id with no command must be absent (not a null entry). */
+    LIVE_DB_OR_SKIP(dbc);
+    auto asset_id = get_test_asset_id(*dbc);
+    insert_test_command(asset_id);
+    auto newest_id = insert_test_command(asset_id);
+
+    constexpr uint64_t absent_asset = 999999999ULL; /* no such asset -> no command */
+    auto commands = dbc->getCommands({asset_id, absent_asset});
+
+    REQUIRE(commands.count(asset_id) == 1);
+    REQUIRE(commands.at(asset_id)->getDBId() == newest_id);
+    REQUIRE(commands.count(absent_asset) == 0);
+}
+
+TEST_CASE("db_connection: getCommands agrees with getCommand for the same asset")
+{
+    /* The batched and single-row reads must never disagree about which row is
+     * newest, or the poller would dispatch a different command than the
+     * identify-time path. */
+    LIVE_DB_OR_SKIP(dbc);
+    auto asset_id = get_test_asset_id(*dbc);
+    insert_test_command(asset_id);
+
+    auto single = dbc->getCommand(asset_id);
+    auto batch = dbc->getCommands({asset_id});
+    REQUIRE(single != nullptr);
+    REQUIRE(batch.count(asset_id) == 1);
+    REQUIRE(batch.at(asset_id)->getDBId() == single->getDBId());
+}
 
 TEST_CASE("db_connection: recordCommandDispatch stores the dispatch id")
 {

--- a/tests/mock_database.hpp
+++ b/tests/mock_database.hpp
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "fss-server.hpp"
@@ -171,6 +172,23 @@ public:
             }
         }
         return newest;
+    }
+
+    auto getCommands(const std::vector<uint64_t> &ids)
+        -> std::unordered_map<uint64_t, std::shared_ptr<flight_safety_system::server::asset_command>> override
+    {
+        /* Reuse getCommand's newest-by-timestamp selection so batched and
+         * single reads can never disagree; assets with no command are omitted,
+         * matching the production "absent == nullptr" contract. */
+        std::unordered_map<uint64_t, std::shared_ptr<flight_safety_system::server::asset_command>> res;
+        for (uint64_t asset_id : ids)
+        {
+            if (auto cmd = getCommand(asset_id))
+            {
+                res[asset_id] = std::move(cmd);
+            }
+        }
+        return res;
     }
 
     auto getActiveServers() -> std::optional<std::vector<flight_safety_system::server::fss_server_details>> override


### PR DESCRIPTION
## Description

Add getCommands(asset_ids) to the IDatabase seam and implement it in db_connection over the new db_asset_commands_get ECPG entry point: one round-trip returns the newest command per asset, keyed by asset_id, with absent assets treated exactly as getCommand's nullptr. A mid-read error yields a partial map (the same envelope the per-asset getCommand path already produces when the shared read connection is down), so the poller simply retries next tick.

MockDatabase implements it by reusing getCommand's newest-by-timestamp selection so batched and single reads can never disagree; stub_database returns an empty map. Adds live-DB tests (newest-per-asset, absent omitted, agreement with getCommand) plus a non-live empty-input short-circuit test.

Not yet wired into the poller.

## Summary by Sourcery

Introduce a batched command retrieval API to IDatabase and db_connection that returns the newest command per asset in a single query, with absent assets treated as having no pending command and partial results on mid-read errors.

New Features:
- Add IDatabase::getCommands to fetch the newest command for multiple assets in one call, keyed by asset_id.

Enhancements:
- Implement db_connection::getCommands over the new db_asset_commands_get entry point with error logging on partial reads.
- Extend MockDatabase and stub_database to support the new batched getCommands interface, keeping behavior consistent with single-asset getCommand.

Tests:
- Add live-DB tests verifying getCommands returns the newest command per asset, omits assets with no command, and matches getCommand results.
- Add a non-live test ensuring db_connection::getCommands short-circuits empty input without hitting the database.