### PR TITLE
docs: add a tracked design-record directory (todo/54)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 AUTOMAKE_OPTIONS = foreign
 ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = src examples tests
-EXTRA_DIST = debian e2e .clang-format certs LICENSE.md CHANGELOG.md
+EXTRA_DIST = debian e2e .clang-format certs LICENSE.md CHANGELOG.md docs
 
 # `make distcheck` must build everything the release ships — the server,
 # the tests, and the example client — so a header missing from the tarball

--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ Primarily flight-safety-system is designed to run alongside [Search Management M
 
 There is an [ADS-B Integration](https://github.com/canterbury-air-patrol/fss-adsb/) that allows position reports from ADS-B Out aircraft to be relayed to FSS clients.
 
+## Design record
+
+Settled design decisions — including the alternatives that were considered and
+rejected, and the evidence behind each rejection — are recorded in
+[docs/](docs/README.md). Start there before changing protocol semantics, the
+database seam, or the fail-safe behaviour.
+
 ## Release strategy
 
 Stable releases are cut from long-lived `release/X.Y` branches. The `develop` branch carries ongoing work and merges into a `release/X.Y` branch when a release is prepared. Bug fixes are applied to `develop` first and then cherry-picked to the relevant `release/X.Y` branch, resulting in patch releases (`X.Y.1`, `X.Y.2`, etc.). The `master` branch always points to the latest stable release.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,47 @@
+# Design record
+
+This directory is the project's tracked design record. It holds the things a
+future maintainer cannot recover from the code or from `git log`:
+
+- **`decisions/`** — one file per settled design decision, including the
+  alternatives that were considered and *rejected*, and the evidence behind the
+  rejection. These are written to be read years later, by someone who has only
+  the repository.
+- **`release-checklist.md`** — the steps that must be performed when cutting a
+  release, including the ABI check that a soname bump depends on.
+
+## What does *not* live here
+
+Open work items, scratch plans and in-progress investigation notes live in the
+gitignored `todo/` directory (see `.gitignore`, "Local working notes"). Those
+are transient by nature. When a `todo/` item ships and leaves behind a decision
+worth keeping, the decision is promoted into `decisions/` and the plan file is
+deleted.
+
+## Numbering
+
+Decision files are named `NN-slug.md`, where `NN` is the number of the `todo/`
+item the decision came from. The numbering is deliberately preserved so that
+existing citations stay resolvable: a commit message reading
+`feat(server): todo/49 …`, or a code comment reading "see todo/49", refers to
+the same decision now recorded in `decisions/49-server-command-id-semantics.md`.
+
+Numbers are historical identifiers, not an ordering. A decision that spans
+several `todo/` items is filed under all of them (`34-45-47-…`).
+
+## The record
+
+| Decision | Subject |
+|---|---|
+
+## Citing a decision
+
+New code comments, `CHANGELOG.md` entries and commit messages should cite the
+tracked path (`docs/decisions/49-…`) rather than the bare `todo/49`, so the
+reference resolves in any clone. Existing `todo/NN` citations in the tree are
+retargeted opportunistically, whenever a file is touched for other reasons —
+the table above is the map in the meantime.
+
+Citations to *other repositories'* todo items (cap-fmu, `CAP/test-plan`) can
+never resolve locally, so they always carry a one-line gloss of what the
+referenced item is about.


### PR DESCRIPTION
## Description

todo/ is gitignored, yet it is the project's de-facto design record: code comments, CHANGELOG entries and commit messages all cite todo/NN as the authority for a decision. For anyone else who clones the repo those are dangling pointers.

Add docs/ as the tracked home for settled decisions, keeping the todo numbering so existing citations stay resolvable (todo/49 becomes docs/decisions/49-...). Wire it into EXTRA_DIST so it ships in the release tarball, and point at it from the README. The decision files themselves follow in the next commits.

## Summary by Sourcery

Introduce a tracked design record directory and reference it from project documentation and release artifacts.

Build:
- Include the new docs directory in EXTRA_DIST so design records ship with release tarballs.

Documentation:
- Add a README section pointing to the docs-based design record for settled decisions.
- Create docs/README.md describing the structure, numbering, and usage of the tracked design record and decision files.