### PR TITLE
refactor(db): getCommand reports read failure by status (todo/69)

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -1035,7 +1035,20 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                     return;
                 }
                 this->cached_asset_id.store(asset_id);
-                this->setPendingCommand(this->dbc->getCommand(asset_id));
+                /* nullopt is the read failing, not the asset having nothing
+                 * pending: leave pending_command alone and let the 100 ms
+                 * poller pick the command up, rather than recording "no
+                 * command waiting" on the strength of a failed read
+                 * (todo/69). */
+                if (auto pending = this->dbc->getCommand(asset_id))
+                {
+                    this->setPendingCommand(*pending);
+                }
+                else
+                {
+                    FSS_LOG_WARN("server", "Pending-command read failed during identify of asset_id "
+                                               << asset_id << "; the command poller will retry");
+                }
                 {
                     std::scoped_lock guard(this->client_lock);
                     this->name = std::move(client_name);

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -232,7 +232,8 @@ void flight_safety_system::server::db_connection::recordPosition(uint64_t asset_
     }
 }
 
-auto flight_safety_system::server::db_connection::getCommand(uint64_t asset_id) -> std::shared_ptr<asset_command>
+auto flight_safety_system::server::db_connection::getCommand(uint64_t asset_id)
+    -> std::optional<std::shared_ptr<asset_command>>
 {
     std::shared_ptr<asset_command> res = nullptr;
     int fetch_error = 0;
@@ -256,12 +257,13 @@ auto flight_safety_system::server::db_connection::getCommand(uint64_t asset_id) 
                                                   command->altitude_null == 0);
         }
     }
-    /* Logged rather than returned for now: the caller still cannot tell this
-     * from "no pending command" until getCommand reports failure by status
-     * (todo/69). Called once per identify, so no throttling is needed. */
+    /* nullopt tells the caller the read failed, so it must not treat this as
+     * "no pending command" and clear one it already holds (todo/69). Called
+     * once per identify, so no throttling is needed. */
     if (fetch_error != 0)
     {
         FSS_LOG_ERROR("db", "pending-command read failed for asset " << asset_id);
+        return std::nullopt;
     }
     return res;
 }

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -121,7 +121,13 @@ public:
      * fss_command_ack_outcome/fss_command_ack_reason ints. */
     virtual void recordCommandAck(uint64_t asset_id, uint64_t dispatch_id, uint8_t ack_state, uint64_t ack_timestamp,
                                   uint8_t ack_reason) = 0;
-    virtual auto getCommand(uint64_t asset_id) -> std::shared_ptr<asset_command> = 0;
+    /* The asset's newest pending command, or nullopt when the read failed.
+     * nullopt is NOT "no pending command": that is an engaged null pointer.
+     * The distinction matters most on this read — it carries TERM and DISARM,
+     * so a read outage reported as "nothing waiting" is the wrong failure
+     * direction (todo/69). A caller that cannot act on the failure should
+     * leave whatever pending command it already holds untouched. */
+    virtual auto getCommand(uint64_t asset_id) -> std::optional<std::shared_ptr<asset_command>> = 0;
     /* Batched getCommand: the newest command for each id in asset_ids, keyed by
      * asset_id. Assets with no pending command are simply absent from the map,
      * so callers treat "absent" exactly as getCommand's nullptr. Lets the
@@ -192,7 +198,7 @@ public:
     void recordCommandDispatch(uint64_t command_dbid, uint64_t dispatch_id) override;
     void recordCommandAck(uint64_t asset_id, uint64_t dispatch_id, uint8_t ack_state, uint64_t ack_timestamp,
                           uint8_t ack_reason) override;
-    auto getCommand(uint64_t asset_id) -> std::shared_ptr<asset_command> override;
+    auto getCommand(uint64_t asset_id) -> std::optional<std::shared_ptr<asset_command>> override;
     auto getCommands(const std::vector<uint64_t> &asset_ids)
         -> std::unordered_map<uint64_t, std::shared_ptr<asset_command>> override;
     auto getActiveServers() -> std::optional<std::vector<fss_server_details>> override;

--- a/tests/concurrency_client_test.cpp
+++ b/tests/concurrency_client_test.cpp
@@ -108,8 +108,9 @@ public:
     void recordSearchStatus(uint64_t, uint64_t, uint64_t, uint64_t) override {}
     void recordCommandDispatch(uint64_t, uint64_t) override {}
     void recordCommandAck(uint64_t, uint64_t, uint8_t, uint64_t, uint8_t) override {}
-    auto getCommand(uint64_t) -> std::shared_ptr<flight_safety_system::server::asset_command> override
+    auto getCommand(uint64_t) -> std::optional<std::shared_ptr<flight_safety_system::server::asset_command>> override
     {
+        /* An engaged null pointer: no pending command, not a failed read. */
         return nullptr;
     }
     auto getCommands(const std::vector<uint64_t> &)

--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -381,7 +381,8 @@ TEST_CASE("db_connection: getCommand returns non-null for asset with pending com
     LIVE_DB_OR_SKIP(dbc);
     auto asset_id = get_test_asset_id(*dbc);
     auto cmd = dbc->getCommand(asset_id);
-    REQUIRE(cmd != nullptr);
+    REQUIRE(cmd.has_value());
+    REQUIRE(*cmd != nullptr);
 }
 
 namespace {
@@ -481,9 +482,10 @@ TEST_CASE("db_connection: getCommands agrees with getCommand for the same asset"
 
     auto single = dbc->getCommand(asset_id);
     auto batch = dbc->getCommands({asset_id});
-    REQUIRE(single != nullptr);
+    REQUIRE(single.has_value());
+    REQUIRE(*single != nullptr);
     REQUIRE(batch.count(asset_id) == 1);
-    REQUIRE(batch.at(asset_id)->getDBId() == single->getDBId());
+    REQUIRE(batch.at(asset_id)->getDBId() == (*single)->getDBId());
 }
 
 TEST_CASE("db_connection: recordCommandDispatch stores the dispatch id")

--- a/tests/mock_database.hpp
+++ b/tests/mock_database.hpp
@@ -38,6 +38,9 @@ public:
      * tests can exercise the todo/69 split from an asset that genuinely has no
      * settings row (which stays a null pointer inside the optional). */
     bool smm_read_fail{false};
+    /* Same, for getCommand and the batched getCommands: nullopt is a failed
+     * read, distinct from an asset with no pending command (todo/69). */
+    bool command_read_fail{false};
 
     struct recorded_rtt {
         uint64_t asset_id;
@@ -160,8 +163,13 @@ public:
         return acks;
     }
 
-    auto getCommand(uint64_t asset_id) -> std::shared_ptr<flight_safety_system::server::asset_command> override
+    auto getCommand(uint64_t asset_id)
+        -> std::optional<std::shared_ptr<flight_safety_system::server::asset_command>> override
     {
+        if (command_read_fail)
+        {
+            return std::nullopt;
+        }
         auto it = commands.find(asset_id);
         if (it == commands.end() || it->second.empty())
         {
@@ -187,9 +195,10 @@ public:
         std::unordered_map<uint64_t, std::shared_ptr<flight_safety_system::server::asset_command>> res;
         for (uint64_t asset_id : ids)
         {
-            if (auto cmd = getCommand(asset_id))
+            auto cmd = getCommand(asset_id);
+            if (cmd.has_value() && *cmd != nullptr)
             {
-                res[asset_id] = std::move(cmd);
+                res[asset_id] = std::move(*cmd);
             }
         }
         return res;


### PR DESCRIPTION
## Description

IDatabase::getCommand now returns std::optional<std::shared_ptr<...>>, with nullopt meaning the read failed and an engaged null pointer meaning the asset genuinely has nothing pending. This is the read that carries TERM and DISARM, so a read outage arriving as "nothing waiting" was the wrong failure direction.

The identify path no longer calls setPendingCommand(nullptr) on a failed read: it warns and leaves pending_command alone, letting the 100 ms poller pick the command up. The shape mirrors the server-list handling a few lines below it.

MockDatabase grows command_read_fail. Its getCommands still unwraps getCommand per asset, so the batched read keeps its current envelope until the next commit converts it.

## Summary by Sourcery

Differentiate command-read failures from assets with no pending command, and adjust client and database handling accordingly.

Bug Fixes:
- Ensure failed pending-command reads during asset identification do not incorrectly clear existing pending commands.
- Report database command-read failures via an optional return status instead of conflating them with "no pending command" results.

Enhancements:
- Change IDatabase::getCommand to return an optional shared pointer, making the distinction between read failures and genuine absence of commands explicit.
- Update batched getCommands and related mock/stub implementations to preserve the new semantics while continuing to omit assets that truly have no pending command.

Tests:
- Adapt db_connection and concurrency client tests to the new optional-return contract for getCommand, including coverage for the updated batched getCommands behavior.