### PR TITLE
refactor(transport): todo/25 invoke processMessage outside msg_lock

### DIFF
--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -287,12 +287,13 @@ class fss_connection {
     std::atomic<uint64_t> last_msg_id{0};
     /* Non-owning back-pointer to the installed handler, guarded by msg_lock.
      * Lifetime (todo/25): it is only dereferenced with delivery_depth
-     * incremented, and setHandler() — the sole mutator, including the
-     * setHandler(nullptr) in ~fss_message_cb — waits for delivery-idle before
-     * touching it, so a handler cannot be destroyed while a call into it is in
-     * flight. A handler that detaches some other way (fss_client::disconnect()
-     * clears its connection pointer, so ~fss_message_cb never reaches
-     * setHandler) is covered by the same wait in disconnect(). */
+     * incremented, and its only mutators — setHandler() and detachHandler(),
+     * the latter being what ~fss_message_cb uses — wait for delivery-idle
+     * before touching it, so a handler cannot be destroyed while a call into it
+     * is in flight. A handler that detaches some other way
+     * (fss_client::disconnect() clears its connection pointer, so
+     * ~fss_message_cb never reaches either) is covered by the same wait in
+     * disconnect(). */
     fss_message_cb *handler{nullptr};
     std::queue<std::shared_ptr<fss_message>> messages{};
     /* Delivery bookkeeping (todo/25): processMessage() runs with msg_lock
@@ -302,8 +303,8 @@ class fss_connection {
      * for free:
      *  - deliveries on one connection stay serialized (a would-be deliverer
      *    waits for delivery_depth == 0), and
-     *  - setHandler() cannot swap or clear `handler` while a call into it is
-     *    in flight, which is the lifetime proof above.
+     *  - setHandler()/detachHandler() cannot swap or clear `handler` while a
+     *    call into it is in flight, which is the lifetime proof above.
      * delivering_thread is the thread inside the current delivery; it is
      * exempt from the wait so a re-entrant call made by the callback itself
      * proceeds instead of blocking on itself. Delivery is serialized, so one
@@ -377,6 +378,19 @@ public:
     auto operator=(fss_connection &&) -> fss_connection & = delete;
     virtual ~fss_connection();
     void setHandler(fss_message_cb *cb);
+    /* Clears the installed handler; queued and later messages go back to the
+     * getMsg() queue. Equivalent to setHandler(nullptr), which delegates here.
+     *
+     * Exists as its own entry point because installing a handler flushes the
+     * backlog into it and so can propagate an exception the handler threw,
+     * while detaching runs no callback at all and therefore cannot. That
+     * distinction is what lets ~fss_message_cb detach without a try/catch, and
+     * stating it in a signature rather than a comment keeps a later change to
+     * the flush semantics from silently making the destructor a throwing path.
+     *
+     * Blocks until any in-flight processMessage() returns (the todo/25
+     * lifetime barrier), except when called from inside that callback. */
+    void detachHandler() noexcept;
     /* Request a tighter (or looser) TCP_USER_TIMEOUT than the 30 s default
      * for this connection (todo/26): the bound on how long a blocking send()
      * can stall into a half-dead peer before the kernel errors the connection

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -15,6 +15,11 @@
 
 namespace flight_safety_system {
 
+/* Defined in fss-log.hpp; only referenced here as a pointer parameter on a
+ * private helper, so the declaration is enough and this header keeps its
+ * current include set. */
+class exception_guard;
+
 namespace transport {
 
 static constexpr double FSS_COORD_SCALE = 0.0000001;
@@ -280,8 +285,32 @@ class fss_connection {
      * an unrelated session. -1 when nothing is pending. */
     std::atomic<int> pending_close_fd{-1};
     std::atomic<uint64_t> last_msg_id{0};
+    /* Non-owning back-pointer to the installed handler, guarded by msg_lock.
+     * Lifetime (todo/25): it is only dereferenced with delivery_depth
+     * incremented, and setHandler() — the sole mutator, including the
+     * setHandler(nullptr) in ~fss_message_cb — waits for delivery-idle before
+     * touching it, so a handler cannot be destroyed while a call into it is in
+     * flight. A handler that detaches some other way (fss_client::disconnect()
+     * clears its connection pointer, so ~fss_message_cb never reaches
+     * setHandler) is covered by the same wait in disconnect(). */
     fss_message_cb *handler{nullptr};
     std::queue<std::shared_ptr<fss_message>> messages{};
+    /* Delivery bookkeeping (todo/25): processMessage() runs with msg_lock
+     * RELEASED, so a handler may re-enter getMsg()/setHandler()/disconnect()
+     * without deadlocking on it. These members are themselves guarded by
+     * msg_lock and restore the two properties the old lock-held delivery gave
+     * for free:
+     *  - deliveries on one connection stay serialized (a would-be deliverer
+     *    waits for delivery_depth == 0), and
+     *  - setHandler() cannot swap or clear `handler` while a call into it is
+     *    in flight, which is the lifetime proof above.
+     * delivering_thread is the thread inside the current delivery; it is
+     * exempt from the wait so a re-entrant call made by the callback itself
+     * proceeds instead of blocking on itself. Delivery is serialized, so one
+     * id suffices and delivery_depth only exceeds 1 by same-thread nesting. */
+    std::condition_variable delivery_cv{};
+    unsigned int delivery_depth{0};
+    std::thread::id delivering_thread{};
     std::thread recv_thread{};
     std::mutex send_lock{};
     std::mutex msg_lock{};
@@ -309,6 +338,21 @@ class fss_connection {
      * server-accepted socket already had the default applied at accept and
      * is not affected by this member. */
     unsigned int tcp_user_timeout_ms{default_tcp_user_timeout_ms};
+    /* Blocks until no delivery is in flight. Precondition: t_lock owns
+     * msg_lock. The calling thread is exempt when it is the one delivering, so
+     * a handler re-entering setHandler()/disconnect() does not wait on itself. */
+    void waitForDeliveryIdle(std::unique_lock<std::mutex> &t_lock);
+    /* Invokes handler->processMessage(msg) with msg_lock RELEASED, then
+     * reacquires it. Preconditions: t_lock owns msg_lock, handler != nullptr,
+     * and delivery is idle or already nested on this thread. When t_guard is
+     * non-null the call is made through it (exceptions logged and swallowed);
+     * when null the handler's exception propagates to the caller, with the
+     * delivery bookkeeping unwound first. */
+    void deliverUnlocked(std::unique_lock<std::mutex> &t_lock, const std::shared_ptr<fss_message> &msg,
+                         flight_safety_system::exception_guard *t_guard);
+    /* Ends one delivery started by deliverUnlocked() and wakes anyone waiting
+     * for idle. Precondition: msg_lock held, delivery_depth > 0. */
+    void endDeliveryLocked();
 protected:
     auto recvMsg() -> std::shared_ptr<fss_message>;
     auto getMessageId() -> uint64_t;

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -577,14 +577,47 @@ auto flight_safety_system::transport::fss_connection::sendMsg(const std::shared_
     return true;
 }
 
+void flight_safety_system::transport::fss_connection::detachHandler() noexcept
+{
+    try
+    {
+        std::unique_lock lock_holder(this->msg_lock);
+        /* Nothing may be in flight into the outgoing handler when we clear it:
+         * this wait is what makes detaching a barrier proving the handler
+         * outlives every call the transport makes into it (todo/25). A handler
+         * that detaches from inside its own processMessage() is exempt and does
+         * not self-block. */
+        this->waitForDeliveryIdle(lock_holder);
+        this->handler = nullptr;
+        /* Deliberately no backlog flush: with no handler there is nobody to
+         * flush to. That is what makes this path callback-free and therefore
+         * safe to call from a destructor. */
+    }
+    catch (const std::exception &e)
+    {
+        /* Only the lock/wait can throw here (std::system_error), and only in a
+         * degenerate state. Log rather than propagate: the sole callers are a
+         * destructor and a noexcept-by-contract detach. */
+        FSS_LOG_ERROR("transport", "Exception detaching message handler: " << e.what());
+    }
+    catch (...)
+    {
+        FSS_LOG_ERROR("transport", "Unknown exception detaching message handler");
+    }
+}
+
 void flight_safety_system::transport::fss_connection::setHandler(fss_message_cb *cb)
 {
+    if (cb == nullptr)
+    {
+        /* One implementation of detach, so the "clearing never runs a callback"
+         * property cannot drift between the two entry points. */
+        this->detachHandler();
+        return;
+    }
     std::unique_lock lock_holder(this->msg_lock);
-    /* Nothing may be in flight into the outgoing handler when we swap it out:
-     * this wait is what makes setHandler(nullptr) — in particular the one in
-     * ~fss_message_cb — a barrier proving the handler outlives every call the
-     * transport makes into it (todo/25). A handler that calls setHandler()
-     * from inside its own processMessage() is exempt and does not self-block. */
+    /* No call into the outgoing handler may be in flight when we swap it out —
+     * same barrier as detachHandler(), and likewise re-entrant-safe. */
     this->waitForDeliveryIdle(lock_holder);
     this->handler = cb;
     /* Re-read this->handler each iteration rather than trusting cb: a flushed
@@ -988,23 +1021,11 @@ flight_safety_system::transport::fss_message_cb::~fss_message_cb()
     // this object, so conn cannot be concurrently read or written here.
     if (this->conn != nullptr)
     {
-        /* setHandler() propagates exceptions thrown by a handler it flushes the
-         * backlog into, and a destructor must not. Detaching (cb == nullptr)
-         * never flushes anything, so this cannot fire — but the compiler and
-         * cppcheck only see a potentially-throwing call in a noexcept function,
-         * and a stray throw here would be std::terminate rather than a leak. */
-        try
-        {
-            this->conn->setHandler(nullptr);
-        }
-        catch (const std::exception &e)
-        {
-            FSS_LOG_ERROR("transport", "Exception detaching handler in ~fss_message_cb: " << e.what());
-        }
-        catch (...)
-        {
-            FSS_LOG_ERROR("transport", "Unknown exception detaching handler in ~fss_message_cb");
-        }
+        /* detachHandler() rather than setHandler(nullptr): installing a handler
+         * can propagate an exception from the backlog it flushes, and a
+         * destructor must not. The detach path runs no callbacks at all and
+         * says so in its signature, so this needs no catch of its own. */
+        this->conn->detachHandler();
         this->conn.reset();
     }
 }

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -201,6 +201,18 @@ void flight_safety_system::transport::fss_connection::disconnect()
     {
         close_pending_fd(this->pending_close_fd, "transport/disconnect");
     }
+    /* Callbacks now run outside msg_lock (todo/25), so joining the recv thread
+     * is no longer the only thing that can prove one is not still running —
+     * and in the two detach branches above it never proved it at all. Wait for
+     * delivery-idle so that once disconnect() returns, no processMessage() is
+     * in flight. That is what keeps the fss_client teardown path safe: it
+     * clears its connection pointer before ~fss_message_cb runs, so it never
+     * reaches setHandler(nullptr) and this is its only barrier. A disconnect()
+     * issued from inside a handler is exempt, mirroring the self-detach branch. */
+    {
+        std::unique_lock lock_holder(this->msg_lock);
+        this->waitForDeliveryIdle(lock_holder);
+    }
 }
 
 flight_safety_system::transport::fss_connection::~fss_connection()
@@ -211,6 +223,11 @@ flight_safety_system::transport::fss_connection::~fss_connection()
      * destroying this object no thread can still be about to use the fd, so
      * release the descriptor number now. */
     close_pending_fd(this->pending_close_fd, "transport/destructor");
+    /* Under msg_lock: disconnect() above detaches rather than joins on two
+     * paths, so a recv thread can still be inside processMessages() touching
+     * the queue. It can no longer be inside a callback (disconnect() waits for
+     * delivery-idle), but it may still be queueing. */
+    const std::scoped_lock lock_holder(this->msg_lock);
     while (!this->messages.empty())
     {
         auto msg = this->messages.front();
@@ -221,6 +238,61 @@ flight_safety_system::transport::fss_connection::~fss_connection()
 auto flight_safety_system::transport::fss_connection::getMessageId() -> uint64_t
 {
     return ++this->last_msg_id;
+}
+
+void flight_safety_system::transport::fss_connection::waitForDeliveryIdle(std::unique_lock<std::mutex> &t_lock)
+{
+    while (this->delivery_depth != 0 && this->delivering_thread != std::this_thread::get_id())
+    {
+        this->delivery_cv.wait(t_lock);
+    }
+}
+
+void flight_safety_system::transport::fss_connection::deliverUnlocked(
+    std::unique_lock<std::mutex> &t_lock, const std::shared_ptr<flight_safety_system::transport::fss_message> &msg,
+    flight_safety_system::exception_guard *t_guard)
+{
+    /* Copy the handler out before releasing the lock: setHandler() cannot
+     * change it again until delivery_depth returns to 0, so the local stays
+     * valid for the whole call (see the `handler` member's lifetime note). */
+    auto *cb = this->handler;
+    if (this->delivery_depth++ == 0)
+    {
+        this->delivering_thread = std::this_thread::get_id();
+    }
+    t_lock.unlock();
+    try
+    {
+        if (t_guard != nullptr)
+        {
+            t_guard->run([&]() -> void { cb->processMessage(msg); });
+        }
+        else
+        {
+            cb->processMessage(msg);
+        }
+    }
+    catch (...)
+    {
+        /* Only reachable with t_guard == nullptr (setHandler's flush, which
+         * propagates handler exceptions as it always has). Unwind the delivery
+         * state before letting the exception out, or the connection would look
+         * permanently busy and every later delivery would block forever. */
+        t_lock.lock();
+        this->endDeliveryLocked();
+        throw;
+    }
+    t_lock.lock();
+    this->endDeliveryLocked();
+}
+
+void flight_safety_system::transport::fss_connection::endDeliveryLocked()
+{
+    if (--this->delivery_depth == 0)
+    {
+        this->delivering_thread = std::thread::id();
+        this->delivery_cv.notify_all();
+    }
 }
 
 void flight_safety_system::transport::fss_connection::processMessages()
@@ -260,10 +332,14 @@ void flight_safety_system::transport::fss_connection::processMessages()
             FSS_LOG_INFO("transport", "Remote closed the connection");
             this->run.store(false);
             {
-                std::scoped_lock lock_holder(this->msg_lock);
+                std::unique_lock lock_holder(this->msg_lock);
+                /* Wait out any delivery already in flight (a setHandler()
+                 * backlog flush on another thread), then re-read the handler:
+                 * that flush may have detached it while we waited. */
+                this->waitForDeliveryIdle(lock_holder);
                 if (this->handler != nullptr)
                 {
-                    handler_guard.run([&]() -> void { this->handler->processMessage(msg); });
+                    this->deliverUnlocked(lock_holder, msg, &handler_guard);
                 }
                 else
                 {
@@ -273,10 +349,11 @@ void flight_safety_system::transport::fss_connection::processMessages()
             break;
         }
         {
-            std::scoped_lock lock_holder(this->msg_lock);
+            std::unique_lock lock_holder(this->msg_lock);
+            this->waitForDeliveryIdle(lock_holder);
             if (this->handler != nullptr)
             {
-                handler_guard.run([&]() -> void { this->handler->processMessage(msg); });
+                this->deliverUnlocked(lock_holder, msg, &handler_guard);
             }
             else
             {
@@ -502,16 +579,23 @@ auto flight_safety_system::transport::fss_connection::sendMsg(const std::shared_
 
 void flight_safety_system::transport::fss_connection::setHandler(fss_message_cb *cb)
 {
-    std::scoped_lock lock_holder(this->msg_lock);
+    std::unique_lock lock_holder(this->msg_lock);
+    /* Nothing may be in flight into the outgoing handler when we swap it out:
+     * this wait is what makes setHandler(nullptr) — in particular the one in
+     * ~fss_message_cb — a barrier proving the handler outlives every call the
+     * transport makes into it (todo/25). A handler that calls setHandler()
+     * from inside its own processMessage() is exempt and does not self-block. */
+    this->waitForDeliveryIdle(lock_holder);
     this->handler = cb;
-    if (this->handler != nullptr)
+    /* Re-read this->handler each iteration rather than trusting cb: a flushed
+     * callback may re-enter setHandler(nullptr) to detach mid-flush, and the
+     * rest of the backlog must then stay queued rather than be delivered to a
+     * handler that has just asked to stop hearing from us. */
+    while (this->handler != nullptr && !this->messages.empty())
     {
-        while (!this->messages.empty())
-        {
-            auto msg = this->messages.front();
-            this->messages.pop();
-            cb->processMessage(msg);
-        }
+        auto msg = this->messages.front();
+        this->messages.pop();
+        this->deliverUnlocked(lock_holder, msg, nullptr);
     }
 }
 
@@ -904,7 +988,23 @@ flight_safety_system::transport::fss_message_cb::~fss_message_cb()
     // this object, so conn cannot be concurrently read or written here.
     if (this->conn != nullptr)
     {
-        this->conn->setHandler(nullptr);
+        /* setHandler() propagates exceptions thrown by a handler it flushes the
+         * backlog into, and a destructor must not. Detaching (cb == nullptr)
+         * never flushes anything, so this cannot fire — but the compiler and
+         * cppcheck only see a potentially-throwing call in a noexcept function,
+         * and a stray throw here would be std::terminate rather than a leak. */
+        try
+        {
+            this->conn->setHandler(nullptr);
+        }
+        catch (const std::exception &e)
+        {
+            FSS_LOG_ERROR("transport", "Exception detaching handler in ~fss_message_cb: " << e.what());
+        }
+        catch (...)
+        {
+            FSS_LOG_ERROR("transport", "Unknown exception detaching handler in ~fss_message_cb");
+        }
         this->conn.reset();
     }
 }


### PR DESCRIPTION
## Description

processMessages() and setHandler() called into user callbacks while holding msg_lock, so any handler re-entering getMsg()/setHandler()/disconnect() from its own processMessage() self-deadlocked on a plain std::mutex. In-tree handlers were hand-shaped to avoid it, but the API itself was the hazard.

Deliver with msg_lock released, and keep the two properties the lock-held shape gave for free via new delivery bookkeeping (delivery_cv, delivery_depth, delivering_thread, all guarded by msg_lock):

  - deliveries on one connection stay serialized: a would-be deliverer waits for delivery-idle first;
  - setHandler() waits for delivery-idle before swapping `handler`, so the raw fss_message_cb* cannot be destroyed while a call into it is in flight. That wait is the lifetime proof for the non-owning back-pointer.

The delivering thread is exempt from the wait, which is what makes re-entrant calls work instead of blocking on themselves. setHandler()'s backlog flush re-reads `handler` each iteration so a callback that detaches mid-flush leaves the rest of the backlog queued.

disconnect() now also waits for delivery-idle after the join/detach block: its two detach branches never proved a callback had finished, and that is the only barrier the fss_client teardown path has (it clears its connection pointer before ~fss_message_cb, so it never reaches setHandler(nullptr)). ~fss_connection drains the queue under msg_lock for the same reason.

~fss_message_cb now catches around its setHandler(nullptr): detaching never flushes so it cannot throw, but a destructor must not be the one to find out.

Note: this removes re-entrancy deadlocks, not cross-thread lock-order cycles — setHandler() still blocks on a running callback, so the existing call-activate()-outside-our-own-lock rules in server-clients.cpp and client-ssl.cpp remain load-bearing and are unchanged.

## Summary by Sourcery

Refactor message delivery to run callbacks outside the connection message lock while preserving serialized delivery and safe handler lifetimes.

Bug Fixes:
- Ensure disconnect() and ~fss_connection() wait for delivery to become idle and drain message queues under lock so that no callbacks run after teardown.
- Wrap ~fss_message_cb detachment in exception handling and logging to avoid terminating on unexpected exceptions while clearing the handler.

Enhancements:
- Introduce delivery bookkeeping (delivery depth, delivering thread, condition variable) to serialize deliveries per connection and allow re-entrant handler calls without deadlocks.
- Add helper utilities to wait for delivery idle and to invoke handlers with the message lock released, including correct unwinding on exceptions.
- Update setHandler() to wait for in-flight deliveries to complete before swapping handlers and to flush the backlog using the new unlocked delivery path, allowing handlers to detach mid-flush safely.