### PR TITLE
fix(session): keep a good SMM cache when the read comes back empty

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -775,6 +775,16 @@ void fss::server::fss_client::refreshSmmSettings()
     }
     auto smm = this->dbc->getSmmSettings(asset_id);
     std::scoped_lock guard(this->client_lock);
+    /* todo/69, interim: getSmmSettings still reports a read failure in-band, as
+     * the same nullptr an asset with no settings row produces, so the only way
+     * to stop a transient failure wiping a good cache is to refuse the
+     * overwrite entirely. That also holds a cache whose row was genuinely
+     * deleted, which is the lesser of the two wrongs until the seam reports
+     * failure by status and this guard becomes precise. */
+    if (smm == nullptr && this->cached_smm_settings != nullptr)
+    {
+        return;
+    }
     this->cached_smm_settings = std::move(smm);
 }
 

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -2622,16 +2622,18 @@ TEST_CASE("session: sendSMMSettings sends from cache without re-reading the data
     REQUIRE(find_sent<fss::transport::fss_message_smm_settings>(conn->sent) != nullptr);
     REQUIRE(mock.smm_reads == reads_after_identify);
 
-    /* refreshSmmSettings (poller path) re-reads: the entry is gone, so the
-     * cache empties and nothing further is sent. */
+    /* refreshSmmSettings (poller path) re-reads, and the entry is gone.
+     *
+     * todo/69, temporary: this used to assert the cache empties. The interim
+     * guard in refreshSmmSettings() cannot distinguish a deleted row from a
+     * failed read — both arrive as nullptr — so it holds the cache in both
+     * cases. Restored to the empties-the-cache assertion once getSmmSettings
+     * reports failure by status. The read itself must still happen. */
     session->refreshSmmSettings();
     REQUIRE(mock.smm_reads == reads_after_identify + 1);
-    conn->sent.clear();
-    session->sendSMMSettings();
-    REQUIRE(find_sent<fss::transport::fss_message_smm_settings>(conn->sent) == nullptr);
 }
 
-TEST_CASE("session: a failed SMM read leaves the cached settings intact", "[!shouldfail][todo69]")
+TEST_CASE("session: a failed SMM read leaves the cached settings intact")
 {
     /* Regression test for todo/69-getcommand-getsmm-inband-read-failure.md.
      * getSmmSettings reports a read failure in-band, as the same nullptr an
@@ -2639,10 +2641,7 @@ TEST_CASE("session: a failed SMM read leaves the cached settings intact", "[!sho
      * straight over the cache. So one transient failure on the poller thread
      * wipes an aircraft's SMM settings until a later read succeeds, while the
      * server-list path two lines away in server.cpp keeps its previous good
-     * cache — the discipline decision 24 exists to enforce.
-     *
-     * This asserts the correct behaviour and therefore fails until the fix
-     * lands; remove the [!shouldfail] tag then. */
+     * cache — the discipline decision 24 exists to enforce. */
     fss_test::MockDatabase mock;
     constexpr uint64_t asset_id = 21;
     mock.asset_ids["craft"] = asset_id;


### PR DESCRIPTION
## Description

refreshSmmSettings() assigned the read result straight over the cache, so a transient read failure — which surfaces as the same nullptr an asset with no settings row produces — wiped an aircraft's SMM settings until a later read succeeded. The server-list path in server.cpp keeps its previous good cache in exactly this situation; this brings the settings path in line.

Interim by construction: with the failure reported in-band there is no way to separate a deleted row from a failed read, so the guard holds the cache in both cases. That also suspends the "a refresh finding no row empties the cache" assertion, restored once getSmmSettings reports failure by status.

The todo/69 regression test now passes and loses its [!shouldfail] tag.

## Summary by Sourcery

Prevent transient SMM read failures from wiping previously cached settings in client sessions.

Bug Fixes:
- Guard SMM settings refresh to avoid overwriting a valid cache with a nullptr result from getSmmSettings.

Tests:
- Update SMM settings session tests to reflect the new cache-guard behaviour and re-enable the previously should-fail regression test.