### PR TITLE
client: hand the outbound queue over by move, not element by element

### DIFF
--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -690,8 +690,16 @@ auto flight_safety_system::client_ssl::fss_server::waitForOutboundWork()
     }
     work.reconnect = this->out_reconnect_pending;
     this->out_reconnect_pending = false;
-    work.sends.assign(std::make_move_iterator(this->pending_sends.begin()),
-                      std::make_move_iterator(this->pending_sends.end()));
+    /* Hand the whole queue over rather than moving element by element: this is
+     * a pointer swap, it cannot throw, and it leaves nothing to copy under the
+     * lock. The clear() is still required — a moved-from container is valid but
+     * unspecified, and pending_sends must be empty for the wait predicate.
+     *
+     * Element-wise (vector::assign over move_iterators) also tripped a GCC 14
+     * -Wnull-dereference false positive on the inlined shared_ptr swap chain,
+     * which is -Werror on Debian trixie. Not the reason for the change, but it
+     * is the reason not to quietly revert it. */
+    work.sends = std::move(this->pending_sends);
     this->pending_sends.clear();
     return work;
 }

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -10,7 +10,6 @@
 #include <mutex>
 #include <random>
 #include <thread>
-#include <vector>
 
 namespace flight_safety_system {
 namespace client_ssl {
@@ -300,7 +299,11 @@ private:
     struct outbound_work {
         bool stop{false};
         bool reconnect{false};
-        std::vector<std::shared_ptr<const flight_safety_system::transport::buf_len>> sends{};
+        /* Same container type as pending_sends so waitForOutboundWork() can
+         * hand the queue over with a whole-container move rather than copying
+         * element by element. It is only ever iterated once, in order, so a
+         * deque costs the consumer nothing over a vector. */
+        std::deque<std::shared_ptr<const flight_safety_system::transport::buf_len>> sends{};
     };
     /* Block until there is work or a stop request, then atomically take and
      * clear the pending work. */


### PR DESCRIPTION
## Description

Fixes the Debian trixie (GCC 14) build, which has been failing since todo/66 landed the per-server outbound worker in 30183027381 (2026-07-26); ubuntu resolute was unaffected, so only one of the two docker jobs went red.

waitForOutboundWork() drained pending_sends into outbound_work::sends with vector::assign over a pair of move_iterators. GCC 14 traces the inlined shared_ptr swap chain through that (deque iterator -> __copy_move_dit -> __shared_count::_M_swap) and reports

  shared_ptr_base.h:1097: error: potential null pointer dereference

which is a false positive, but -Wnull-dereference is in AM_CXXFLAGS under -Werror, so it fails the build. GCC 16 (the local toolchain) does not warn, which is why it was not caught before the push.

Rather than suppress the warning, drop the element-wise copy: make outbound_work::sends the same deque type as pending_sends and hand the whole container over with a move. That is a pointer swap instead of N shared_ptr moves plus a vector allocation, it cannot throw, and it holds the lock for less time. The consumer only iterates once in order, so the container change costs it nothing. The existing clear() is still required — a moved-from container is valid but unspecified, and the wait predicate needs it empty.

<vector> is no longer used in the header, so it goes.

Verified by building both docker/fss-server-trixie.Dockerfile and docker/fss-server-resolute.Dockerfile locally; the trixie build reproduces the failure before the change and succeeds after.

## Summary by Sourcery

Move outbound send queue ownership between client SSL worker structures using whole-container moves instead of element-wise moves to fix GCC 14 build issues and reduce locking overhead.

Bug Fixes:
- Resolve Debian trixie GCC 14 -Wnull-dereference build failure triggered by element-wise moves of shared_ptrs in the outbound send path.

Enhancements:
- Align outbound_work::sends container type with pending_sends and transfer sends via deque move for cheaper, non-throwing queue handoff under lock.