### PR TITLE
client: expire and cap servers learned from broadcasts (todo/67)

### DIFF
--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -44,6 +44,14 @@ flight_safety_system::client_ssl::fss_client::fss_client(const std::string &t_fi
         {
             this->setTcpUserTimeoutMs(config["tcp_user_timeout_ms"].asUInt());
         }
+        if (config.isMember("learned_server_expiry_ms"))
+        {
+            this->setLearnedServerExpiryMs(config["learned_server_expiry_ms"].asUInt64());
+        }
+        if (config.isMember("max_learned_servers"))
+        {
+            this->setMaxLearnedServers(config["max_learned_servers"].asUInt());
+        }
 
         this->ca_file = config["ssl"]["ca_public_key"].asString();
         this->private_key_file = config["ssl"]["client_private_key"].asString();
@@ -90,6 +98,9 @@ flight_safety_system::client_ssl::fss_client::~fss_client()
         std::scoped_lock lock(this->servers_lock);
         all.splice(all.end(), this->servers);
         all.splice(all.end(), this->reconnect_servers);
+        /* Anything expired but not yet drained by attemptReconnect() (todo/67)
+         * still owns a worker thread and possibly a connection. */
+        all.splice(all.end(), this->expired_servers);
     }
     for (const auto &server : all)
     {
@@ -154,6 +165,29 @@ void flight_safety_system::client_ssl::fss_client::setTcpUserTimeoutMs(unsigned 
      * reads it at every (re)connect, so it also applies to servers learned
      * later from a server-list update, not just config-file entries. */
     this->tcp_user_timeout_ms = t_timeout_ms;
+}
+
+void flight_safety_system::client_ssl::fss_client::setLearnedServerExpiryMs(uint64_t t_expiry_ms)
+{
+    /* Set once during configuration, before concurrent use (same as
+     * setAssetName above) -- no lock needed. */
+    this->learned_server_expiry_ms = t_expiry_ms;
+}
+
+void flight_safety_system::client_ssl::fss_client::setMaxLearnedServers(size_t t_max)
+{
+    /* Set once during configuration, before concurrent use (same as
+     * setAssetName above) -- no lock needed. */
+    this->max_learned_servers = t_max;
+}
+
+void flight_safety_system::client_ssl::fss_client::setClock(std::shared_ptr<flight_safety_system::IClock> t_clock)
+{
+    if (t_clock == nullptr)
+    {
+        return;
+    }
+    this->clock = std::move(t_clock);
 }
 
 auto flight_safety_system::client_ssl::fss_client::getSkewedTimestamp() const -> uint64_t
@@ -250,9 +284,25 @@ void flight_safety_system::client_ssl::fss_client::attemptReconnect()
         }
     }
 
-    /* Phase (e): notify outside the lock — connectionStatusChange() is a
+    /* Phase (e): tear down anything updateServers() expired (todo/67). It
+     * removed them from both lists but could not disconnect them: it runs on a
+     * recv thread, and the expiring server can be the one the list arrived on,
+     * so the join would be a self-join. Here we are on the thread that already
+     * owns connection lifecycle, and the shared_ptr keeps each object alive
+     * until we are done with it. */
+    std::list<std::shared_ptr<fss_server>> expired;
+    {
+        std::scoped_lock lock(this->servers_lock);
+        expired.splice(expired.end(), this->expired_servers);
+    }
+    for (auto const &server : expired)
+    {
+        server->disconnect();
+    }
+
+    /* Phase (f): notify outside the lock — connectionStatusChange() is a
      * virtual user callback that may re-enter the client. */
-    if (any_connected)
+    if (any_connected || !expired.empty())
     {
         this->notifyConnectionStatus();
     }
@@ -306,6 +356,12 @@ auto flight_safety_system::client_ssl::fss_client::isConfigured() const -> bool
     return this->configured;
 }
 
+auto flight_safety_system::client_ssl::fss_client::getServerCount() const -> size_t
+{
+    std::scoped_lock lock(this->servers_lock);
+    return this->servers.size() + this->reconnect_servers.size();
+}
+
 void flight_safety_system::client_ssl::fss_client::addServer(
     const std::shared_ptr<flight_safety_system::client_ssl::fss_server> &server)
 {
@@ -329,38 +385,151 @@ void flight_safety_system::client_ssl::fss_client::addServer(
     this->updateConfigured();
 }
 
-static auto server_list_matches(const std::list<std::shared_ptr<flight_safety_system::client_ssl::fss_server>> &servers,
-                                const std::string &address, uint16_t port) -> bool
+void flight_safety_system::client_ssl::fss_client::addLearnedServer(const std::string &t_address, uint16_t t_port)
 {
-    return std::any_of(servers.begin(), servers.end(), [&address, &port](const auto &n) -> auto {
+    auto server = std::make_shared<flight_safety_system::client_ssl::fss_server>(
+        this, t_address, t_port, this->ca_file, this->private_key_file, this->public_key_file);
+    /* Set before addServer() publishes it into a list: from that moment on
+     * these fields belong to servers_lock. */
+    server->setLearned(true);
+    server->setLastSeenMs(this->clock->now_ms());
+    this->addServer(server);
+}
+
+static auto find_server(const std::list<std::shared_ptr<flight_safety_system::client_ssl::fss_server>> &servers,
+                        const std::string &address, uint16_t port)
+    -> std::shared_ptr<flight_safety_system::client_ssl::fss_server>
+{
+    auto found = std::find_if(servers.begin(), servers.end(), [&address, &port](const auto &n) -> bool {
         return (n->getAddress().compare(address) == 0 && n->getPort() == port);
     });
+    return found != servers.end() ? *found : nullptr;
+}
+
+/* Remove every learned server last seen before `cutoff_ms` from `from` and
+ * return them. Precondition: servers_lock held. */
+static auto take_stale_servers(std::list<std::shared_ptr<flight_safety_system::client_ssl::fss_server>> &from,
+                               uint64_t cutoff_ms)
+    -> std::list<std::shared_ptr<flight_safety_system::client_ssl::fss_server>>
+{
+    std::list<std::shared_ptr<flight_safety_system::client_ssl::fss_server>> stale;
+    for (auto it = from.begin(); it != from.end();)
+    {
+        if ((*it)->isLearned() && (*it)->getLastSeenMs() < cutoff_ms)
+        {
+            stale.push_back(std::move(*it));
+            it = from.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+    return stale;
+}
+
+/* Count of learned entries in a list. Precondition: servers_lock held. */
+static auto count_learned(const std::list<std::shared_ptr<flight_safety_system::client_ssl::fss_server>> &servers)
+    -> size_t
+{
+    return static_cast<size_t>(
+        std::count_if(servers.begin(), servers.end(), [](const auto &n) -> bool { return n->isLearned(); }));
+}
+
+auto flight_safety_system::client_ssl::fss_client::getLearnedServerCount() const -> size_t
+{
+    std::scoped_lock lock(this->servers_lock);
+    return count_learned(this->servers) + count_learned(this->reconnect_servers);
 }
 
 void flight_safety_system::client_ssl::fss_client::updateServers(
     const std::shared_ptr<flight_safety_system::transport::fss_message_server_list> &msg)
 {
-    /* Snapshot both lists under the lock so that the existence checks below
-     * see a consistent view.  connectTo() -> addServer() will re-acquire
-     * servers_lock for the push_back, so we must not hold it here. */
-    std::list<std::shared_ptr<fss_server>> servers_snap;
-    std::list<std::shared_ptr<fss_server>> reconnect_snap;
+    /* Before todo/67 this method only ever ADDED: there was no removal path
+     * anywhere in the file, so a server deactivated in config_serverconfig
+     * dropped out of the broadcast list but every client that had ever seen it
+     * kept it forever — and kept paying a blocking connect attempt for it every
+     * backoff interval, silently. The list is now maintained: an entry present
+     * in the broadcast refreshes its last-seen time, an entry absent for the
+     * whole expiry window is dropped, and the number that can be learned is
+     * capped. Servers from the config file are never expired (see the
+     * fss_server::learned member). */
+    uint64_t now = this->clock->now_ms();
+    std::list<std::pair<std::string, uint16_t>> to_learn;
+    size_t learned_count = 0;
+    size_t expired_count = 0;
     {
         std::scoped_lock lock(this->servers_lock);
-        servers_snap = this->servers;
-        reconnect_snap = this->reconnect_servers;
+        for (auto const &server_entry : msg->getServers())
+        {
+            auto known = find_server(this->servers, server_entry.first, server_entry.second);
+            if (known == nullptr)
+            {
+                known = find_server(this->reconnect_servers, server_entry.first, server_entry.second);
+            }
+            if (known != nullptr)
+            {
+                known->setLastSeenMs(now);
+            }
+            else
+            {
+                to_learn.push_back(server_entry);
+            }
+        }
+        /* An expiry window of 0 disables expiry entirely, keeping the old
+         * never-drop behaviour for anyone who wants it. */
+        if (this->learned_server_expiry_ms > 0)
+        {
+            /* Clamped rather than computed as (now - last_seen) > window so the
+             * subtraction cannot wrap on a clock whose epoch is inside the
+             * window (a fake clock starting at 0, or a freshly booted host):
+             * before the window has elapsed at all, nothing is expirable. */
+            uint64_t cutoff = now > this->learned_server_expiry_ms ? now - this->learned_server_expiry_ms : 0;
+            std::list<std::shared_ptr<fss_server>> doomed = take_stale_servers(this->servers, cutoff);
+            doomed.splice(doomed.end(), take_stale_servers(this->reconnect_servers, cutoff));
+            expired_count = doomed.size();
+            for (auto const &server : doomed)
+            {
+                FSS_LOG_WARN("client", "Server " << server->getAddress() << ":" << server->getPort()
+                                                 << " absent from server lists for " << this->learned_server_expiry_ms
+                                                 << "ms, dropping it");
+            }
+            /* Teardown is deferred to attemptReconnect(): see expired_servers
+             * in the header — this runs on a recv thread, possibly the one
+             * belonging to the server being expired. */
+            this->expired_servers.splice(this->expired_servers.end(), doomed);
+        }
+        learned_count = count_learned(this->servers) + count_learned(this->reconnect_servers);
     }
-    for (auto const &server_entry : msg->getServers())
+    /* Learn outside the lock: addServer() re-acquires it. */
+    bool cap_reached = false;
+    for (auto const &server_entry : to_learn)
     {
-        bool exists = server_list_matches(servers_snap, server_entry.first, server_entry.second);
-        if (!exists)
+        if (learned_count >= this->max_learned_servers)
         {
-            exists = server_list_matches(reconnect_snap, server_entry.first, server_entry.second);
+            cap_reached = true;
+            break;
         }
-        if (!exists)
+        this->addLearnedServer(server_entry.first, server_entry.second);
+        learned_count++;
+    }
+    if (cap_reached)
+    {
+        bool report = false;
         {
-            this->connectTo(server_entry.first, server_entry.second, false);
+            std::scoped_lock lock(this->servers_lock);
+            report = !this->learned_cap_logged;
+            this->learned_cap_logged = true;
         }
+        if (report)
+        {
+            FSS_LOG_WARN("client",
+                         "Refusing to learn more than " << this->max_learned_servers << " servers from server lists");
+        }
+    }
+    if (expired_count > 0)
+    {
+        this->updateConfigured();
     }
 }
 

--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -205,6 +205,14 @@ void flight_safety_system::client_ssl::fss_client::connectTo(const std::string &
         this, t_address, t_port, this->ca_file, this->private_key_file, this->public_key_file);
     if (t_connect)
     {
+        /* This dial is synchronous, on the caller's thread, so it is the one
+         * (re)connect that no queueReconnect() has seeded the client snapshot
+         * for. Seed it here rather than from the fss_server constructor: the
+         * file constructor builds servers while the fss_client is itself still
+         * under construction, and reading a virtual off an object under
+         * construction would both miss a subclass override and be exactly the
+         * ctor-side twin of the teardown race the snapshot exists to remove. */
+        server->refreshClientConfig();
         server->reconnect();
     }
     this->addServer(server);
@@ -768,6 +776,11 @@ void flight_safety_system::client_ssl::fss_server::queueSend(
 
 void flight_safety_system::client_ssl::fss_server::queueReconnect()
 {
+    /* Refresh the client snapshot here, on the caller's thread, so the worker
+     * never has to touch the client (see the snapshot members in the header).
+     * Doing it per attempt is also what keeps a configuration change picked up
+     * as promptly as reading the client live used to. */
+    this->refreshClientConfig();
     {
         std::scoped_lock guard(this->outbound_lock);
         if (this->outbound_stopping || this->reconnect_busy)
@@ -879,7 +892,16 @@ auto flight_safety_system::client_ssl::fss_server::getClient() -> fss_client *
 
 void flight_safety_system::client_ssl::fss_server::sendIdentify()
 {
-    if (this->client->isNonAircraft())
+    /* From the snapshot, not from the client: reconnect() calls this on the
+     * outbound worker (see the snapshot members in the header). */
+    bool non_aircraft = false;
+    std::string asset_name;
+    {
+        std::scoped_lock guard(this->outbound_lock);
+        non_aircraft = this->client_non_aircraft;
+        asset_name = this->client_asset_name;
+    }
+    if (non_aircraft)
     {
         /* The server derives the identity from the peer cert's CN on this
          * path (todo/28), not from a message field. */
@@ -887,9 +909,26 @@ void flight_safety_system::client_ssl::fss_server::sendIdentify()
             std::make_shared<flight_safety_system::transport::fss_message_identity_non_aircraft>());
         return;
     }
-    auto ident_msg =
-        std::make_shared<flight_safety_system::transport::fss_message_identity>(this->client->getAssetName());
+    auto ident_msg = std::make_shared<flight_safety_system::transport::fss_message_identity>(asset_name);
     this->getConnection()->sendMsg(ident_msg);
+}
+
+void flight_safety_system::client_ssl::fss_server::refreshClientConfig()
+{
+    if (this->client == nullptr)
+    {
+        return;
+    }
+    /* Read the client OUTSIDE outbound_lock: these are virtual calls into
+     * consumer code, and holding a lock the worker also takes across arbitrary
+     * user code would be a hazard of its own. */
+    auto timeout_ms = this->client->getTcpUserTimeoutMs();
+    bool non_aircraft = this->client->isNonAircraft();
+    auto asset_name = this->client->getAssetName();
+    std::scoped_lock guard(this->outbound_lock);
+    this->client_tcp_user_timeout_ms = timeout_ms;
+    this->client_non_aircraft = non_aircraft;
+    this->client_asset_name = std::move(asset_name);
 }
 
 void flight_safety_system::client_ssl::fss_server::sendVersion()
@@ -900,12 +939,18 @@ void flight_safety_system::client_ssl::fss_server::sendVersion()
 
 auto flight_safety_system::client_ssl::fss_server::reconnect_to() -> bool
 {
-    /* Read the client's requested send bound at every (re)connect rather
-     * than capturing it at construction, so it uniformly covers config-file
-     * servers, programmatic connectTo, and servers learned from a
-     * server-list update (todo/26). Null client (some tests): default. */
-    auto timeout_ms = this->client != nullptr ? this->client->getTcpUserTimeoutMs()
-                                              : flight_safety_system::transport::default_tcp_user_timeout_ms;
+    /* The client's requested send bound, taken from the snapshot rather than
+     * read live: this runs on the outbound worker, which must not reach into
+     * the client (see the snapshot members in the header). The snapshot is
+     * refreshed at every queueReconnect(), so the bound still tracks a
+     * configuration change per attempt, and still covers config-file servers,
+     * programmatic connectTo, and servers learned from a server-list update
+     * uniformly (todo/26). */
+    unsigned int timeout_ms = 0;
+    {
+        std::scoped_lock guard(this->outbound_lock);
+        timeout_ms = this->client_tcp_user_timeout_ms;
+    }
     auto new_conn = flight_safety_system::transport_ssl::fss_connection_client::create(
         this->ca_file, this->private_key_file, this->public_key_file, this->getAddress(), this->getPort(), timeout_ms);
     if (new_conn == nullptr)

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -256,6 +256,20 @@ private:
      * attemptReconnect() cannot pile attempts up behind a 10 s handshake. */
     bool out_reconnect_pending{false};
     bool reconnect_busy{false};
+    /* Snapshot of the fss_client configuration the (re)connect path needs,
+     * refreshed on the application's own thread (fss_client::connectTo(), and
+     * every queueReconnect()). The outbound worker must NOT reach back through
+     * `client`: an fss_client subclass is destroyed derived-part-first, so a
+     * virtual call arriving from a worker during teardown races the vptr
+     * rewrite. That is not theoretical — ThreadSanitizer reports it as a data
+     * race in ~fss_client(), and it is undefined behaviour whichever vtable the
+     * call happens to land in. Keeping the worker's reads inside its own object
+     * removes the cross-object access rather than trying to time it, which is
+     * the only version that stays correct for a subclass this library has never
+     * seen. Guarded by outbound_lock. */
+    unsigned int client_tcp_user_timeout_ms{flight_safety_system::transport::default_tcp_user_timeout_ms};
+    bool client_non_aircraft{false};
+    std::string client_asset_name{};
     /* Set by the worker only AFTER reconnect() has returned true — i.e. after
      * the version + identity handshake has been sent — and consumed by
      * fss_client::attemptReconnect(). Harvesting on connected() instead would
@@ -335,6 +349,12 @@ public:
      * backoff throttle still lives in reconnect() itself, so a queued attempt
      * inside the retry window costs a worker wake-up and nothing else. */
     void queueReconnect();
+    /* Re-read the owning client's configuration into this server's snapshot
+     * (see the snapshot members). Must be called on a thread where the client
+     * is known alive and fully constructed; queueReconnect() and
+     * fss_client::connectTo() both already do, so a consumer only needs this
+     * after changing client configuration on an already-registered server. */
+    void refreshClientConfig();
     /* Consume the "the queued reconnect succeeded" signal (clearing it).
      * fss_client::attemptReconnect() polls this to move the server from
      * reconnect_servers to servers, which keeps every list mutation on the

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -18,6 +18,22 @@ namespace client_ssl {
 class fss_client;
 class fss_server;
 
+/* How long a server learned from a server-list broadcast may go unmentioned
+ * before the client drops it (docs/decisions/66-67-client-outbound-fanout.md).
+ * Servers broadcast their list every 15 s, so the default is four rounds: long
+ * enough that a missed or delayed broadcast expires nothing, short enough that
+ * a decommissioned server stops costing reconnect attempts within a minute.
+ * Config field "learned_server_expiry_ms". */
+constexpr uint64_t default_learned_server_expiry_ms = 60000;
+/* Ceiling on how many servers a client will learn from broadcasts. The list is
+ * authenticated (it arrives over mTLS from a server that chained to our CA), so
+ * this is not an unauthenticated attack surface — it bounds what a trusted but
+ * misconfigured server can grow the connection set to. Config field
+ * "max_learned_servers". Servers from the config file do not count against it
+ * and are never expired: they are the operator's declared intent and must
+ * survive an outage that empties every broadcast list. */
+constexpr size_t default_max_learned_servers = 16;
+
 enum connection_status {
     CLIENT_CONNECTION_STATUS_UNKNOWN,
     CLIENT_CONNECTION_STATUS_CONNECTED_1_SERVER,
@@ -51,12 +67,29 @@ private:
     std::string public_key_file{""};
     std::list<std::shared_ptr<flight_safety_system::client_ssl::fss_server>> servers{};
     std::list<std::shared_ptr<flight_safety_system::client_ssl::fss_server>> reconnect_servers{};
+    /* Servers removed from both lists by expiry (todo/67) and awaiting
+     * teardown. updateServers() runs on a recv thread and the server it expires
+     * can be the very one the list arrived on, so disconnecting there would
+     * have that thread join itself; attemptReconnect() — which already owns
+     * connection lifecycle — drains this instead. Guarded by servers_lock. */
+    std::list<std::shared_ptr<flight_safety_system::client_ssl::fss_server>> expired_servers{};
     /* servers_lock guards the server lists and the derived `configured` flag.
      * It does NOT guard asset_name, which is configuration state set before the
      * client is used concurrently (mutable so the const isConfigured() can lock
      * it to read the flag). */
     mutable std::mutex servers_lock{};
     bool configured{false}; // guarded by servers_lock
+    /* Expiry window and cap for servers learned from broadcasts (todo/67); see
+     * the constants above. Configuration state, set before concurrent use. */
+    uint64_t learned_server_expiry_ms{default_learned_server_expiry_ms};
+    size_t max_learned_servers{default_max_learned_servers};
+    /* One WARN per process when the cap first refuses an advertised server —
+     * the silence was half the problem this fixed. Guarded by servers_lock. */
+    bool learned_cap_logged{false};
+    /* Drives learned-server expiry. Injectable so the timing is testable, and a
+     * clock rather than a tick count deliberately (todo/70): this is the only
+     * new timekeeping in the client and it should not repeat that pattern. */
+    std::shared_ptr<flight_safety_system::IClock> clock{std::make_shared<flight_safety_system::MonotonicClock>()};
     /* Recompute `configured` from the current asset name + server lists. Called
      * from every path that sets the name or adds a server so isConfigured()
      * stays accurate however the client was built, not just the file ctor.
@@ -71,7 +104,16 @@ protected:
     /* Call before connecting (configuration state, like the setters above);
      * an already-established connection keeps the bound it connected with. */
     void setTcpUserTimeoutMs(unsigned int t_timeout_ms);
+    /* Configuration state, like the setters above. 0 disables expiry, keeping
+     * the pre-todo/67 behaviour of never dropping a learned server. */
+    void setLearnedServerExpiryMs(uint64_t t_expiry_ms);
+    void setMaxLearnedServers(size_t t_max);
     void addServer(const std::shared_ptr<fss_server> &server);
+    /* Add a server learned from a server-list broadcast, as distinct from one
+     * the operator configured: only these are subject to the expiry window and
+     * the cap. Separate entry point rather than an extra parameter on
+     * connectTo() so existing overriders of that virtual are unaffected. */
+    void addLearnedServer(const std::string &t_address, uint16_t t_port);
 public:
     explicit fss_client(const std::string &config_file);
     explicit fss_client();
@@ -102,6 +144,20 @@ public:
     virtual auto isNonAircraft() const -> bool { return this->non_aircraft; }
     virtual auto getClockOffsetMs() const -> int64_t { return this->clock_offset_ms; }
     virtual auto getTcpUserTimeoutMs() const -> unsigned int { return this->tcp_user_timeout_ms; }
+    virtual auto getLearnedServerExpiryMs() const -> uint64_t { return this->learned_server_expiry_ms; }
+    virtual auto getMaxLearnedServers() const -> size_t { return this->max_learned_servers; }
+    /* How many servers this client currently knows of — live plus pending
+     * reconnect — and how many of those it learned from a broadcast rather than
+     * being configured with. Exposed because the todo/67 failure was invisible:
+     * connectionStatusChange() reports only the count of LIVE servers, so a
+     * client quietly carrying eleven decommissioned ones, and paying a connect
+     * attempt for each every backoff interval, looked identical to a healthy
+     * one. */
+    auto getServerCount() const -> size_t;
+    auto getLearnedServerCount() const -> size_t;
+    /* Replace the clock driving learned-server expiry. Call before concurrent
+     * use; a null clock is ignored (matching fss_server::setClock). */
+    void setClock(std::shared_ptr<flight_safety_system::IClock> t_clock);
     /* fss_current_timestamp() + clock_offset_ms (todo/33): the single
      * source of truth for "what time does this client think it is", used
      * both for the RTT response's reported client clock and for any
@@ -173,6 +229,14 @@ private:
     std::atomic<bool> liveness_active{false};
     std::atomic<uint64_t> last_message_received_time{0};
     uint64_t server_timeout_ms{30000};
+    /* Learned-server bookkeeping (todo/67). Owned by the fss_client, not by
+     * this object: both are read and written only under fss_client's
+     * servers_lock, or before the server has been published into either list.
+     * `learned` is true only for a server discovered from a server-list
+     * broadcast — a config-file or programmatic entry stays false and is
+     * therefore never expired. */
+    bool learned{false};
+    uint64_t last_seen_ms{0};
     /* Per-server outbound writer
      * (docs/decisions/66-67-client-outbound-fanout.md). The caller's thread
      * schedules *what* to send; this worker performs the blocking socket
@@ -289,6 +353,13 @@ public:
     virtual void sendIdentify();
     virtual void sendVersion();
     void setClock(std::shared_ptr<flight_safety_system::IClock> t_clock);
+    /* Learned-server accessors (todo/67). See the members: the caller must hold
+     * fss_client::servers_lock, or be working on a server not yet published
+     * into either list. */
+    auto isLearned() const -> bool { return this->learned; }
+    void setLearned(bool t_learned) { this->learned = t_learned; }
+    auto getLastSeenMs() const -> uint64_t { return this->last_seen_ms; }
+    void setLastSeenMs(uint64_t t_now_ms) { this->last_seen_ms = t_now_ms; }
     void setServerTimeoutMs(uint64_t ms) { this->server_timeout_ms = ms; }
     auto isServerTimedOut() -> bool;
     auto getEffectiveDelay() const -> uint64_t { return this->effective_delay; }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -34,6 +34,7 @@ all_test_SOURCES = main.cpp messages.cpp connection.cpp client.cpp \
 	coordinate_precision_test.cpp \
 	queue_test.cpp \
 	reconnect_test.cpp \
+	client_server_list_test.cpp \
 	client_fanout_test.cpp \
 	connection_negative_test.cpp \
 	oversized_message_test.cpp \

--- a/tests/client_server_list_test.cpp
+++ b/tests/client_server_list_test.cpp
@@ -1,0 +1,245 @@
+#ifdef HAVE_CATCH2_CATCH_ALL_HPP
+#include <catch2/catch_all.hpp>
+#elif HAVE_CATCH2_CATCH_HPP
+#include <catch2/catch.hpp>
+#elif HAVE_CATCH_CATCH_HPP
+#include <catch/catch.hpp>
+#elif HAVE_CATCH_HPP
+#include <catch.hpp>
+#else
+#error No catch header
+#endif
+
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "fss-client-ssl.hpp"
+#include "fss-transport.hpp"
+
+/* todo/67: updateServers() only ever ADDED. There was no removal path anywhere
+ * in client-ssl.cpp — entries migrated between `servers` and
+ * `reconnect_servers` forever and never left either — so a server deactivated
+ * in config_serverconfig dropped out of every broadcast list while every client
+ * that had ever seen it kept it, and kept paying a blocking connect attempt for
+ * it every backoff interval. Silently, too: nothing logged that the client was
+ * carrying dead servers. These cases pin the maintenance the list now gets. */
+
+namespace {
+
+namespace fss = flight_safety_system;
+
+struct FakeClock : public fss::IClock {
+    uint64_t t{0};
+    auto now_ms() const -> uint64_t override { return t; }
+    void advance(uint64_t ms) { t += ms; }
+};
+
+/* Exposes the configuration setters, which are protected because they are meant
+ * to be driven from a config file. Nothing here ever dials, so every server
+ * stays in the pending-reconnect list — which is where the expiry work is
+ * visible without needing a socket. */
+class ListClient : public fss::client_ssl::fss_client {
+public:
+    using fss_client::fss_client;
+    ListClient(const ListClient &) = delete;
+    ListClient(ListClient &&) = delete;
+    auto operator=(const ListClient &) -> ListClient & = delete;
+    auto operator=(ListClient &&) -> ListClient & = delete;
+    ~ListClient() override = default;
+    void setExpiry(uint64_t ms) { this->setLearnedServerExpiryMs(ms); }
+    void setCap(size_t n) { this->setMaxLearnedServers(n); }
+};
+
+auto make_list(const std::vector<std::pair<std::string, uint16_t>> &entries)
+    -> std::shared_ptr<fss::transport::fss_message_server_list>
+{
+    auto msg = std::make_shared<fss::transport::fss_message_server_list>();
+    for (const auto &entry : entries)
+    {
+        msg->addServer(entry.first, entry.second);
+    }
+    return msg;
+}
+
+constexpr uint64_t expiry_window_ms = 60000;
+constexpr uint64_t broadcast_interval_ms = 15000;
+
+} // namespace
+
+TEST_CASE("client: a learned server absent from later lists is expired (todo/67)")
+{
+    auto client = std::make_shared<ListClient>();
+    auto clock = std::make_shared<FakeClock>();
+    client->setClock(clock);
+    client->setExpiry(expiry_window_ms);
+
+    client->updateServers(make_list({{"learned.example", 20200}, {"other.example", 20201}}));
+    REQUIRE(client->getServerCount() == 2);
+    REQUIRE(client->getLearnedServerCount() == 2);
+
+    /* While it keeps being advertised the window never starts, however long the
+     * client runs. */
+    for (int round = 0; round < 10; round++)
+    {
+        clock->advance(broadcast_interval_ms);
+        client->updateServers(make_list({{"learned.example", 20200}, {"other.example", 20201}}));
+    }
+    REQUIRE(client->getServerCount() == 2);
+
+    /* It is decommissioned: it drops out of the broadcast. Nothing goes until
+     * the whole window has passed without a sighting. */
+    clock->advance(expiry_window_ms - 1000);
+    client->updateServers(make_list({{"other.example", 20201}}));
+    REQUIRE(client->getServerCount() == 2);
+
+    clock->advance(2000); // now past the window since it was last seen
+    client->updateServers(make_list({{"other.example", 20201}}));
+    REQUIRE(client->getServerCount() == 1);
+    REQUIRE(client->getLearnedServerCount() == 1);
+
+    /* attemptReconnect() is what tears the expired entry down; it must not
+     * resurrect it or disturb the survivor. */
+    client->attemptReconnect();
+    REQUIRE(client->getServerCount() == 1);
+}
+
+TEST_CASE("client: a config-file server is never expired (todo/67)")
+{
+    /* The operator's declared intent must survive an outage that empties every
+     * broadcast list — otherwise a client that lost contact during a server
+     * restart would prune away the only address it could come back on. */
+    auto client = std::make_shared<ListClient>();
+    auto clock = std::make_shared<FakeClock>();
+    client->setClock(clock);
+    client->setExpiry(expiry_window_ms);
+
+    client->connectTo("configured.example", uint16_t{20202}, /*connect*/ false);
+    client->updateServers(make_list({{"learned.example", 20203}}));
+    REQUIRE(client->getServerCount() == 2);
+    REQUIRE(client->getLearnedServerCount() == 1);
+
+    for (int round = 0; round < 20; round++)
+    {
+        clock->advance(broadcast_interval_ms);
+        client->updateServers(make_list({}));
+        client->attemptReconnect();
+    }
+
+    /* The learned one is gone; the configured one is untouched. */
+    REQUIRE(client->getServerCount() == 1);
+    REQUIRE(client->getLearnedServerCount() == 0);
+}
+
+TEST_CASE("client: a learned server seen again inside the window is not expired (todo/67)")
+{
+    auto client = std::make_shared<ListClient>();
+    auto clock = std::make_shared<FakeClock>();
+    client->setClock(clock);
+    client->setExpiry(expiry_window_ms);
+
+    client->updateServers(make_list({{"learned.example", 20204}}));
+    REQUIRE(client->getServerCount() == 1);
+
+    /* Absent from one broadcast, present in the next: the sighting resets the
+     * window, so twice the window's worth of elapsed time expires nothing. */
+    clock->advance(expiry_window_ms - 10000);
+    client->updateServers(make_list({}));
+    clock->advance(expiry_window_ms - 10000);
+    client->updateServers(make_list({{"learned.example", 20204}}));
+    clock->advance(expiry_window_ms - 10000);
+    client->updateServers(make_list({{"learned.example", 20204}}));
+    REQUIRE(client->getServerCount() == 1);
+}
+
+TEST_CASE("client: an empty list from one broadcast round expires nothing early (todo/67)")
+{
+    /* Server-side, a failed read of config_serverconfig returns nullopt and the
+     * poller keeps its previous cache, so a read outage cannot broadcast an
+     * empty list. This pins the client side of that contract anyway: even if an
+     * empty list did arrive, one round is not enough to drop anything. */
+    auto client = std::make_shared<ListClient>();
+    auto clock = std::make_shared<FakeClock>();
+    client->setClock(clock);
+    client->setExpiry(expiry_window_ms);
+
+    client->updateServers(make_list({{"learned.example", 20205}}));
+    clock->advance(broadcast_interval_ms);
+    client->updateServers(make_list({}));
+    clock->advance(broadcast_interval_ms);
+    client->updateServers(make_list({}));
+    REQUIRE(client->getServerCount() == 1);
+}
+
+TEST_CASE("client: expiry can be disabled (todo/67)")
+{
+    /* 0 keeps the pre-todo/67 behaviour for a deployment that wants it. */
+    auto client = std::make_shared<ListClient>();
+    auto clock = std::make_shared<FakeClock>();
+    client->setClock(clock);
+    client->setExpiry(0);
+
+    client->updateServers(make_list({{"learned.example", 20206}}));
+    clock->advance(100000000);
+    client->updateServers(make_list({}));
+    client->attemptReconnect();
+    REQUIRE(client->getServerCount() == 1);
+}
+
+TEST_CASE("client: the learned-server cap refuses further entries (todo/67)")
+{
+    auto client = std::make_shared<ListClient>();
+    auto clock = std::make_shared<FakeClock>();
+    client->setClock(clock);
+    client->setCap(4);
+
+    std::vector<std::pair<std::string, uint16_t>> entries;
+    for (uint16_t i = 0; i < 10; i++)
+    {
+        entries.emplace_back("learned" + std::to_string(i) + ".example", static_cast<uint16_t>(20300 + i));
+    }
+    client->updateServers(make_list(entries));
+    REQUIRE(client->getLearnedServerCount() == 4);
+
+    /* Re-advertising the same list must not grow it past the cap either. */
+    client->updateServers(make_list(entries));
+    REQUIRE(client->getLearnedServerCount() == 4);
+}
+
+TEST_CASE("client: config-file servers do not count against the learned cap (todo/67)")
+{
+    auto client = std::make_shared<ListClient>();
+    client->setCap(2);
+    client->connectTo("configured1.example", uint16_t{20400}, false);
+    client->connectTo("configured2.example", uint16_t{20401}, false);
+    client->connectTo("configured3.example", uint16_t{20402}, false);
+
+    client->updateServers(make_list({{"learned1.example", 20403}, {"learned2.example", 20404}}));
+    REQUIRE(client->getLearnedServerCount() == 2);
+    REQUIRE(client->getServerCount() == 5);
+}
+
+TEST_CASE("client: config keys set the expiry window and the cap (todo/67)")
+{
+    const char *tmppath = "client-server-list-test.json";
+    {
+        std::ofstream cfg(tmppath);
+        cfg << R"({"name":"test-asset","learned_server_expiry_ms":1234,"max_learned_servers":3,)"
+            << R"("ssl":{"ca_public_key":"","client_private_key":"","client_public_key":""},"servers":[]})";
+    }
+    fss::client_ssl::fss_client client(tmppath);
+    REQUIRE(client.getLearnedServerExpiryMs() == 1234);
+    REQUIRE(client.getMaxLearnedServers() == 3);
+    std::remove(tmppath);
+}
+
+TEST_CASE("client: expiry and cap defaults are the documented ones (todo/67)")
+{
+    fss::client_ssl::fss_client client;
+    REQUIRE(client.getLearnedServerExpiryMs() == fss::client_ssl::default_learned_server_expiry_ms);
+    REQUIRE(client.getMaxLearnedServers() == fss::client_ssl::default_max_learned_servers);
+}


### PR DESCRIPTION
## Description

updateServers() only ever ADDED. There was no removal path anywhere in client-ssl.cpp: entries migrated between `servers` and `reconnect_servers` and never left either. A server deactivated in config_serverconfig therefore dropped out of every broadcast list while every client that had ever seen it kept it for the process lifetime -- and kept paying a blocking connect attempt for it every backoff interval, which is what turned todo/66 from annoying into compounding. The failure was also silent: connectionStatusChange() reports only the count of LIVE servers, so a client carrying eleven decommissioned ones looked exactly like a healthy one.

A server learned from a broadcast now carries a last-seen time. Each list that mentions it refreshes that; one absent for the whole expiry window (default 60000ms, four 15 s broadcast rounds) is dropped, with a WARN naming it. The number of servers that can be learned is capped (default 16), with one WARN when the cap first refuses one. Both are configurable -- "learned_server_expiry_ms" (0 disables expiry entirely) and "max_learned_servers".

Servers from the config file are never expired and do not count against the cap: they are the operator's declared intent and must survive an outage that empties every broadcast list, or a client that lost contact during a server restart would prune away the only address it could come back on. Server-side, a failed read of config_serverconfig returns nullopt and the poller keeps its previous cache, so a read outage cannot broadcast an empty list in the first place; there is a test for the client half of that contract regardless.

Expiry is driven by an injectable IClock rather than a count of rounds. The number of lists per window depends on how many servers are connected, and todo/70 is already a standing complaint about the one class in the tree that counts ticks instead of reading a clock -- this is new timekeeping and should not repeat it.

Teardown of an expired server is deferred to attemptReconnect() rather than done inline: updateServers() runs on a recv thread, and the server being expired can be the very one whose list this is, so disconnecting there would have that thread join itself.

getServerCount() and getLearnedServerCount() are new, because the silence was half the problem -- there was no way for an operator or a test to see what a client was actually carrying.

## Summary by Sourcery

Add expiry and capacity limits for servers learned from broadcast lists so clients stop indefinitely retrying decommissioned endpoints, and expose counts and configuration to make learned server state observable.

New Features:
- Introduce configurable expiry window and maximum count for servers learned from broadcast server lists, with defaults and JSON config keys to override them.
- Expose APIs to query total server count and learned server count on the client, as well as getters for learned server expiry and cap, and an injectable clock for timing.

Bug Fixes:
- Ensure learned servers that disappear from broadcasts are eventually dropped instead of being retried forever, while preserving config-file servers.
- Avoid silent accumulation of dead learned servers by logging when entries expire or when the learned-server cap is reached and by triggering reconfiguration on expiry.

Enhancements:
- Refactor server-list handling to track learned servers with last-seen timestamps, separate learned vs configured servers, and manage expiry teardown on the reconnect lifecycle thread.
- Add unit tests covering learned-server expiry behavior, cap enforcement, config-file server immunity to expiry, configuration integration, and default values.

Tests:
- Add client_server_list_test suite to validate learned server expiry semantics, cap behavior, interaction with configured servers, configuration-driven settings, and documented defaults.