### PR TITLE
docs: record the fss-web migration coupling (todo/73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **The server verifies the database schema at startup and refuses to run
+  without it** (todo/73,
+  `docs/decisions/73-startup-schema-verification.md`). The tables FSS reads and
+  writes belong to `fss-web`, a separate repository, and are created by its
+  Django migrations; nothing checked that the deployed database actually had
+  them. A deployment whose `fss-web` had not applied the migration carrying the
+  command-ack columns started cleanly, accepted every aircraft, and then severed
+  the entire fleet on the first command dispatch — permanently, because the
+  fail-safe cannot clear while the schema is still wrong. The server now
+  anti-joins every column its statements touch against `information_schema`
+  (plus the PostGIS extension) before the listener binds, and refuses to start
+  naming what is missing. A column merely declared wider than the host buffer it
+  is read into warns instead of refusing, so a benign widening migration cannot
+  itself cause an outage. There is no config key to skip the check.
+  **Deployments require `fss-web`'s `assets` migration 0008 or later**
+  (`dispatch_id`, `ack_state`, `ack_timestamp`, `ack_superseded_by` on
+  `assets_assetcommand`); this is now stated in the README and
+  `docs/release-checklist.md`. Provisioning the e2e schema from `fss-web`'s real
+  migrations, which would catch a breaking migration when it lands rather than
+  when it deploys, remains open.
 - A tracked design record under `docs/` (todo/54). The project's settled design
   decisions previously lived only in the gitignored `todo/` directory, which
   code comments, changelog entries and commit messages all cite by number — so

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The flight-safety-system server uses a [postgresql](https://www.postgresql.org/)
 
 The [web frontend](https://github.com/canterbury-air-patrol/flight-safety-system-web/) is a separate project and will need to be set up and connected to the database before the server is run.
 
+The tables belong to that project, and its migrations must be applied first. This release requires its `assets` migration **0008 or later**, which provides the command-acknowledgement columns (`dispatch_id`, `ack_state`, `ack_timestamp`, `ack_superseded_by`) on `assets_assetcommand`. The server checks the schema when it starts and refuses to run against a database that is missing anything it needs, naming what is absent — so an un-migrated database is a startup failure you can read, rather than a fleet-wide disconnection some minutes later. See [docs/decisions/73](docs/decisions/73-startup-schema-verification.md).
+
 Create a [server.json](examples/server.json) file with the correct port and database settings.
 
 Then start the server:

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@ several `todo/` items is filed under all of them (`34-45-47-…`).
 | [49 — the FMU command identifier is per-server](decisions/49-server-command-id-semantics.md) | Protocol |
 | [51 — optional trailing wire fields are prefix-closed](decisions/51-optional-trailing-field-rule.md) | Protocol |
 | [66/67 — the client fans out through per-server workers, and prunes what it learns](decisions/66-67-client-outbound-fanout.md) | Client library |
+| [73 — the server verifies the database schema at startup](decisions/73-startup-schema-verification.md) | Database seam |
 
 ## Citing a decision
 

--- a/docs/decisions/73-startup-schema-verification.md
+++ b/docs/decisions/73-startup-schema-verification.md
@@ -1,0 +1,121 @@
+# 73 — The server verifies the database schema at startup and refuses to run without it
+
+**Decided** 2026-07-28. Unreleased.
+
+## Context
+
+The tables FSS reads and writes are not FSS's. They belong to
+[fss-web](https://github.com/canterbury-air-patrol/flight-safety-system-web/), a
+separate repository, and are created by its Django migrations. The
+command-ack columns on `assets_assetcommand` — `dispatch_id`, `ack_state`,
+`ack_timestamp`, `ack_superseded_by` — exist because *this* project added the
+command-ack feature, so they arrived in an fss-web migration written for FSS's
+benefit.
+
+Nothing verified that the database FSS was pointed at actually had them, and the
+failure mode of finding out at runtime is the worst one in the tree:
+
+1. The server starts cleanly. Connecting proves nothing about the schema.
+2. Every aircraft connects and identifies. Telemetry writes touch none of the
+   ack columns, so the deployment looks healthy.
+3. The first command dispatch calls `recordCommandDispatch`, which throws
+   `database_error`.
+4. `db_write_queue` counts sustained write failures and the
+   [34/45/47 fail-safe](34-45-47-db-failsafe-latch.md) latches after ~5 s:
+   `disconnectAll()` plus the admission gate.
+5. **Every aircraft is severed and none can reconnect.** The condition never
+   clears, because the schema is still wrong. Per todo/68 the dispatch write
+   also recurs every 10 s per aircraft, so there is no quiet period in which the
+   mismatch stays latent.
+
+A missing migration in another repository therefore presented as a total,
+self-sustaining fleet outage, minutes after an apparently successful deploy.
+
+The e2e suite could not catch it: it provisions from `e2e/schema/001_init.sql`,
+a hand-written mirror of fss-web's migrations with nothing verifying the
+correspondence, so the suite passes against the schema FSS expects rather than
+the one that will be there.
+
+## Decision
+
+`db_schema_check()` runs once at startup, on the read connection, immediately
+after `isConnected()` and before the write queue exists or the listener binds.
+It anti-joins every column the statements in `server-db.pgc` read or write —
+listed in `required_columns[]` in that same file — against
+`information_schema.columns`, in one round-trip, and also checks that the
+PostGIS extension every position read and write depends on is installed. The
+server refuses to start if anything required is missing, naming it.
+
+All missing columns are logged before the refusal, so a single restart tells the
+operator the whole gap rather than the first item of several.
+
+`required_columns[]` is deliberately part of the statements above it: adding a
+column to a query means adding it to that list. This is a second thing that can
+drift, knowingly accepted, because it drifts *loudly* — the server stops
+starting, at deploy time, on a developer's machine, naming what is wrong. The
+positive case in `db_connection_test.cpp` fires the moment the list runs ahead
+of the schema the suite is provisioned with.
+
+### A missing column is fatal; a too-wide column is a warning
+
+Five columns are fetched into fixed C buffers (`assets_assetcommand.command`,
+`config_smmconfig.address`, `config_serverconfig.address`,
+`config_assetconfig.smm_login`, `config_assetconfig.smm_password`). ECPG fills
+such a buffer to capacity with no room for a terminator, so a value at or beyond
+the buffer size is truncated, and `server-db.pgc`'s truncation guards then drop
+the row — silently, from the caller's point of view.
+
+The check reports a column declared wide enough for that to happen, but only as
+a warning. Refusing to start over it would be the stricter reading of "exists
+with a compatible type", and it is the wrong trade: widening a `VARCHAR` is a
+routine fss-web migration that is harmless until something actually stores an
+over-long value, and turning it into a refusal would produce exactly the
+fleet-wide outage this check exists to prevent. A warning surfaces the drift
+without betting availability on it.
+
+### There is no way to skip the check
+
+Considered and rejected: an optional `verify_schema` key in `server.json`,
+defaulting true. A skip flag is set during an incident and never unset, which
+restores precisely the failure mode above with the added irony of a log line
+saying it was disabled on purpose. The check has no false positives to escape
+from — it asserts only that columns the server unconditionally uses exist.
+
+### A check that cannot be completed is also a refusal
+
+If the check query itself fails, or an allocation failure would have dropped a
+problem from the list, `error_out` is set and the server refuses. An incomplete
+check must never read as a clean one, and a database that has just connected but
+cannot be introspected is a broken deployment; the supervisor's restart is the
+right response.
+
+## What this does not close
+
+todo/73 offered three fixes; this is option 3, and it is the only one that
+protects a *production* deployment, which is where the risk actually lives.
+The other two remain **deferred, not rejected** — they close the different gap
+that the e2e schema is an unverified copy of another repo's migrations:
+
+1. **Provision e2e from fss-web's real migrations** (`manage.py migrate` against
+   the test Postgres, with `001_init.sql` kept as an offline fallback). Catches a
+   breaking migration on the day it lands rather than the day it deploys. Needs
+   an fss-web image and cross-repo CI access this repository does not have today.
+2. **Diff the e2e database against a checked-in `information_schema` dump** from
+   a migrated fss-web. No runtime dependency, but still a hand-maintained mirror
+   — one with a tripwire.
+
+Both need scheduling with whoever owns fss-web's CI. Until then the deployment
+coupling is stated in `docs/release-checklist.md` and the README rather than
+enforced by a test.
+
+## Verification
+
+- `tests/db_connection_test.cpp` — the check accepts the provisioned schema, and
+  refuses it with `ack_state` dropped (RAII-restored).
+- `e2e/test_schema_check.py` — the process-level half: with `ack_state` dropped,
+  `fss-server` exits non-zero, the log names the column, and no listener is left
+  behind.
+- Manually confirmed during implementation: the boundary is exact
+  (`VARCHAR(15)` against a 16-byte buffer warns not at all, `VARCHAR(32)` warns
+  and still starts), a dropped table reports each of its columns, and an empty
+  database reports the missing PostGIS extension followed by all 40 columns.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -53,7 +53,27 @@ Two build traps this step walks straight into:
   into its `.la`, and `make install` then writes to the previous prefix. Remove
   the `.la` files and `make` again before `make install`.
 
-## 2. Version numbers
+## 2. Check what the release requires of fss-web
+
+The database belongs to
+[fss-web](https://github.com/canterbury-air-patrol/flight-safety-system-web/),
+not to this project. A release that reads or writes a column fss-web has not
+migrated is not a degraded deployment — it severs the fleet on the first command
+and cannot recover, because the schema stays wrong
+(see [decision 73](decisions/73-startup-schema-verification.md)).
+
+**As of this release, FSS requires fss-web's `assets` migration 0008 or later**,
+which provides `dispatch_id`, `ack_state`, `ack_timestamp` and
+`ack_superseded_by` on `assets_assetcommand`. The server verifies this at
+startup and refuses to run against a database without them, so the failure is a
+restart rather than an outage — but the requirement still has to reach whoever
+does the deploy, in the release notes, ahead of it.
+
+If this release added or changed any column in `required_columns[]`
+(`src/server-db.pgc`), raise the minimum stated above, here and in the README's
+*Running the Server* section, and say so in `CHANGELOG.md`.
+
+## 3. Version numbers
 
 Bump, in this order, and keep them consistent:
 
@@ -64,7 +84,7 @@ Bump, in this order, and keep them consistent:
   and call out any soname change explicitly under a "consumers must rebuild"
   note
 
-## 3. Verify
+## 4. Verify
 
 - `./check-code.sh` — clean
 - `make check` — the full unit suite
@@ -76,7 +96,7 @@ Bump, in this order, and keep them consistent:
   so a header missing from the tarball fails here rather than at a user's site
 - the e2e suite (`make e2e-test`; requires Docker and Python)
 
-## 4. Tag and publish
+## 5. Tag and publish
 
 Tag on the `release/X.Y` branch. Fast-forward `master` to the tag.
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -54,13 +54,28 @@ make e2e-test
 time. If the server starts referencing a new column, this file needs a
 matching edit.
 
-The plan's **primary schema provisioning path** — running the `fss-web`
-Django container's `manage.py migrate` against the same Postgres — is not
-implemented here because `fss-web` is a separate repo. To switch over:
+**The deploy-time half of this is now covered by the server itself.** It
+verifies the schema at startup against `required_columns[]` in
+`src/server-db.pgc` and refuses to run against a database missing anything it
+needs, so a production deployment against an un-migrated `fss-web` fails
+visibly instead of severing the fleet on the first command
+(`test_schema_check.py`, and
+[docs/decisions/73](../docs/decisions/73-startup-schema-verification.md)).
+
+What remains open is the **test-time** gap: this file is still an unverified
+copy of another repository's migrations, so a breaking fss-web migration is
+caught on the day it is deployed rather than the day it lands. The plan's
+**primary schema provisioning path** — running the `fss-web` Django
+container's `manage.py migrate` against the same Postgres — is not implemented
+here because `fss-web` is a separate repo. To switch over:
 
 1. Add an `fss-web` fixture that runs `docker run --rm -e DB_HOST=... fss-web
    python manage.py migrate --noinput` against `pg_container`.
 2. Remove `schema/001_init.sql` (or keep as a fallback).
+
+That needs fss-web's CI owner; the fallback is a checked-in
+`information_schema` dump from a migrated fss-web database, diffed against the
+live e2e database by a test.
 
 ## Writing new tests
 


### PR DESCRIPTION
## Description

The database belongs to fss-web, not to this project, and nothing said so anywhere a release engineer would look. Decision 73 records why the startup check exists, why a missing column refuses but a too-wide one only warns, why there is no skip flag, and that provisioning the e2e schema from fss-web's real migrations is deferred rather than rejected.

The release checklist gains a numbered step rather than a footnote to the abidiff step: the minimum required migration has to be re-checked every release, not just this one, and the checklist now points at required_columns[] as the thing to diff when deciding whether to raise it.

e2e/README.md's "Schema drift" caveat is narrowed to what is still true. The deploy-time half is covered; the test-time half -- that 001_init.sql remains an unverified copy of another repository's migrations -- is not, and saying so plainly is the point of keeping the section.

## Summary by Sourcery

Document the startup schema verification decision and its operational impact, and update user-facing docs to record the fss-web migration dependency and release checklist step.

Documentation:
- Add a decision record describing server startup schema verification, failure modes, and rationale for treating missing vs too-wide columns differently.
- Document the required fss-web `assets` migration version and schema coupling in the main README and release checklist, including guidance for updating `required_columns[]` and changelog entries.
- Clarify e2e schema-drift documentation by distinguishing deploy-time schema checks from the remaining test-time gap and outlining future provisioning options.