### PR TITLE
test(session): pin the SMM cache against a failed read (todo/69)

### DIFF
--- a/tests/mock_database.hpp
+++ b/tests/mock_database.hpp
@@ -34,6 +34,9 @@ public:
      * DB read failure so tests can exercise the todo/60 split from a
      * genuinely unknown asset (which stays a 0 lookup miss). */
     bool asset_id_lookup_fail{false};
+    /* When set, getSmmSettings behaves as a failed read does today: it returns
+     * nullptr, indistinguishable from an asset with no settings row (todo/69). */
+    bool smm_read_fail{false};
 
     struct recorded_rtt {
         uint64_t asset_id;
@@ -203,6 +206,10 @@ public:
     auto getSmmSettings(uint64_t asset_id) -> std::shared_ptr<flight_safety_system::server::smm_settings> override
     {
         smm_reads++;
+        if (smm_read_fail)
+        {
+            return nullptr;
+        }
         auto it = smm.find(asset_id);
         return it == smm.end() ? nullptr : it->second;
     }

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -2631,6 +2631,41 @@ TEST_CASE("session: sendSMMSettings sends from cache without re-reading the data
     REQUIRE(find_sent<fss::transport::fss_message_smm_settings>(conn->sent) == nullptr);
 }
 
+TEST_CASE("session: a failed SMM read leaves the cached settings intact", "[!shouldfail][todo69]")
+{
+    /* Regression test for todo/69-getcommand-getsmm-inband-read-failure.md.
+     * getSmmSettings reports a read failure in-band, as the same nullptr an
+     * asset with no settings row produces, and refreshSmmSettings() writes it
+     * straight over the cache. So one transient failure on the poller thread
+     * wipes an aircraft's SMM settings until a later read succeeds, while the
+     * server-list path two lines away in server.cpp keeps its previous good
+     * cache — the discipline decision 24 exists to enforce.
+     *
+     * This asserts the correct behaviour and therefore fails until the fix
+     * lands; remove the [!shouldfail] tag then. */
+    fss_test::MockDatabase mock;
+    constexpr uint64_t asset_id = 21;
+    mock.asset_ids["craft"] = asset_id;
+    mock.smm[asset_id] = std::make_shared<fss::server::smm_settings>("https://smm.test", fss::secure_string{"u"},
+                                                                     fss::secure_string{"p"});
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+    REQUIRE(mock.smm_reads >= 1); /* identify primed the cache */
+
+    /* The settings row is still there; only the read fails. */
+    mock.smm_read_fail = true;
+    session->refreshSmmSettings();
+
+    conn->sent.clear();
+    session->sendSMMSettings();
+    REQUIRE(find_sent<fss::transport::fss_message_smm_settings>(conn->sent) != nullptr);
+}
+
 TEST_CASE("session: sendRTTRequest skips second request within retry interval")
 {
     /* When two RTT requests are enqueued consecutively (clock not advanced),


### PR DESCRIPTION
## Description

getSmmSettings reports a read failure in-band, as the same nullptr an asset with no settings row produces, and refreshSmmSettings() writes it straight over the cache. One transient failure on the poller thread therefore wipes an aircraft's SMM settings until a later read succeeds, while the server-list path two lines away in server.cpp keeps its previous good cache.

Tagged [!shouldfail][todo69] per the house rule: it asserts the correct behaviour, so it fails until the fix lands rather than turning CI red. MockDatabase grows smm_read_fail to model the failure as callers see it today, alongside the existing active_servers_fail / asset_id_lookup_fail.

## Summary by Sourcery

Add coverage for SMM settings cache behavior when SMM reads fail and extend the mock database to simulate SMM read failures.

Enhancements:
- Extend MockDatabase to support simulating SMM read failures in getSmmSettings via a new smm_read_fail flag.

Tests:
- Add a regression test asserting that failed SMM reads do not clear the cached SMM settings, currently marked as should-fail until the fix lands.