### PR TITLE
feat(transport): todo/55 sendPacked stamps the id into cloned bytes

### DIFF
--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -475,11 +475,28 @@ public:
     virtual auto getPacked() -> std::shared_ptr<buf_len>;
     /* Byte offset of the 8-byte big-endian id within a packed frame. createHeader
      * lays the header out as [length:u16][type:u16][id:u64], so the id follows the
-     * length and type fields. Exposed as the single source of truth for that
-     * offset so a byte-clone sender (fss_connection::sendPacked) can stamp the
-     * per-connection id straight into packed bytes without re-packing, and can
-     * never drift from where createHeader actually writes it. */
+     * length and type fields. The single source of truth for that offset, shared
+     * by createHeader (which writes it while packing) and stampId (which restamps
+     * it into an already-packed frame), with a static_assert in createHeader
+     * pinning it to the layout actually written. */
     static constexpr size_t id_offset = sizeof(uint16_t) + sizeof(uint16_t);
+    /* Restamp the per-connection sequence id into an already-packed frame, in
+     * place, at id_offset (big-endian, matching createHeader). This is how a
+     * byte-clone sender (fss_connection::sendPacked) gives each broadcast
+     * recipient its own uniquely-stamped copy without decoding and re-packing.
+     * The one place that owns the id write, so callers hold no offset/endianness
+     * assumptions of their own. Returns false without writing if `bl` is too
+     * short to hold a full header (so the caller can roll its sequence id back
+     * rather than emit a gap); a frame from getPacked() always fits. */
+    static auto stampId(buf_len &bl, uint64_t t_id) -> bool;
+    /* Read the message type out of an already-packed frame without decoding the
+     * whole message, mapping any undefined wire value to message_type_unknown
+     * (same validation decode() applies). Returns message_type_unknown if `bl` is
+     * too short to hold the length+type prefix. Lets a byte-level sender inspect a
+     * frame's type — e.g. sendPacked refusing to broadcast a credential-bearing
+     * message_type_smm_settings — with the header layout owned here, not the
+     * caller. */
+    static auto peekType(buf_len &bl) -> fss_message_type;
     void createHeader(const std::shared_ptr<buf_len> &bl);
     static void updateSize(const std::shared_ptr<buf_len> &bl);
     static auto decode(const std::shared_ptr<buf_len> &bl) -> std::shared_ptr<fss_message>;

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -350,15 +350,25 @@ public:
     /* Sends one message on this connection. NOTE: this mutates the message —
      * it stamps the per-connection sequence id into msg (setId) before packing.
      * Invariant (todo/12 C8): a single fss_message instance must not be sent
-     * concurrently on multiple connections; the id stamp would race. Every
-     * broadcaster (server_clients::broadcastMsg, one msg logically bound for
-     * every client) satisfies this by giving each recipient its own
-     * independent clone (todo/36) rather than sharing one instance.
+     * concurrently on multiple connections; the id stamp would race.
      * sendRTTRequest sends a single message and then reads its assigned id back
      * immediately after this returns, so it too relies on the stamp being
      * synchronous and unraced. (sendSMMSettings builds a fresh message per
-     * client, so it never shares an instance.) */
+     * client, so it never shares an instance.) Broadcasters do NOT use this
+     * path — see sendPacked. */
     auto sendMsg(const std::shared_ptr<fss_message> &msg) -> bool;
+    /* Byte-clone send for broadcasts (todo/55): takes a frame already packed by
+     * fss_message::getPacked() and shared, unmodified, across every recipient.
+     * Copies the bytes, stamps this connection's next sequence id straight into
+     * the copy at fss_message::id_offset under send_lock, and sends — no decode,
+     * no re-pack. This is how a broadcaster satisfies the C8 invariant above: the
+     * shared packed frame is read-only, and each recipient stamps only its own
+     * private copy, so no fss_message instance is shared or its id raced (todo/36).
+     * Precondition: `packed` is a valid, fully framed frame whose payload carries
+     * no credentials (never message_type_smm_settings) — broadcasts are only
+     * server_list / position_report, so the todo/43 wipeSecure scrub does not
+     * apply here. */
+    auto sendPacked(const std::shared_ptr<buf_len> &packed) -> bool;
     auto getMsg() -> std::shared_ptr<fss_message>;
     virtual void processMessages();
     /* The shutdown-only half of disconnect() (todo/52): wakes any thread
@@ -463,6 +473,13 @@ public:
     virtual auto getAltitude() -> uint32_t;
     virtual auto getTimeStamp() -> uint64_t;
     virtual auto getPacked() -> std::shared_ptr<buf_len>;
+    /* Byte offset of the 8-byte big-endian id within a packed frame. createHeader
+     * lays the header out as [length:u16][type:u16][id:u64], so the id follows the
+     * length and type fields. Exposed as the single source of truth for that
+     * offset so a byte-clone sender (fss_connection::sendPacked) can stamp the
+     * per-connection id straight into packed bytes without re-packing, and can
+     * never drift from where createHeader actually writes it. */
+    static constexpr size_t id_offset = sizeof(uint16_t) + sizeof(uint16_t);
     void createHeader(const std::shared_ptr<buf_len> &bl);
     static void updateSize(const std::shared_ptr<buf_len> &bl);
     static auto decode(const std::shared_ptr<buf_len> &bl) -> std::shared_ptr<fss_message>;

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -3,6 +3,7 @@
 #include "fss-log.hpp"
 
 #include <cmath>
+#include <cstring>
 #include <limits>
 #include <memory>
 
@@ -600,6 +601,28 @@ auto flight_safety_system::transport::fss_message::getPacked() -> std::shared_pt
     this->updateSize(bl);
 
     return bl;
+}
+
+auto flight_safety_system::transport::fss_message::stampId(buf_len &bl, uint64_t t_id) -> bool
+{
+    if (bl.getLength() < id_offset + sizeof(uint64_t))
+    {
+        return false;
+    }
+    uint64_t id_n = fss_htobe64(t_id);
+    bl.writeAt(id_offset, &id_n, sizeof(uint64_t));
+    return true;
+}
+
+auto flight_safety_system::transport::fss_message::peekType(buf_len &bl) -> fss_message_type
+{
+    if (bl.getLength() < sizeof(uint16_t) + sizeof(uint16_t))
+    {
+        return message_type_unknown;
+    }
+    uint16_t type_n = 0;
+    std::memcpy(&type_n, bl.getData() + sizeof(uint16_t), sizeof(type_n));
+    return decode_message_type(fss_be16toh(type_n));
 }
 
 void flight_safety_system::transport::fss_message_closed::packData(std::shared_ptr<buf_len> bl __attribute__((unused)))

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -543,7 +543,11 @@ auto flight_safety_system::transport::fss_message::getTimeStamp() -> uint64_t
 
 void flight_safety_system::transport::fss_message::createHeader(const std::shared_ptr<buf_len> &bl)
 {
-    /* Make space for length (filled in by updateSize), type, id */
+    /* Make space for length (filled in by updateSize), type, id. The id lands at
+     * id_offset (past length+type); fss_connection::sendPacked stamps directly
+     * there, so keep this layout and that constant in lockstep. */
+    static_assert(id_offset == sizeof(uint16_t) + sizeof(uint16_t),
+                  "id_offset must match the length+type prefix written here");
     uint16_t placeholder = 0;
     uint16_t type_n = fss_htobe16(this->getType());
     uint64_t id_n = fss_htobe64(this->getId());

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 #include "fss-transport.hpp"
 #include "fss-log.hpp"
+#include "fss-endian.hpp"
 
 #include <iostream>
 
@@ -395,6 +396,30 @@ auto flight_safety_system::transport::fss_connection::sendMsg(const std::shared_
         bl->wipeSecure();
     }
     return ret;
+}
+
+auto flight_safety_system::transport::fss_connection::sendPacked(const std::shared_ptr<buf_len> &packed) -> bool
+{
+    /* The frame was built and framed by getPacked() and validated by the
+     * broadcaster before it reached the outbound queue, so the too-big-to-frame
+     * case that sendMsg(fss_message) rolls an id back for (todo/38) cannot occur
+     * here. Guard defensively anyway and bail BEFORE consuming a sequence id, so
+     * a bad frame never leaves a gap the peer's v2 sequence check treats as
+     * out-of-order (todo/39). */
+    if (packed == nullptr || !packed->isValid() || packed->getLength() < fss_message::id_offset + sizeof(uint64_t))
+    {
+        return false;
+    }
+    std::scoped_lock lock_holder(this->send_lock);
+    uint64_t assigned_id = this->getMessageId();
+    /* Clone the bytes, not the message (todo/55): the shared `packed` frame is
+     * read-only and identical for every recipient — the only per-connection
+     * difference is the id — so copy it once and stamp the id straight in at the
+     * fixed header offset, bypassing decode and re-pack entirely. */
+    auto bl = std::make_shared<buf_len>(*packed);
+    uint64_t id_n = flight_safety_system::fss_htobe64(assigned_id);
+    bl->writeAt(fss_message::id_offset, &id_n, sizeof(uint64_t));
+    return this->sendMsg(bl);
 }
 
 #ifdef DEBUG

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -10,7 +10,6 @@
 #include <vector>
 #include "fss-transport.hpp"
 #include "fss-log.hpp"
-#include "fss-endian.hpp"
 
 #include <iostream>
 
@@ -400,25 +399,39 @@ auto flight_safety_system::transport::fss_connection::sendMsg(const std::shared_
 
 auto flight_safety_system::transport::fss_connection::sendPacked(const std::shared_ptr<buf_len> &packed) -> bool
 {
-    /* The frame was built and framed by getPacked() and validated by the
-     * broadcaster before it reached the outbound queue, so the too-big-to-frame
-     * case that sendMsg(fss_message) rolls an id back for (todo/38) cannot occur
-     * here. Guard defensively anyway and bail BEFORE consuming a sequence id, so
-     * a bad frame never leaves a gap the peer's v2 sequence check treats as
-     * out-of-order (todo/39). */
-    if (packed == nullptr || !packed->isValid() || packed->getLength() < fss_message::id_offset + sizeof(uint64_t))
+    if (packed == nullptr || !packed->isValid())
     {
         return false;
     }
     std::scoped_lock lock_holder(this->send_lock);
+    /* Enforce the no-credentials precondition at runtime, not just by convention:
+     * this path deliberately skips the message_type_smm_settings wipeSecure scrub
+     * sendMsg() does (todo/43), and a shared broadcast frame must never carry
+     * credentials in the first place. Refuse (loudly — a routing bug) before an id
+     * is consumed, so a misrouted settings frame is dropped rather than broadcast
+     * in the clear. */
+    if (fss_message::peekType(*packed) == flight_safety_system::transport::message_type_smm_settings)
+    {
+        FSS_LOG_ERROR("transport", "sendPacked refused a message_type_smm_settings frame; credentials must not be "
+                                   "broadcast — dropping");
+        return false;
+    }
     uint64_t assigned_id = this->getMessageId();
     /* Clone the bytes, not the message (todo/55): the shared `packed` frame is
      * read-only and identical for every recipient — the only per-connection
      * difference is the id — so copy it once and stamp the id straight in at the
-     * fixed header offset, bypassing decode and re-pack entirely. */
+     * fixed header offset (fss_message owns that layout), bypassing decode and
+     * re-pack entirely. */
     auto bl = std::make_shared<buf_len>(*packed);
-    uint64_t id_n = flight_safety_system::fss_htobe64(assigned_id);
-    bl->writeAt(fss_message::id_offset, &id_n, sizeof(uint64_t));
+    if (!fss_message::stampId(*bl, assigned_id))
+    {
+        /* Too short to hold a header — the frame the broadcaster validated should
+         * never be, but if it is, roll the id back (still under send_lock, as
+         * getMessageId() incremented it) so the peer's v2 sequence check sees no
+         * gap (todo/38, todo/39), exactly as sendMsg(fss_message) does. */
+        --this->last_msg_id;
+        return false;
+    }
     return this->sendMsg(bl);
 }
 

--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -427,3 +427,26 @@ TEST_CASE("client: base class handleCommand, handlePositionReport, handleSMMSett
                                                                           fss::secure_string(std::string_view{"pass"}));
     server->processMessage(smm); /* fss_client::handleSMMSettings — no-op */
 }
+
+TEST_CASE("fss_connection::sendPacked stamps a broadcast and refuses credentials (todo/55)")
+{
+    /* sendPacked is the byte-clone broadcast path: it copies a shared, pre-packed
+     * frame and stamps this connection's next sequence id into the copy. A normal
+     * broadcast frame goes out with a stamped id; a credential-bearing
+     * smm_settings frame must be refused at runtime (it would otherwise skip the
+     * wipeSecure scrub sendMsg does and leak credentials to every recipient). */
+    auto conn = std::make_shared<CapturingConnection>();
+
+    auto position = std::make_shared<fss::transport::fss_message_position_report>(
+        1.0, 2.0, 50U, 0U, 0U, int16_t{0}, 0U, std::string{}, 0U, uint8_t{0}, 0U, uint8_t{0}, uint8_t{0}, uint64_t{0});
+    REQUIRE(conn->sendPacked(position->getPacked()));
+    REQUIRE(conn->sent.size() == 1);
+    REQUIRE(conn->sent[0]->getType() == fss::transport::message_type_position_report);
+    REQUIRE(conn->sent[0]->getId() != 0); // a per-connection id was stamped in
+
+    auto settings = std::make_shared<fss::transport::fss_message_smm_settings>(
+        "https://smm.example/", fss::secure_string(std::string_view{"user"}),
+        fss::secure_string(std::string_view{"pass"}));
+    REQUIRE_FALSE(conn->sendPacked(settings->getPacked())); // refused
+    REQUIRE(conn->sent.size() == 1);                        // nothing sent
+}

--- a/tests/messages.cpp
+++ b/tests/messages.cpp
@@ -1,6 +1,7 @@
 #include <cstdlib>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #ifdef HAVE_CATCH2_CATCH_ALL_HPP
@@ -1163,4 +1164,58 @@ TEST_CASE("messages: BufferReader readUint32 short-read returns false")
         fss_test::make_framed_buffer(static_cast<uint16_t>(message_type_version), 1, std::string(payload, '\0'), total);
     auto decoded = flight_safety_system::transport::fss_message::decode(bl);
     REQUIRE(decoded != nullptr);
+}
+
+/* peekType is the front half of decode() (todo/55): it reads the framed type
+ * straight out of a packed frame so a byte-level sender (fss_connection::
+ * sendPacked) can refuse a credential-bearing frame without reconstructing the
+ * message. */
+TEST_CASE("fss_message::peekType reads the framed type without decoding (todo/55)")
+{
+    auto position = std::make_shared<flight_safety_system::transport::fss_message_position_report>(
+        1.0, 2.0, 100U, 0U, 0U, int16_t{0}, 0U, std::string{}, 0U, uint8_t{0}, 0U, uint8_t{0}, uint8_t{0}, uint64_t{0});
+    auto position_bl = position->getPacked();
+    REQUIRE(flight_safety_system::transport::fss_message::peekType(*position_bl) ==
+            flight_safety_system::transport::message_type_position_report);
+
+    auto settings = std::make_shared<flight_safety_system::transport::fss_message_smm_settings>(
+        "https://smm.example/", flight_safety_system::secure_string(std::string_view{"user"}),
+        flight_safety_system::secure_string(std::string_view{"pass"}));
+    auto settings_bl = settings->getPacked();
+    REQUIRE(flight_safety_system::transport::fss_message::peekType(*settings_bl) ==
+            flight_safety_system::transport::message_type_smm_settings);
+
+    /* A frame too short to hold the length+type prefix cannot name a type. */
+    flight_safety_system::transport::buf_len empty;
+    REQUIRE(flight_safety_system::transport::fss_message::peekType(empty) ==
+            flight_safety_system::transport::message_type_unknown);
+}
+
+/* stampId writes the per-connection id at the same offset decode() reads it from
+ * (todo/55), so a broadcaster can restamp one shared packed frame per recipient
+ * without decoding and re-packing. */
+TEST_CASE("fss_message::stampId restamps the id where decode reads it (todo/55)")
+{
+    auto msg = std::make_shared<flight_safety_system::transport::fss_message_rtt_request>();
+    msg->setId(0);
+    auto bl = msg->getPacked();
+    REQUIRE(bl != nullptr);
+
+    REQUIRE(flight_safety_system::transport::fss_message::stampId(*bl, 0xA1B2C3D4E5F6ULL));
+    auto decoded = flight_safety_system::transport::fss_message::decode(bl);
+    REQUIRE(decoded != nullptr);
+    REQUIRE(decoded->getId() == 0xA1B2C3D4E5F6ULL);
+
+    /* Restamping overwrites in place — each recipient's id off one shared frame. */
+    REQUIRE(flight_safety_system::transport::fss_message::stampId(*bl, 7ULL));
+    decoded = flight_safety_system::transport::fss_message::decode(bl);
+    REQUIRE(decoded != nullptr);
+    REQUIRE(decoded->getId() == 7ULL);
+
+    /* A frame too short to hold a header is left untouched and reported false, so
+     * a caller can roll its sequence id back rather than emit a gap. */
+    flight_safety_system::transport::buf_len tiny;
+    uint16_t two_bytes = 0;
+    tiny.addData(&two_bytes, sizeof(two_bytes));
+    REQUIRE_FALSE(flight_safety_system::transport::fss_message::stampId(tiny, 1ULL));
 }


### PR DESCRIPTION
## Description

Add fss_connection::sendPacked(): a broadcast send path that takes a frame already produced by getPacked() and shared, read-only, across every recipient. It copies the bytes, stamps this connection's next sequence id straight into the copy at the fixed header offset under send_lock, and sends — no decode, no re-pack. This is how a broadcaster satisfies the C8 invariant (no fss_message instance shared or its id raced across connections) without the per-recipient pack+decode clone the broadcast path uses today.

The id offset is exposed as fss_message::id_offset, the single source of truth for where createHeader writes the id, with a static_assert in createHeader so the layout and the stamp point can never drift.

No caller yet; wiring the broadcast relay onto this path is the next commit.

## Summary by Sourcery

Introduce a byte-clone broadcast send path that stamps per-connection sequence ids directly into packed frames without decoding or re-packing.

New Features:
- Add fss_connection::sendPacked() to send already-packed frames per connection while enforcing the C8 invariant on message ids.
- Expose fss_message::id_offset as the canonical header id offset for packed frames.

Enhancements:
- Add a static assert in fss_message::createHeader to keep the header layout and id_offset definition in sync.
- Document that broadcasters should use sendPacked instead of sendMsg for shared frames.