### PR TITLE
client: dispatch reconnection onto the per-server worker (todo/66)

### DIFF
--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -203,9 +203,20 @@ void flight_safety_system::client_ssl::fss_client::attemptReconnect()
         this->serverRequiresReconnect(server);
     }
 
-    /* Phase (c): snapshot reconnect_servers under the lock, then try to
-     * reconnect each entry outside the lock (reconnect() does a blocking
-     * SSL connect — must never hold the lock across it). */
+    /* Phase (c): snapshot reconnect_servers under the lock, then, outside it,
+     * harvest the servers whose queued reconnect has since succeeded and
+     * schedule an attempt for the rest.
+     *
+     * The dial itself runs on each server's own outbound worker (todo/66).
+     * Calling the blocking reconnect() here — a connect() plus a TLS
+     * handshake, ~7 s for a host that drops SYNs and up to 10 s for one that
+     * stalls the handshake — made this loop cost the SUM of every unreachable
+     * entry's timeout, delaying reconnection to a healthy server that dropped
+     * in the same window. queueReconnect() returns immediately, so the cost of
+     * a pass is now the slowest server's timeout in parallel rather than every
+     * server's in series, and unreachable entries no longer hold each other up.
+     * List mutation stays here, on the thread that owns servers_lock; the
+     * worker never reaches back into the client. */
     std::list<std::shared_ptr<fss_server>> reconnect_snapshot;
     {
         std::scoped_lock lock(this->servers_lock);
@@ -215,10 +226,14 @@ void flight_safety_system::client_ssl::fss_client::attemptReconnect()
     bool any_connected = false;
     for (auto const &server : reconnect_snapshot)
     {
-        if (server->reconnect())
+        if (server->takeReconnectSucceeded())
         {
             reconnected.push_back(server);
             any_connected = true;
+        }
+        else
+        {
+            server->queueReconnect();
         }
     }
 
@@ -368,6 +383,7 @@ void flight_safety_system::client_ssl::fss_client::serverRequiresReconnect(
      * (e.g. call sendMsgAll or attemptReconnect), so the lock must not be
      * held when it is called. */
     size_t count = 0;
+    bool found = false;
     {
         std::scoped_lock lock(this->servers_lock);
         for (auto it = this->servers.begin(); it != this->servers.end(); ++it)
@@ -376,10 +392,22 @@ void flight_safety_system::client_ssl::fss_client::serverRequiresReconnect(
             {
                 this->reconnect_servers.push_back(std::move(*it));
                 this->servers.erase(it);
+                found = true;
                 break;
             }
         }
         count = this->servers.size();
+    }
+    if (!found && server != nullptr)
+    {
+        /* Not in the live list, so this is a connection that died in the window
+         * between its worker finishing a reconnect and attemptReconnect()
+         * harvesting the result (todo/66). Discard the stale success: promoting
+         * it would move an already-dead connection into `servers`, where
+         * nothing would flag it — a fresh connection starts with liveness
+         * disarmed, so isServerTimedOut() would never fire. Dropping the flag
+         * simply leaves it in reconnect_servers to be dialled again. */
+        server->takeReconnectSucceeded();
     }
     this->connectionStatusChange(status_for_server_count(count));
 }
@@ -463,13 +491,17 @@ auto flight_safety_system::client_ssl::fss_server::waitForOutboundWork()
     -> flight_safety_system::client_ssl::fss_server::outbound_work
 {
     std::unique_lock<std::mutex> lock(this->outbound_lock);
-    this->outbound_cv.wait(lock, [this]() -> bool { return this->outbound_stopping || !this->pending_sends.empty(); });
+    this->outbound_cv.wait(lock, [this]() -> bool {
+        return this->outbound_stopping || this->out_reconnect_pending || !this->pending_sends.empty();
+    });
     outbound_work work;
     if (this->outbound_stopping)
     {
         work.stop = true;
         return work;
     }
+    work.reconnect = this->out_reconnect_pending;
+    this->out_reconnect_pending = false;
     work.sends.assign(std::make_move_iterator(this->pending_sends.begin()),
                       std::make_move_iterator(this->pending_sends.end()));
     this->pending_sends.clear();
@@ -487,6 +519,25 @@ void flight_safety_system::client_ssl::fss_server::outboundWorkerRun()
         if (work.stop)
         {
             return;
+        }
+        if (work.reconnect)
+        {
+            /* Blocking: connect() plus the TLS handshake, and the retirement of
+             * any previous connection. Doing it here is the whole point — the
+             * caller's thread no longer waits on it, so an unreachable server
+             * cannot delay reconnection to a healthy one. */
+            bool ok = this->reconnect();
+            {
+                std::scoped_lock guard(this->outbound_lock);
+                this->reconnect_busy = false;
+            }
+            /* Publish success only now: reconnect() has sent the version and
+             * identity handshake by the time it returns true, so the client can
+             * safely promote this server to its live list (see the header). */
+            if (ok)
+            {
+                this->reconnect_succeeded.store(true, std::memory_order_release);
+            }
         }
         for (const auto &packed : work.sends)
         {
@@ -546,6 +597,26 @@ void flight_safety_system::client_ssl::fss_server::queueSend(
     this->outbound_cv.notify_one();
 }
 
+void flight_safety_system::client_ssl::fss_server::queueReconnect()
+{
+    {
+        std::scoped_lock guard(this->outbound_lock);
+        if (this->outbound_stopping || this->reconnect_busy)
+        {
+            return;
+        }
+        this->reconnect_busy = true;
+        this->out_reconnect_pending = true;
+        this->startOutboundWorkerLocked();
+    }
+    this->outbound_cv.notify_one();
+}
+
+auto flight_safety_system::client_ssl::fss_server::takeReconnectSucceeded() -> bool
+{
+    return this->reconnect_succeeded.exchange(false, std::memory_order_acquire);
+}
+
 auto flight_safety_system::client_ssl::fss_server::getDroppedSends() -> uint64_t
 {
     std::scoped_lock guard(this->outbound_lock);
@@ -561,6 +632,12 @@ void flight_safety_system::client_ssl::fss_server::requestOutboundStop()
             return;
         }
         this->outbound_stopping = true;
+        /* Drop any reconnect that was queued but not yet started, and release
+         * the in-flight latch: a worker still inside reconnect() will clear it
+         * again on the way out, and leaving it set would make every later
+         * queueReconnect() a no-op for a server that came back up. */
+        this->out_reconnect_pending = false;
+        this->reconnect_busy = false;
     }
     this->outbound_cv.notify_all();
 }

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -150,17 +150,22 @@ private:
     std::string private_key_file{""};
     std::string public_key_file{""};
     /* Backoff bookkeeping (last_tried, retry_count, retry_delay,
-     * effective_delay, rng) is touched only from the application thread that
-     * drives reconnection — the caller of attemptReconnect() / reconnect()
-     * and connectTo(..., true). The recv thread must NOT write these
-     * directly: when a connection closes it requests a reset via the atomic
-     * backoff_reset_requested flag, which reconnect() consumes. */
+     * effective_delay, rng) is touched only from the single thread that runs
+     * reconnect(): this server's outbound worker when the reconnection was
+     * scheduled by attemptReconnect() (the normal path), or the caller's own
+     * thread on the configuration-time connectTo(..., true). Those two never
+     * overlap — connectTo builds a server that is not yet in any list, so
+     * nothing can have queued a reconnect for it. The recv thread must NOT
+     * write these directly: when a connection closes it requests a reset via
+     * the atomic backoff_reset_requested flag, which reconnect() consumes.
+     * effective_delay is the exception: getEffectiveDelay() is a public read
+     * from other threads, so it is atomic. */
     uint64_t last_tried{0};
     uint64_t retry_count{0};
     static constexpr uint64_t retry_delay_start = 1000;
     static constexpr uint64_t retry_delay_cap = 30000;
     uint64_t retry_delay{retry_delay_start};
-    uint64_t effective_delay{retry_delay_start};
+    std::atomic<uint64_t> effective_delay{retry_delay_start};
     std::mt19937 rng{std::random_device{}()};
     std::atomic<bool> backoff_reset_requested{false};
     void resetBackoff();
@@ -178,6 +183,22 @@ private:
     std::mutex outbound_lock{};
     std::condition_variable outbound_cv{};
     bool outbound_stopping{false};
+    /* Reconnection is dispatched onto the same worker (todo/66): reconnect()
+     * blocks for a connect() plus a TLS handshake, and doing that serially for
+     * every entry on the caller's thread delayed reconnection to a healthy
+     * server by the sum of every unreachable one's timeout.
+     * out_reconnect_pending is the queued flag; reconnect_busy stays set from
+     * the moment one is queued until the worker has finished it, so a 1 Hz
+     * attemptReconnect() cannot pile attempts up behind a 10 s handshake. */
+    bool out_reconnect_pending{false};
+    bool reconnect_busy{false};
+    /* Set by the worker only AFTER reconnect() has returned true — i.e. after
+     * the version + identity handshake has been sent — and consumed by
+     * fss_client::attemptReconnect(). Harvesting on connected() instead would
+     * expose the window inside reconnect() between installing the connection
+     * and sending the handshake, during which sendMsgAll() could put telemetry
+     * ahead of the mandatory version message. */
+    std::atomic<bool> reconnect_succeeded{false};
     /* Bounded, drop-oldest: telemetry is loss-tolerant, so under sustained
      * backlog into a half-dead server the OLDEST queued frame is dropped
      * rather than the queue growing without bound — the same policy and
@@ -197,6 +218,7 @@ private:
      * so the worker performs the (blocking) sends with no lock held. */
     struct outbound_work {
         bool stop{false};
+        bool reconnect{false};
         std::vector<std::shared_ptr<const flight_safety_system::transport::buf_len>> sends{};
     };
     /* Block until there is work or a stop request, then atomically take and
@@ -243,6 +265,17 @@ public:
      * using the inline fss_message_cb::sendMsg() on the recv thread, where a
      * stall can only affect the one connection it belongs to. */
     void queueSend(const std::shared_ptr<const flight_safety_system::transport::buf_len> &packed);
+    /* Schedule a reconnect on this server's outbound worker instead of dialling
+     * inline (todo/66). Returns immediately, and is a no-op while an attempt is
+     * already queued or in flight, so calling it every tick is safe. The
+     * backoff throttle still lives in reconnect() itself, so a queued attempt
+     * inside the retry window costs a worker wake-up and nothing else. */
+    void queueReconnect();
+    /* Consume the "the queued reconnect succeeded" signal (clearing it).
+     * fss_client::attemptReconnect() polls this to move the server from
+     * reconnect_servers to servers, which keeps every list mutation on the
+     * thread that owns servers_lock and out of the worker. */
+    auto takeReconnectSucceeded() -> bool;
     /* Cumulative frames this server's bounded outbound queue has dropped. */
     auto getDroppedSends() -> uint64_t;
     /* Stops this server's outbound worker and then the connection. Overrides

--- a/tests/client_fanout_test.cpp
+++ b/tests/client_fanout_test.cpp
@@ -137,6 +137,74 @@ public:
     auto operator=(FanoutClient &&) -> FanoutClient & = delete;
     ~FanoutClient() override = default;
     void add(const std::shared_ptr<fss::client_ssl::fss_server> &server) { this->addServer(server); }
+    std::atomic<fss::client_ssl::connection_status> last_status{fss::client_ssl::CLIENT_CONNECTION_STATUS_UNKNOWN};
+private:
+    void connectionStatusChange(fss::client_ssl::connection_status status) override { this->last_status.store(status); }
+};
+
+/* A server whose dial blocks until released, standing in for a host that drops
+ * SYNs or stalls the TLS handshake — the two cases that cost ~7 s and ~10 s
+ * respectively on a real connect. */
+class StallingDialServer : public fss::client_ssl::fss_server {
+    std::mutex dial_lock{};
+    std::condition_variable dial_cv{};
+    bool released{false};
+public:
+    using fss_server::fss_server;
+    StallingDialServer(const StallingDialServer &) = delete;
+    StallingDialServer(StallingDialServer &&) = delete;
+    auto operator=(const StallingDialServer &) -> StallingDialServer & = delete;
+    auto operator=(StallingDialServer &&) -> StallingDialServer & = delete;
+    ~StallingDialServer() override { this->release(); }
+
+    std::atomic<int> dials_entered{0};
+
+    void release()
+    {
+        {
+            std::scoped_lock guard(this->dial_lock);
+            this->released = true;
+        }
+        this->dial_cv.notify_all();
+    }
+    /* A real dial is bounded by the connect/handshake timeout, so a disconnect
+     * that lands mid-dial completes once that expires. Release here so this
+     * double has the same property: without it, disconnect() would join a
+     * worker that nothing can ever wake. */
+    void disconnect() override
+    {
+        this->release();
+        fss_server::disconnect();
+    }
+protected:
+    auto reconnect_to() -> bool override
+    {
+        this->dials_entered++;
+        std::unique_lock<std::mutex> guard(this->dial_lock);
+        this->dial_cv.wait(guard, [this]() -> bool { return this->released; });
+        return false;
+    }
+};
+
+/* A server whose dial succeeds immediately, installing a connection that
+ * accepts whatever is written to it. */
+class InstantDialServer : public fss::client_ssl::fss_server {
+public:
+    using fss_server::fss_server;
+    InstantDialServer(const InstantDialServer &) = delete;
+    InstantDialServer(InstantDialServer &&) = delete;
+    auto operator=(const InstantDialServer &) -> InstantDialServer & = delete;
+    auto operator=(InstantDialServer &&) -> InstantDialServer & = delete;
+    ~InstantDialServer() override = default;
+
+    std::atomic<int> dials_entered{0};
+protected:
+    auto reconnect_to() -> bool override
+    {
+        this->dials_entered++;
+        this->setConnection(std::make_shared<RecordingConnection>());
+        return true;
+    }
 };
 
 auto make_position() -> std::shared_ptr<fss::transport::fss_message_position_report>
@@ -239,6 +307,74 @@ TEST_CASE("client: a wedged server's outbound queue drops oldest and counts the 
         client->sendMsgAll(make_position());
     }
     REQUIRE(wedged->getDroppedSends() == backlog - queue_cap);
+
+    client->disconnect();
+}
+
+TEST_CASE("client: an unreachable server does not delay reconnection to a healthy one (todo/66)")
+{
+    /* attemptReconnect() used to dial each entry in reconnect_servers in turn,
+     * on the caller's thread, so a pass cost the SUM of every unreachable
+     * server's connect/handshake timeout and a healthy server that dropped in
+     * the same window waited behind all of them. */
+    auto client = std::make_shared<FanoutClient>();
+
+    auto stalling = std::make_shared<StallingDialServer>(client.get(), "black.example", uint16_t{20205}, "", "", "");
+    auto healthy = std::make_shared<InstantDialServer>(client.get(), "good.example", uint16_t{20206}, "", "", "");
+    /* Neither is connected, so both land in reconnect_servers — the stalling
+     * one first, which is the ordering that starved the healthy one pre-fix. */
+    client->add(stalling);
+    client->add(healthy);
+
+    auto start = std::chrono::steady_clock::now();
+    client->attemptReconnect();
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    REQUIRE(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count() < 500);
+
+    /* Both dials are in flight at once: the healthy server connects while the
+     * other is still stuck in its connect(). */
+    REQUIRE(fss_test::wait_for([&]() -> bool { return healthy->dials_entered.load() == 1; }));
+    REQUIRE(fss_test::wait_for([&]() -> bool { return stalling->dials_entered.load() == 1; }));
+    REQUIRE(healthy->connected());
+
+    /* The pass after the dial lands harvests it into the live server list. */
+    REQUIRE(fss_test::wait_for([&]() -> bool {
+        client->attemptReconnect();
+        return client->last_status.load() == fss::client_ssl::CLIENT_CONNECTION_STATUS_CONNECTED_1_SERVER;
+    }));
+
+    /* Being in the live list is what matters: telemetry now reaches it. The
+     * connection already carries the version + identity handshake reconnect()
+     * sent, so count from there rather than from zero. */
+    auto healthy_conn = std::dynamic_pointer_cast<RecordingConnection>(healthy->getConnection());
+    REQUIRE(healthy_conn != nullptr);
+    const size_t handshake_frames = healthy_conn->count();
+    REQUIRE(handshake_frames == 2);
+    REQUIRE(healthy_conn->at(0)->getType() == fss::transport::message_type_version);
+
+    client->sendMsgAll(make_position());
+    REQUIRE(fss_test::wait_for([&]() -> bool { return healthy_conn->count() == handshake_frames + 1; }));
+    REQUIRE(healthy_conn->at(handshake_frames)->getType() == fss::transport::message_type_position_report);
+
+    client->disconnect();
+}
+
+TEST_CASE("client: repeated attemptReconnect does not pile up dials on a stalled server (todo/66)")
+{
+    auto client = std::make_shared<FanoutClient>();
+    auto stalling = std::make_shared<StallingDialServer>(client.get(), "black.example", uint16_t{20207}, "", "", "");
+    client->add(stalling);
+
+    client->attemptReconnect();
+    REQUIRE(fss_test::wait_for([&]() -> bool { return stalling->dials_entered.load() == 1; }));
+
+    /* An application driving reconnection at 1 Hz keeps calling while the dial
+     * is stuck. Each call must be a no-op, not another queued attempt. */
+    for (int i = 0; i < 20; i++)
+    {
+        client->attemptReconnect();
+    }
+    REQUIRE(stalling->dials_entered.load() == 1);
 
     client->disconnect();
 }

--- a/tests/reconnect_test.cpp
+++ b/tests/reconnect_test.cpp
@@ -192,11 +192,13 @@ TEST_CASE("reconnect: attemptReconnect is throttled within the retry window")
     client->connectTo("127.0.0.1", closed_port, /*connect*/ true);
 
     /* Rapid-fire attemptReconnect: within the 1s retry window none of
-     * these should produce an outbound connect. We can't observe that
-     * directly here, but we can observe wall-clock cost — 100 calls in
-     * <100ms is well under one per ms, which is only possible if each
-     * call is a no-op (actual connect() attempts to a closed port take
-     * a kernel round-trip each). */
+     * these should produce an outbound connect. Since todo/66 the dial runs
+     * on the server's own worker, so the caller's thread is cheap by
+     * construction and this only holds the *caller* side to being a no-op —
+     * that the dialling itself stays throttled is asserted directly by the
+     * fake-clock case below (which counts reconnect_to calls) and by
+     * "repeated attemptReconnect does not pile up dials on a stalled server"
+     * in client_fanout_test.cpp (which counts queued attempts). */
     auto start = std::chrono::steady_clock::now();
     for (int i = 0; i < 100; ++i)
     {

--- a/tests/timeout_test.cpp
+++ b/tests/timeout_test.cpp
@@ -10,6 +10,7 @@
 #error No catch header
 #endif
 
+#include <atomic>
 #include <memory>
 
 #include "fss-transport.hpp"
@@ -17,6 +18,7 @@
 #include "fss-client-ssl.hpp"
 #include "mock_database.hpp"
 #include "db-write-queue.hpp"
+#include "test_helpers.hpp"
 
 namespace fss = flight_safety_system;
 
@@ -244,7 +246,9 @@ public:
     auto operator=(ReconnectingServer &&) -> ReconnectingServer & = delete;
     ~ReconnectingServer() override = default;
     auto connected() -> bool override { return true; }
-    int reconnects{0};
+    /* Incremented on the outbound worker thread and read by the test thread
+     * since todo/66 moved the dial off the caller's thread. */
+    std::atomic<int> reconnects{0};
 protected:
     auto reconnect_to() -> bool override
     {
@@ -355,8 +359,12 @@ TEST_CASE("timeout: successful reconnect restores cold-start liveness")
     clock->advance(30001);
     REQUIRE(server->isServerTimedOut());
 
+    /* attemptReconnect() schedules the dial on the server's outbound worker
+     * rather than blocking on it (todo/66), so the redial lands asynchronously
+     * and the following pass is the one that harvests it into the live list. */
     client->attemptReconnect();
-    REQUIRE(server->reconnects == 1);
+    REQUIRE(fss_test::wait_for([&]() -> bool { return server->reconnects.load() == 1; }));
+    client->attemptReconnect();
     REQUIRE(client->last_status == fss::client_ssl::CLIENT_CONNECTION_STATUS_CONNECTED_1_SERVER);
 
     /* Nothing has been received on the new connection: however long it stays


### PR DESCRIPTION
## Description

attemptReconnect() dialled each entry in reconnect_servers in turn, on the caller's thread. reconnect() blocks for a connect() plus a TLS handshake -- roughly 7 s for a host that drops SYNs, up to 10 s for one that accepts TCP and then stalls the handshake -- and additionally joins the previous connection's recv thread. A pass therefore cost the SUM of every unreachable server's timeout, so a healthy server that dropped in the same window waited behind all of them, and todo/67 (a learned server list that is never pruned) keeps growing the set of dead entries to wait on.

The dial now runs on the server's own outbound worker: attemptReconnect() queues an attempt and returns. Every list mutation stays where it was, on the thread that owns servers_lock, so the worker never reaches back into the client -- it publishes a flag the next pass harvests.

The flag is set only after reconnect() has RETURNED true, not when the connection appears. Harvesting on connected() would expose the window inside reconnect() between installing the connection and sending the version and identity handshake, during which sendMsgAll() could put telemetry ahead of the mandatory version message. Setting it afterwards preserves the previous ordering exactly.

queueReconnect() is a no-op while an attempt is queued or in flight, so an application driving reconnection at 1 Hz cannot pile attempts up behind a 10 s handshake; the backoff throttle itself is unchanged, still inside reconnect(). serverRequiresReconnect() now discards a stale success for a server that is not in the live list: that is a connection which died between its worker finishing the dial and the harvest, and promoting it would park a dead connection in `servers` where nothing would flag it (a fresh connection starts with liveness disarmed, so isServerTimedOut() would never fire).

effective_delay becomes atomic -- getEffectiveDelay() is a public read and the backoff is now written by the worker.

The timeout-test redial case is updated for the new asynchrony: attemptReconnect schedules, and the following pass harvests.

## Summary by Sourcery

Dispatch client reconnection attempts onto each server's outbound worker so unreachable servers no longer block reconnecting to healthy ones, and adjust reconnection bookkeeping and tests for the new asynchronous behavior.

Bug Fixes:
- Prevent unreachable servers from delaying reconnection to healthy servers by running their dials in parallel on per-server workers.
- Avoid promoting connections that died between a worker finishing reconnect and the client harvesting the result, preventing dead servers from remaining in the live list.

Enhancements:
- Make server reconnection scheduling idempotent while a reconnect is queued or in flight, so frequent attemptReconnect calls do not accumulate work.
- Move reconnection success signaling into the server worker, publishing it only after the version and identity handshake has completed.
- Make the reconnection backoff effective_delay field atomic to support concurrent reads from other threads.

Tests:
- Add fanout client tests covering non-blocking reconnection when one server stalls and ensuring repeated attemptReconnect does not queue multiple dials.
- Update timeout and reconnect throttling tests to account for the asynchronous reconnection flow and to validate that reconnect attempts remain properly throttled.