### PR TITLE
refactor(db): getSmmSettings reports read failure by status (todo/69)

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -774,18 +774,18 @@ void fss::server::fss_client::refreshSmmSettings()
         return;
     }
     auto smm = this->dbc->getSmmSettings(asset_id);
-    std::scoped_lock guard(this->client_lock);
-    /* todo/69, interim: getSmmSettings still reports a read failure in-band, as
-     * the same nullptr an asset with no settings row produces, so the only way
-     * to stop a transient failure wiping a good cache is to refuse the
-     * overwrite entirely. That also holds a cache whose row was genuinely
-     * deleted, which is the lesser of the two wrongs until the seam reports
-     * failure by status and this guard becomes precise. */
-    if (smm == nullptr && this->cached_smm_settings != nullptr)
+    /* nullopt is the read failing, not the asset having no settings: keep the
+     * previous good cache rather than wiping an aircraft's settings over a
+     * transient outage, the same discipline the server-list cache follows in
+     * server.cpp (todo/69). An engaged null pointer still clears the cache --
+     * that is a settings row genuinely gone. */
+    if (!smm.has_value())
     {
+        FSS_LOG_WARN("server", "SMM settings read failed for asset " << asset_id << "; keeping the cached settings");
         return;
     }
-    this->cached_smm_settings = std::move(smm);
+    std::scoped_lock guard(this->client_lock);
+    this->cached_smm_settings = std::move(*smm);
 }
 
 void fss::server::fss_client::sendSMMSettings()

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -313,7 +313,8 @@ auto flight_safety_system::server::db_connection::getCommands(const std::vector<
     return res;
 }
 
-auto flight_safety_system::server::db_connection::getSmmSettings(uint64_t asset_id) -> std::shared_ptr<smm_settings>
+auto flight_safety_system::server::db_connection::getSmmSettings(uint64_t asset_id)
+    -> std::optional<std::shared_ptr<smm_settings>>
 {
     std::shared_ptr<smm_settings> res = nullptr;
     int fetch_error = 0;
@@ -349,13 +350,13 @@ auto flight_safety_system::server::db_connection::getSmmSettings(uint64_t asset_
                 flight_safety_system::secure_string(std::string_view(settings->password)));
         }
     }
-    /* Logged rather than returned for now: the caller's interim guard in
-     * refreshSmmSettings() has to hold the cache on any empty result because it
-     * cannot tell this from a deleted settings row (todo/69). Called at
-     * identify and on the 15 s poller refresh, so no throttling is needed. */
+    /* nullopt tells the caller to keep whatever settings it already cached; a
+     * null pointer inside the optional is the genuinely-absent answer and does
+     * clear the cache (todo/69). */
     if (fetch_error != 0)
     {
         FSS_LOG_ERROR("db", "SMM settings read failed for asset " << asset_id);
+        return std::nullopt;
     }
     return res;
 }

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -138,7 +138,13 @@ public:
      * aircraft as "no servers". An explicit status, not an exception, so the
      * contract is visible at every call site (todo/24). */
     virtual auto getActiveServers() -> std::optional<std::vector<fss_server_details>> = 0;
-    virtual auto getSmmSettings(uint64_t asset_id) -> std::shared_ptr<smm_settings> = 0;
+    /* The asset's SMM settings, or nullopt when the read failed. nullopt is NOT
+     * "no settings": a null pointer inside the optional is the genuinely-absent
+     * answer, and only that one may overwrite a cached copy. Without the split,
+     * one transient failure on the poller thread wipes an aircraft's settings
+     * until a later read succeeds (todo/69, same convention as
+     * getActiveServers above). */
+    virtual auto getSmmSettings(uint64_t asset_id) -> std::optional<std::shared_ptr<smm_settings>> = 0;
     virtual auto isConnected() const -> bool = 0;
     virtual void tryReconnectIfNeeded() = 0;
 };
@@ -149,8 +155,8 @@ private:
      * block a command/config read. Each connection is guarded by its own
      * mutex and therefore only ever used by one thread at a time — the
      * thread-safe usage pattern ECPG documents. read_lock covers getAssetId,
-     * getCommand, getActiveServers and getSmmSettings; write_lock covers the
-     * record* telemetry inserts. */
+     * getCommand, getCommands, getActiveServers and getSmmSettings; write_lock
+     * covers the record* telemetry inserts. */
     std::mutex read_lock;
     std::mutex write_lock;
     /* Read without holding either mutex by isConnected(), and written from
@@ -190,7 +196,7 @@ public:
     auto getCommands(const std::vector<uint64_t> &asset_ids)
         -> std::unordered_map<uint64_t, std::shared_ptr<asset_command>> override;
     auto getActiveServers() -> std::optional<std::vector<fss_server_details>> override;
-    auto getSmmSettings(uint64_t asset_id) -> std::shared_ptr<smm_settings> override;
+    auto getSmmSettings(uint64_t asset_id) -> std::optional<std::shared_ptr<smm_settings>> override;
     auto isConnected() const -> bool override;
     void tryReconnectIfNeeded() override;
     /* Startup gate: checks the connected database carries every column

--- a/tests/concurrency_client_test.cpp
+++ b/tests/concurrency_client_test.cpp
@@ -122,8 +122,9 @@ public:
         /* An engaged empty vector: no servers configured, not a failed read. */
         return std::vector<flight_safety_system::server::fss_server_details>{};
     }
-    auto getSmmSettings(uint64_t) -> std::shared_ptr<flight_safety_system::server::smm_settings> override
+    auto getSmmSettings(uint64_t) -> std::optional<std::shared_ptr<flight_safety_system::server::smm_settings>> override
     {
+        /* An engaged null pointer: no settings configured, not a failed read. */
         return nullptr;
     }
     auto isConnected() const -> bool override { return true; }

--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -217,16 +217,21 @@ TEST_CASE("db_connection: getSmmSettings returns non-null for configured asset")
     LIVE_DB_OR_SKIP(dbc);
     auto asset_id = get_test_asset_id(*dbc);
     auto settings = dbc->getSmmSettings(asset_id);
-    REQUIRE(settings != nullptr);
-    REQUIRE_FALSE(settings->getAddress().empty());
-    REQUIRE(settings->getUsername() == "testuser");
-    REQUIRE_FALSE(settings->getPassword().empty());
+    REQUIRE(settings.has_value());
+    REQUIRE(*settings != nullptr);
+    REQUIRE_FALSE((*settings)->getAddress().empty());
+    REQUIRE((*settings)->getUsername() == "testuser");
+    REQUIRE_FALSE((*settings)->getPassword().empty());
 }
 
-TEST_CASE("db_connection: getSmmSettings returns null for asset with no config")
+TEST_CASE("db_connection: getSmmSettings returns an engaged null for asset with no config")
 {
+    /* A successful read finding no settings row: engaged, holding nullptr —
+     * distinct from the nullopt a failed read returns (todo/69). */
     LIVE_DB_OR_SKIP(dbc);
-    REQUIRE(dbc->getSmmSettings(uint64_t{999999}) == nullptr);
+    auto settings = dbc->getSmmSettings(uint64_t{999999});
+    REQUIRE(settings.has_value());
+    REQUIRE(*settings == nullptr);
 }
 
 TEST_CASE("db_connection: getActiveServers returns pre-configured server")

--- a/tests/mock_database.hpp
+++ b/tests/mock_database.hpp
@@ -34,8 +34,9 @@ public:
      * DB read failure so tests can exercise the todo/60 split from a
      * genuinely unknown asset (which stays a 0 lookup miss). */
     bool asset_id_lookup_fail{false};
-    /* When set, getSmmSettings behaves as a failed read does today: it returns
-     * nullptr, indistinguishable from an asset with no settings row (todo/69). */
+    /* When set, getSmmSettings returns nullopt, simulating a read failure so
+     * tests can exercise the todo/69 split from an asset that genuinely has no
+     * settings row (which stays a null pointer inside the optional). */
     bool smm_read_fail{false};
 
     struct recorded_rtt {
@@ -203,12 +204,13 @@ public:
         return active_servers;
     }
 
-    auto getSmmSettings(uint64_t asset_id) -> std::shared_ptr<flight_safety_system::server::smm_settings> override
+    auto getSmmSettings(uint64_t asset_id)
+        -> std::optional<std::shared_ptr<flight_safety_system::server::smm_settings>> override
     {
         smm_reads++;
         if (smm_read_fail)
         {
-            return nullptr;
+            return std::nullopt;
         }
         auto it = smm.find(asset_id);
         return it == smm.end() ? nullptr : it->second;

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -2622,15 +2622,15 @@ TEST_CASE("session: sendSMMSettings sends from cache without re-reading the data
     REQUIRE(find_sent<fss::transport::fss_message_smm_settings>(conn->sent) != nullptr);
     REQUIRE(mock.smm_reads == reads_after_identify);
 
-    /* refreshSmmSettings (poller path) re-reads, and the entry is gone.
-     *
-     * todo/69, temporary: this used to assert the cache empties. The interim
-     * guard in refreshSmmSettings() cannot distinguish a deleted row from a
-     * failed read — both arrive as nullptr — so it holds the cache in both
-     * cases. Restored to the empties-the-cache assertion once getSmmSettings
-     * reports failure by status. The read itself must still happen. */
+    /* refreshSmmSettings (poller path) re-reads: the entry is gone, so the
+     * cache empties and nothing further is sent. A successful read returning
+     * no row is distinct from a failed read, which keeps the cache — see
+     * "a failed SMM read leaves the cached settings intact" below (todo/69). */
     session->refreshSmmSettings();
     REQUIRE(mock.smm_reads == reads_after_identify + 1);
+    conn->sent.clear();
+    session->sendSMMSettings();
+    REQUIRE(find_sent<fss::transport::fss_message_smm_settings>(conn->sent) == nullptr);
 }
 
 TEST_CASE("session: a failed SMM read leaves the cached settings intact")


### PR DESCRIPTION
## Description

IDatabase::getSmmSettings now returns std::optional<std::shared_ptr<...>>: nullopt is the read having failed, an engaged null pointer is the asset genuinely having no settings row. Only the latter may clear a cached copy.

That makes refreshSmmSettings()'s guard precise. The interim version had to hold the cache on any empty result, which also held settings whose row had genuinely been deleted; it now keeps the cache on nullopt with a WARN and clears it on an engaged null, so "a refresh finding no row empties the cache" goes back to being asserted.

Same convention as getActiveServers, and the read_lock comment now lists getCommands, which it has been covering since todo/23.

## Summary by Sourcery

Differentiate SMM settings read failures from genuinely absent settings and align caching behavior and tests with the new optional-return contract.

Bug Fixes:
- Prevent transient SMM settings read failures from wiping valid cached settings by distinguishing failures from missing rows.

Enhancements:
- Change IDatabase::getSmmSettings to return an optional shared pointer, where nullopt signals a read failure and an engaged null indicates no settings configured.
- Update client session caching logic and logging to preserve or clear SMM settings cache based on the new optional semantics.
- Adjust db_connection, mock database, and stub database implementations to conform to the new getSmmSettings contract and document the distinction in comments.

Tests:
- Adapt and extend database, server session, and concurrency tests to cover the new getSmmSettings optional semantics and cache behavior on failures vs. missing settings.