### PR TITLE
Style fixups

### DIFF
--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -464,9 +464,9 @@ auto flight_safety_system::client_ssl::fss_client::getLearnedServerCount() const
 void flight_safety_system::client_ssl::fss_client::updateServers(
     const std::shared_ptr<flight_safety_system::transport::fss_message_server_list> &msg)
 {
-    /* Before docs/decisions/66-67-client-outbound-fanout.md
-     * this method only ever ADDED: there was no removal path
-     * anywhere in the file, so a server deactivated in config_serverconfig
+    /* Before docs/decisions/66-67-client-outbound-fanout.md this method only
+     * ever ADDED: there was no removal path anywhere in the file, so a server
+     * deactivated in config_serverconfig
      * dropped out of the broadcast list but every client that had ever seen it
      * kept it forever — and kept paying a blocking connect attempt for it every
      * backoff interval, silently. The list is now maintained: an entry present

--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -250,7 +250,8 @@ void flight_safety_system::client_ssl::fss_client::attemptReconnect()
      * harvest the servers whose queued reconnect has since succeeded and
      * schedule an attempt for the rest.
      *
-     * The dial itself runs on each server's own outbound worker (docs/decisions/66-67-client-outbound-fanout.md).
+     * The dial itself runs on each server's own outbound worker
+     * (docs/decisions/66-67-client-outbound-fanout.md).
      * Calling the blocking reconnect() here — a connect() plus a TLS
      * handshake, ~7 s for a host that drops SYNs and up to 10 s for one that
      * stalls the handshake — made this loop cost the SUM of every unreachable
@@ -301,8 +302,9 @@ void flight_safety_system::client_ssl::fss_client::attemptReconnect()
         }
     }
 
-    /* Phase (e): tear down anything updateServers() expired (docs/decisions/66-67-client-outbound-fanout.md). It
-     * removed them from both lists but could not disconnect them: it runs on a
+    /* Phase (e): tear down anything updateServers() expired
+     * (docs/decisions/66-67-client-outbound-fanout.md). It removed them from
+     * both lists but could not disconnect them: it runs on a
      * recv thread, and the expiring server can be the one the list arrived on,
      * so the join would be a self-join. Here we are on the thread that already
      * owns connection lifecycle, and the shared_ptr keeps each object alive

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -245,10 +245,9 @@ private:
     std::atomic<uint64_t> last_message_received_time{0};
     uint64_t server_timeout_ms{30000};
     /* Learned-server bookkeeping
-     * (docs/decisions/66-67-client-outbound-fanout.md). Owned by the
-     * fss_client, not by
-     * this object: both are read and written only under fss_client's
-     * servers_lock, or before the server has been published into either list.
+     * (docs/decisions/66-67-client-outbound-fanout.md). Owned by the fss_client
+     * rather than by this object: both are read and written only under
+     * fss_client's servers_lock, or before the server has been published.
      * `learned` is true only for a server discovered from a server-list
      * broadcast — a config-file or programmatic entry stays false and is
      * therefore never expired. */
@@ -264,10 +263,10 @@ private:
     std::mutex outbound_lock{};
     std::condition_variable outbound_cv{};
     bool outbound_stopping{false};
-    /* Reconnection is dispatched onto the same worker: reconnect()
-     * blocks for a connect() plus a TLS handshake, and doing that serially for
-     * every entry on the caller's thread delayed reconnection to a healthy
-     * server by the sum of every unreachable one's timeout.
+    /* Reconnection is dispatched onto the same worker: reconnect() blocks for a
+     * connect() plus a TLS handshake, and doing that serially for every entry
+     * on the caller's thread delayed reconnection to a healthy server by the
+     * sum of every unreachable one's timeout.
      * out_reconnect_pending is the queued flag; reconnect_busy stays set from
      * the moment one is queued until the worker has finished it, so a 1 Hz
      * attemptReconnect() cannot pile attempts up behind a 10 s handshake. */


### PR DESCRIPTION
## Summary by Sourcery

Clarify outbound fanout behaviour and thread-safety rationale in documentation and inline comments without changing runtime behaviour.

Enhancements:
- Improve inline comments in fss_client and fss_server around reconnection, learned-server bookkeeping, and server list updates for readability and cross-referencing.

Documentation:
- Expand the design decision document for client outbound fanout with rationale about worker/thread interaction, data-race avoidance, and ThreadSanitizer coverage.