### PR TITLE
docs: state the new blocking semantics on the client's public entry points

### DIFF
--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -122,7 +122,22 @@ public:
     auto operator=(fss_client &) -> fss_client & = delete;
     auto operator=(fss_client &&) -> fss_client & = delete;
     virtual ~fss_client();
+    /* Register a server the operator configured, optionally dialling it now.
+     * The dial on this path IS synchronous — it is configuration-time, on the
+     * caller's own thread — unlike the ones attemptReconnect() schedules. A
+     * server added here is never expired
+     * (docs/decisions/66-67-client-outbound-fanout.md). */
     virtual void connectTo(const std::string &t_address, uint16_t t_port, bool connect);
+    /* One pass of connection maintenance; call it periodically (the shipped
+     * example does so at 1 Hz). NON-BLOCKING
+     * (docs/decisions/66-67-client-outbound-fanout.md): it schedules a dial on
+     * each pending server's own worker and promotes the ones whose dial has
+     * since succeeded, so a pass no longer costs the sum of every unreachable
+     * server's connect and handshake timeouts. Consequently a server does not
+     * become live within the same call that first schedules it — the following
+     * pass is the one that promotes it. Also the point at which servers dropped
+     * by server-list expiry are torn down, so it must keep being called for
+     * that to happen. */
     virtual void attemptReconnect();
     virtual void disconnect();
     /* Fan a message out to every currently connected server. NON-BLOCKING


### PR DESCRIPTION
## Description

connectTo() and attemptReconnect() now differ in an observable way that a consumer has to know about: the configuration-time dial is still synchronous, while attemptReconnect() only schedules, so a server does not become live within the same call that first schedules it. attemptReconnect() is also now the point at which servers dropped by server-list expiry are torn down, so a consumer that stops calling it stops reclaiming them.

## Summary by Sourcery

Document the blocking and lifecycle semantics of the fss_client public connection APIs.

Documentation:
- Clarify that connectTo performs a synchronous, configuration-time dial and that servers added this way never expire.
- Explain that attemptReconnect is a non-blocking, periodic maintenance pass that schedules dials, promotes successful connections on subsequent passes, and tears down servers dropped by server-list expiry.