### PR TITLE
Update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Broadcast relays now pack the source message once and share that frame,
+  read-only, across every recipient instead of decoding a fresh clone per
+  recipient (todo/55). Previously each relayed position report to N connected
+  aircraft cost N+1 full message decodes (heap allocation, a field-by-field
+  buffer walk, a `std::string` callsign) plus N re-packs; fleet-wide, that relay
+  work grew as O(N²) decodes/second. A new `fss_connection::sendPacked()` copies
+  the shared packed bytes and stamps the per-connection sequence id straight into
+  the header at send time, so each recipient still gets its own uniquely-stamped
+  frame (the C8 no-shared-instance invariant is preserved) but the per-recipient
+  decode and re-pack are gone. Delivered behaviour per recipient is unchanged;
+  this raises the fleet size the server sustains before broadcast fan-out becomes
+  the bottleneck. Companion to the todo/23 batched command poll below.
 - The command poller now issues a single batched database read per tick for
   the newest pending command across all connected aircraft, instead of one
   `getCommand` query per connected aircraft (todo/23). This drops the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The command poller now issues a single batched database read per tick for
+  the newest pending command across all connected aircraft, instead of one
+  `getCommand` query per connected aircraft (todo/23). This drops the
+  steady-state command-read load on the single serialised read connection from
+  ~10*N queries/second (N = connected aircraft) to a constant ~10/second,
+  raising the fleet size the server sustains before that connection becomes the
+  bottleneck. Behaviour per aircraft is unchanged: each still receives its own
+  newest command, an asset with no pending command is cleared exactly as
+  before, and the resend-window dedup still governs what reaches the aircraft.
+  A new `DISTINCT ON (asset_id)` cursor read (`db_asset_commands_get`) backs the
+  new `IDatabase::getCommands` batch method; the single-row `getCommand` is
+  retained for the identify-time dispatch path.
+
 ### Security
 - `secure_string::operator==` (both the `secure_string` and `string_view`
   overloads) now compares in constant time — an accumulated XOR over the

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ fss-server server.json
 | SIGINT  | Same as SIGTERM. |
 | SIGHUP  | Reloads the CRL file (if configured) and disconnects any currently connected clients whose certificates appear on the updated CRL. No restart required. |
 
+#### Supported scale
+
+The server is sized for RPAS fleets of tens of aircraft against a single local PostgreSQL+PostGIS database. Command dispatch runs from in-memory caches on the main loop; the poller performs one batched database read per tick for the newest pending command across all connected aircraft, so the steady-state command-read rate is a constant (~10 queries/second) rather than growing with the number of aircraft. Each connection uses a small, fixed number of threads. Deployments approaching hundreds of concurrent aircraft should re-evaluate the single read-connection and per-connection thread model first.
+
 ### Client
 
 There is no full client implementation shipped with flight-safety-system, however there is a [library](src/fss-client-ssl.hpp) to use and an [example client](examples/fake_client.cpp) that can be used as a starting point.


### PR DESCRIPTION
## Summary by Sourcery

Document recent performance and scalability improvements to command polling and broadcast relays in the changelog and README.

Documentation:
- Expand CHANGELOG with details on broadcast relay packing and batched command polling behaviour and scalability impact.
- Add README section describing supported fleet scale and database/connection model for typical deployments.