### PR TITLE
perf(server): todo/55 broadcast relays share one packed frame

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -250,11 +250,14 @@ void fss::server::fss_client::outboundWorkerRun()
         }
         if (work.server_list_broadcast != nullptr)
         {
-            this->getConnection()->sendMsg(work.server_list_broadcast);
+            /* Broadcast frames are pre-packed and shared read-only across
+             * recipients; sendPacked copies and stamps this connection's id
+             * (todo/55) rather than re-packing a decoded clone. */
+            this->getConnection()->sendPacked(work.server_list_broadcast);
         }
         for (const auto &relay_msg : work.position_relay)
         {
-            this->getConnection()->sendMsg(relay_msg);
+            this->getConnection()->sendPacked(relay_msg);
         }
     }
 }
@@ -298,7 +301,7 @@ void fss::server::fss_client::queueSMMSettings()
     this->outbound_cv.notify_one();
 }
 
-void fss::server::fss_client::queueServerListBroadcast(std::shared_ptr<fss::transport::fss_message> msg)
+void fss::server::fss_client::queueServerListBroadcast(std::shared_ptr<fss::transport::buf_len> packed)
 {
     {
         std::scoped_lock guard(this->outbound_lock);
@@ -306,12 +309,12 @@ void fss::server::fss_client::queueServerListBroadcast(std::shared_ptr<fss::tran
         {
             return;
         }
-        this->pending_server_list_broadcast = std::move(msg);
+        this->pending_server_list_broadcast = std::move(packed);
     }
     this->outbound_cv.notify_one();
 }
 
-void fss::server::fss_client::queuePositionRelay(std::shared_ptr<fss::transport::fss_message> msg)
+void fss::server::fss_client::queuePositionRelay(std::shared_ptr<fss::transport::buf_len> packed)
 {
     uint64_t dropped = 0;
     {
@@ -325,7 +328,7 @@ void fss::server::fss_client::queuePositionRelay(std::shared_ptr<fss::transport:
             this->pending_position_relay.pop_front();
             dropped = ++this->position_relay_dropped;
         }
-        this->pending_position_relay.push_back(std::move(msg));
+        this->pending_position_relay.push_back(std::move(packed));
     }
     this->outbound_cv.notify_one();
     /* Logged outside outbound_lock: getName() takes client_lock, and name is

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -301,7 +301,7 @@ void fss::server::fss_client::queueSMMSettings()
     this->outbound_cv.notify_one();
 }
 
-void fss::server::fss_client::queueServerListBroadcast(std::shared_ptr<fss::transport::buf_len> packed)
+void fss::server::fss_client::queueServerListBroadcast(std::shared_ptr<const fss::transport::buf_len> packed)
 {
     {
         std::scoped_lock guard(this->outbound_lock);
@@ -314,7 +314,7 @@ void fss::server::fss_client::queueServerListBroadcast(std::shared_ptr<fss::tran
     this->outbound_cv.notify_one();
 }
 
-void fss::server::fss_client::queuePositionRelay(std::shared_ptr<fss::transport::buf_len> packed)
+void fss::server::fss_client::queuePositionRelay(std::shared_ptr<const fss::transport::buf_len> packed)
 {
     uint64_t dropped = 0;
     {

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -353,14 +353,14 @@ private:
      * list, every 15s) or another client's recv thread (position relay).
      * Coalescing: only the latest server-list matters, so a new one simply
      * replaces any not-yet-sent previous one. Guarded by outbound_lock. */
-    std::shared_ptr<transport::buf_len> pending_server_list_broadcast{nullptr};
+    std::shared_ptr<const transport::buf_len> pending_server_list_broadcast{nullptr};
     /* Bounded, drop-oldest (todo/36): position relay is loss-tolerant
      * telemetry (mirrors the transport queue's drop policy and todo/20's
      * command/telemetry distinction), so under sustained backlog the oldest
      * queued report is dropped rather than growing unboundedly. Guarded by
      * outbound_lock. */
     static constexpr size_t max_pending_position_relay = 8;
-    std::deque<std::shared_ptr<transport::buf_len>> pending_position_relay{};
+    std::deque<std::shared_ptr<const transport::buf_len>> pending_position_relay{};
     /* Cumulative reports dropped for this client by the cap above (never
      * reset); guarded by outbound_lock alongside the queue it counts.
      * Exposed so an operator (or a future metrics hook) can see the loss
@@ -375,8 +375,8 @@ private:
         bool command{false};
         bool rtt{false};
         bool smm{false};
-        std::shared_ptr<transport::buf_len> server_list_broadcast{nullptr};
-        std::vector<std::shared_ptr<transport::buf_len>> position_relay{};
+        std::shared_ptr<const transport::buf_len> server_list_broadcast{nullptr};
+        std::vector<std::shared_ptr<const transport::buf_len>> position_relay{};
     };
     /* Block until there is work or a stop request, then atomically take and clear
      * the pending flags. */
@@ -438,7 +438,7 @@ public:
      * recipient — the worker copies it and stamps the id per connection
      * (fss_connection::sendPacked, todo/55). Returns immediately; no-op once
      * disconnecting. */
-    void queueServerListBroadcast(std::shared_ptr<transport::buf_len> packed);
+    void queueServerListBroadcast(std::shared_ptr<const transport::buf_len> packed);
     /* Schedule a relayed position report on this client's outbound worker
      * thread (todo/36) instead of sending inline from the reporting client's
      * recv thread, so one black-holed peer cannot stall every other client's
@@ -446,7 +446,7 @@ public:
      * `packed` is a getPacked() frame shared read-only across recipients; the
      * worker copies it and stamps the id per connection (sendPacked, todo/55).
      * Returns immediately; no-op once disconnecting. */
-    void queuePositionRelay(std::shared_ptr<transport::buf_len> packed);
+    void queuePositionRelay(std::shared_ptr<const transport::buf_len> packed);
     /* Cumulative position reports dropped from this client's relay queue by
      * the bounded-cap policy above. 0 unless the queue has ever overflowed. */
     auto getPositionRelayDropped() -> uint64_t;

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -353,14 +353,14 @@ private:
      * list, every 15s) or another client's recv thread (position relay).
      * Coalescing: only the latest server-list matters, so a new one simply
      * replaces any not-yet-sent previous one. Guarded by outbound_lock. */
-    std::shared_ptr<transport::fss_message> pending_server_list_broadcast{nullptr};
+    std::shared_ptr<transport::buf_len> pending_server_list_broadcast{nullptr};
     /* Bounded, drop-oldest (todo/36): position relay is loss-tolerant
      * telemetry (mirrors the transport queue's drop policy and todo/20's
      * command/telemetry distinction), so under sustained backlog the oldest
      * queued report is dropped rather than growing unboundedly. Guarded by
      * outbound_lock. */
     static constexpr size_t max_pending_position_relay = 8;
-    std::deque<std::shared_ptr<transport::fss_message>> pending_position_relay{};
+    std::deque<std::shared_ptr<transport::buf_len>> pending_position_relay{};
     /* Cumulative reports dropped for this client by the cap above (never
      * reset); guarded by outbound_lock alongside the queue it counts.
      * Exposed so an operator (or a future metrics hook) can see the loss
@@ -375,8 +375,8 @@ private:
         bool command{false};
         bool rtt{false};
         bool smm{false};
-        std::shared_ptr<transport::fss_message> server_list_broadcast{nullptr};
-        std::vector<std::shared_ptr<transport::fss_message>> position_relay{};
+        std::shared_ptr<transport::buf_len> server_list_broadcast{nullptr};
+        std::vector<std::shared_ptr<transport::buf_len>> position_relay{};
     };
     /* Block until there is work or a stop request, then atomically take and clear
      * the pending flags. */
@@ -433,17 +433,20 @@ public:
     /* Schedule a server-list broadcast on this client's outbound worker thread
      * (todo/36) instead of sending inline, so a black-holed peer cannot stall
      * the main loop's periodic broadcast for other clients. Coalescing: a new
-     * call simply replaces any not-yet-sent previous one. `msg` must be an
-     * instance not shared with any other client (see broadcastMsg's C8 note).
-     * Returns immediately; no-op once disconnecting. */
-    void queueServerListBroadcast(std::shared_ptr<transport::fss_message> msg);
+     * call simply replaces any not-yet-sent previous one. `packed` is a frame
+     * already produced by getPacked() and may be shared read-only across every
+     * recipient — the worker copies it and stamps the id per connection
+     * (fss_connection::sendPacked, todo/55). Returns immediately; no-op once
+     * disconnecting. */
+    void queueServerListBroadcast(std::shared_ptr<transport::buf_len> packed);
     /* Schedule a relayed position report on this client's outbound worker
      * thread (todo/36) instead of sending inline from the reporting client's
      * recv thread, so one black-holed peer cannot stall every other client's
      * telemetry relay. Bounded, drop-oldest: position relay is loss-tolerant.
-     * `msg` must be an instance not shared with any other client (see
-     * broadcastMsg's C8 note). Returns immediately; no-op once disconnecting. */
-    void queuePositionRelay(std::shared_ptr<transport::fss_message> msg);
+     * `packed` is a getPacked() frame shared read-only across recipients; the
+     * worker copies it and stamps the id per connection (sendPacked, todo/55).
+     * Returns immediately; no-op once disconnecting. */
+    void queuePositionRelay(std::shared_ptr<transport::buf_len> packed);
     /* Cumulative position reports dropped from this client's relay queue by
      * the bounded-cap policy above. 0 unless the queue has ever overflowed. */
     auto getPositionRelayDropped() -> uint64_t;

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -224,13 +224,13 @@ public:
     auto operator=(buf_len &&) -> buf_len & = delete;
     virtual ~buf_len();
     auto operator=(const buf_len &other) -> buf_len &;
-    auto isValid() -> bool;
+    auto isValid() const -> bool;
     auto addData(const char *new_data, size_t len) -> bool;
     auto addData(const void *new_data, size_t len) -> bool;
     void writeAt(size_t offset, const char *src, size_t len);
     void writeAt(size_t offset, const void *src, size_t len);
-    auto getData() -> const char *;
-    auto getLength() -> size_t;
+    auto getData() const -> const char *;
+    auto getLength() const -> size_t;
     /* Marks an already-built buffer as unusable (todo/38): clears the content
      * so isValid() reports false. Used when a packed message turns out too
      * large to frame — the buffer already holds the unframed bytes by that
@@ -362,13 +362,14 @@ public:
      * Copies the bytes, stamps this connection's next sequence id straight into
      * the copy at fss_message::id_offset under send_lock, and sends — no decode,
      * no re-pack. This is how a broadcaster satisfies the C8 invariant above: the
-     * shared packed frame is read-only, and each recipient stamps only its own
-     * private copy, so no fss_message instance is shared or its id raced (todo/36).
+     * shared packed frame is read-only — `shared_ptr<const buf_len>` enforces that
+     * at the type level — and each recipient stamps only its own private copy, so
+     * no fss_message instance is shared or its id raced (todo/36).
      * Precondition: `packed` is a valid, fully framed frame whose payload carries
      * no credentials (never message_type_smm_settings) — broadcasts are only
      * server_list / position_report, so the todo/43 wipeSecure scrub does not
      * apply here. */
-    auto sendPacked(const std::shared_ptr<buf_len> &packed) -> bool;
+    auto sendPacked(const std::shared_ptr<const buf_len> &packed) -> bool;
     auto getMsg() -> std::shared_ptr<fss_message>;
     virtual void processMessages();
     /* The shutdown-only half of disconnect() (todo/52): wakes any thread
@@ -496,7 +497,7 @@ public:
      * frame's type — e.g. sendPacked refusing to broadcast a credential-bearing
      * message_type_smm_settings — with the header layout owned here, not the
      * caller. */
-    static auto peekType(buf_len &bl) -> fss_message_type;
+    static auto peekType(const buf_len &bl) -> fss_message_type;
     void createHeader(const std::shared_ptr<buf_len> &bl);
     static void updateSize(const std::shared_ptr<buf_len> &bl);
     static auto decode(const std::shared_ptr<buf_len> &bl) -> std::shared_ptr<fss_message>;

--- a/src/server-clients.cpp
+++ b/src/server-clients.cpp
@@ -149,29 +149,32 @@ void server_clients::broadcastMsg(const std::shared_ptr<flight_safety_system::tr
 {
     bool is_server_list = msg->getType() == flight_safety_system::transport::message_type_server_list;
     auto packed = msg->getPacked();
-    /* decode() failing is a property of `packed` (truncated/corrupt bytes
-     * or a type it refuses to reconstruct), not of any one recipient, so
-     * check once here rather than per-client: a per-client `continue`
-     * would look like "skip this one client" but actually silently drops
-     * the whole broadcast, one client at a time, with no record of why. */
-    if (flight_safety_system::transport::fss_message::decode(packed) == nullptr)
+    /* todo/55: pack once and share the frame, read-only, across every recipient
+     * — each stamps only its own id into a private copy at send time
+     * (fss_connection::sendPacked), so there is no per-recipient decode or
+     * re-pack. We also drop the old once-per-broadcast validation decode:
+     * getPacked() already framed the message and updateSize() invalidates a
+     * frame too large to frame, so isValid() is the cheap equivalent of the old
+     * "did it round-trip" guard. Invalidity is a property of `packed`, not of any
+     * one recipient, so drop the whole broadcast and log once rather than
+     * silently per client. */
+    if (!packed->isValid())
     {
-        FSS_LOG_ERROR("server", "broadcastMsg: message of type "
-                                    << msg->getType() << " did not round-trip through pack/decode; dropping");
+        FSS_LOG_ERROR("server", "broadcastMsg: message of type " << msg->getType()
+                                                                 << " did not pack into a valid frame; dropping");
         return;
     }
     for (const auto &client : this->snapshotClients())
     {
         if (client->isAircraft() && client.get() != except)
         {
-            auto clone = flight_safety_system::transport::fss_message::decode(packed);
             if (is_server_list)
             {
-                client->queueServerListBroadcast(std::move(clone));
+                client->queueServerListBroadcast(packed);
             }
             else
             {
-                client->queuePositionRelay(std::move(clone));
+                client->queuePositionRelay(packed);
             }
         }
     }

--- a/src/transport-messages.cpp
+++ b/src/transport-messages.cpp
@@ -370,7 +370,7 @@ auto flight_safety_system::transport::buf_len::operator=(const buf_len &other) -
     return *this;
 }
 
-auto flight_safety_system::transport::buf_len::isValid() -> bool
+auto flight_safety_system::transport::buf_len::isValid() const -> bool
 {
     return this->data.length() != 0;
 }
@@ -397,12 +397,12 @@ void flight_safety_system::transport::buf_len::writeAt(size_t offset, const void
     this->data.replace(offset, len, static_cast<const char *>(src), len);
 }
 
-auto flight_safety_system::transport::buf_len::getData() -> const char *
+auto flight_safety_system::transport::buf_len::getData() const -> const char *
 {
     return this->data.c_str();
 }
 
-auto flight_safety_system::transport::buf_len::getLength() -> size_t
+auto flight_safety_system::transport::buf_len::getLength() const -> size_t
 {
     return this->data.length();
 }
@@ -614,7 +614,7 @@ auto flight_safety_system::transport::fss_message::stampId(buf_len &bl, uint64_t
     return true;
 }
 
-auto flight_safety_system::transport::fss_message::peekType(buf_len &bl) -> fss_message_type
+auto flight_safety_system::transport::fss_message::peekType(const buf_len &bl) -> fss_message_type
 {
     if (bl.getLength() < sizeof(uint16_t) + sizeof(uint16_t))
     {

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -397,7 +397,7 @@ auto flight_safety_system::transport::fss_connection::sendMsg(const std::shared_
     return ret;
 }
 
-auto flight_safety_system::transport::fss_connection::sendPacked(const std::shared_ptr<buf_len> &packed) -> bool
+auto flight_safety_system::transport::fss_connection::sendPacked(const std::shared_ptr<const buf_len> &packed) -> bool
 {
     if (packed == nullptr || !packed->isValid())
     {

--- a/tests/server_clients_test.cpp
+++ b/tests/server_clients_test.cpp
@@ -337,7 +337,9 @@ TEST_CASE("server_clients: position relay drops oldest and counts drops once the
         auto position = std::make_shared<fss::transport::fss_message_position_report>(
             0.0, 0.0, 0U, 0U, 0U, int16_t{0}, 0U, std::string{}, 0U, uint8_t{0}, 0U, uint8_t{0}, uint8_t{0},
             uint64_t{0});
-        stuck_client->queuePositionRelay(position);
+        /* todo/55: the relay queue now carries the packed frame, shared across
+         * recipients, not a decoded message clone. */
+        stuck_client->queuePositionRelay(position->getPacked());
     }
 
     REQUIRE(stuck_client->getPositionRelayDropped() == reports_sent - queue_cap);
@@ -354,6 +356,60 @@ TEST_CASE("server_clients: broadcastMsg skips the 'except' client")
     auto msg = std::make_shared<fss::transport::fss_message_rtt_request>();
     // Passing aircraft as the 'except' client — should send to 0 clients (no crash)
     sc.broadcastMsg(msg, aircraft.get());
+}
+
+TEST_CASE("server_clients: broadcast stamps a per-connection sequence id into the shared frame (todo/55)")
+{
+    /* todo/55: broadcastMsg now packs once and shares the frame, read-only,
+     * across recipients; sendPacked copies it and stamps this connection's next
+     * sequence id straight into the header bytes rather than decoding and
+     * re-packing a per-recipient clone. Pin both halves of that: (a) the relayed
+     * frame arrives decodable with its payload intact (the bytes were copied),
+     * and (b) the id is a per-connection sequence stamped at the offset decode
+     * reads it back from — proven by two successive broadcasts landing
+     * consecutive ids. A wrong offset would leave the source frame's placeholder
+     * id (0) in place, so both would decode as 0 and 0 != 0 + 1. */
+    server_clients sc;
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft1"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft1");
+    auto writer = make_null_writer();
+    auto client = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &sc);
+    client->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft1"));
+    sc.clientConnected(client);
+
+    auto make_report = [](uint32_t altitude) {
+        return std::make_shared<fss::transport::fss_message_position_report>(0.0, 0.0, altitude, 0U, 0U, int16_t{0}, 0U,
+                                                                             std::string{"TESTID"}, 0U, uint8_t{0}, 0U,
+                                                                             uint8_t{0}, uint8_t{0}, uint64_t{0});
+    };
+
+    sc.broadcastMsg(make_report(11111U));
+    sc.broadcastMsg(make_report(22222U));
+
+    REQUIRE(fss_test::wait_for(
+        [&]() -> bool { return count_sent<fss::transport::fss_message_position_report>(conn->sentSnapshot()) == 2; }));
+
+    std::vector<std::shared_ptr<fss::transport::fss_message_position_report>> reports;
+    for (const auto &m : conn->sentSnapshot())
+    {
+        if (auto report = std::dynamic_pointer_cast<fss::transport::fss_message_position_report>(m))
+        {
+            reports.push_back(report);
+        }
+    }
+    REQUIRE(reports.size() == 2);
+    // Payload copied verbatim through the byte clone (distinct per broadcast).
+    REQUIRE(reports[0]->getAltitude() == 11111U);
+    REQUIRE(reports[1]->getAltitude() == 22222U);
+    REQUIRE(reports[0]->getCallSign() == "TESTID");
+    // Freshly stamped, sequential per-connection id at the header offset.
+    REQUIRE(reports[0]->getId() != 0);
+    REQUIRE(reports[1]->getId() == reports[0]->getId() + 1);
+
+    client->disconnect();
 }
 
 TEST_CASE("server_clients: checkTimeouts disconnects timed-out client")


### PR DESCRIPTION
## Description

broadcastMsg() packed the source message once, then called fss_message::decode() once to validate plus once per recipient to clone, and each clone was re-packed inside sendMsg(). That is N+1 full decodes (heap alloc, field-by-field BufferReader walk, a std::string callsign) plus N re-packs per relayed report to N aircraft; fleet-wide the relay work grows as O(N^2) decodes/sec.

Pack once and share the frame, read-only, across every recipient. The outbound queues (pending_server_list_broadcast, pending_position_relay, and the outbound_work fields) now carry the packed buf_len rather than a decoded fss_message clone, and the worker sends it via sendPacked(), which copies the bytes and stamps this connection's id at send time. Each recipient stamps only its own private copy, so the C8 invariant still holds.

The once-per-broadcast validation decode is gone too: getPacked() already framed the message and updateSize() invalidates a frame too large to frame, so a cheap isValid() check is the equivalent guard for dropping (and logging) a bad broadcast. Behaviour is unchanged; the existing FakeConnection test double intercepts the byte send and decodes there, so the broadcast/relay contracts stay pinned, and a new test asserts the relayed frame arrives with its payload intact and a freshly stamped per-connection sequence id.

## Summary by Sourcery

Optimize server broadcast and position relay handling by sharing a single pre-packed frame across all recipients and validating it once before distribution.

Bug Fixes:
- Ensure invalid packed broadcast frames are detected via isValid() and dropped with a single log rather than failing silently per client.

Enhancements:
- Refactor server client outbound queues and worker to store and send packed frames via sendPacked(), stamping per-connection sequence IDs at send time.
- Update broadcast logic to avoid per-recipient decode/clone/re-pack, reducing CPU and allocation overhead.
- Clarify queueing APIs to accept shared packed frames instead of per-client message instances.

Tests:
- Extend server client tests to cover packed-frame position relay behavior and verify per-connection sequential IDs and payload integrity for broadcasted position reports.