### PR TITLE
docs: record the client fan-out decision (todo/66, todo/67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tracked documents; the rest are retargeted as those files are next touched.
 
 ### Changed
+- **ABI break:** all four library sonames bump `.so.3` → `.so.4`
+  (`-version-info 4:0:0` for `libfss`, `libfss-transport`,
+  `libfss-transport-ssl`, `libfss-client-ssl`). Two independent layout changes
+  land in this release and one bump covers both, since `.so.4` has not been
+  released: the installed `fss-transport.hpp` changed object layout since
+  1.2.1, where `fss_connection` gained the todo/25 delivery members and the
+  todo/52 deferred-close descriptor; and the installed `fss-client-ssl.hpp`
+  added data members and a virtual to `client_ssl::fss_server` and
+  `client_ssl::fss_client`. A same-soname mix of an old library with the new
+  header (or vice versa) would silently corrupt derived-class layouts rather
+  than fail to link, so consumers must rebuild. See
+  `docs/release-checklist.md`.
+- `client_ssl::fss_client::sendMsgAll()` and `attemptReconnect()` are now
+  **non-blocking**: each `fss_server` owns an outbound worker thread that
+  performs its own blocking I/O
+  (`docs/decisions/66-67-client-outbound-fanout.md`, todo/66). Both were serial
+  loops of blocking calls on the caller's thread, so a server that completed TLS
+  and then stopped reading held telemetry to every healthy server behind it for
+  a whole `TCP_USER_TIMEOUT` (30 s by default), and a reconnection pass cost the
+  sum of every unreachable server's connect and handshake timeouts. The shipped
+  example drives both from one thread and the README names it as the starting
+  point for a real client, so the aircraft's telemetry cadence and reconnect
+  latency were set by the slowest server rather than the fastest. This is the
+  aircraft-side counterpart of the hardening todo/21 + todo/36 did on the
+  server. `sendMsgAll()` packs the message once and shares the frame read-only
+  across the workers, each stamping its own sequence id via
+  `fss_connection::sendPacked()` — which is what keeps the todo/12 C8 invariant
+  intact now that the sends are concurrent. Per-server queues are bounded and
+  drop the OLDEST frame under backlog (telemetry is loss-tolerant); the loss is
+  reported by the new `fss_server::getDroppedSends()`.
+- A `client_ssl::fss_client` now expires servers it learned from a server-list
+  broadcast (todo/67). `updateServers()` only ever added — there was no removal
+  path in the client at all — so a server deactivated in `config_serverconfig`
+  was carried by every client that had ever seen it for the process lifetime,
+  costing a blocking connect attempt per backoff interval, and silently: nothing
+  logged it. A learned server absent from every list for
+  `learned_server_expiry_ms` (new client config field, default 60 s = four 15 s
+  broadcast rounds; 0 disables) is now dropped with a WARN naming it, and no
+  more than `max_learned_servers` (new, default 16) are ever learned. Servers
+  from the config file are exempt from both — they are the operator's declared
+  intent and must survive an outage that empties every broadcast list. New
+  `getServerCount()` / `getLearnedServerCount()` make what a client is carrying
+  visible.
 - `fss_connection` now invokes `fss_message_cb::processMessage()` with its
   internal `msg_lock` released, instead of holding it across the callback
   (todo/25). Holding a transport mutex across arbitrary user code meant any
@@ -46,13 +89,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a running callback, so the existing "call `activate()`/`reconnect()` outside
   our own lock" rules in `server-clients.cpp` and `client-ssl.cpp` remain
   load-bearing. No behaviour change for existing handlers.
-- ABI: all four library sonames bump `.so.3` → `.so.4` (`-version-info 4:0:0`
-  for `libfss`, `libfss-transport`, `libfss-transport-ssl`,
-  `libfss-client-ssl`). The installed `fss-transport.hpp` changed object layout
-  since 1.2.1: `fss_connection` gained the todo/25 delivery members above and
-  the todo/52 deferred-close descriptor. A same-soname mix of an old library
-  with the new header (or vice versa) would silently corrupt derived-class
-  layouts rather than fail to link, so consumers must rebuild.
 - Broadcast relays now pack the source message once and share that frame,
   read-only, across every recipient instead of decoding a fresh clone per
   recipient (todo/55). Previously each relayed position report to N connected

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ several `todo/` items is filed under all of them (`34-45-47-…`).
 | [48 — a terminal command ack is final for its dispatch](decisions/48-command-ack-terminal-finality.md) | Protocol / audit |
 | [49 — the FMU command identifier is per-server](decisions/49-server-command-id-semantics.md) | Protocol |
 | [51 — optional trailing wire fields are prefix-closed](decisions/51-optional-trailing-field-rule.md) | Protocol |
+| [66/67 — the client fans out through per-server workers, and prunes what it learns](decisions/66-67-client-outbound-fanout.md) | Client library |
 
 ## Citing a decision
 

--- a/docs/decisions/66-67-client-outbound-fanout.md
+++ b/docs/decisions/66-67-client-outbound-fanout.md
@@ -1,0 +1,180 @@
+# 66/67 — the client fans out through per-server workers, and prunes what it learns
+
+**Decided** 2026-07-26. Config fields `learned_server_expiry_ms` and
+`max_learned_servers` in the client JSON; defaults
+`default_learned_server_expiry_ms` (60 s) and `default_max_learned_servers`
+(16) in `src/fss-client-ssl.hpp`. Broke the ABI of `libfss-client-ssl`; all
+four sonames bumped in lockstep (see `../release-checklist.md`).
+
+## Context
+
+The server was hardened over four work items — todo/21 (per-client outbound
+worker threads), todo/35 (no blocking send under the client lock), todo/36
+(broadcasts and position relay routed onto those workers, bounded drop-oldest
+queues) and todo/55 (byte-clone broadcast) — around a single principle:
+
+> a black-holed peer must never stall anything but itself.
+
+`client_ssl::fss_client`, the aircraft side and the library cap-fmu builds on,
+had the opposite structure. Every fan-out was a serial loop of blocking calls on
+the caller's thread:
+
+- `sendMsgAll()` called `sendMsg()` on each server in turn. A server that
+  completes TCP and TLS and then stops reading — closed receive window, frozen
+  host — blocks that send until `TCP_USER_TIMEOUT` errors the connection out
+  (30 s by default, see decision 26). Every healthy server behind it in the list
+  got nothing for that whole window.
+- `attemptReconnect()` dialled each pending server in turn: a blocking
+  `connect()` plus a TLS handshake (~7 s for a host that drops SYNs, up to 10 s
+  for one that accepts TCP and then stalls the handshake), plus a
+  `disconnect()` that joins the previous connection's recv thread. A pass cost
+  the **sum** of every unreachable entry's timeout.
+- `updateServers()` only ever *added*. There was no removal path anywhere in
+  `client-ssl.cpp`: entries migrated between the live and pending-reconnect
+  lists and never left either. A server deactivated in `config_serverconfig`
+  dropped out of the broadcast list, but every client that had ever seen it kept
+  it — and kept paying a connect attempt for it every backoff interval, for the
+  process lifetime.
+
+The shipped `examples/fake_client.cpp` drives all of it from one thread, and the
+README names that example as the starting point for a real client. So the
+aircraft's telemetry cadence and its reconnection latency were both set by the
+*slowest* server rather than the fastest, and the set of slow servers only ever
+grew.
+
+Command *reception* was never affected — commands arrive on each connection's
+own recv thread — which is the only reason this was a telemetry-availability
+and reconnect-latency defect rather than a command-delivery one.
+
+## Decision
+
+**Give each `client_ssl::fss_server` its own outbound worker**, mirroring the
+server-side per-client worker. `sendMsgAll()` and `attemptReconnect()` are now
+non-blocking: they schedule, and each server's worker performs its own blocking
+I/O. One wedged server stalls only its own thread.
+
+**Telemetry is loss-tolerant, so the queue is bounded and drops the oldest.**
+Under sustained backlog a wedged server sheds its stalest report and keeps the
+freshest — telemetry only gets less useful with age. The cumulative loss is
+available from `getDroppedSends()` and the first drop of each backlog episode
+is logged.
+
+**A learned server carries a last-seen time and is dropped after a window.**
+Servers broadcast their list every 15 s; four missed rounds (60 s) is the
+default before a learned entry is expired, with a WARN naming it. The number
+that can be learned is capped, with one WARN when the cap first refuses one.
+Config-file servers are exempt from both.
+
+## Why C8 survives the fan-out becoming concurrent
+
+The todo/12 **C8 invariant** — a single `fss_message` instance must never be
+sent on two connections at once, because `sendMsg()` stamps the per-connection
+sequence id *into the message* — used to hold for free, purely because the loop
+was serial. Parallelising it had to re-establish the invariant, not assume it.
+
+It is re-established the way todo/55 already did for server-side broadcasts:
+`sendMsgAll()` packs the message **once**, and hands every worker the same
+`shared_ptr<const buf_len>`. `fss_connection::sendPacked()` copies those bytes
+and stamps only its own copy. No `fss_message` instance is shared, and the
+`const` in the type enforces that the shared frame is never mutated. This is
+reuse of already-published machinery, not new mechanism.
+
+The consequence worth stating: **`sendMsgAll()` cannot carry a message that
+needs the mutating path.** `sendPacked()` refuses `message_type_smm_settings`
+outright (it would skip the decision-43 `wipeSecure` scrub), and the client
+never sends one. The per-connection sends that *do* mutate — `sendIdentify()`,
+`sendVersion()`, the RTT reply — deliberately stay inline on the recv thread,
+where a stall can only affect the one connection it belongs to.
+
+## Why a reconnect is harvested by a flag, not by `connected()`
+
+The worker does the dial; the client's next `attemptReconnect()` pass promotes
+the server into the live list. Every list mutation stays on the thread that owns
+`servers_lock`, so the worker never reaches back into the client.
+
+The worker publishes success only **after `reconnect()` has returned true** —
+that is, after the version and identity handshake has been sent. Harvesting on
+`connected()` instead would expose the window inside `reconnect()` between
+installing the connection and sending that handshake, during which
+`sendMsgAll()` could put telemetry ahead of the mandatory version message.
+Setting the flag afterwards preserves the previous ordering exactly.
+
+`serverRequiresReconnect()` discards a stale success for a server that is not in
+the live list: that is a connection which died between the dial finishing and
+the harvest, and promoting it would park a dead connection where nothing would
+flag it — a fresh connection starts with liveness disarmed, so
+`isServerTimedOut()` would never fire.
+
+## Why expiry is time-based, and driven from `attemptReconnect()`
+
+**Time, not rounds.** The obvious implementation is a per-server counter of
+consecutive lists that omitted the entry. It is wrong in a way that matters: the
+number of lists a client sees per unit time depends on how many servers it is
+connected to, since each broadcasts its own. todo/70 is already a standing
+complaint about the one class in the tree that counts ticks instead of reading a
+clock; this is new timekeeping and should not repeat it. The clock is injectable
+for the same reason every other one in the tree is — so the timing is testable.
+
+**Teardown deferred.** `updateServers()` runs on a recv thread, and the server
+being expired can be the very one whose list this is. Disconnecting it there
+would have that thread join itself — survivable, because
+`fss_connection::disconnect()` detaches in that case rather than deadlocking,
+but only by leaking the thread. So `updateServers()` removes the entry from both
+lists into a holding list, and `attemptReconnect()` — which already owns
+connection lifecycle, on a thread that never holds `servers_lock` across a
+blocking call — drains and disconnects it.
+
+**Config-file servers are never expired** and do not count against the cap. They
+are the operator's declared intent: a client that lost contact during a server
+restart must not prune away the only address it could come back on.
+Server-side, a failed read of `config_serverconfig` returns `nullopt` and the
+poller keeps its previous cache, so a read outage cannot broadcast an empty list
+in the first place (decision 24) — but the client must not depend on that being
+true forever, and one empty round expires nothing regardless.
+
+## Alternative deliberately not taken: document the constraint instead
+
+The cheap option was to state in `fss-client-ssl.hpp` and the README that
+`sendMsgAll()` and `attemptReconnect()` block for the sum of per-server
+timeouts, and leave each integrator to thread it themselves. It is honest, and
+it costs no ABI break.
+
+It was rejected for the same reason todo/21 rejected it on the server side: it
+pushes an identical hazard onto every consumer and guarantees each solves it
+differently — or, more likely, discovers it in flight. cap-fmu is the first
+consumer; there will be others.
+
+## Alternative deliberately not taken: just bound the damage
+
+Dropping the client's default `TCP_USER_TIMEOUT` well below 30 s and
+round-robining one reconnect per pass would have reduced the worst case in a few
+lines with no ABI break. It was rejected because it does not remove the
+coupling: a healthy server's telemetry still waits behind an unhealthy one, just
+for less long. The tighter timeout remains available per decision 26 and is
+complementary.
+
+## Known, bounded cost
+
+A `disconnect()` that lands while a worker is inside a blocking
+`connect()`/handshake waits for that attempt to finish. That is bounded by the
+connect and handshake timeouts (≈10 s worst case) — the same bound the caller's
+thread paid for the same work before this change — but it means shutdown is not
+instantaneous when a configured server is unreachable. A subclass that overrides
+`reconnect_to()` with something that can block *indefinitely* must make sure
+`disconnect()` can release it.
+
+Thread count rises to one worker per server on the aircraft. At the handful of
+servers a real deployment configures this is nothing; it is noted here against
+decision 23's thread-count concern.
+
+## Where this is pinned
+
+`tests/client_fanout_test.cpp`: a wedged server does not stall telemetry to a
+healthy one; a fan-out stamps each connection's own id (the C8 case); a
+backlogged queue drops oldest and counts the loss; an unreachable server does
+not delay reconnection to a healthy one; repeated `attemptReconnect()` does not
+pile up dials. `tests/client_server_list_test.cpp`: expiry after the window,
+config servers exempt, a refreshed sighting resets the window, one empty round
+expires nothing, expiry disabled by 0, the cap, and the config keys.
+`e2e/test_server_list.py` covers the removal direction end to end against a real
+server and database — the suite previously only covered learning a server.

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -314,6 +314,14 @@ def certs_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
     return target
 
 
+# The fss_client library default for learned_server_expiry_ms
+# (default_learned_server_expiry_ms in src/fss-client-ssl.hpp). client.json.tmpl
+# and client-non-aircraft.json.tmpl require the substitution, so every caller
+# that renders one directly rather than through the fake_client fixture passes
+# this unless it is deliberately exercising expiry.
+DEFAULT_LEARNED_EXPIRY_MS = 60000
+
+
 def _render_template(template_path: Path, out_path: Path, **subs: object) -> None:
     tmpl = string.Template(template_path.read_text())
     out_path.write_text(tmpl.substitute(**subs))
@@ -421,6 +429,7 @@ def fake_client(
         client_id: str | None = None,
         non_aircraft: bool = False,
         extra_args: list[str] | None = None,
+        learned_expiry_ms: int = 60000,
     ) -> dict[str, object]:
         # client_id labels this launch's config/log file paths; defaults to
         # `name` (existing behaviour for every caller with one client per
@@ -432,12 +441,17 @@ def fake_client(
         config_path = tmp_path / f"client-{label}.json"
         log_path = tmp_path / f"client-{label}.log"
         template = "client-non-aircraft.json.tmpl" if non_aircraft else "client.json.tmpl"
+        # learned_expiry_ms is how long a server learned from a server_list
+        # broadcast may go unmentioned before the client drops it (todo/67).
+        # The library default is 60 s; a test exercising the removal direction
+        # lowers it so it does not have to wait four broadcast rounds.
         _render_template(
             E2E_ROOT / "fixtures" / template,
             config_path,
             CLIENT_NAME=name,
             CERTS_DIR=str(ca_override if ca_override else certs_dir),
             SERVER_PORT=str(server_proc["port"]),
+            LEARNED_EXPIRY_MS=str(learned_expiry_ms),
         )
         env = os.environ.copy()
         env["LD_LIBRARY_PATH"] = str(REPO_ROOT / "src" / ".libs")

--- a/e2e/fixtures/client-non-aircraft.json.tmpl
+++ b/e2e/fixtures/client-non-aircraft.json.tmpl
@@ -1,6 +1,7 @@
 {
     "name": "${CLIENT_NAME}",
     "non_aircraft": true,
+    "learned_server_expiry_ms": ${LEARNED_EXPIRY_MS},
     "ssl": {
         "ca_public_key": "${CERTS_DIR}/ca.public.pem",
         "client_private_key": "${CERTS_DIR}/${CLIENT_NAME}.private.pem",

--- a/e2e/fixtures/client.json.tmpl
+++ b/e2e/fixtures/client.json.tmpl
@@ -1,5 +1,6 @@
 {
     "name": "${CLIENT_NAME}",
+    "learned_server_expiry_ms": ${LEARNED_EXPIRY_MS},
     "ssl": {
         "ca_public_key": "${CERTS_DIR}/ca.public.pem",
         "client_private_key": "${CERTS_DIR}/${CLIENT_NAME}.private.pem",

--- a/e2e/test_crl_revocation.py
+++ b/e2e/test_crl_revocation.py
@@ -27,6 +27,7 @@ import pytest
 
 from conftest import (
     CERT_SCRIPTS,
+    DEFAULT_LEARNED_EXPIRY_MS,
     E2E_ROOT,
     FAKE_CLIENT_BIN,
     REPO_ROOT,
@@ -156,6 +157,7 @@ def test_revocation_disconnects_and_blocks_reconnect_but_not_others(
             CLIENT_NAME=name,
             CERTS_DIR=str(crl_certs_dir),
             SERVER_PORT=str(port),
+            LEARNED_EXPIRY_MS=str(DEFAULT_LEARNED_EXPIRY_MS),
         )
         fp = client_log.open("wb")
         # sourcery skip: dangerous-subprocess-use-audit

--- a/e2e/test_db_disk_full.py
+++ b/e2e/test_db_disk_full.py
@@ -57,6 +57,7 @@ import psycopg2
 import pytest
 
 from conftest import (
+    DEFAULT_LEARNED_EXPIRY_MS,
     E2E_ROOT,
     FAKE_CLIENT_BIN,
     POSTGIS_IMAGE,
@@ -181,6 +182,7 @@ def _spawn_client(server: dict[str, object], certs_dir: Path, tmp_path: Path, na
         CLIENT_NAME="test1",
         CERTS_DIR=str(certs_dir),
         SERVER_PORT=str(server["port"]),
+        LEARNED_EXPIRY_MS=str(DEFAULT_LEARNED_EXPIRY_MS),
     )
     log_fp = client_log.open("wb")
     # sourcery skip: dangerous-subprocess-use-audit

--- a/e2e/test_server_list.py
+++ b/e2e/test_server_list.py
@@ -2,7 +2,11 @@
 
 We assert by side-effect: the fake-client must keep its session healthy
 (continuing to produce position rows) even when config_serverconfig has
-multiple active entries."""
+multiple active entries.
+
+The suite covered only the *learning* direction until todo/67 added a removal
+path to the client; test_deactivated_server_is_dropped_by_client covers losing
+one."""
 from __future__ import annotations
 
 import time
@@ -74,3 +78,75 @@ def test_server_list_with_full_serverconfig_columns(db_conn, fake_client):
         )
         count = cur.fetchone()[0]
     assert count >= 1, "no positions recorded after server_list with full-column row"
+
+
+@pytest.mark.satisfies("TC-SRV-003")
+@pytest.mark.requires_docker
+def test_deactivated_server_is_dropped_by_client(db_conn, fake_client):
+    """A server removed from config_serverconfig must leave the client's list.
+
+    todo/67: updateServers() only ever added, so a decommissioned server stayed
+    in every client that had ever seen it for the process lifetime, costing a
+    blocking connect attempt per backoff interval -- and silently, because
+    nothing logged it. The client now drops a learned server that has been
+    absent from every list for the whole expiry window, and says so.
+
+    The window is lowered from its 60 s default so this does not have to sit
+    through four broadcast rounds; the server rebuilds and rebroadcasts its
+    cached list every 15 s, so the drop lands within roughly two rounds of the
+    row being deactivated.
+    """
+    expiry_ms = 10000
+    with db_conn.cursor() as cur:
+        cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
+        asset_id = cur.fetchone()[0]
+        cur.execute(
+            "INSERT INTO config_serverconfig (address, client_port, active) "
+            "VALUES ('doomed.example', 20303, TRUE) RETURNING id"
+        )
+        doomed_id = cur.fetchone()[0]
+
+    client = fake_client("test1", learned_expiry_ms=expiry_ms)
+
+    # One broadcast round is enough for the client to learn it. It surfaces in
+    # the log because the client then tries to dial it and the address does not
+    # resolve ("Failed to convert 'doomed.example' to a usable address") --
+    # which is itself the cost todo/67 is about paying forever.
+    deadline = time.monotonic() + 30
+    learned = False
+    while time.monotonic() < deadline:
+        if "doomed.example" in client["log"].read_text(errors="replace"):
+            learned = True
+            break
+        time.sleep(1)
+    assert learned, (
+        "client never mentioned the advertised server:\n"
+        + client["log"].read_text(errors="replace")
+    )
+
+    with db_conn.cursor() as cur:
+        cur.execute("UPDATE config_serverconfig SET active = FALSE WHERE id = %s", (doomed_id,))
+
+    # Worst case: up to 15 s for the server to rebuild its cached list without
+    # the row, then the expiry window, then the next broadcast to notice.
+    deadline = time.monotonic() + 60
+    dropped = False
+    while time.monotonic() < deadline:
+        log = client["log"].read_text(errors="replace")
+        if "doomed.example:20303" in log and "dropping it" in log:
+            dropped = True
+            break
+        time.sleep(1)
+
+    log = client["log"].read_text(errors="replace")
+    assert dropped, f"client never dropped the deactivated server:\n{log}"
+    assert client["proc"].poll() is None, f"fake-client exited during expiry:\n{log}"
+
+    # Dropping a server must not disturb the session with the live one.
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM assets_assetposition WHERE asset_id = %s",
+            (asset_id,),
+        )
+        count = cur.fetchone()[0]
+    assert count >= 1, "no positions recorded while the stale server was expiring"

--- a/e2e/test_server_restart.py
+++ b/e2e/test_server_restart.py
@@ -16,6 +16,7 @@ import psycopg2
 import pytest
 
 from conftest import (
+    DEFAULT_LEARNED_EXPIRY_MS,
     E2E_ROOT,
     REPO_ROOT,
     SERVER_BIN,
@@ -126,6 +127,7 @@ def test_client_reconnects_after_server_bounce(
         CLIENT_NAME="test1",
         CERTS_DIR=str(certs_dir),
         SERVER_PORT=str(port),
+        LEARNED_EXPIRY_MS=str(DEFAULT_LEARNED_EXPIRY_MS),
     )
     client_log = tmp_path / "client-test1.log"
     client_fp = client_log.open("wb")

--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -98,8 +98,9 @@ flight_safety_system::client_ssl::fss_client::~fss_client()
         std::scoped_lock lock(this->servers_lock);
         all.splice(all.end(), this->servers);
         all.splice(all.end(), this->reconnect_servers);
-        /* Anything expired but not yet drained by attemptReconnect() (todo/67)
-         * still owns a worker thread and possibly a connection. */
+        /* Anything expired but not yet drained by attemptReconnect()
+         * (docs/decisions/66-67-client-outbound-fanout.md) still owns a worker
+         * thread and possibly a connection. */
         all.splice(all.end(), this->expired_servers);
     }
     for (const auto &server : all)
@@ -249,7 +250,7 @@ void flight_safety_system::client_ssl::fss_client::attemptReconnect()
      * harvest the servers whose queued reconnect has since succeeded and
      * schedule an attempt for the rest.
      *
-     * The dial itself runs on each server's own outbound worker (todo/66).
+     * The dial itself runs on each server's own outbound worker (docs/decisions/66-67-client-outbound-fanout.md).
      * Calling the blocking reconnect() here — a connect() plus a TLS
      * handshake, ~7 s for a host that drops SYNs and up to 10 s for one that
      * stalls the handshake — made this loop cost the SUM of every unreachable
@@ -292,7 +293,7 @@ void flight_safety_system::client_ssl::fss_client::attemptReconnect()
         }
     }
 
-    /* Phase (e): tear down anything updateServers() expired (todo/67). It
+    /* Phase (e): tear down anything updateServers() expired (docs/decisions/66-67-client-outbound-fanout.md). It
      * removed them from both lists but could not disconnect them: it runs on a
      * recv thread, and the expiring server can be the one the list arrived on,
      * so the join would be a self-join. Here we are on the thread that already
@@ -453,7 +454,8 @@ auto flight_safety_system::client_ssl::fss_client::getLearnedServerCount() const
 void flight_safety_system::client_ssl::fss_client::updateServers(
     const std::shared_ptr<flight_safety_system::transport::fss_message_server_list> &msg)
 {
-    /* Before todo/67 this method only ever ADDED: there was no removal path
+    /* Before docs/decisions/66-67-client-outbound-fanout.md
+     * this method only ever ADDED: there was no removal path
      * anywhere in the file, so a server deactivated in config_serverconfig
      * dropped out of the broadcast list but every client that had ever seen it
      * kept it forever — and kept paying a blocking connect attempt for it every
@@ -579,7 +581,8 @@ void flight_safety_system::client_ssl::fss_client::serverRequiresReconnect(
     {
         /* Not in the live list, so this is a connection that died in the window
          * between its worker finishing a reconnect and attemptReconnect()
-         * harvesting the result (todo/66). Discard the stale success: promoting
+         * harvesting the result (see the decision file above). Discard the
+         * stale success: promoting
          * it would move an already-dead connection into `servers`, where
          * nothing would flag it — a fresh connection starts with liveness
          * disarmed, so isServerTimedOut() would never fire. Dropping the flag

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -67,7 +67,7 @@ private:
     std::string public_key_file{""};
     std::list<std::shared_ptr<flight_safety_system::client_ssl::fss_server>> servers{};
     std::list<std::shared_ptr<flight_safety_system::client_ssl::fss_server>> reconnect_servers{};
-    /* Servers removed from both lists by expiry (todo/67) and awaiting
+    /* Servers removed from both lists by expiry and awaiting
      * teardown. updateServers() runs on a recv thread and the server it expires
      * can be the very one the list arrived on, so disconnecting there would
      * have that thread join itself; attemptReconnect() — which already owns
@@ -79,7 +79,7 @@ private:
      * it to read the flag). */
     mutable std::mutex servers_lock{};
     bool configured{false}; // guarded by servers_lock
-    /* Expiry window and cap for servers learned from broadcasts (todo/67); see
+    /* Expiry window and cap for servers learned from broadcasts; see
      * the constants above. Configuration state, set before concurrent use. */
     uint64_t learned_server_expiry_ms{default_learned_server_expiry_ms};
     size_t max_learned_servers{default_max_learned_servers};
@@ -105,7 +105,7 @@ protected:
      * an already-established connection keeps the bound it connected with. */
     void setTcpUserTimeoutMs(unsigned int t_timeout_ms);
     /* Configuration state, like the setters above. 0 disables expiry, keeping
-     * the pre-todo/67 behaviour of never dropping a learned server. */
+     * the previous behaviour of never dropping a learned server. */
     void setLearnedServerExpiryMs(uint64_t t_expiry_ms);
     void setMaxLearnedServers(size_t t_max);
     void addServer(const std::shared_ptr<fss_server> &server);
@@ -148,7 +148,8 @@ public:
     virtual auto getMaxLearnedServers() const -> size_t { return this->max_learned_servers; }
     /* How many servers this client currently knows of — live plus pending
      * reconnect — and how many of those it learned from a broadcast rather than
-     * being configured with. Exposed because the todo/67 failure was invisible:
+     * being configured with. Exposed because the failure this fixed was
+     * invisible:
      * connectionStatusChange() reports only the count of LIVE servers, so a
      * client quietly carrying eleven decommissioned ones, and paying a connect
      * attempt for each every backoff interval, looked identical to a healthy
@@ -229,7 +230,9 @@ private:
     std::atomic<bool> liveness_active{false};
     std::atomic<uint64_t> last_message_received_time{0};
     uint64_t server_timeout_ms{30000};
-    /* Learned-server bookkeeping (todo/67). Owned by the fss_client, not by
+    /* Learned-server bookkeeping
+     * (docs/decisions/66-67-client-outbound-fanout.md). Owned by the
+     * fss_client, not by
      * this object: both are read and written only under fss_client's
      * servers_lock, or before the server has been published into either list.
      * `learned` is true only for a server discovered from a server-list
@@ -247,7 +250,7 @@ private:
     std::mutex outbound_lock{};
     std::condition_variable outbound_cv{};
     bool outbound_stopping{false};
-    /* Reconnection is dispatched onto the same worker (todo/66): reconnect()
+    /* Reconnection is dispatched onto the same worker: reconnect()
      * blocks for a connect() plus a TLS handshake, and doing that serially for
      * every entry on the caller's thread delayed reconnection to a healthy
      * server by the sum of every unreachable one's timeout.
@@ -344,7 +347,8 @@ public:
      * stall can only affect the one connection it belongs to. */
     void queueSend(const std::shared_ptr<const flight_safety_system::transport::buf_len> &packed);
     /* Schedule a reconnect on this server's outbound worker instead of dialling
-     * inline (todo/66). Returns immediately, and is a no-op while an attempt is
+     * inline (see the outbound-worker block above). Returns immediately, and
+     * is a no-op while an attempt is
      * already queued or in flight, so calling it every tick is safe. The
      * backoff throttle still lives in reconnect() itself, so a queued attempt
      * inside the retry window costs a worker wake-up and nothing else. */
@@ -373,7 +377,7 @@ public:
     virtual void sendIdentify();
     virtual void sendVersion();
     void setClock(std::shared_ptr<flight_safety_system::IClock> t_clock);
-    /* Learned-server accessors (todo/67). See the members: the caller must hold
+    /* Learned-server accessors. See the members: the caller must hold
      * fss_client::servers_lock, or be working on a server not yet published
      * into either list. */
     auto isLearned() const -> bool { return this->learned; }


### PR DESCRIPTION
## Description

New docs/decisions/66-67-client-outbound-fanout.md: why the client mirrors the server's per-server worker rather than documenting the constraint for each integrator to solve differently (the argument todo/21 already settled), how the todo/12 C8 invariant survives the fan-out becoming concurrent (pack once, share const, stamp per connection), why per-connection sends that mutate the message stay inline on the recv thread, why a reconnect is harvested by a flag rather than by connected(), why expiry reads a clock instead of counting broadcast rounds, and why expired servers are torn down from attemptReconnect() rather than inline on a recv thread. It also records the two alternatives rejected -- documenting the constraint, and merely bounding the damage with a tighter TCP_USER_TIMEOUT -- and the bounded shutdown latency the design accepts.

The in-tree citations for these two items now point at that file rather than at the gitignored todo/, per the convention todo/54 established.

No soname bump, deliberately. New data members and a new virtual on client_ssl::fss_server and client_ssl::fss_client are an ABI break by the release checklist's own examples, and the break is not theoretical: the e2e run caught it as a SIGABRT in an fss-fake-client that had been built against the old headers and was then run against the new library. But the .so.3 -> .so.4 bump already sitting unreleased in this cycle covers it. libtool's `current` counts released interface generations, not ABI-breaking commits, and the checklist treats the bump as a release step measured against the last tag: 1.2.1 shipped 3:0:0 and 4:0:0 has never been tagged, so going to 5:0:0 would burn a soname on a library no consumer can ever have linked against. The CHANGELOG's two separate ABI entries are folded into one that names both layout changes, since consumers will only ever experience a single break.

Also extends e2e/test_server_list.py with the removal direction it lacked -- deactivate a config_serverconfig row and assert the client drops it and says so -- with a learned_expiry_ms knob on the fake_client fixture so the test does not have to sit through four 15 s broadcast rounds.

## Summary by Sourcery

Document the client outbound fan-out and learned-server expiry decisions, align in-tree references to the new decision file, and exercise the removal path end-to-end against the server list.

Enhancements:
- Describe the ABI break and client outbound worker / learned-server expiry behaviour more fully in the CHANGELOG, consolidating prior entries into a single release note.
- Expose learned-server expiry configuration in client JSON fixtures and the e2e fake client launcher to support tests and real deployments.

Documentation:
- Add decision document 66/67 describing client per-server outbound workers, telemetry fan-out semantics, and pruning of learned servers.
- Reference the new 66/67 decision from the docs README to make the client fan-out and pruning design discoverable.
- Clarify inline documentation in the client SSL header to cite the decision file instead of transient todo items.

Tests:
- Extend the server-list e2e suite with a test that deactivates a server and asserts the client logs dropping it while keeping the session healthy.
- Add configuration plumbing for a shortened learned-server expiry window in e2e fixtures so removal-path tests complete quickly.