### PR TITLE
perf(server): todo/23 batch the command poll into one query per tick

### DIFF
--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -138,13 +138,36 @@ public:
     };
     void pollCommands(flight_safety_system::server::IDatabase *dbc)
     {
+        /* Capture (client, asset_id) once rather than re-reading the atomic
+         * cached_asset_id when mapping results back: a client that identifies
+         * mid-pass must not be queried under one id and looked up under
+         * another. */
+        std::vector<std::pair<std::shared_ptr<flight_safety_system::server::fss_client>, uint64_t>> identified;
+        std::vector<uint64_t> asset_ids;
         for (const auto &client : this->snapshotClients())
         {
             uint64_t asset_id = client->getCachedAssetId(); /* atomic */
             if (asset_id != 0)
             {
-                client->setPendingCommand(dbc->getCommand(asset_id));
+                identified.emplace_back(client, asset_id);
+                asset_ids.push_back(asset_id);
             }
+        }
+        if (identified.empty())
+        {
+            return;
+        }
+        /* One query for the whole fleet's newest-command-per-asset instead of a
+         * getCommand round-trip per client (todo/23): 10*N reads/sec collapse to
+         * 10/sec. An asset absent from the map has no pending command -- the same
+         * as getCommand returning nullptr -- so clear it, preserving the prior
+         * per-client behaviour exactly (the resend-window dedup in sendCommand
+         * still governs what actually reaches the aircraft). */
+        auto commands = dbc->getCommands(asset_ids);
+        for (const auto &[client, asset_id] : identified)
+        {
+            auto found = commands.find(asset_id);
+            client->setPendingCommand(found != commands.end() ? found->second : nullptr);
         }
     };
     void sendCommand()

--- a/tests/server_clients_test.cpp
+++ b/tests/server_clients_test.cpp
@@ -1066,3 +1066,44 @@ TEST_CASE("server_clients: gate-then-sever leaves no session live or admissible 
     sc.clientConnected(returned);
     REQUIRE(sc.getTotalClients() == 1);
 }
+
+TEST_CASE("server_clients: pollCommands fans the batched read out to the owning clients")
+{
+    /* The batched pollCommands (todo/23) must deliver each asset's newest
+     * command to exactly the client that owns that asset, and stage nothing for
+     * a client whose asset has no pending command -- the same per-client outcome
+     * the old one-getCommand-per-client loop produced. Built inline rather than
+     * via make_aircraft_client so the test keeps each FakeConnection to inspect
+     * what was sent. */
+    server_clients sc;
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft1"] = 1;
+    mock.asset_ids["craft2"] = 2;
+
+    auto conn1 = std::make_shared<FakeConnection>();
+    conn1->cert_names.push_back("craft1");
+    auto client1 = std::make_shared<fss::server::fss_client>(conn1, &mock, make_null_writer(), &sc);
+    /* Identify before pushing the command so the identify-time dispatch path
+     * does not deliver it -- this isolates pollCommands as the sole delivery. */
+    client1->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft1"));
+    sc.clientConnected(client1);
+
+    auto conn2 = std::make_shared<FakeConnection>();
+    conn2->cert_names.push_back("craft2");
+    auto client2 = std::make_shared<fss::server::fss_client>(conn2, &mock, make_null_writer(), &sc);
+    client2->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft2"));
+    sc.clientConnected(client2);
+
+    /* Only craft1 (asset 1) has a pending command. */
+    mock.pushCommand(
+        1, std::make_shared<fss::server::asset_command>(uint64_t{100}, uint64_t{1000}, "RTL", 0.0, 0.0, uint32_t{0}));
+
+    sc.pollCommands(&mock);
+
+    /* sendCommand() is synchronous; it dispatches whatever pollCommands staged. */
+    client1->sendCommand();
+    client2->sendCommand();
+
+    REQUIRE(count_sent<fss::transport::fss_message_asset_command>(conn1->sentSnapshot()) == 1);
+    REQUIRE(count_sent<fss::transport::fss_message_asset_command>(conn2->sentSnapshot()) == 0);
+}


### PR DESCRIPTION
## Description

pollCommands now collects the identified clients' asset ids, issues a single getCommands() for the whole fleet, and fans the newest-command-per-asset result back to each client via setPendingCommand. This replaces the one-getCommand-per-client loop, cutting the steady-state read load from ~10*N reads/sec to ~10/sec through the single serialised read connection (todo/23 option 2).

Behaviour is preserved per client: an asset absent from the batch result is cleared exactly as getCommand returning nullptr did, and the resend-window dedup in sendCommand still governs what actually reaches the aircraft. The (client, asset_id) pair is captured once so a client identifying mid-pass cannot be queried under one id and looked up under another.

Adds a server_clients test asserting the batched read reaches only the owning client and stages nothing for an asset with no pending command.

## Summary by Sourcery

Batch server command polling into a single fleet-wide query per tick while preserving per-client behavior.

Enhancements:
- Change server_clients::pollCommands to batch identified clients' asset IDs into one getCommands() call and fan results back to each client.

Tests:
- Add a server_clients test verifying batched command polling delivers commands only to owning clients and stages nothing for assets without pending commands.