### PR TITLE
client: give each server its own outbound worker (todo/66)

### DIFF
--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -246,16 +246,37 @@ void flight_safety_system::client_ssl::fss_client::attemptReconnect()
 void flight_safety_system::client_ssl::fss_client::sendMsgAll(
     const std::shared_ptr<flight_safety_system::transport::fss_message> &msg)
 {
+    if (msg == nullptr)
+    {
+        return;
+    }
     /* Copy the list under the lock so that concurrent serverRequiresReconnect
-     * calls cannot invalidate the iterator mid-send. */
+     * calls cannot invalidate the iterator mid-fan-out. */
     std::list<std::shared_ptr<fss_server>> snapshot;
     {
         std::scoped_lock lock(this->servers_lock);
         snapshot = this->servers;
     }
+    if (snapshot.empty())
+    {
+        return;
+    }
+    /* Pack ONCE, then hand the same read-only frame to every server's outbound
+     * worker (docs/decisions/66-67-client-outbound-fanout.md). This replaced a
+     * serial loop of blocking server->sendMsg() calls, in which one server that
+     * completed TLS and then stopped reading held up every healthy server
+     * behind it for a whole TCP_USER_TIMEOUT.
+     *
+     * The sends are now concurrent, so the todo/12 C8 invariant (one
+     * fss_message instance must not be sent on two connections at once — the
+     * id stamp would race) can no longer hold for free. It is re-established
+     * exactly as todo/55 did for server-side broadcasts: `packed` is shared as
+     * const and never mutated, and each connection copies it and stamps only
+     * its own id (fss_connection::sendPacked). */
+    std::shared_ptr<const flight_safety_system::transport::buf_len> packed = msg->getPacked();
     for (auto const &server : snapshot)
     {
-        server->sendMsg(msg);
+        server->queueSend(packed);
     }
 }
 
@@ -420,7 +441,179 @@ flight_safety_system::client_ssl::fss_server::fss_server(flight_safety_system::c
 {
 }
 
-flight_safety_system::client_ssl::fss_server::~fss_server() = default;
+flight_safety_system::client_ssl::fss_server::~fss_server()
+{
+    /* Single teardown entry point: disconnect() stops the outbound worker
+     * (shutting the socket down first so a blocked send returns) and clears the
+     * connection. It is idempotent, so this is safe whether or not disconnect()
+     * was already called. */
+    fss_server::disconnect();
+}
+
+void flight_safety_system::client_ssl::fss_server::startOutboundWorkerLocked()
+{
+    if (this->outbound_stopping || this->outbound_worker.joinable())
+    {
+        return;
+    }
+    this->outbound_worker = std::thread(&fss_server::outboundWorkerRun, this);
+}
+
+auto flight_safety_system::client_ssl::fss_server::waitForOutboundWork()
+    -> flight_safety_system::client_ssl::fss_server::outbound_work
+{
+    std::unique_lock<std::mutex> lock(this->outbound_lock);
+    this->outbound_cv.wait(lock, [this]() -> bool { return this->outbound_stopping || !this->pending_sends.empty(); });
+    outbound_work work;
+    if (this->outbound_stopping)
+    {
+        work.stop = true;
+        return work;
+    }
+    work.sends.assign(std::make_move_iterator(this->pending_sends.begin()),
+                      std::make_move_iterator(this->pending_sends.end()));
+    this->pending_sends.clear();
+    return work;
+}
+
+void flight_safety_system::client_ssl::fss_server::outboundWorkerRun()
+{
+    for (;;)
+    {
+        auto work = this->waitForOutboundWork();
+        /* Queued telemetry is best-effort: a disconnecting client has nothing
+         * left to say, and anything unsent is superseded by the next report.
+         * Exit promptly on stop so a join never waits on a send. */
+        if (work.stop)
+        {
+            return;
+        }
+        for (const auto &packed : work.sends)
+        {
+            /* Re-read the connection each time rather than caching it: a
+             * reconnect can swap it underneath us, and a cleared one must send
+             * nothing rather than fault. sendPacked copies the shared frame and
+             * stamps this connection's own id into the copy (todo/55). */
+            auto active_conn = this->getConnection();
+            if (active_conn == nullptr)
+            {
+                continue;
+            }
+            active_conn->sendPacked(packed);
+        }
+    }
+}
+
+void flight_safety_system::client_ssl::fss_server::queueSend(
+    const std::shared_ptr<const flight_safety_system::transport::buf_len> &packed)
+{
+    if (packed == nullptr)
+    {
+        return;
+    }
+    bool report_drop = false;
+    {
+        std::scoped_lock guard(this->outbound_lock);
+        if (this->outbound_stopping)
+        {
+            return;
+        }
+        /* Drop-oldest, not drop-newest: telemetry only gets less useful with
+         * age, so a backlogged server should shed its stalest report and keep
+         * the freshest one. */
+        while (this->pending_sends.size() >= max_pending_sends)
+        {
+            this->pending_sends.pop_front();
+            this->sends_dropped++;
+            /* One line per backlog episode, not per dropped frame: a wedged
+             * server drops continuously, and the running total is available
+             * from getDroppedSends(). Re-armed by reconnect(), so a server that
+             * wedges again after coming back says so again. */
+            if (!this->sends_drop_logged)
+            {
+                this->sends_drop_logged = true;
+                report_drop = true;
+            }
+        }
+        this->pending_sends.push_back(packed);
+        this->startOutboundWorkerLocked();
+    }
+    if (report_drop)
+    {
+        FSS_LOG_WARN("client", "Outbound queue full for " << this->address << ":" << this->port
+                                                          << ", dropping oldest telemetry for this server");
+    }
+    this->outbound_cv.notify_one();
+}
+
+auto flight_safety_system::client_ssl::fss_server::getDroppedSends() -> uint64_t
+{
+    std::scoped_lock guard(this->outbound_lock);
+    return this->sends_dropped;
+}
+
+void flight_safety_system::client_ssl::fss_server::requestOutboundStop()
+{
+    {
+        std::scoped_lock guard(this->outbound_lock);
+        if (this->outbound_stopping)
+        {
+            return;
+        }
+        this->outbound_stopping = true;
+    }
+    this->outbound_cv.notify_all();
+}
+
+void flight_safety_system::client_ssl::fss_server::stopOutboundWorker()
+{
+    this->requestOutboundStop();
+    if (!this->outbound_worker.joinable())
+    {
+        return;
+    }
+    if (this->outbound_worker.get_id() == std::this_thread::get_id())
+    {
+        /* The worker must never join itself; detach so it can finish. Mirrors
+         * the recv-thread guard in fss_connection::disconnect(). */
+        this->outbound_worker.detach();
+        this->outbound_worker = std::thread();
+        return;
+    }
+    try
+    {
+        this->outbound_worker.join();
+    }
+    catch (const std::system_error &e)
+    {
+        FSS_LOG_ERROR("client", "outbound_worker.join() failed, detaching: " << e.what());
+        this->outbound_worker.detach();
+        this->outbound_worker = std::thread();
+    }
+}
+
+void flight_safety_system::client_ssl::fss_server::disconnect()
+{
+    /* Order matters (todo/21, todo/52): signal the worker to stop, then shut
+     * the socket down -- not close it -- so a worker blocked in send() returns
+     * while the descriptor number stays reserved, then join the worker, and
+     * only then run the connection's disconnect(), which joins the recv thread
+     * and performs the deferred close. Closing any earlier would free the fd
+     * number for reuse while the worker may still be about to pass its stale
+     * value to send() -- I/O into an unrelated session (todo/52). */
+    this->requestOutboundStop();
+    auto active_conn = this->getConnection();
+    if (active_conn != nullptr)
+    {
+        active_conn->shutdownSocket(); // unblocks a stalled worker send and the recv thread
+    }
+    this->stopOutboundWorker();
+    if (active_conn != nullptr)
+    {
+        active_conn->disconnect(); // joins the recv thread, then closes the fd
+    }
+    flight_safety_system::transport::fss_message_cb::disconnect(); // a second disconnect() here is a safe no-op
+}
 
 auto flight_safety_system::client_ssl::fss_server::getAddress() -> std::string
 {
@@ -558,6 +751,19 @@ auto flight_safety_system::client_ssl::fss_server::reconnect() -> bool
              * Store before setHandler() so a message delivered immediately
              * cannot have its arming overwritten by this reset. */
             this->liveness_active.store(false, std::memory_order_relaxed);
+            /* Re-arm the outbound worker. Unlike the server-side fss_client,
+             * an fss_server outlives its connections: disconnect() stops the
+             * worker, but this object can come back up on a new connection and
+             * must be able to send again. Safe here because reconnect() and
+             * disconnect() both belong to the reconnect-driving thread and are
+             * never concurrent (see the ownership note in the header); the
+             * previous worker has already been joined by stopOutboundWorker().
+             * The worker itself is started lazily by the first queueSend(). */
+            {
+                std::scoped_lock guard(this->outbound_lock);
+                this->outbound_stopping = false;
+                this->sends_drop_logged = false;
+            }
             this->getConnection()->setHandler(this);
             /* Protocol version handshake must be the first message
              * exchanged after TLS connect, before identity. */

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -2,11 +2,15 @@
 #include <fss.hpp>
 
 #include <atomic>
+#include <condition_variable>
 #include <cstdint>
+#include <deque>
 #include <list>
 #include <memory>
 #include <mutex>
 #include <random>
+#include <thread>
+#include <vector>
 
 namespace flight_safety_system {
 namespace client_ssl {
@@ -80,6 +84,19 @@ public:
     virtual void connectTo(const std::string &t_address, uint16_t t_port, bool connect);
     virtual void attemptReconnect();
     virtual void disconnect();
+    /* Fan a message out to every currently connected server. NON-BLOCKING
+     * (docs/decisions/66-67-client-outbound-fanout.md): the frame is packed
+     * once here and handed to each server's own outbound worker, which
+     * performs the blocking write. A server that completes TLS and then stops
+     * reading can therefore only stall its own telemetry, never the fan-out to
+     * the healthy ones. Loss-tolerant by design: each worker's queue is
+     * bounded and drops the OLDEST frame under sustained backlog (see
+     * fss_server::getDroppedSends()), so a wedged server sheds stale telemetry
+     * rather than growing without bound.
+     * Packing once is also what keeps the todo/12 C8 invariant intact now that
+     * the sends are concurrent: the packed frame is shared read-only and each
+     * connection stamps its own sequence id into its own copy
+     * (fss_connection::sendPacked), so no fss_message instance is shared. */
     virtual void sendMsgAll(const std::shared_ptr<flight_safety_system::transport::fss_message> &msg);
     virtual auto getAssetName() -> std::string;
     virtual auto isNonAircraft() const -> bool { return this->non_aircraft; }
@@ -151,6 +168,59 @@ private:
     std::atomic<bool> liveness_active{false};
     std::atomic<uint64_t> last_message_received_time{0};
     uint64_t server_timeout_ms{30000};
+    /* Per-server outbound writer
+     * (docs/decisions/66-67-client-outbound-fanout.md). The caller's thread
+     * schedules *what* to send; this worker performs the blocking socket
+     * write, so one black-holed server can only stall its own telemetry, never
+     * the fan-out to every other server. The aircraft-side mirror of the
+     * server's per-client worker (todo/21 + todo/36). Every member below is
+     * guarded by outbound_lock. */
+    std::mutex outbound_lock{};
+    std::condition_variable outbound_cv{};
+    bool outbound_stopping{false};
+    /* Bounded, drop-oldest: telemetry is loss-tolerant, so under sustained
+     * backlog into a half-dead server the OLDEST queued frame is dropped
+     * rather than the queue growing without bound — the same policy and
+     * reasoning as the server side's pending_position_relay. */
+    static constexpr size_t max_pending_sends = 8;
+    std::deque<std::shared_ptr<const flight_safety_system::transport::buf_len>> pending_sends{};
+    /* Cumulative frames dropped by the cap above (never reset). Exposed so the
+     * loss is observable rather than silent, mirroring
+     * fss_connection::getDroppedMessages() for the inbound queue. */
+    uint64_t sends_dropped{0};
+    /* True once the WARN for the current backlog episode has been emitted, so a
+     * continuously wedged server produces one line rather than one per frame.
+     * Cleared by reconnect(). */
+    bool sends_drop_logged{false};
+    std::thread outbound_worker{};
+    /* What the worker should do this wake-up. Returned by waitForOutboundWork()
+     * so the worker performs the (blocking) sends with no lock held. */
+    struct outbound_work {
+        bool stop{false};
+        std::vector<std::shared_ptr<const flight_safety_system::transport::buf_len>> sends{};
+    };
+    /* Block until there is work or a stop request, then atomically take and
+     * clear the pending work. */
+    auto waitForOutboundWork() -> outbound_work;
+    /* The worker loop: waits for work, then performs the blocking send(s) off
+     * the caller's thread. */
+    void outboundWorkerRun();
+    /* Idempotent: set the stop flag and wake the worker. The single place that
+     * owns the stop signal, so disconnect() and stopOutboundWorker() cannot
+     * drift apart. */
+    void requestOutboundStop();
+    /* Idempotent: request the stop (above) and join the worker. Safe to call
+     * more than once and from any thread other than the worker itself. The
+     * caller must have already shut the connection's socket down if the worker
+     * might be blocked in a send, otherwise the join waits for the send
+     * timeout. */
+    void stopOutboundWorker();
+    /* Start the worker if it is not already running and no stop has been
+     * requested. Precondition: outbound_lock held. Started lazily rather than
+     * in the constructor so an fss_server that never sends costs no thread,
+     * and so the worker can never call a virtual (reconnect_to) before a
+     * subclass constructor has finished. */
+    void startOutboundWorkerLocked();
 protected:
     virtual auto reconnect_to() -> bool;
 public:
@@ -162,6 +232,23 @@ public:
     auto operator=(fss_server &&) -> fss_server & = delete;
     ~fss_server() override;
     void processMessage(std::shared_ptr<flight_safety_system::transport::fss_message> message) override;
+    /* Queue a pre-packed frame for this server's outbound worker instead of
+     * sending it inline (docs/decisions/66-67-client-outbound-fanout.md).
+     * Returns immediately; the worker copies the shared frame and stamps this
+     * connection's own sequence id into the copy (fss_connection::sendPacked),
+     * which is what lets one frame be fanned out concurrently without
+     * violating the todo/12 C8 invariant. Drops the oldest queued frame if the
+     * queue is already full. Per-connection sends that must mutate the message
+     * -- sendIdentify(), sendVersion(), the RTT reply -- deliberately keep
+     * using the inline fss_message_cb::sendMsg() on the recv thread, where a
+     * stall can only affect the one connection it belongs to. */
+    void queueSend(const std::shared_ptr<const flight_safety_system::transport::buf_len> &packed);
+    /* Cumulative frames this server's bounded outbound queue has dropped. */
+    auto getDroppedSends() -> uint64_t;
+    /* Stops this server's outbound worker and then the connection. Overrides
+     * fss_message_cb::disconnect so a stalled writer is unblocked and joined
+     * before the connection is torn down (the todo/21 + todo/52 order). */
+    void disconnect() override;
     virtual auto getAddress() -> std::string;
     virtual auto getPort() -> uint16_t;
     virtual auto reconnect() -> bool;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -34,6 +34,7 @@ all_test_SOURCES = main.cpp messages.cpp connection.cpp client.cpp \
 	coordinate_precision_test.cpp \
 	queue_test.cpp \
 	reconnect_test.cpp \
+	client_fanout_test.cpp \
 	connection_negative_test.cpp \
 	oversized_message_test.cpp \
 	fd_lifecycle_test.cpp \

--- a/tests/client_fanout_test.cpp
+++ b/tests/client_fanout_test.cpp
@@ -1,0 +1,244 @@
+#ifdef HAVE_CATCH2_CATCH_ALL_HPP
+#include <catch2/catch_all.hpp>
+#elif HAVE_CATCH2_CATCH_HPP
+#include <catch2/catch.hpp>
+#elif HAVE_CATCH_CATCH_HPP
+#include <catch/catch.hpp>
+#elif HAVE_CATCH_HPP
+#include <catch.hpp>
+#else
+#error No catch header
+#endif
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "fss-client-ssl.hpp"
+#include "fss-transport.hpp"
+#include "test_helpers.hpp"
+
+/* todo/66: the client used to fan a message out over its servers with a serial
+ * loop of blocking sends on the caller's thread, so a server that completed
+ * TLS and then stopped reading stalled telemetry to every healthy server
+ * behind it for a whole TCP_USER_TIMEOUT (30 s by default). Each server now
+ * owns an outbound worker; these cases pin that one wedged server can only
+ * stall itself, that the per-connection id stamp (the todo/12 C8 invariant)
+ * survives the fan-out becoming concurrent, and that a backlogged queue sheds
+ * its oldest telemetry instead of growing. */
+
+namespace {
+
+namespace fss = flight_safety_system;
+
+/* A connection whose send blocks until it is released, standing in for a peer
+ * that completes TLS and then stops reading. shutdownSocket() is the release
+ * hook — that is exactly what fss_server::disconnect() calls to unblock a
+ * stalled worker before joining it, so overriding it here exercises the real
+ * teardown path rather than a test-only escape. */
+class BlackHoleConnection : public fss::transport::fss_connection {
+    std::mutex block_lock{};
+    std::condition_variable block_cv{};
+    bool released{false};
+public:
+    BlackHoleConnection() = default;
+    BlackHoleConnection(const BlackHoleConnection &) = delete;
+    BlackHoleConnection(BlackHoleConnection &&) = delete;
+    auto operator=(const BlackHoleConnection &) -> BlackHoleConnection & = delete;
+    auto operator=(BlackHoleConnection &&) -> BlackHoleConnection & = delete;
+    ~BlackHoleConnection() override { this->release(); }
+
+    std::atomic<int> sends_entered{0};
+    std::atomic<int> sends_completed{0};
+
+    void release()
+    {
+        {
+            std::scoped_lock guard(this->block_lock);
+            this->released = true;
+        }
+        this->block_cv.notify_all();
+    }
+    void shutdownSocket() override { this->release(); }
+protected:
+    auto sendMsg(const std::shared_ptr<fss::transport::buf_len> &) -> bool override
+    {
+        this->sends_entered++;
+        {
+            std::unique_lock<std::mutex> guard(this->block_lock);
+            this->block_cv.wait(guard, [this]() -> bool { return this->released; });
+        }
+        this->sends_completed++;
+        return true;
+    }
+};
+
+/* Records what the client actually put on the wire. The frames now arrive on
+ * the server's outbound worker thread while the test reads them, so unlike the
+ * single-threaded CapturingConnection in client.cpp this one publishes them
+ * under a lock. */
+class RecordingConnection : public fss::transport::fss_connection {
+    mutable std::mutex sent_lock{};
+    std::vector<std::shared_ptr<fss::transport::fss_message>> sent{};
+public:
+    RecordingConnection() = default;
+    RecordingConnection(const RecordingConnection &) = delete;
+    RecordingConnection(RecordingConnection &&) = delete;
+    auto operator=(const RecordingConnection &) -> RecordingConnection & = delete;
+    auto operator=(RecordingConnection &&) -> RecordingConnection & = delete;
+    ~RecordingConnection() override = default;
+
+    auto count() const -> size_t
+    {
+        std::scoped_lock guard(this->sent_lock);
+        return this->sent.size();
+    }
+    auto at(size_t idx) const -> std::shared_ptr<fss::transport::fss_message>
+    {
+        std::scoped_lock guard(this->sent_lock);
+        return idx < this->sent.size() ? this->sent[idx] : nullptr;
+    }
+protected:
+    auto sendMsg(const std::shared_ptr<fss::transport::buf_len> &bl) -> bool override
+    {
+        if (auto decoded = fss::transport::fss_message::decode(bl))
+        {
+            std::scoped_lock guard(this->sent_lock);
+            this->sent.push_back(decoded);
+        }
+        return true;
+    }
+};
+
+/* fss_server with the protected setConnection exposed so a test can wire it to
+ * one of the doubles above without a real socket. */
+class InjectableServer : public fss::client_ssl::fss_server {
+public:
+    using fss_server::fss_server;
+    using fss::transport::fss_message_cb::setConnection;
+    InjectableServer(const InjectableServer &) = delete;
+    InjectableServer(InjectableServer &&) = delete;
+    auto operator=(const InjectableServer &) -> InjectableServer & = delete;
+    auto operator=(InjectableServer &&) -> InjectableServer & = delete;
+    ~InjectableServer() override = default;
+};
+
+/* fss_client with the protected addServer exposed. */
+class FanoutClient : public fss::client_ssl::fss_client {
+public:
+    using fss_client::fss_client;
+    FanoutClient(const FanoutClient &) = delete;
+    FanoutClient(FanoutClient &&) = delete;
+    auto operator=(const FanoutClient &) -> FanoutClient & = delete;
+    auto operator=(FanoutClient &&) -> FanoutClient & = delete;
+    ~FanoutClient() override = default;
+    void add(const std::shared_ptr<fss::client_ssl::fss_server> &server) { this->addServer(server); }
+};
+
+auto make_position() -> std::shared_ptr<fss::transport::fss_message_position_report>
+{
+    return std::make_shared<fss::transport::fss_message_position_report>(-43.5, 172.5, 300U, 0U, 0U, int16_t{0}, 0U,
+                                                                         std::string{"T"}, 0U, uint8_t{0}, 0U,
+                                                                         uint8_t{0}, uint8_t{0}, uint64_t{0});
+}
+
+} // namespace
+
+TEST_CASE("client: sendMsgAll does not stall healthy servers behind a black-holed one (todo/66)")
+{
+    auto client = std::make_shared<FanoutClient>();
+
+    auto wedged_conn = std::make_shared<BlackHoleConnection>();
+    auto wedged = std::make_shared<InjectableServer>(client.get(), "wedged.example", uint16_t{20200}, "", "", "");
+    wedged->setConnection(wedged_conn);
+
+    auto healthy_conn = std::make_shared<RecordingConnection>();
+    auto healthy = std::make_shared<InjectableServer>(client.get(), "healthy.example", uint16_t{20201}, "", "", "");
+    healthy->setConnection(healthy_conn);
+
+    /* Wedged first, so it is ahead of the healthy server in the fan-out order:
+     * pre-fix this is precisely the ordering that starved the healthy one. */
+    client->add(wedged);
+    client->add(healthy);
+
+    auto start = std::chrono::steady_clock::now();
+    client->sendMsgAll(make_position());
+    auto elapsed = std::chrono::steady_clock::now() - start;
+
+    /* The caller's thread must not have waited on the wedged server's send. */
+    REQUIRE(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count() < 500);
+
+    /* The healthy server gets its telemetry while the other is still stuck. */
+    REQUIRE(fss_test::wait_for([&]() -> bool { return healthy_conn->count() == 1; }));
+    REQUIRE(healthy_conn->at(0)->getType() == fss::transport::message_type_position_report);
+    REQUIRE(fss_test::wait_for([&]() -> bool { return wedged_conn->sends_entered.load() == 1; }));
+    REQUIRE(wedged_conn->sends_completed.load() == 0);
+
+    /* disconnect() shuts the socket down before joining, which is what releases
+     * the stalled worker; if that order were wrong this would hang. */
+    client->disconnect();
+}
+
+TEST_CASE("client: a concurrent fan-out still stamps each connection's own id (todo/12 C8)")
+{
+    /* sendMsgAll packs once and shares the frame read-only, so no fss_message
+     * instance is sent on two connections. Each connection must still stamp its
+     * own sequence id into its own copy. Give the two connections different
+     * starting counters so a shared id would be unmistakable. */
+    auto client = std::make_shared<FanoutClient>();
+
+    auto conn_a = std::make_shared<RecordingConnection>();
+    auto server_a = std::make_shared<InjectableServer>(client.get(), "a.example", uint16_t{20202}, "", "", "");
+    server_a->setConnection(conn_a);
+
+    auto conn_b = std::make_shared<RecordingConnection>();
+    auto server_b = std::make_shared<InjectableServer>(client.get(), "b.example", uint16_t{20203}, "", "", "");
+    server_b->setConnection(conn_b);
+
+    /* Advance connection A's id counter to 3 before the fan-out. */
+    for (int i = 0; i < 3; i++)
+    {
+        REQUIRE(conn_a->sendPacked(make_position()->getPacked()));
+    }
+    REQUIRE(conn_a->count() == 3);
+
+    client->add(server_a);
+    client->add(server_b);
+    client->sendMsgAll(make_position());
+
+    REQUIRE(fss_test::wait_for([&]() -> bool { return conn_a->count() == 4 && conn_b->count() == 1; }));
+    REQUIRE(conn_a->at(3)->getId() == 4); // A's own fourth id
+    REQUIRE(conn_b->at(0)->getId() == 1); // B's own first id
+
+    client->disconnect();
+}
+
+TEST_CASE("client: a wedged server's outbound queue drops oldest and counts the loss (todo/66)")
+{
+    auto client = std::make_shared<FanoutClient>();
+
+    auto wedged_conn = std::make_shared<BlackHoleConnection>();
+    auto wedged = std::make_shared<InjectableServer>(client.get(), "wedged.example", uint16_t{20204}, "", "", "");
+    wedged->setConnection(wedged_conn);
+    client->add(wedged);
+
+    /* Park the worker inside the first send, so everything queued after this
+     * point stays in the bounded queue and the arithmetic below is exact. */
+    client->sendMsgAll(make_position());
+    REQUIRE(fss_test::wait_for([&]() -> bool { return wedged_conn->sends_entered.load() == 1; }));
+    REQUIRE(wedged->getDroppedSends() == 0);
+
+    constexpr int backlog = 20;
+    constexpr uint64_t queue_cap = 8; // fss_server::max_pending_sends
+    for (int i = 0; i < backlog; i++)
+    {
+        client->sendMsgAll(make_position());
+    }
+    REQUIRE(wedged->getDroppedSends() == backlog - queue_cap);
+
+    client->disconnect();
+}


### PR DESCRIPTION
## Description

sendMsgAll() fanned a message out over the server list as a serial loop of blocking sendMsg() calls on the caller's thread. A server that completed TCP and TLS and then stopped reading blocked that send until TCP_USER_TIMEOUT errored the connection out -- 30 s by default -- and every healthy server behind it in the list got no telemetry for the whole window. The shipped example drives sendMsgAll() and attemptReconnect() from one thread, and the README names it as the starting point for a real client, so this is the aircraft-side mirror of the exact hazard todo/21 + todo/36 removed from the server.

Each client_ssl::fss_server now owns the same shape of outbound worker the server side gives each client: a bounded, drop-oldest queue of pre-packed frames plus a thread that performs the blocking write. sendMsgAll() packs the message ONCE and hands the same read-only frame to every server's queue, so a black-holed server can only stall its own telemetry.

Packing once is also what keeps the todo/12 C8 invariant intact now that the sends are concurrent: sharing one fss_message instance across connections would race the per-connection id stamp, so this reuses the todo/55 byte-clone path -- fss_connection::sendPacked() copies the shared frame and stamps only its own id into its own copy. Per-connection sends that must mutate the message (sendIdentify, sendVersion, the RTT reply) deliberately stay inline on the recv thread, where a stall can only affect the connection it belongs to.

Telemetry is loss-tolerant, so the queue drops the OLDEST frame under sustained backlog rather than growing: a wedged server sheds stale reports and keeps the freshest. The running total is available from getDroppedSends() and the first drop of each backlog episode is logged, so the loss is visible instead of silent.

fss_server::disconnect() overrides the base to run the todo/21 + todo/52 teardown order -- stop the worker, shut the socket down (not close it) so a blocked send returns while the fd number stays reserved, join the worker, then disconnect the connection. Unlike a server-side fss_client, an fss_server outlives its connections, so reconnect() re-arms the worker.

## Summary by Sourcery

Introduce per-server outbound workers for the client to make telemetry fan-out non-blocking and resilient to wedged servers, while preserving per-connection sequencing guarantees.

Enhancements:
- Change client sendMsgAll to pack messages once and dispatch via each server’s own outbound worker instead of performing serial blocking sends on the caller thread.
- Add a bounded, drop-oldest outbound queue and worker thread to each client-side server, with observable drop counts and graceful teardown and reconnect behaviour.
- Ensure client-side server disconnect and reconnect manage the outbound worker and socket shutdown in a safe, ordered fashion to avoid stalled sends and fd reuse hazards.

Tests:
- Add client_fanout_test exercising non-blocking fan-out behavior, per-connection id stamping under concurrent sends, and drop-oldest semantics of the outbound queue.