### PR TITLE
build: instrument server-db.c in the test binary, and make the coverage link explicit

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -2,10 +2,16 @@ AUTOMAKE_OPTIONS = subdir-objects
 ACLOCAL_AMFLAGS = $(ACLOCAL_FLAGS)
 AM_CXXFLAGS = -pthread -fPIC -std=c++17 -I. -Werror -Wall -Wshadow -Wunused -Wnull-dereference -Wformat=2 -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wpedantic -Weffc++ -I$(top_srcdir)/src -include config.h
 
+# Nothing in examples/ is measured (AM_CXXFLAGS above carries no coverage
+# flags), so this is inert today. It is kept in step with tests/ and src/ so
+# that instrumenting examples/ later is a one-line change to AM_CXXFLAGS rather
+# than a two-line change someone half-makes.
+AM_LDFLAGS = $(CODE_COVERAGE_LDFLAGS)
+
 # Whole-tree ThreadSanitizer (empty unless --enable-tsan): the example binaries
 # link the instrumented libraries, so they must be built/linked with TSan too.
 AM_CXXFLAGS += $(TSAN_CXXFLAGS)
-AM_LDFLAGS = $(TSAN_LDFLAGS)
+AM_LDFLAGS += $(TSAN_LDFLAGS)
 
 bin_PROGRAMS =
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,10 +2,27 @@ AUTOMAKE_OPTIONS = subdir-objects
 ACLOCAL_AMFLAGS = $(ACLOCAL_FLAGS)
 AM_CXXFLAGS = -pthread -fPIC -std=c++17 -I. -Werror -Wall -Wshadow -Wunused -Wnull-dereference -Wformat=2 -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wpedantic -Weffc++ -I$(top_srcdir)/src -include config.h $(CODE_COVERAGE_CXXFLAGS)
 
+# The C leg, for the one C source in the test binary (../src/server-db.c).
+# all_test_CFLAGS below must expand this rather than replace it, or that
+# translation unit is compiled uninstrumented and produces no .gcda — which is
+# what happened until todo/72.
+AM_CFLAGS = $(CODE_COVERAGE_CFLAGS)
+
+# --coverage must reach the *link* as well as the compile: it is what pulls in
+# libgcov. It already does so today via AM_CXXFLAGS, which automake's C++ link
+# rule passes to the linker as well as the compiler — so this line changes
+# nothing about the current build. It is here because that route is incidental:
+# a per-target all_test_CXXFLAGS that did not expand $(AM_CXXFLAGS) would
+# silently drop coverage from both the compile and the link at once (the
+# pattern concurrency_tsan_test_CXXFLAGS below already uses). AM_LDFLAGS is an
+# independent channel, and mirrors src/Makefile.am: assign coverage, then
+# append TSan.
+AM_LDFLAGS = $(CODE_COVERAGE_LDFLAGS)
+
 # Whole-tree ThreadSanitizer (empty unless --enable-tsan): instrument the test
 # objects and link all_test against the (also-instrumented) libraries with TSan.
 AM_CXXFLAGS += $(TSAN_CXXFLAGS)
-AM_LDFLAGS = $(TSAN_LDFLAGS)
+AM_LDFLAGS += $(TSAN_LDFLAGS)
 
 # EXTRA_DIST must stay outside every conditional: automake only distributes
 # conditional EXTRA_DIST entries when the condition was true in the tree that
@@ -62,7 +79,7 @@ nodist_all_test_SOURCES = ../src/server-db.c
 # Header search path belongs at the preprocessor layer so it applies to both
 # the C (server-db.c) and C++ sources, independent of CFLAGS/CXXFLAGS.
 all_test_CPPFLAGS = -I$(top_srcdir)/src
-all_test_CFLAGS = $(ECPG_CFLAGS)
+all_test_CFLAGS = $(AM_CFLAGS) $(ECPG_CFLAGS)
 all_test_LDADD = ../src/libfss-transport.la ../src/libfss-client-ssl.la ../src/libfss.la $(JSONCPP_LIBS) $(ECPG_LIBS)
 
 all_test_SOURCES += connection-ssl.cpp


### PR DESCRIPTION
## Description

todo/72 item A, with a correction to its diagnosis.

The item claimed all_test was compiled with --coverage but linked without it, surviving only because libgcov symbols leak out of the coverage-linked libfss*.so. Measured on an --enable-coverage build, that is not what happens: automake's C++ link rule passes AM_CXXFLAGS to the linker as well as the compiler, and tests/Makefile.am:3 already carries CODE_COVERAGE_CXXFLAGS, so --coverage was on the link line all along. The item's negative case (drop CODE_COVERAGE_LDFLAGS from src/Makefile.am, expect a link failure) does not fail, for the same reason on the library side.

There was a real hole, one the item missed. all_test_CFLAGS assigned $(ECPG_CFLAGS), replacing AM_CFLAGS rather than expanding it, and tests/ defined no AM_CFLAGS at all. ../src/server-db.c — one of the four translation units the item's own acceptance criteria name — was compiled without --coverage and produced no .gcda. src/Makefile.am:63 has had the correct "fss_server_CFLAGS = $(AM_CFLAGS) $(ECPG_CFLAGS)" form all along; the tests/ copy diverged. All five directly-compiled src/ units now emit .gcda.

The AM_LDFLAGS append in tests/ and examples/ is kept as documented defence, not as a fix: the AM_CXXFLAGS route is incidental, and a per-target all_test_CXXFLAGS that did not expand $(AM_CXXFLAGS) would drop coverage from the compile and the link at once.

## Summary by Sourcery

Ensure test and example binaries are correctly wired for code coverage while keeping ThreadSanitizer integration intact.

Enhancements:
- Instrument the C source used by the all_test binary with coverage flags so all relevant translation units emit coverage data.
- Make coverage linker flags explicit in tests and examples via AM_LDFLAGS, decoupling coverage from incidental CXXFLAGS propagation and preserving TSan flags by appending instead of overwriting.