### PR TITLE
feat(db): report read failure from the command and SMM reads (todo/69)

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -235,6 +235,7 @@ void flight_safety_system::server::db_connection::recordPosition(uint64_t asset_
 auto flight_safety_system::server::db_connection::getCommand(uint64_t asset_id) -> std::shared_ptr<asset_command>
 {
     std::shared_ptr<asset_command> res = nullptr;
+    int fetch_error = 0;
     {
         std::scoped_lock guard(this->read_lock);
         // Own the malloc'd C struct via RAII so it is freed on every exit
@@ -247,13 +248,20 @@ auto flight_safety_system::server::db_connection::getCommand(uint64_t asset_id) 
             }
         };
         std::unique_ptr<struct asset_command_s, decltype(cmd_deleter)> command(
-            db_asset_command_get(read_conn_name, asset_id), cmd_deleter);
+            db_asset_command_get(read_conn_name, asset_id, &fetch_error), cmd_deleter);
         if (command)
         {
             res = std::make_shared<asset_command>(command->dbid, command->timestamp, std::string(command->command),
                                                   command->latitude, command->longitude, command->altitude,
                                                   command->altitude_null == 0);
         }
+    }
+    /* Logged rather than returned for now: the caller still cannot tell this
+     * from "no pending command" until getCommand reports failure by status
+     * (todo/69). Called once per identify, so no throttling is needed. */
+    if (fetch_error != 0)
+    {
+        FSS_LOG_ERROR("db", "pending-command read failed for asset " << asset_id);
     }
     return res;
 }
@@ -308,6 +316,7 @@ auto flight_safety_system::server::db_connection::getCommands(const std::vector<
 auto flight_safety_system::server::db_connection::getSmmSettings(uint64_t asset_id) -> std::shared_ptr<smm_settings>
 {
     std::shared_ptr<smm_settings> res = nullptr;
+    int fetch_error = 0;
     {
         std::scoped_lock guard(this->read_lock);
         // Own the malloc'd C struct via RAII so it is freed -- and the
@@ -331,7 +340,7 @@ auto flight_safety_system::server::db_connection::getSmmSettings(uint64_t asset_
             }
         };
         std::unique_ptr<struct smm_settings_s, decltype(settings_deleter)> settings(
-            db_asset_smm_settings_get(read_conn_name, asset_id), settings_deleter);
+            db_asset_smm_settings_get(read_conn_name, asset_id, &fetch_error), settings_deleter);
         if (settings)
         {
             res = std::make_shared<smm_settings>(
@@ -339,6 +348,14 @@ auto flight_safety_system::server::db_connection::getSmmSettings(uint64_t asset_
                 flight_safety_system::secure_string(std::string_view(settings->username)),
                 flight_safety_system::secure_string(std::string_view(settings->password)));
         }
+    }
+    /* Logged rather than returned for now: the caller's interim guard in
+     * refreshSmmSettings() has to hold the cache on any empty result because it
+     * cannot tell this from a deleted settings row (todo/69). Called at
+     * identify and on the 15 s poller refresh, so no throttling is needed. */
+    if (fetch_error != 0)
+    {
+        FSS_LOG_ERROR("db", "SMM settings read failed for asset " << asset_id);
     }
     return res;
 }

--- a/src/server-db.h
+++ b/src/server-db.h
@@ -92,7 +92,14 @@ struct asset_command_s {
     int altitude_null;
 };
 
-struct asset_command_s *db_asset_command_get(const char *conn, unsigned long long asset_id_arg);
+/* The asset's newest command row, or NULL when it has none. error_out (may be
+ * NULL) is set to 1 when the read itself failed -- a query error or an
+ * allocation failure -- so a read outage on the path that carries TERM and
+ * DISARM is never returned as "no pending command" (todo/69, the
+ * db_get_asset_id convention above). A row whose command string was truncated
+ * is reported as absent rather than as a failure: it is named on stderr and is
+ * undispatchable either way. */
+struct asset_command_s *db_asset_command_get(const char *conn, unsigned long long asset_id_arg, int *error_out);
 
 /* One newest-command row per asset, as returned by the batched read below.
  * Carries the same fields as asset_command_s plus the asset_id it belongs to,
@@ -139,7 +146,12 @@ struct smm_settings_s {
     char *password;
 };
 
-struct smm_settings_s *db_asset_smm_settings_get(const char *conn, unsigned long long asset_id_arg);
+/* The asset's SMM settings, or NULL when it has none configured. error_out (may
+ * be NULL) is set to 1 when the read itself failed -- a query error or an
+ * allocation failure -- so the caller can keep its cached settings instead of
+ * overwriting them with a failure (todo/69). Truncated credentials are reported
+ * as absent rather than as a failure, as in db_asset_command_get. */
+struct smm_settings_s *db_asset_smm_settings_get(const char *conn, unsigned long long asset_id_arg, int *error_out);
 
 struct fss_server_s {
     char *address;

--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -273,8 +273,13 @@ int db_command_record_ack(const char *conn_arg, unsigned long long asset_id_arg,
 }
 
 struct asset_command_s *
-db_asset_command_get(const char *conn_arg, unsigned long long asset_id_arg)
+db_asset_command_get(const char *conn_arg, unsigned long long asset_id_arg, int *error_out)
 {
+    if (error_out != NULL)
+    {
+        *error_out = 0;
+    }
+
     EXEC SQL BEGIN DECLARE SECTION;
     const char *conn = conn_arg;
     unsigned long long asset_id = asset_id_arg;
@@ -292,13 +297,33 @@ db_asset_command_get(const char *conn_arg, unsigned long long asset_id_arg)
 
     EXEC SQL AT :conn SELECT 1, AC.id, (extract(epoch from AC.timestamp) * 1000)::bigint, AC.command, ST_Y(AC.position::geometry), ST_X(AC.position::geometry), AC.altitude INTO :success, :id, :ts, :command, :lat :lat_ind, :lng :lng_ind, :alt :alt_ind FROM assets_assetcommand AS AC WHERE AC.asset_id = :asset_id ORDER BY AC.timestamp DESC LIMIT 1;
 
+    if (sqlca.sqlcode < 0)
+    {
+        /* The query itself failed (connection down, etc.). Without error_out
+         * that is indistinguishable from a NOT FOUND -- "this asset has no
+         * pending command" -- on the read that carries TERM and DISARM
+         * (todo/69), the same split db_get_asset_id makes. */
+        sqlprint();
+        if (error_out != NULL)
+        {
+            *error_out = 1;
+        }
+        return NULL;
+    }
+
     if (success == 1 && sqlca.sqlwarn[1] == 'W')
     {
         /* The command host variable was truncated (a DB command string longer
          * than COMMAND_LEN). A truncated command must not be dispatched: it
          * would silently become a different (or unknown) command. Treat the row
          * as absent and say why, mirroring the truncation guard in
-         * db_asset_smm_settings_get. */
+         * db_asset_smm_settings_get.
+         *
+         * Deliberately NOT an error_out failure, unlike the truncation guard in
+         * db_active_fss_servers_get: this is one identified row, named on
+         * stderr, and it is undispatchable whatever we report. Reporting a read
+         * failure would make the batched sibling blind the whole fleet's
+         * command polling on a single bad row until an operator fixed it. */
         fprintf(stderr, "command for asset %llu exceeds buffer size; ignoring row\n", asset_id);
         success = 0;
     }
@@ -307,25 +332,35 @@ db_asset_command_get(const char *conn_arg, unsigned long long asset_id_arg)
     if (success == 1)
     {
         res = malloc(sizeof(struct asset_command_s));
-        if (res != NULL)
+        if (res == NULL)
         {
-            res->command = strdup(command);
-            if (res->command == NULL)
+            /* Out of memory is not "no pending command" either. */
+            if (error_out != NULL)
             {
-                free(res);
-                return NULL;
+                *error_out = 1;
             }
-            res->dbid = id;
-            res->timestamp = ts;
-            /* A NULL position must not decode as (0,0) -- Null Island is a
-             * legal coordinate, so a GOTO built from it would dispatch.  Map
-             * NULL to NaN, which the dispatch layer's coordinate validation
-             * refuses.  Altitude has no NaN, so carry an explicit flag. */
-            res->latitude = (lat_ind < 0) ? NAN : lat;
-            res->longitude = (lng_ind < 0) ? NAN : lng;
-            res->altitude = alt;
-            res->altitude_null = (alt_ind < 0);
+            return NULL;
         }
+        res->command = strdup(command);
+        if (res->command == NULL)
+        {
+            free(res);
+            if (error_out != NULL)
+            {
+                *error_out = 1;
+            }
+            return NULL;
+        }
+        res->dbid = id;
+        res->timestamp = ts;
+        /* A NULL position must not decode as (0,0) -- Null Island is a
+         * legal coordinate, so a GOTO built from it would dispatch.  Map
+         * NULL to NaN, which the dispatch layer's coordinate validation
+         * refuses.  Altitude has no NaN, so carry an explicit flag. */
+        res->latitude = (lat_ind < 0) ? NAN : lat;
+        res->longitude = (lng_ind < 0) ? NAN : lng;
+        res->altitude = alt;
+        res->altitude_null = (alt_ind < 0);
     }
     return res;
 }
@@ -526,8 +561,13 @@ convert_to_http(const char *address, int port, bool https)
 }
 
 struct smm_settings_s *
-db_asset_smm_settings_get(const char *conn_arg, unsigned long long asset_id_arg)
+db_asset_smm_settings_get(const char *conn_arg, unsigned long long asset_id_arg, int *error_out)
 {
+    if (error_out != NULL)
+    {
+        *error_out = 0;
+    }
+
     EXEC SQL BEGIN DECLARE SECTION;
     const char *conn = conn_arg;
     unsigned long long asset_id = asset_id_arg;
@@ -542,11 +582,29 @@ db_asset_smm_settings_get(const char *conn_arg, unsigned long long asset_id_arg)
     EXEC SQL AT :conn SELECT 1, SMM.address, SMM.port, SMM.https, A.smm_login, A.smm_password INTO :success, :server_address, :server_port, :server_https, :smm_login, :smm_password FROM config_assetconfig AS A, config_smmconfig AS SMM WHERE A.asset_id = :asset_id AND A.smm_id = SMM.id;
 
 
-    if (success == 1 && sqlca.sqlwarn[1] == 'W')
+    /* Every exit below falls through to the credential wipe at the tail rather
+     * than returning early, so a failure path never leaves login/password bytes
+     * resident (todo/43). */
+    if (sqlca.sqlcode < 0)
+    {
+        /* The query itself failed. Reported by status because the caller caches
+         * this result: without the split, one transient failure is read as
+         * "this asset has no SMM settings" and overwrites a good cache
+         * (todo/69). */
+        sqlprint();
+        if (error_out != NULL)
+        {
+            *error_out = 1;
+        }
+        success = 0;
+    }
+    else if (success == 1 && sqlca.sqlwarn[1] == 'W')
     {
         /* A host variable was truncated (address/login/password longer than
          * its buffer). Truncated credentials must not be shipped to an
-         * aircraft; treat the row as absent and say why. */
+         * aircraft; treat the row as absent and say why. Not an error_out
+         * failure: the row is identified on stderr and is unusable whatever we
+         * report, matching db_asset_command_get's truncation guard. */
         fprintf(stderr, "smm settings for asset %llu exceed buffer sizes; ignoring row\n", asset_id);
         success = 0;
     }
@@ -555,7 +613,15 @@ db_asset_smm_settings_get(const char *conn_arg, unsigned long long asset_id_arg)
     if (success == 1)
     {
         settings = malloc(sizeof(struct smm_settings_s));
-        if (settings != NULL)
+        if (settings == NULL)
+        {
+            /* Out of memory is not "no settings for this asset" either. */
+            if (error_out != NULL)
+            {
+                *error_out = 1;
+            }
+        }
+        else
         {
             settings->address = convert_to_http(server_address, server_port, server_https);
             settings->username = strdup(smm_login);
@@ -569,6 +635,10 @@ db_asset_smm_settings_get(const char *conn_arg, unsigned long long asset_id_arg)
                 free(settings->password);
                 free(settings);
                 settings = NULL;
+                if (error_out != NULL)
+                {
+                    *error_out = 1;
+                }
             }
         }
     }


### PR DESCRIPTION
## Description

db_asset_command_get and db_asset_smm_settings_get had no error_out at all: a failed SELECT left success at 0 and returned NULL, the same answer as "this asset has no pending command" / "no settings configured". Both now clear error_out on entry and set it on a query error (sqlprint, as db_get_asset_id does) or an allocation failure.

Truncation deliberately stays a per-row absence rather than a read failure, unlike db_active_fss_servers_get: the row is identified on stderr and is undispatchable whatever we report, and failing the read there would let the batched sibling blind fleet-wide command polling on one bad row. Recorded in both header comments.

db_asset_smm_settings_get's new exits fall through to the existing explicit_bzero tail rather than returning early, so no failure path leaves credential bytes resident.

db.cpp consumes the flag and logs; no API change above it yet, so callers still cannot act on the distinction. That lands with the std::optional conversion.

## Summary by Sourcery

Report and log database read failures for asset commands and SMM settings instead of silently treating them as "no data" conditions.

Bug Fixes:
- Distinguish failed SELECTs and allocation errors from legitimate absence of pending commands or SMM settings in database accessors.

Enhancements:
- Extend db_asset_command_get and db_asset_smm_settings_get APIs with an error_out flag and document failure semantics and truncation handling.
- Plumb the new error_out signal through db_connection::getCommand and getSmmSettings and emit structured error logs when reads fail.