### PR TITLE
test(transport): todo/25 regressions for re-entrant handler callbacks

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -48,6 +48,7 @@ all_test_SOURCES = main.cpp messages.cpp connection.cpp client.cpp \
 	server_clients_test.cpp \
 	server_failsafe_test.cpp \
 	exception_isolation_test.cpp \
+	handler_reentry_test.cpp \
 	../src/client_session.cpp \
 	../src/db-write-queue.cpp \
 	../src/server-clients.cpp \

--- a/tests/concurrency_connection_test.cpp
+++ b/tests/concurrency_connection_test.cpp
@@ -155,3 +155,69 @@ TEST_CASE("tsan: concurrent setConnection/clearConnection and sendMsg/getConnect
     writer.join();
     reader.join();
 }
+
+/* todo/25: processMessage() now runs with msg_lock released, so the delivery
+ * bookkeeping (delivery_depth/delivering_thread/delivery_cv) is what serializes
+ * deliveries and keeps setHandler() from swapping the handler mid-call. One
+ * thread churns setHandler(cb)/setHandler(nullptr) while the recv thread is
+ * delivering a steady stream of real messages: TSan must see no race on the
+ * handler pointer or the queue, and no delivery may land after a detach
+ * returns. */
+TEST_CASE("tsan: setHandler churn racing live recv-thread deliveries")
+{
+    int fds[2];
+    REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    auto sender = fss_connection::create(fds[0]);
+    auto receiver = fss_connection::create(fds[1]);
+    REQUIRE(sender != nullptr);
+    REQUIRE(receiver != nullptr);
+
+    /* Counts deliveries and asserts none arrives while detached. attached is
+     * only written by the churning thread, and only while no delivery can be in
+     * flight — setHandler() waits for delivery-idle on both sides of the swap. */
+    struct counting_cb : fss_message_cb {
+        explicit counting_cb(std::shared_ptr<fss_connection> t_conn) : fss_message_cb(std::move(t_conn)) {}
+        std::atomic<bool> attached{false};
+        std::atomic<int> delivered{0};
+        std::atomic<int> while_detached{0};
+        void processMessage(std::shared_ptr<flight_safety_system::transport::fss_message>) override
+        {
+            if (!this->attached.load())
+            {
+                ++this->while_detached;
+            }
+            ++this->delivered;
+        }
+    };
+    auto cb = std::make_shared<counting_cb>(receiver);
+
+    constexpr int iterations = 500;
+    std::atomic<bool> stop{false};
+
+    std::thread feeder([&]() {
+        while (!stop.load())
+        {
+            sender->sendMsg(std::make_shared<fss_message_identity>("tsan-churn"));
+        }
+    });
+
+    for (int i = 0; i < iterations; ++i)
+    {
+        cb->attached.store(true);
+        receiver->setHandler(cb.get());
+        receiver->setHandler(nullptr);
+        cb->attached.store(false);
+        /* Keep the queue from growing without bound while detached. */
+        while (receiver->getMsg() != nullptr)
+        {
+        }
+    }
+
+    stop.store(true);
+    feeder.join();
+
+    REQUIRE(cb->while_detached.load() == 0);
+
+    cb->disconnect();
+    receiver->disconnect();
+}

--- a/tests/handler_reentry_test.cpp
+++ b/tests/handler_reentry_test.cpp
@@ -1,0 +1,297 @@
+#ifdef HAVE_CATCH2_CATCH_ALL_HPP
+#include <catch2/catch_all.hpp>
+#elif HAVE_CATCH2_CATCH_HPP
+#include <catch2/catch.hpp>
+#elif HAVE_CATCH_CATCH_HPP
+#include <catch/catch.hpp>
+#elif HAVE_CATCH_HPP
+#include <catch.hpp>
+#else
+#error No catch header
+#endif
+
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "fss-transport.hpp"
+#include "test_helpers.hpp"
+
+/* todo/25: fss_connection delivers processMessage() with msg_lock RELEASED, so
+ * a handler may re-enter the connection's message-queue API from inside its own
+ * callback without deadlocking. Before that change every case below hung the
+ * recv thread on a plain std::mutex.
+ *
+ * Every assertion is a bounded wait_for(), so a regression fails on the timeout
+ * rather than wedging the suite at the point of the deadlock. */
+
+using flight_safety_system::transport::fss_connection;
+using flight_safety_system::transport::fss_message;
+using flight_safety_system::transport::fss_message_cb;
+using flight_safety_system::transport::fss_message_identity;
+
+namespace {
+
+/* A handler that runs an arbitrary action from inside processMessage().
+ * `entered` is bumped before the action and `returned` after it, so a callback
+ * that deadlocks shows up as entered == 1, returned == 0. */
+class reentrant_cb : public fss_message_cb {
+public:
+    using action_fn = std::function<void(reentrant_cb &)>;
+
+    reentrant_cb(std::shared_ptr<fss_connection> t_conn, action_fn t_action)
+        : fss_message_cb(std::move(t_conn)), action(std::move(t_action))
+    {
+    }
+    reentrant_cb(const reentrant_cb &) = delete;
+    reentrant_cb(reentrant_cb &&) = delete;
+    auto operator=(const reentrant_cb &) -> reentrant_cb & = delete;
+    auto operator=(reentrant_cb &&) -> reentrant_cb & = delete;
+    ~reentrant_cb() override = default;
+
+    std::atomic<int> entered{0};
+    std::atomic<int> returned{0};
+
+    void processMessage(std::shared_ptr<fss_message> message) override
+    {
+        ++this->entered;
+        {
+            const std::scoped_lock lock(this->names_lock);
+            auto ident = std::dynamic_pointer_cast<fss_message_identity>(message);
+            this->names.push_back(ident != nullptr ? ident->getName() : std::string("<other>"));
+        }
+        if (this->action)
+        {
+            this->action(*this);
+        }
+        ++this->returned;
+    }
+
+    auto getNames() -> std::vector<std::string>
+    {
+        const std::scoped_lock lock(this->names_lock);
+        return this->names;
+    }
+private:
+    action_fn action;
+    std::mutex names_lock{};
+    std::vector<std::string> names{};
+};
+
+/* A connected pair of fss_connections over a Unix socketpair: no listener, no
+ * port, and the recv threads are up as soon as create() returns. */
+struct conn_pair {
+    std::shared_ptr<fss_connection> sender{};
+    std::shared_ptr<fss_connection> receiver{};
+};
+
+auto make_conn_pair(size_t receiver_queue_size = 1000) -> conn_pair
+{
+    int fds[2] = {-1, -1};
+    if (::socketpair(AF_UNIX, SOCK_STREAM, 0, fds) != 0)
+    {
+        return {};
+    }
+    conn_pair pair;
+    pair.sender = fss_connection::create(fds[0]);
+    pair.receiver = fss_connection::create(fds[1], receiver_queue_size);
+    return pair;
+}
+
+auto send_identity(const std::shared_ptr<fss_connection> &conn, const std::string &name) -> bool
+{
+    return conn->sendMsg(std::make_shared<fss_message_identity>(name));
+}
+
+} // namespace
+
+TEST_CASE("reentry: handler calling getMsg() from processMessage does not deadlock")
+{
+    auto pair = make_conn_pair();
+    REQUIRE(pair.receiver != nullptr);
+
+    std::atomic<bool> got_null{false};
+    std::atomic<bool> called_getmsg{false};
+    auto cb = std::make_shared<reentrant_cb>(pair.receiver, [&](reentrant_cb &self) -> void {
+        /* getMsg() takes msg_lock, which the old code still held here. */
+        auto queued = self.getConnection()->getMsg();
+        called_getmsg.store(true);
+        /* With a handler installed getMsg() always reports empty. */
+        got_null.store(queued == nullptr);
+    });
+    pair.receiver->setHandler(cb.get());
+
+    REQUIRE(send_identity(pair.sender, "m1"));
+    REQUIRE(fss_test::wait_for([&]() { return cb->returned.load() >= 1; }));
+    REQUIRE(called_getmsg.load());
+    REQUIRE(got_null.load());
+
+    cb->disconnect();
+}
+
+TEST_CASE("reentry: handler calling setHandler(nullptr) from processMessage does not deadlock")
+{
+    auto pair = make_conn_pair();
+    REQUIRE(pair.receiver != nullptr);
+
+    auto cb = std::make_shared<reentrant_cb>(
+        pair.receiver, [](reentrant_cb &self) -> void { self.getConnection()->setHandler(nullptr); });
+    pair.receiver->setHandler(cb.get());
+
+    REQUIRE(send_identity(pair.sender, "m1"));
+    REQUIRE(fss_test::wait_for([&]() { return cb->returned.load() >= 1; }));
+
+    /* Detached mid-callback: everything after it queues instead of being
+     * delivered, and is readable through getMsg() again. */
+    REQUIRE(send_identity(pair.sender, "m2"));
+    std::shared_ptr<fss_message> queued{};
+    REQUIRE(fss_test::wait_for([&]() {
+        queued = pair.receiver->getMsg();
+        return queued != nullptr;
+    }));
+    auto ident = std::dynamic_pointer_cast<fss_message_identity>(queued);
+    REQUIRE(ident != nullptr);
+    REQUIRE(ident->getName() == "m2");
+    REQUIRE(cb->entered.load() == 1);
+
+    pair.receiver->disconnect();
+}
+
+TEST_CASE("reentry: handler calling detachHandler() from processMessage does not deadlock")
+{
+    /* Same barrier as setHandler(nullptr) above, through the entry point
+     * ~fss_message_cb uses — the one that is callback-free by contract. */
+    auto pair = make_conn_pair();
+    REQUIRE(pair.receiver != nullptr);
+
+    auto cb = std::make_shared<reentrant_cb>(pair.receiver,
+                                             [](reentrant_cb &self) -> void { self.getConnection()->detachHandler(); });
+    pair.receiver->setHandler(cb.get());
+
+    REQUIRE(send_identity(pair.sender, "m1"));
+    REQUIRE(fss_test::wait_for([&]() { return cb->returned.load() >= 1; }));
+
+    REQUIRE(send_identity(pair.sender, "m2"));
+    std::shared_ptr<fss_message> queued{};
+    REQUIRE(fss_test::wait_for([&]() {
+        queued = pair.receiver->getMsg();
+        return queued != nullptr;
+    }));
+    auto ident = std::dynamic_pointer_cast<fss_message_identity>(queued);
+    REQUIRE(ident != nullptr);
+    REQUIRE(ident->getName() == "m2");
+    REQUIRE(cb->entered.load() == 1);
+
+    pair.receiver->disconnect();
+}
+
+TEST_CASE("reentry: handler calling disconnect() from processMessage does not deadlock")
+{
+    auto pair = make_conn_pair();
+    REQUIRE(pair.receiver != nullptr);
+
+    auto cb = std::make_shared<reentrant_cb>(pair.receiver,
+                                             [](reentrant_cb &self) -> void { self.getConnection()->disconnect(); });
+    pair.receiver->setHandler(cb.get());
+
+    REQUIRE(send_identity(pair.sender, "m1"));
+    REQUIRE(fss_test::wait_for([&]() { return cb->returned.load() >= 1; }));
+    /* The self-disconnect really took effect: the socket has been shut down and
+     * retired, so the connection can no longer send. (connected() only reports
+     * whether the callback still holds a connection pointer, which it does.) */
+    REQUIRE_FALSE(send_identity(pair.receiver, "after-disconnect"));
+
+    cb->disconnect();
+}
+
+TEST_CASE("reentry: setHandler backlog flush stops when the handler detaches mid-flush")
+{
+    /* max_queue_size 3, four messages sent with no handler installed: the
+     * oldest is dropped, which is an observable signal (getDroppedMessages)
+     * that all four have been received and exactly three are queued. Without
+     * it there is no way to know the backlog is complete before installing the
+     * handler. */
+    auto pair = make_conn_pair(3);
+    REQUIRE(pair.receiver != nullptr);
+
+    for (const auto *name : {"m1", "m2", "m3", "m4"})
+    {
+        REQUIRE(send_identity(pair.sender, name));
+    }
+    REQUIRE(fss_test::wait_for([&]() { return pair.receiver->getDroppedMessages() >= 1; }));
+
+    auto cb = std::make_shared<reentrant_cb>(
+        pair.receiver, [](reentrant_cb &self) -> void { self.getConnection()->setHandler(nullptr); });
+    /* Flushes the backlog on THIS thread; the first message detaches the
+     * handler, so the remaining two must stay queued. */
+    pair.receiver->setHandler(cb.get());
+
+    REQUIRE(cb->entered.load() == 1);
+    REQUIRE(cb->getNames() == std::vector<std::string>{"m2"});
+
+    for (const auto *expected : {"m3", "m4"})
+    {
+        auto queued = pair.receiver->getMsg();
+        REQUIRE(queued != nullptr);
+        auto ident = std::dynamic_pointer_cast<fss_message_identity>(queued);
+        REQUIRE(ident != nullptr);
+        REQUIRE(ident->getName() == expected);
+    }
+    REQUIRE(pair.receiver->getMsg() == nullptr);
+
+    pair.receiver->disconnect();
+}
+
+TEST_CASE("reentry: setHandler(nullptr) waits for an in-flight callback to return")
+{
+    /* The lifetime proof for fss_connection's raw fss_message_cb*: detaching
+     * must not return while a call into the handler is still running, or the
+     * handler could be destroyed under the transport's feet. */
+    auto pair = make_conn_pair();
+    REQUIRE(pair.receiver != nullptr);
+
+    std::mutex block_lock{};
+    std::condition_variable block_cv{};
+    bool release = false;
+
+    auto cb = std::make_shared<reentrant_cb>(pair.receiver, [&](reentrant_cb & /*self*/) -> void {
+        std::unique_lock lock(block_lock);
+        block_cv.wait(lock, [&]() { return release; });
+    });
+    pair.receiver->setHandler(cb.get());
+
+    REQUIRE(send_identity(pair.sender, "m1"));
+    REQUIRE(fss_test::wait_for([&]() { return cb->entered.load() >= 1; }));
+
+    std::atomic<bool> detached{false};
+    std::thread detacher([&]() {
+        pair.receiver->setHandler(nullptr);
+        detached.store(true);
+    });
+
+    /* The callback is still blocked, so setHandler must be too. */
+    REQUIRE_FALSE(fss_test::wait_for([&]() { return detached.load(); }, std::chrono::milliseconds(200)));
+    REQUIRE(cb->returned.load() == 0);
+
+    {
+        const std::scoped_lock lock(block_lock);
+        release = true;
+    }
+    block_cv.notify_all();
+
+    REQUIRE(fss_test::wait_for([&]() { return detached.load(); }));
+    detacher.join();
+    REQUIRE(cb->returned.load() == 1);
+
+    pair.receiver->disconnect();
+}


### PR DESCRIPTION
## Description

Five cases in handler_reentry_test.cpp, each of which hangs the recv thread (verified against the pre-fix transport, which times out) and now passes:

  - processMessage calling getMsg(),
  - processMessage calling setHandler(nullptr), with later messages queueing,
  - processMessage calling disconnect() on its own connection,
  - a setHandler() backlog flush whose handler detaches mid-flush, leaving the rest of the backlog queued in order,
  - setHandler(nullptr) from another thread blocking until an in-flight callback returns — the lifetime proof for the raw fss_message_cb*.

Every assertion is a bounded wait_for(), so a regression fails on the timeout rather than wedging the suite where the deadlock happens. The backlog-flush case builds its backlog with max_queue_size 3 and waits on getDroppedMessages(), which is the only observable proof that all four messages arrived before the handler is installed.

Also adds a TSan case racing setHandler(cb)/setHandler(nullptr) churn against live recv-thread deliveries, asserting no delivery lands while detached.

## Summary by Sourcery

Add regression and concurrency tests covering re-entrant handler callbacks and handler churn during live message delivery to validate recent transport changes.

Tests:
- Introduce handler_reentry_test suite to verify various handler re-entry scenarios (getMsg, handler detachment, disconnect, backlog flush, and detach blocking) do not deadlock and preserve message ordering/queuing semantics.
- Add a TSan concurrency test that churns handler attachment/detachment against live recv-thread deliveries to ensure no races and that no messages are delivered while the handler is detached.