### PR TITLE
Add docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- A tracked design record under `docs/` (todo/54). The project's settled design
+  decisions previously lived only in the gitignored `todo/` directory, which
+  code comments, changelog entries and commit messages all cite by number — so
+  every one of those citations was a dangling pointer in any other clone, and
+  the only copy of the decision history was one developer's working tree.
+  `docs/decisions/` now holds one file per settled decision, keeping the `todo`
+  numbering so existing citations stay resolvable (`todo/49` is
+  `docs/decisions/49-server-command-id-semantics.md`), and each records the
+  alternatives that were rejected along with the evidence — the part that cannot
+  be recovered from the code. `docs/release-checklist.md` is new, and carries
+  the ABI check (`abidiff` the installed headers and libraries against the last
+  tag, *before* choosing the version number) that todo/61 left outstanding after
+  an ABI break reached a tag unbumped. Open work items stay in `todo/`.
+  Citations in the public headers and the fail-safe monitor now point at the
+  tracked documents; the rest are retargeted as those files are next touched.
+
 ### Changed
 - `fss_connection` now invokes `fss_message_cb::processMessage()` with its
   internal `msg_lock` released, instead of holding it across the callback

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ fss-server server.json
 
 #### Supported scale
 
-The server is sized for RPAS fleets of tens of aircraft against a single local PostgreSQL+PostGIS database. Command dispatch runs from in-memory caches on the main loop; the poller performs one batched database read per tick for the newest pending command across all connected aircraft, so the steady-state command-read rate is a constant (~10 queries/second) rather than growing with the number of aircraft. Each connection uses a small, fixed number of threads. Deployments approaching hundreds of concurrent aircraft should re-evaluate the single read-connection and per-connection thread model first.
+The server is sized for RPAS fleets of tens of aircraft against a single local PostgreSQL+PostGIS database. Command dispatch runs from in-memory caches on the main loop; the poller performs one batched database read per tick for the newest pending command across all connected aircraft, so the steady-state command-read rate is a constant (~10 queries/second) rather than growing with the number of aircraft. Each connection uses a small, fixed number of threads. Deployments approaching hundreds of concurrent aircraft should re-evaluate the single read-connection and per-connection thread model first; see [docs/decisions/23](docs/decisions/23-supported-scale-assumption.md) for what sets the ceiling and the order in which to raise it.
 
 ### Client
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,11 @@ several `todo/` items is filed under all of them (`34-45-47-…`).
 
 | Decision | Subject |
 |---|---|
+| [26 — client send timeouts use `TCP_USER_TIMEOUT`, not `SO_SNDTIMEO`](decisions/26-client-send-timeout.md) | Transport |
+| [43 — `secure_string` scope](decisions/43-secure-string-scope.md) | Security boundary |
+| [48 — a terminal command ack is final for its dispatch](decisions/48-command-ack-terminal-finality.md) | Protocol / audit |
+| [49 — the FMU command identifier is per-server](decisions/49-server-command-id-semantics.md) | Protocol |
+| [51 — optional trailing wire fields are prefix-closed](decisions/51-optional-trailing-field-rule.md) | Protocol |
 
 ## Citing a decision
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ several `todo/` items is filed under all of them (`34-45-47-…`).
 
 | Decision | Subject |
 |---|---|
+| [16 — `-fanalyzer` evaluated and not adopted](decisions/16-gcc-fanalyzer-not-adopted.md) | Static-analysis tooling |
 | [23 — supported scale: tens of aircraft](decisions/23-supported-scale-assumption.md) | Standing assumption |
 | [24 — database reads report failure by status, never throw](decisions/24-database-read-error-control-flow.md) | Database seam |
 | [25 — transport callbacks run without the connection's lock](decisions/25-transport-callback-reentrancy.md) | Standing assumption |

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,9 @@ several `todo/` items is filed under all of them (`34-45-47-…`).
 
 | Decision | Subject |
 |---|---|
+| [23 — supported scale: tens of aircraft](decisions/23-supported-scale-assumption.md) | Standing assumption |
 | [24 — database reads report failure by status, never throw](decisions/24-database-read-error-control-flow.md) | Database seam |
+| [25 — transport callbacks run without the connection's lock](decisions/25-transport-callback-reentrancy.md) | Standing assumption |
 | [26 — client send timeouts use `TCP_USER_TIMEOUT`, not `SO_SNDTIMEO`](decisions/26-client-send-timeout.md) | Transport |
 | [31 — duplicate asset identity rejects the newcomer](decisions/31-duplicate-identity-policy.md) | Server policy |
 | [34/45/47 — the database fail-safe is one latched degraded state](decisions/34-45-47-db-failsafe-latch.md) | Safety behaviour |

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,8 +33,12 @@ several `todo/` items is filed under all of them (`34-45-47-…`).
 
 | Decision | Subject |
 |---|---|
+| [24 — database reads report failure by status, never throw](decisions/24-database-read-error-control-flow.md) | Database seam |
 | [26 — client send timeouts use `TCP_USER_TIMEOUT`, not `SO_SNDTIMEO`](decisions/26-client-send-timeout.md) | Transport |
+| [31 — duplicate asset identity rejects the newcomer](decisions/31-duplicate-identity-policy.md) | Server policy |
+| [34/45/47 — the database fail-safe is one latched degraded state](decisions/34-45-47-db-failsafe-latch.md) | Safety behaviour |
 | [43 — `secure_string` scope](decisions/43-secure-string-scope.md) | Security boundary |
+| [46 — no `statement_timeout`; DB stalls are bounded at the socket](decisions/46-no-statement-timeout.md) | Database seam |
 | [48 — a terminal command ack is final for its dispatch](decisions/48-command-ack-terminal-finality.md) | Protocol / audit |
 | [49 — the FMU command identifier is per-server](decisions/49-server-command-id-semantics.md) | Protocol |
 | [51 — optional trailing wire fields are prefix-closed](decisions/51-optional-trailing-field-rule.md) | Protocol |

--- a/docs/decisions/16-gcc-fanalyzer-not-adopted.md
+++ b/docs/decisions/16-gcc-fanalyzer-not-adopted.md
@@ -1,0 +1,58 @@
+# 16 — GCC `-fanalyzer` evaluated and not adopted
+
+**Measured 2026-06-13; not adopted.** This record exists so the question is not
+re-litigated from first principles.
+
+## What was measured
+
+The full project was built with `-fanalyzer` on the CI-relevant compilers
+(Ubuntu 24.04 containers, gcc-13.3 and gcc-14.2) and locally on gcc-16.1.
+
+**gcc-13 / gcc-14: ~52 analyzer warnings, all false positives.**
+
+- 41 are locationless `cc1plus: warning: use of uninitialized value
+  '<unknown>'` — analyzer-internal noise with no source location, and therefore
+  not suppressible by a source pragma.
+- ~10 are `-Wanalyzer-use-of-uninitialized-value` where the analyzer loses track
+  of `std::shared_ptr` / `std::function` contents while iterating the
+  `snapshotClients()` vectors in `server-clients.hpp`, and in the gnutls session
+  handling in `transport-ssl.cpp`.
+- 1 is `-Wanalyzer-malloc-leak` flagging `credentials(new ...)` in the
+  `transport_ssl` constructor — a `std::unique_ptr` member freed in the
+  destructor; the analyzer does not model smart-pointer ownership through the
+  gnutls C++ wrapper.
+
+**gcc-16: 6 warnings** — the same `shared_ptr` false positives. Newer gcc
+suppresses more of the noise but adds nothing of value.
+
+**Zero** warnings in `server-db.c`, the generated ECPG C file that is excluded
+from clang-tidy and cppcheck, and the one place the analyzer would actually be
+trustworthy. That was the only potential payoff, and it found nothing.
+
+## Why not adopted
+
+- The project builds with `-Werror`, so a gating job is red on day one.
+- Suppressing the noise means disabling
+  `-Wanalyzer-use-of-uninitialized-value` — which is also the category most
+  likely to find a *real* uninitialized-value bug. Gating after that suppression
+  provides almost nothing.
+- An informational, non-gating job would emit ~52 noise lines per run that
+  nobody reads.
+- The warning set varies by gcc version, so any suppression list is fragile.
+- `-fanalyzer` is mature on C but still false-positive-prone on C++/STL, and
+  this codebase is almost entirely C++.
+
+## What already covers this ground
+
+clang-tidy and cppcheck (`check-code.sh`), ASan+UBSan, ThreadSanitizer,
+valgrind, and CodeQL. These found and gated the real defects during the 1.0.3
+work; `-fanalyzer` adds nothing they do not.
+
+## If revisited
+
+Only worth reconsidering if either:
+
+- a future gcc materially cuts the C++ false-positive rate; or
+- substantial new hand-written **C** lands — the analyzer's strong suit — in
+  which case gate `-fanalyzer` on just those C translation units, not the C++
+  tree.

--- a/docs/decisions/23-supported-scale-assumption.md
+++ b/docs/decisions/23-supported-scale-assumption.md
@@ -1,0 +1,47 @@
+# 23 — Supported scale: tens of aircraft, not hundreds
+
+**Standing assumption.** Recorded 2026-07-24; the batched command poll that
+raised the read ceiling shipped the same day.
+
+## The assumption
+
+The server is sized for RPAS fleets of **tens of aircraft** against a single
+local PostgreSQL+PostGIS database. Every capacity judgement in the codebase — the
+single read connection, the per-connection thread counts, the poll cadence — is
+made against that number.
+
+It is stated in the README's *Supported scale* section for operators; this file
+is the engineering record of *why* it is where it is, and what to do about it.
+
+## What actually sets the ceiling
+
+Two things scale with the number of connected aircraft, and one no longer does.
+
+- **No longer:** the command poller used to issue one `getCommand(asset_id)`
+  read per client per 100 ms tick, all serialised on the single read connection
+  — about 10·N reads/second. It now issues one batched
+  `DISTINCT ON (asset_id)` query per tick, so the steady-state command-read rate
+  is a constant ~10 queries/second regardless of N.
+- **Threads:** roughly 2 per client, plus the handshake worker pool.
+- **The single read connection** remains a serialisation point for everything
+  the poller does.
+
+## If a deployment approaches ~100 concurrent aircraft
+
+In order:
+
+1. Re-measure. The batched poll already removed the original bottleneck, so the
+   next limit is unknown rather than predicted.
+2. Reconsider the per-connection thread model — it is the remaining term that
+   grows linearly.
+3. Then consider LISTEN/NOTIFY push in place of polling, or a read-connection
+   pool. Note that FSS never inserts commands itself (the external fss-web does),
+   so a NOTIFY-based push requires a trigger on the fss-web side plus libpq
+   here — it is a cross-repo change, not a local one.
+
+## Related
+
+The broadcast relay's O(N²) decode cost was a genuine super-linear term and was
+fixed independently (todo/55): `broadcastMsg` now packs a position report once
+and `sendPacked` stamps each recipient's sequence id into a copy of those bytes,
+instead of decoding once per recipient and re-packing each clone.

--- a/docs/decisions/24-database-read-error-control-flow.md
+++ b/docs/decisions/24-database-read-error-control-flow.md
@@ -1,0 +1,51 @@
+# 24 — Database reads report failure by status; only writes throw
+
+**Decided** 2026-07-16. Shipped in 1.2.0.
+
+## Context
+
+`getActiveServers()` signalled a cut-short read by throwing `database_error`
+across a thread boundary, and the throw was swallowed by the recv thread's
+`exception_guard`. Control flow that depends on an exception unwinding through
+callers that never see it is not control flow anyone can reason about.
+
+## Decision
+
+**Reads return a status; they never throw.** `IDatabase::getActiveServers()`
+returns `std::optional<std::vector<fss_server_details>>`, where `nullopt` means
+the read was cut short — a mid-cursor error, or a
+[41 truncation](#related) — with `db.cpp` logging and returning `nullopt`
+instead of throwing.
+
+`getServersListMsg` / `build_server_list_msg` translate that into a **nullptr
+message**, which is deliberately distinct from a non-null zero-server message
+for a genuinely empty set. The poller updates the cached list *and* runs
+`refreshSmmSettings()` only on a non-null build, exactly matching the old
+unwind-skips-both behaviour; the identify path skips the server-list send with a
+WARN, where the old throw was swallowed with the send equally skipped. Both
+production paths' observable behaviour is unchanged.
+
+The filing named two callers. There turned out to be three — the poller, identify
+on the recv thread, and both of those via `getServersListMsg`.
+
+## `database_error` stays, for writes
+
+The [34/45/47](34-45-47-db-failsafe-latch.md) write wrappers still throw
+`database_error` into `db_write_queue`'s catch. That is a single-thread-local
+idiom the fail-safe counts on: throw and catch are in the same thread, a few
+frames apart. The exception's doc comment now states that reads never throw.
+
+`getAssetId()` follows the same convention (todo/60): it returns
+`std::optional<uint64_t>` where `nullopt` means the read failed and `0` means
+definitively unknown, and the two identify call sites log those two cases
+differently — ERROR "asset lookup failed (DB read error)" versus the existing
+genuine-miss wording. The non-aircraft branch treats `nullopt` as "cannot prove
+this CN is not an aircraft's" and rejects, rather than claiming it "belongs to a
+known aircraft".
+
+## Related
+
+todo/41: `db_active_fss_servers_get` also fails the read when
+`sqlca.sqlwarn[0] == 'W'`, so a truncation-triggered `WHENEVER SQLWARNING DO
+BREAK` exit reports failure rather than shipping a partial active-server list as
+if it were complete.

--- a/docs/decisions/25-transport-callback-reentrancy.md
+++ b/docs/decisions/25-transport-callback-reentrancy.md
@@ -1,0 +1,61 @@
+# 25 — Transport callbacks run with the connection's message lock released
+
+**Standing constraint on the transport API.** Decided and shipped 2026-07-25.
+Carries an ABI break: sonames `.so.3` → `.so.4`.
+
+## The constraint
+
+`fss_connection` delivers `fss_message_cb::processMessage()` with `msg_lock`
+**released**. A handler may therefore re-enter the connection's message-queue
+API from inside its own callback — `getMsg()`, `setHandler()`, `disconnect()`,
+or anything reaching them — without deadlocking.
+
+Anyone writing an `fss_message_cb`, in this repo or a consumer, may rely on
+that. Anyone changing the transport must preserve it.
+
+## Why it is written down
+
+The original implementation held `msg_lock` across the callback, so any such
+re-entry self-deadlocked on a plain `std::mutex`. It was never a *live* bug —
+the in-tree handlers had been hand-shaped around it — which is precisely why it
+survived so long. The API was the hazard, for every future callback, and the
+hazard was invisible from the call site.
+
+## What upholds it
+
+Delivery bookkeeping guarded by `msg_lock` (`delivery_cv`, `delivery_depth`,
+`delivering_thread`) restores the two properties lock-held delivery gave for
+free:
+
+- deliveries on one connection stay **serialized** — a would-be deliverer waits
+  for `delivery_depth == 0`;
+- `setHandler()` and `detachHandler()` **wait for an in-flight callback to
+  return** before swapping or clearing the handler. That wait is the lifetime
+  proof for the non-owning `fss_message_cb *`: it cannot be destroyed while a
+  call into it is in flight.
+
+The delivering thread is exempt from the wait, so a re-entrant call made by the
+callback itself proceeds instead of blocking on itself.
+
+`disconnect()` gained the same wait, which also closed a pre-existing hole in
+its two thread-detach branches — the server-side client teardown path's only
+barrier.
+
+`detachHandler()` exists as its own entry point rather than as
+`setHandler(nullptr)` because installing a handler flushes the backlog into it
+and can therefore propagate an exception the handler threw, while detaching runs
+no callback and cannot. That distinction is what lets `~fss_message_cb` detach
+without a try/catch, and stating it in a signature keeps a later change to the
+flush semantics from silently making the destructor a throwing path.
+
+## What this does *not* fix
+
+**Cross-thread lock-order cycles.** `setHandler()` still blocks on a running
+callback, so the "call `activate()` / `reconnect()` outside our own lock" rules
+in `server-clients.cpp` and `client-ssl.cpp` remain load-bearing. Removing them
+because callbacks are "lock-free now" would reintroduce a deadlock.
+
+## Where this is pinned
+
+Five regression tests in `tests/handler_reentry_test.cpp`, each verified to hang
+against the pre-fix transport, plus a TSan `setHandler`-churn case.

--- a/docs/decisions/26-client-send-timeout.md
+++ b/docs/decisions/26-client-send-timeout.md
@@ -1,0 +1,43 @@
+# 26 — Client send timeouts use `TCP_USER_TIMEOUT`, not `SO_SNDTIMEO`
+
+**Decided** 2026-07-16. Shipped in 1.2.0. Config field `tcp_user_timeout_ms`
+in the client JSON; default `default_tcp_user_timeout_ms` (30 s) in
+`src/fss-transport.hpp`.
+
+## Context
+
+`sendMsg()` writes to a blocking socket. Against a half-dead peer — one whose
+host has vanished, or whose receive window has been closed for good — that write
+can block for as long as the kernel keeps retransmitting. A flight-safety client
+needs a tighter, configurable bound than the server's 30 s liveness envelope.
+
+## Decision
+
+Bound it per connection with **`TCP_USER_TIMEOUT`**: how long transmitted data
+may stay unacknowledged before the kernel errors the connection out.
+`fss_server::reconnect_to()` reads the configured value at every (re)connect —
+so it also covers servers learned from a server-list update — and threads it
+through into `fss_connection::setTcpUserTimeoutMs()`, applied by both
+`connectTo()` paths.
+
+`set_tcp_keepalive(fd, ms)` deliberately has **no default argument**: every call
+site states its own bound, and the server accept path passes
+`default_tcp_user_timeout_ms` explicitly.
+
+## Alternative deliberately not taken: `SO_SNDTIMEO`
+
+Two independent reasons:
+
+1. A timed-out `send()` can return after a **partial** write, leaving a
+   half-frame on the stream. The connection is unrecoverable at that point —
+   which is exactly what `TCP_USER_TIMEOUT` already delivers, without breaking
+   the blocking-socket invariant both `sendMsg()` loops rely on.
+2. On Linux `TCP_USER_TIMEOUT` also bounds the zero-window case (peer alive but
+   not reading), so `SO_SNDTIMEO` adds no coverage it lacks.
+
+## Where this is pinned
+
+The 30 s default pin test also pins that a caller-supplied bound is applied
+verbatim; plain-TCP and TLS `connectTo` each pin that the option lands on the
+socket, via fd-exposing test subclasses; client JSON config parsing is covered
+for the field present and absent.

--- a/docs/decisions/31-duplicate-identity-policy.md
+++ b/docs/decisions/31-duplicate-identity-policy.md
@@ -1,0 +1,61 @@
+# 31 — Duplicate asset identity: reject the newcomer by default
+
+**Decided** 2026-07-05, race closed 2026-07-13 (todo/44). Shipped in 1.1.0 and
+1.2.0. Config: `duplicate_identity_policy` in `server.json`.
+
+## Context
+
+Two clients identifying as the same asset had no defined behaviour: no dedup
+existed at all, and both sessions went live. Applies to the aircraft path only —
+non-aircraft clients never claim an asset id.
+
+## Decision
+
+Default **`duplicate_identity_reject_newcomer`**: keep the existing session and
+refuse the newcomer.
+
+Chosen to avoid flip-flopping on a genuine misconfiguration — the common real
+cause of a duplicate is two processes pointed at the same certificate, and
+eviction turns that into an endless sever/reconnect cycle across both. This is
+the default *even though* mTLS makes a stolen-key hijack the less likely reading
+of "duplicate": the failure mode of the wrong choice is worse for
+misconfiguration than for hijack, and a hijack is already gated by possession of
+a CA-signed key.
+
+`evict_oldest` is available for deployments that would rather favour a fast
+reconnect after an unclean client death.
+
+**This decision is mirrored in the CAP master plan** — change it in both places
+or not at all.
+
+## Why the check and the claim are one critical section
+
+The first implementation checked *published* `cached_asset_id`s and left
+publication to the caller, so two concurrent identifies for the same asset could
+each miss the other's unpublished claim and both go live (todo/44).
+
+`server_clients` now owns an `asset_owners` claim map guarded by its existing
+`lock`, and the duplicate check plus the claim are a single critical section in
+`resolveDuplicateIdentity()`. First claimant wins; `reject_newcomer` refuses the
+loser, `evict_oldest` dethrones the recorded owner — exactly one, since claims
+are unique. Publication timing no longer matters, because the check reads the
+claim map.
+
+Claims are released in `clientDisconnected()` by scanning for the client as
+**owner**, not by its published id. Releasing by published id would leave an
+asset permanently unclaimable when an identify was evicted or timed out before
+it published.
+
+The evictee's blocking `disconnect()` stays **outside** `lock`, preserving the
+established lock-ordering rule.
+
+## Where this is pinned
+
+Both policy branches plus a distinct-asset-ids sanity case; the two distilled
+interleavings with publication withheld (these fail deterministically on the
+pre-fix code); concurrent identifies through the real `processMessage` path
+(exactly-one-winner over 20 rounds, plus an `evict_oldest`
+exactly-one-survivor and claim-transfer check); release-on-disconnect for both a
+published and a never-published claim; and `e2e/test_duplicate_identity.py`,
+which drives two real fake-client processes under the same certificate against
+the real server.

--- a/docs/decisions/34-45-47-db-failsafe-latch.md
+++ b/docs/decisions/34-45-47-db-failsafe-latch.md
@@ -1,0 +1,76 @@
+# 34/45/47 — The database fail-safe is one latched degraded state
+
+**Decided** 2026-07-14 (45 and 47 shipped together; supersedes the 2026-07-13
+incident tracker from 34). Shipped in 1.2.0. Implementation: `db_failsafe` in
+`src/server-failsafe.hpp`.
+
+## Context
+
+This is a safety service. If the server cannot record what it dispatched and
+what the aircraft acknowledged, the audit trail it exists to produce is being
+silently destroyed. Three findings converged on one mechanism:
+
+- **34** — the ECPG write functions returned `void` and never checked
+  `sqlca.sqlcode`, so a failed write got ECPG's default `sqlprint()` while the
+  C++ wrapper returned as if it had succeeded. `write_failure_count()` stayed at
+  0 through an entire run against a genuinely full disk.
+- **45** — a lost command/ack write did not degrade the server at all.
+- **47** — degradation that severs clients without also refusing their
+  reconnects just flaps: sever, re-identify within a second, sever again, every
+  ~7 s. That flap was captured live against the pre-fix binary.
+
+## Decision
+
+One state machine owning both triggers and the latch.
+
+**Triggers.** A `command_dropped_count()` increase trips *immediately* — a
+dropped dispatch or ack write is known-destroyed audit state, with no threshold
+to age through. A write-*failure* incident trips only when a **new** failure
+arrives while the incident is already `db_write_failure_disconnect_ticks` old.
+
+That second condition also fixed a defect in the shipped 34 tracker: a *single*
+transient failure kept the incident active through the recovery grace and
+tripped at the age threshold with no further failure — one blipped INSERT
+severed the fleet 5 s later, despite the code's own comment claiming "a single
+transient failure never trips this".
+
+**On trip.** The main loop raises `server_clients`' admission gate
+(`setDegraded(true)`) **before** `disconnectAll()`. Ordering is load-bearing:
+the gate check shares `lock`'s critical section with list insertion, so no
+connection can slip in between the severance snapshot and the gate. Refused
+clients are severed unactivated.
+
+**Recovery.** The write queue draining to zero *and* more than
+`db_write_failure_recovery_grace_secs` of quiet lowers the gate; readmitted
+traffic is itself the health probe. A persistent fault re-latches on the
+incident timescale rather than flapping.
+
+## Alternatives deliberately not taken
+
+- **A command-write journal with backpressure** — 45's own "preferred
+  architecture". Minimum containment plus the unified gate meets the acceptance
+  criteria, and a command-only queue overflow requires the entire
+  default-10 000-deep queue to be command writes.
+- **Exiting non-zero on trip.** Drain-plus-quiet defines an in-process recovery,
+  so a restart is not the only safe path out of the degraded state. A safety
+  service that can recover in place should.
+
+## Notes from the verification work, worth keeping
+
+- `REVOKE` is useless for simulating write failure in the e2e suite: the e2e
+  server connects as a superuser, which bypasses grants. Use `BEFORE INSERT`
+  triggers that `RAISE` on the telemetry tables instead —
+  `e2e/test_db_write_only_failure.py` does exactly this and gets a genuine
+  write-only failure.
+- PostgreSQL does not degrade gracefully near WAL-segment exhaustion (~16 MB
+  free): it PANICs, and because its own crash recovery also needs to write WAL,
+  the whole instance exits rather than restarting. This is not a fixable test
+  artifact, so `e2e/test_db_disk_full.py`'s recovery check uses a fresh
+  container plus a fresh server and client.
+
+## Related
+
+[46 — no `statement_timeout`](46-no-statement-timeout.md) explains why a stalled
+database must *not* be turned into write failures that feed this latch.
+[48](48-command-ack-terminal-finality.md) explains why a policy-refused ack
+matches zero rows instead of raising — so a forged ack cannot trip this.

--- a/docs/decisions/43-secure-string-scope.md
+++ b/docs/decisions/43-secure-string-scope.md
@@ -1,0 +1,46 @@
+# 43 — `secure_string` limits long-lived resident copies, not every transient
+
+**Decided** 2026-07-10. Shipped in 1.2.0. The scope statement also lives at the
+top of `src/secure-string.hpp`, where anyone reaching for the type will read it.
+
+## Context
+
+`secure_string` scrubs its storage on destruction. Once such a type exists there
+is a standing temptation to chase every `std::string` a credential ever touched,
+which in this codebase means the wire I/O buffers and the parsed `Json::Value`
+configuration — neither of which can be scrubbed without invasive changes (a
+wiping allocator for `std::string`, and for jsoncpp).
+
+## Decision
+
+The goal is limiting **long-lived resident copies** of credentials — cache and
+member fields such as `smm_settings`' username/password and
+`db_connection::pass_` — not eliminating every transient copy a credential
+passes through on its way there.
+
+Explicitly out of scope: wire I/O buffers and the parsed `Json::Value` config.
+They are freed promptly, and scrubbing them buys defence-in-depth only against
+an adversary who can already read process memory.
+
+Two cheap exceptions are closed directly rather than left inconsistent:
+
+- the recv-side frame for `message_type_smm_settings` is wiped right after
+  decode (`buf_len::wipeSecure()`, from `fss_connection::recvMsg`);
+- the packed `buf_len` for an outgoing `smm_settings` message is wiped right
+  after the send attempt (`fss_connection::sendMsg`).
+
+## Implementation trap: the ECPG accessor returns by value
+
+`toNulTerminated()` returns a `std::string` **by value**, not a cached pointer
+into the `secure_string`. `pass_` is shared by the read and the write database
+connections, which reconnect concurrently from separate threads, so a cached
+mutable scratch buffer races. The first implementation did cache, and it was
+caught by a heap-corruption abort during `make check` — not by review.
+
+## Related
+
+`secure_string::operator==` is constant-time (todo/57): both overloads check
+length first (length is not the secret) then accumulate
+`volatile unsigned char diff |= a[i] ^ b[i]` across the full content, so a
+mismatch anywhere costs the same to detect. No production caller compares
+secrets today; the property exists so that the first one to try it is safe.

--- a/docs/decisions/46-no-statement-timeout.md
+++ b/docs/decisions/46-no-statement-timeout.md
@@ -1,0 +1,70 @@
+# 46 — No `statement_timeout`; DB stalls are bounded at the socket
+
+**Decided** 2026-07-15. Shipped in 1.2.0.
+
+## Context
+
+The main loop made blocking database calls — `tryReconnectIfNeeded()` issued a
+live `SELECT 1` per connection — violating its own no-synchronous-read contract.
+A wedged database therefore stopped command dispatch entirely.
+
+## Decision
+
+Two parts, neither of them a statement timeout.
+
+1. **Move the work off the main loop.** `tryReconnectIfNeeded()` now runs on the
+   `command_poller`, which already owns every database read: reconnect-before-
+   read at the same 1 s cadence via the existing tick counter. A black-holed
+   connection now degrades to "caches go stale", never to "commands stop
+   dispatching".
+2. **Bound in-flight stalls at the socket.** `PGTCPUSERTIMEOUT=25000` in
+   `db_connect()`'s run-once env block puts in-flight death on the same 25 s
+   clock as the keepalive envelope, so idle death and in-flight death agree. As
+   an *intended* consequence, a sustained network partition makes writes fail
+   after ~25 s and trips the
+   [34/45/47 fail-safe](34-45-47-db-failsafe-latch.md) instead of hanging the
+   writer forever.
+
+## Alternative deliberately rejected: `statement_timeout`
+
+Two reasons:
+
+- It is **backend-enforced**, so it bounds neither black-hole variant. If the
+  database host is frozen or partitioned, the backend that would have enforced
+  the timeout is exactly the thing that is not running or not reachable.
+- It would turn legitimate lock waits into fail-safe-feeding write failures.
+  `e2e/test_slow_db_does_not_stall.py` deliberately rides out an `EXCLUSIVE`
+  lock; under a statement timeout that becomes a fleet severance.
+
+## Test deviation, and what it taught
+
+The planned unit test (a blocking `db_ping` stub) was not buildable: the
+loop/poller composition lives only in `main()` and is not linkable into
+`all_test`. The property is pinned end-to-end instead —
+`e2e/test_db_blackhole.py` freezes PostgreSQL with `docker pause`, the pure
+black-hole case (the container kernel still ACKs, so no client-side option can
+unwedge an in-flight query; only the thread move protects the loop) and counts
+client-side `RCVD_RTT_REQ` lines. Verified against the pre-fix binary: 0 RTT
+requests during a 25 s freeze — a 60 s probe also showed 0, the wedge is total —
+versus ~24 on the fixed binary, 3 runs out of 3. The test also pins that the
+fail-safe does **not** trip on a stall: frozen-DB writes hang, they do not fail.
+
+Two findings from that verification worth remembering:
+
+- Server RTT requests flow at ~1/s — a fresh request whenever none is
+  outstanding. `rtt_retry_interval` only throttles *re-requests* while one is
+  unanswered.
+- The first version of that test opened its counting window *before* the freeze
+  landed, letting in-flight sends mask a genuine wedge. The window now opens
+  post-freeze plus a settle.
+
+## Residual, documented and accepted
+
+- Identify and the poller itself still stall behind a wedged connection's mutex
+  — bounded at ~25 s in the partition case, unbounded for a frozen host. No
+  client-side option can detect an ACKed-but-unanswered query.
+- The SIGHUP CRL reload still runs `disconnectRevokedClients()` (blocking joins)
+  on the main loop.
+- The network-partition e2e variant (a dedicated container on a user-defined
+  docker network) that would exercise `PGTCPUSERTIMEOUT` and the fail-safe trip
+  end to end was deferred, not done.

--- a/docs/decisions/48-command-ack-terminal-finality.md
+++ b/docs/decisions/48-command-ack-terminal-finality.md
@@ -1,0 +1,55 @@
+# 48 — A terminal command ack is final *for its dispatch*
+
+**Decided** 2026-07-16. Shipped in 1.2.0. Enforced in the query, in
+`db_command_record_ack` (`src/server-db.pgc`).
+
+## Context
+
+Command acks are audit state: they record what the aircraft did with an
+operator's command. A later ack arriving for a command that had already
+reported a terminal outcome could overwrite that outcome, destroying the record
+of what actually happened.
+
+## Decision
+
+The write guard is **"writable only while unsettled"**: `db_command_record_ack`
+updates the row only when the stored `ack_state IS NULL OR = 0`. This subsumes
+the earlier "received cannot regress" rule and refuses any second terminal
+outcome.
+
+To keep redelivery working, `db_command_set_dispatch_id` **reopens the ack
+cycle**: when it stamps a new dispatch id it clears the three ack columns. The
+ack columns therefore always describe the *latest dispatch*, not the row's
+lifetime.
+
+There is no ordering race in that pairing: an ack for the new delivery can only
+match the row via the new dispatch id, and that dispatch id does not exist on
+the row until the same statement that clears the acks lands.
+
+## Alternative deliberately not taken: blanket "terminal is final"
+
+A terminal outcome that is final for the *row* was rejected because a
+legitimate terminal-over-terminal exists and is pinned by
+`e2e/test_server_restart.py`: a command redelivered after a server bounce must
+settle back to `actioned` with a fresh `ack_timestamp`. Blanket finality would
+leave that row stuck at its pre-bounce outcome forever.
+
+## A refused write is not an error
+
+A policy-refused ack matches zero rows, which is not an SQL error. That is
+deliberate: if a refused write raised, a forged or duplicated ack could
+masquerade as a database write failure and feed the
+[34/45/47 fail-safe](34-45-47-db-failsafe-latch.md), letting a malicious or
+buggy peer sever the fleet.
+
+## When todo/17's system-health work lands
+
+todo/17 item 2 introduces an accepted-but-not-transmitted outcome. Extend the
+*writable set* — classify that outcome as non-terminal — rather than weakening
+finality.
+
+## Where this is pinned
+
+Unit tests: a second terminal is refused for each of the three outcomes; the
+conforming received→terminal flow is unaffected; redispatch reopens and
+re-acks. The server-bounce e2e still passes against the guard.

--- a/docs/decisions/49-server-command-id-semantics.md
+++ b/docs/decisions/49-server-command-id-semantics.md
@@ -1,0 +1,77 @@
+# 49 — The FMU command identifier is the server's DB row id, scoped per server
+
+**Decided** 2026-07-17. Shipped in 1.2.0. Wire field:
+`fss_message_asset_command::server_command_id`, gated by
+`FSS_FEATURE_SERVER_COMMAND_ID` (0x8).
+
+## Context
+
+cap-fmu (`todo/86` in that repo — the FMU-side dedup of redelivered commands)
+needed to tell two cases apart when it receives an asset command:
+
+- a *redelivery* of an operator action it has already actioned (the resend
+  window, a reconnect identify, a server bounce), which must not be actioned
+  twice; versus
+- a genuine *operator retry* — the operator pressed the button again — which
+  must be actioned, even when the command, payload and timestamp are byte-for-
+  byte identical to the previous one.
+
+Nothing on the wire distinguished them, so the FMU could swallow a real retry.
+
+## Decision
+
+The identifier is the **server's command DB row id** (`assets_assetcommand.id`,
+a plain auto-increment primary key — no change required on the web side), and
+it is **scoped per server**.
+
+The contract the receiver may rely on is recorded in full on the field itself in
+`src/fss-transport.hpp`; in summary:
+
+1. Within one connection, the same id means the same operator action; a new id
+   means a new action.
+2. Ids must **never** be compared across connections.
+3. A deliberate operator retry inserts a new row in *every* server's database,
+   so it arrives as a fresh id on every connection — this is the property that
+   closes the swallowed-retry hole.
+4. `0` means "not reported" (legacy peer, or the capability was not negotiated).
+5. The id is the row primary key — remembered forever — and the server only ever
+   dispatches the latest row per asset, so an id can reappear only as a
+   redelivery of that same action.
+
+## Deliberate deviation from the original request
+
+The filing asked for an identifier that is **identical across all connections**
+for one operator push. That was not built, and should not be retrofitted
+without revisiting this record.
+
+Each server owns its own database. There is no shared id space and no
+coordination channel between servers, so a cross-connection-stable identifier
+would require inventing one (a shared sequence service, or a synthetic
+content hash). What cap-fmu actually needs is retry-vs-redundant
+distinguishability, and per-server ids deliver exactly that via property 3
+above, at zero infrastructure cost.
+
+## Not to be conflated with `dispatch_id`
+
+`dispatch_id` is the per-connection message header id used for command-ack
+correlation. It is scoped to a *single delivery* and is stable across resends of
+that delivery. `server_command_id` is scoped to the *operator action* and
+survives reconnects. They are different values with different lifetimes.
+
+## Implementation trap, found during the work
+
+The optional trailing read in `unpackData` must come **after**
+`assign_coordinates`. A failed optional read latches the `BufferReader`
+not-ok, and the truncation judgement must cover mandatory fields only —
+reading the optional tail first makes every legacy GOTO frame decode to NaN
+coordinates.
+
+## Where this is pinned
+
+Transport round-trip, legacy-frame and byte-layout tests; session tests for both
+dialects; `e2e/test_command_identity.py` (delivered id equals the DB row id, and
+an identical-payload retry row arrives under a fresh id); the server-bounce
+test also pins that a redelivery reuses the same id.
+
+See also [51 — optional trailing wire fields are prefix-closed](51-optional-trailing-field-rule.md),
+which governs this field.

--- a/docs/decisions/51-optional-trailing-field-rule.md
+++ b/docs/decisions/51-optional-trailing-field-rule.md
@@ -1,0 +1,42 @@
+# 51 — Optional trailing wire fields are prefix-closed
+
+**Decided** 2026-07-18. Shipped in 1.2.0 as documentation only; the rule is
+recorded beside the `FSS_FEATURE_*` block in `src/fss-transport.hpp`, with
+pointer comments at both fields it governs.
+
+## Context
+
+Two messages carry an optional trailing field:
+`fss_message_rtt_response::client_timestamp` (todo/17 item 3) and
+`fss_message_asset_command::server_command_id`
+([49](49-server-command-id-semantics.md)). Both are omitted when 0 so that a
+peer which does not implement the feature sees a frame it already understands.
+
+`fss_message::decode()` is **static and connection-blind**: it has no access to
+the negotiated `feature_flags`. An optional field's presence can therefore only
+be inferred from the remaining frame length.
+
+## Decision
+
+Presence stays length-inferred, and the optional tail is **prefix-closed**: the
+day a message gains a *second* optional trailing field, that new field may be
+emitted only together with every earlier optional field of that message —
+0-filled if unset or unknown — never on its own.
+
+A peer implementing the new field always emits both, so a frame carrying only
+one optional field can only mean a peer unaware of the new field; the 0-filled
+earlier field decodes to its existing "not reported" sentinel, which every
+consumer already handles. Emitting the new field alone would be
+indistinguishable *by length* from today's one-field dialect.
+
+## Alternative not taken
+
+Making presence explicit — a presence bitmap or TLV encoding for the optional
+tail — is the structurally correct answer, and is **not possible without a
+protocol v3**: it changes the framing every existing peer parses. If a v3 ever
+happens, fold these optional tails into an explicit presence mechanism and
+retire this rule.
+
+Passing the negotiated `feature_flags` into `decode()` was also rejected: it
+would make decoding connection-dependent, which is precisely the property that
+keeps `decode()` testable in isolation and usable by the fuzz corpus.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,84 @@
+# Release checklist
+
+Branching model is in the README's *Release strategy* section: releases are cut
+from `release/X.Y`, `develop` is the integration branch, `master` points at the
+latest stable release.
+
+This file is the mechanical checklist. The ABI step exists because an ABI break
+once reached a tag unbumped, and was only caught because release planning
+happened to diff the headers by hand (todo/61).
+
+## 1. Check the ABI before choosing the version
+
+**Run this before deciding whether the release is X.Y+1 or X.Y.Z+1, not after.**
+
+Install the candidate and the last tag into separate prefixes and compare:
+
+```sh
+# candidate (the libraries and their headers build by default)
+./configure --prefix=/tmp/abi-new && make && make install
+
+# last released tag, in a clean worktree
+git worktree add /tmp/abi-old-src <last-tag>
+cd /tmp/abi-old-src && ./autogen.sh && ./configure --prefix=/tmp/abi-old \
+  && make && make install
+
+abidiff --headers-dir1 /tmp/abi-old/include --headers-dir2 /tmp/abi-new/include \
+        /tmp/abi-old/lib/libfss-transport.so /tmp/abi-new/lib/libfss-transport.so
+```
+
+Repeat for each of the four installed libraries: `libfss`, `libfss-transport`,
+`libfss-transport-ssl`, `libfss-client-ssl`.
+
+If `abidiff` reports **any** incompatible change, `-version-info` in
+`src/Makefile.am` must be bumped for every library — the project keeps all four
+sonames in lockstep, and the form used is `N:0:0`, i.e. each bump declares a
+clean break with no backward compatibility (`age` is always 0). A same-soname
+mix of an old library and new headers is exactly the failure this step prevents,
+and it does not fail to link — it corrupts at runtime.
+
+Things that have historically broken the ABI without looking like it:
+
+- a new **data member** on `fss_connection` (layout change), and
+- a new **virtual function** anywhere in a class (vtable slot shift, and
+  inserting one mid-class shifts every later slot).
+
+Two build traps this step walks straight into:
+
+- This tree is commonly configured with `--disable-dependency-tracking`, so a
+  header edit recompiles **nothing**. Build the candidate from a clean tree
+  (`make clean && make`), or the comparison is against a half-stale library.
+- Re-running `configure` with a different `--prefix` does not force a relink. A
+  library that automake considers up to date keeps the **old** `libdir` baked
+  into its `.la`, and `make install` then writes to the previous prefix. Remove
+  the `.la` files and `make` again before `make install`.
+
+## 2. Version numbers
+
+Bump, in this order, and keep them consistent:
+
+- `AC_INIT` in `configure.ac`
+- `-version-info` in `src/Makefile.am` — only if step 1 says so
+- `debian/changelog` — a new stanza
+- `CHANGELOG.md` — move the accumulated entries under the new version heading,
+  and call out any soname change explicitly under a "consumers must rebuild"
+  note
+
+## 3. Verify
+
+- `./check-code.sh` — clean
+- `make check` — the full unit suite
+- ThreadSanitizer: configure with `--enable-tsan --enable-tests`, which
+  instruments the whole tree so plain `make check` runs the unit suite
+  race-checked; `make check-tsan` in `tests/` runs the dedicated concurrency
+  binary. 0 races, with only the one documented `disconnect` suppression
+- `make distcheck` — this builds the server, the tests and the example client,
+  so a header missing from the tarball fails here rather than at a user's site
+- the e2e suite (`make e2e-test`; requires Docker and Python)
+
+## 4. Tag and publish
+
+Tag on the `release/X.Y` branch. Fast-forward `master` to the tag.
+
+Publishing to any remote — pushing branches or tags, opening PRs — is a separate,
+explicit step; nothing above pushes.

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -35,7 +35,8 @@ private:
      * needing root/faketime. Positive = client clock ahead of real time. */
     int64_t clock_offset_ms{0};
     /* TCP_USER_TIMEOUT requested for every server connection this client
-     * makes (todo/26): the bound on how long a blocking send() can stall
+     * makes (docs/decisions/26-client-send-timeout.md): the bound on how
+     * long a blocking send() can stall
      * into a half-dead server before the kernel errors the connection out.
      * A flight-safety client (e.g. cap-fmu) can set this well below the
      * 30 s default so a wedged send worker recovers on its own clock.
@@ -117,7 +118,8 @@ public:
      * already been sent by the transport handler, so an override observes
      * rather than answers. Exists so a test client can surface the server's
      * liveness tick externally — e2e's DB black-hole test asserts these keep
-     * arriving while both DB connections are wedged (todo/46). */
+     * arriving while both DB connections are wedged
+     * (docs/decisions/46-no-statement-timeout.md). */
     virtual void handleRTTRequest(const std::shared_ptr<flight_safety_system::transport::fss_message_rtt_request> &msg
                                   __attribute__((unused)));
 };

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -87,10 +87,11 @@ inline auto negotiateFeatureFlags(uint32_t peer_flags) -> uint32_t
  * X-unaware peer; the 0-filled scid decodes to its existing "not reported"
  * sentinel, which every consumer already handles. Emitting X alone with scid
  * omitted would be indistinguishable by length from today's one-field
- * dialect — hence the rule. (todo/51; the two fields it already governs are
- * todo/17 item 3 and todo/49.) If a protocol v3 ever happens, fold these
- * optional tails into an explicit presence mechanism (bitmap/TLV) and retire
- * this rule. */
+ * dialect — hence the rule. (docs/decisions/51-optional-trailing-field-rule.md;
+ * the two fields it already governs are todo/17 item 3 and
+ * docs/decisions/49-server-command-id-semantics.md.) If a protocol v3 ever
+ * happens, fold these optional tails into an explicit presence mechanism
+ * (bitmap/TLV) and retire this rule. */
 
 /* Maximum payload length accepted from the wire. Anything larger is rejected
  * before allocation to prevent memory exhaustion attacks. Sized well above the
@@ -103,7 +104,8 @@ static constexpr uint16_t FSS_MAX_MESSAGE_BYTES = 8192;
  * peer. 30 s matches the server's application-layer liveness timeout
  * (default client_timeout) and is the right bound for the server; a
  * flight-safety *client* (e.g. cap-fmu's FSS send worker) can request a
- * tighter bound per connection via setTcpUserTimeoutMs (todo/26). */
+ * tighter bound per connection via setTcpUserTimeoutMs
+ * (docs/decisions/26-client-send-timeout.md). */
 static constexpr unsigned int default_tcp_user_timeout_ms = 30000;
 
 class fss_connection;
@@ -286,7 +288,8 @@ class fss_connection {
     std::atomic<int> pending_close_fd{-1};
     std::atomic<uint64_t> last_msg_id{0};
     /* Non-owning back-pointer to the installed handler, guarded by msg_lock.
-     * Lifetime (todo/25): it is only dereferenced with delivery_depth
+     * Lifetime (docs/decisions/25-transport-callback-reentrancy.md): it is
+     * only dereferenced with delivery_depth
      * incremented, and its only mutators — setHandler() and detachHandler(),
      * the latter being what ~fss_message_cb uses — wait for delivery-idle
      * before touching it, so a handler cannot be destroyed while a call into it
@@ -296,7 +299,8 @@ class fss_connection {
      * disconnect(). */
     fss_message_cb *handler{nullptr};
     std::queue<std::shared_ptr<fss_message>> messages{};
-    /* Delivery bookkeeping (todo/25): processMessage() runs with msg_lock
+    /* Delivery bookkeeping (docs/decisions/25-transport-callback-reentrancy.md):
+     * processMessage() runs with msg_lock
      * RELEASED, so a handler may re-enter getMsg()/setHandler()/disconnect()
      * without deadlocking on it. These members are themselves guarded by
      * msg_lock and restore the two properties the old lock-held delivery gave
@@ -388,11 +392,13 @@ public:
      * stating it in a signature rather than a comment keeps a later change to
      * the flush semantics from silently making the destructor a throwing path.
      *
-     * Blocks until any in-flight processMessage() returns (the todo/25
-     * lifetime barrier), except when called from inside that callback. */
+     * Blocks until any in-flight processMessage() returns (the lifetime
+     * barrier in docs/decisions/25-transport-callback-reentrancy.md), except
+     * when called from inside that callback. */
     void detachHandler() noexcept;
     /* Request a tighter (or looser) TCP_USER_TIMEOUT than the 30 s default
-     * for this connection (todo/26): the bound on how long a blocking send()
+     * for this connection (docs/decisions/26-client-send-timeout.md): the
+     * bound on how long a blocking send()
      * can stall into a half-dead peer before the kernel errors the connection
      * out. Must be called BEFORE connectTo() — it is applied to the socket at
      * connect time and has no effect afterwards, nor on a server-accepted
@@ -606,7 +612,8 @@ private:
      * frozen 1970 clock has no usable offset to feed it anyway.
      *
      * This is the first of the two optional trailing fields the
-     * prefix-closed extension rule above (todo/51) governs — read that
+     * prefix-closed extension rule above
+     * (docs/decisions/51-optional-trailing-field-rule.md) governs — read that
      * before adding a second optional field to this message. */
     uint64_t client_timestamp{0};
 protected:
@@ -701,7 +708,9 @@ private:
     uint32_t altitude;
     uint64_t timestamp;
     /* The dispatching server's identifier for the operator action this command
-     * carries — its command DB row id (todo/49). Contract the receiver may
+     * carries — its command DB row id
+     * (docs/decisions/49-server-command-id-semantics.md). Contract the
+     * receiver may
      * rely on:
      *   - Within one connection, this id identifies the operator action: the
      *     same id means the same action (a redelivery — resend window,
@@ -723,8 +732,9 @@ private:
      * and survives reconnects.
      *
      * The other of the two optional trailing fields the prefix-closed
-     * extension rule above (todo/51) governs — read that before adding a
-     * second optional field to this message. */
+     * extension rule above (docs/decisions/51-optional-trailing-field-rule.md)
+     * governs — read that before adding a second optional field to this
+     * message. */
     uint64_t server_command_id{0};
 protected:
     void unpackData(const std::shared_ptr<buf_len> &bl);

--- a/src/secure-string.hpp
+++ b/src/secure-string.hpp
@@ -7,7 +7,8 @@
 
 namespace flight_safety_system {
 
-/* Scope decision (todo/43, 2026-07-10): secure_string's goal is limiting
+/* Scope decision (docs/decisions/43-secure-string-scope.md, 2026-07-10):
+ * secure_string's goal is limiting
  * *long-lived resident copies* of credentials — cache/member fields such as
  * smm_settings' username/password and db_connection::pass_ — not eliminating
  * every transient copy a credential passes through on its way there. Wire

--- a/src/server-clients.cpp
+++ b/src/server-clients.cpp
@@ -292,11 +292,12 @@ auto server_clients::disconnectRevokedClients(const std::string &crl_file) -> st
     return disconnected_count;
 }
 
-/* todo/34: unconditional version of disconnectRevokedClients above, for
- * the main loop's sustained-DB-write-failure guard — every currently
- * live session gets severed (Tier-3 Path M m05 expects this to trigger
- * aircraft comms-loss RTL) rather than the server silently continuing
- * to accept telemetry it cannot store.
+/* docs/decisions/34-45-47-db-failsafe-latch.md: unconditional version of
+ * disconnectRevokedClients above, for the main loop's sustained-DB-write-
+ * failure guard — every currently live session gets severed (CAP/test-plan's
+ * Tier-3 Path M step m05, the integration test that expects a severed session
+ * to trigger aircraft comms-loss RTL) rather than the server silently
+ * continuing to accept telemetry it cannot store.
  *
  * Same disconnect()+clientDisconnected() pattern as
  * disconnectRevokedClients() above, so it is safe by the same reasoning:

--- a/src/server-failsafe.hpp
+++ b/src/server-failsafe.hpp
@@ -6,24 +6,25 @@
 namespace flight_safety_system {
 namespace server {
 
-/* Unified DB fail-safe monitor for the main loop's per-second tick (todo/34,
- * todo/45, todo/47). Watches the db_write_queue's failure counters and owns
- * the decision to degrade:
+/* Unified DB fail-safe monitor for the main loop's per-second tick. The
+ * rationale, and the two architectures rejected in favour of this one, are in
+ * docs/decisions/34-45-47-db-failsafe-latch.md. Watches the db_write_queue's
+ * failure counters and owns the decision to degrade:
  *
- * - A *sustained* write-failure incident (todo/34): failures recurring within
+ * - A *sustained* write-failure incident: failures recurring within
  *   recovery_grace_secs of each other form one incident; the trip requires a
  *   new failure arriving once the incident is at least disconnect_age_secs
  *   old, i.e. failures genuinely spanning the window. A single transient
- *   failure ages out quietly and never trips (the pre-todo/47 tracker let a
+ *   failure ages out quietly and never trips (the tracker this replaced let a
  *   lone failure trip at the age threshold purely by staying "active" through
  *   the grace period, despite documenting the opposite).
  *
- * - Any command dispatch/ack drop (todo/45): trips immediately on the first
+ * - Any command dispatch/ack drop: trips immediately on the first
  *   counter increase. A dropped command write is known-destroyed audit state
  *   (the command/ack link, or the aircraft's reported outcome), so there is
  *   no threshold to age through.
  *
- * A trip latches the degraded state (todo/47): the caller severs every client
+ * A trip latches the degraded state: the caller severs every client
  * *and* gates new admissions (server_clients::setDegraded) so aircraft get one
  * clean comms-loss event instead of a disconnect/reconnect flap into the same
  * unhealthy server. Recovery requires the write queue fully drained AND more


### PR DESCRIPTION
## Summary by Sourcery

Document and expose previously internal design decisions under docs/decisions, retarget public comments and README references to those records, and add a release checklist capturing ABI checks and verification steps.

Enhancements:
- Retarget existing in-code references from private todo items to the new tracked decision documents in public headers and server components so downstream consumers can resolve rationale without the private todo tree.

Documentation:
- Introduce a docs/decisions directory recording key architectural and behavioural decisions with one file per decision, including protocol, database, transport, safety, security, and tooling choices.
- Document a release checklist that standardises ABI compatibility checks, versioning, verification steps, and tagging workflow.
- Extend docs README and main README to list and reference the new decision records, including the supported scale assumption for deployments.