### PR TITLE
client: do not resurrect an expired server when harvesting a reconnect

### DIFF
--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -281,14 +281,22 @@ void flight_safety_system::client_ssl::fss_client::attemptReconnect()
     }
 
     /* Phase (d): move the newly connected servers from reconnect_servers to
-     * servers under the lock. */
+     * servers under the lock. Promote only entries still *in* that list: the
+     * snapshot above was taken with the lock released, so updateServers() can
+     * have expired one in between, and blindly pushing would resurrect a
+     * server that phase (e) is about to disconnect. */
     {
         std::scoped_lock lock(this->servers_lock);
         while (!reconnected.empty())
         {
             auto server = reconnected.front();
             reconnected.pop_front();
-            this->reconnect_servers.remove(server);
+            auto found = std::find(this->reconnect_servers.begin(), this->reconnect_servers.end(), server);
+            if (found == this->reconnect_servers.end())
+            {
+                continue;
+            }
+            this->reconnect_servers.erase(found);
             this->servers.push_back(server);
         }
     }


### PR DESCRIPTION
## Description

attemptReconnect() snapshots reconnect_servers with the lock released, so updateServers() can expire an entry between the snapshot and the promotion. Blindly pushing the harvested server into `servers` would then put back a server that phase (e) is about to disconnect, leaving a dead connection parked in the live list where nothing would flag it. Promote only entries still present in reconnect_servers.

Narrow -- the window is microseconds and needs the expiry to land inside it -- but the two features only became able to interact when todo/67 added the removal path, so it is new.

## Summary by Sourcery

Bug Fixes:
- Avoid resurrecting servers that were expired from the reconnect list between snapshot and promotion during client reconnect handling.