### PR TITLE
refactor(db): getCommands discards a partial batch (todo/69)

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -269,7 +269,7 @@ auto flight_safety_system::server::db_connection::getCommand(uint64_t asset_id)
 }
 
 auto flight_safety_system::server::db_connection::getCommands(const std::vector<uint64_t> &asset_ids)
-    -> std::unordered_map<uint64_t, std::shared_ptr<asset_command>>
+    -> std::optional<std::unordered_map<uint64_t, std::shared_ptr<asset_command>>>
 {
     std::unordered_map<uint64_t, std::shared_ptr<asset_command>> res;
     if (asset_ids.empty())
@@ -303,14 +303,15 @@ auto flight_safety_system::server::db_connection::getCommands(const std::vector<
         db_free_asset_commands(rows);
     }
     /* A mid-cursor failure leaves res holding only the assets read before the
-     * error; the rest are absent (treated as "no pending command"). This is the
-     * same outcome the per-asset getCommand path already produces when the read
-     * connection is down — both serialise on the one read connection, so a drop
-     * fails them all — so the poller's next tick simply retries. No discard. */
+     * error. Discard it: in a partial map an absent asset cannot be told from
+     * one that was never read, so a caller acting on it would clear pending
+     * commands it merely failed to read. nullopt tells the poller to leave
+     * every client's pending command alone and retry next tick (todo/69). */
     if (fetch_error != 0)
     {
-        FSS_LOG_ERROR("db",
-                      "batched command read failed mid-cursor; " << res.size() << " asset(s) read before the error");
+        FSS_LOG_ERROR("db", "batched command read failed mid-cursor; partial result discarded ("
+                                << res.size() << " asset(s) read before the error)");
+        return std::nullopt;
     }
     return res;
 }

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -130,13 +130,17 @@ public:
     virtual auto getCommand(uint64_t asset_id) -> std::optional<std::shared_ptr<asset_command>> = 0;
     /* Batched getCommand: the newest command for each id in asset_ids, keyed by
      * asset_id. Assets with no pending command are simply absent from the map,
-     * so callers treat "absent" exactly as getCommand's nullptr. Lets the
-     * command poller issue one query per tick instead of one per client
-     * (todo/23). A mid-read error yields a partial map — the same envelope as
-     * getCommand returning nullptr per asset when the read connection is down,
-     * since both share the one read connection. */
+     * so callers treat "absent" exactly as getCommand's engaged nullptr. Lets
+     * the command poller issue one query per tick instead of one per client
+     * (todo/23).
+     *
+     * nullopt means the read was cut short, and the partial map is discarded
+     * rather than returned: in a partial map "absent" cannot be told from "not
+     * read", which is precisely the confusion this convention exists to
+     * prevent, so the caller must leave every pending command it holds alone
+     * and wait for the next tick (todo/69). */
     virtual auto getCommands(const std::vector<uint64_t> &asset_ids)
-        -> std::unordered_map<uint64_t, std::shared_ptr<asset_command>> = 0;
+        -> std::optional<std::unordered_map<uint64_t, std::shared_ptr<asset_command>>> = 0;
     /* The complete set of active servers, or nullopt when the read was cut
      * short (mid-cursor error, truncated row) and could only produce a
      * partial, misleading list. nullopt is NOT an empty list: the caller must
@@ -200,7 +204,7 @@ public:
                           uint8_t ack_reason) override;
     auto getCommand(uint64_t asset_id) -> std::optional<std::shared_ptr<asset_command>> override;
     auto getCommands(const std::vector<uint64_t> &asset_ids)
-        -> std::unordered_map<uint64_t, std::shared_ptr<asset_command>> override;
+        -> std::optional<std::unordered_map<uint64_t, std::shared_ptr<asset_command>>> override;
     auto getActiveServers() -> std::optional<std::vector<fss_server_details>> override;
     auto getSmmSettings(uint64_t asset_id) -> std::optional<std::shared_ptr<smm_settings>> override;
     auto isConnected() const -> bool override;

--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -160,14 +160,22 @@ public:
         /* One query for the whole fleet's newest-command-per-asset instead of a
          * getCommand round-trip per client (todo/23): 10*N reads/sec collapse to
          * 10/sec. An asset absent from the map has no pending command -- the same
-         * as getCommand returning nullptr -- so clear it, preserving the prior
-         * per-client behaviour exactly (the resend-window dedup in sendCommand
-         * still governs what actually reaches the aircraft). */
+         * as getCommand returning an engaged nullptr -- so clear it, preserving
+         * the prior per-client behaviour exactly (the resend-window dedup in
+         * sendCommand still governs what actually reaches the aircraft). */
         auto commands = dbc->getCommands(asset_ids);
+        /* nullopt is the read failing, in which case "absent from the map" means
+         * "not read", not "no command". Leave every client's pending command as
+         * it stands and retry on the next 100 ms tick rather than clearing the
+         * fleet's commands on the strength of a failed read (todo/69). */
+        if (!commands.has_value())
+        {
+            return;
+        }
         for (const auto &[client, asset_id] : identified)
         {
-            auto found = commands.find(asset_id);
-            client->setPendingCommand(found != commands.end() ? found->second : nullptr);
+            auto found = commands->find(asset_id);
+            client->setPendingCommand(found != commands->end() ? found->second : nullptr);
         }
     };
     void sendCommand()

--- a/tests/concurrency_client_test.cpp
+++ b/tests/concurrency_client_test.cpp
@@ -113,10 +113,11 @@ public:
         /* An engaged null pointer: no pending command, not a failed read. */
         return nullptr;
     }
-    auto getCommands(const std::vector<uint64_t> &)
-        -> std::unordered_map<uint64_t, std::shared_ptr<flight_safety_system::server::asset_command>> override
+    auto getCommands(const std::vector<uint64_t> &) -> std::optional<
+        std::unordered_map<uint64_t, std::shared_ptr<flight_safety_system::server::asset_command>>> override
     {
-        return {};
+        /* An engaged empty map: nobody has a pending command, not a failed read. */
+        return std::unordered_map<uint64_t, std::shared_ptr<flight_safety_system::server::asset_command>>{};
     }
     auto getActiveServers() -> std::optional<std::vector<flight_safety_system::server::fss_server_details>> override
     {

--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -55,7 +55,9 @@ TEST_CASE("db_connection: getCommands short-circuits empty input without a round
      * identified. */
     flight_safety_system::server::db_connection dbc(
         "db.invalid", 5432, "user", flight_safety_system::secure_string(std::string_view{"pass"}), "db");
-    REQUIRE(dbc.getCommands({}).empty());
+    auto commands = dbc.getCommands({});
+    REQUIRE(commands.has_value()); /* engaged and empty, not a failed read */
+    REQUIRE(commands->empty());
 }
 
 namespace {
@@ -466,9 +468,10 @@ TEST_CASE("db_connection: getCommands returns the newest command per asset and o
     constexpr uint64_t absent_asset = 999999999ULL; /* no such asset -> no command */
     auto commands = dbc->getCommands({asset_id, absent_asset});
 
-    REQUIRE(commands.count(asset_id) == 1);
-    REQUIRE(commands.at(asset_id)->getDBId() == newest_id);
-    REQUIRE(commands.count(absent_asset) == 0);
+    REQUIRE(commands.has_value());
+    REQUIRE(commands->count(asset_id) == 1);
+    REQUIRE(commands->at(asset_id)->getDBId() == newest_id);
+    REQUIRE(commands->count(absent_asset) == 0);
 }
 
 TEST_CASE("db_connection: getCommands agrees with getCommand for the same asset")
@@ -484,8 +487,9 @@ TEST_CASE("db_connection: getCommands agrees with getCommand for the same asset"
     auto batch = dbc->getCommands({asset_id});
     REQUIRE(single.has_value());
     REQUIRE(*single != nullptr);
-    REQUIRE(batch.count(asset_id) == 1);
-    REQUIRE(batch.at(asset_id)->getDBId() == (*single)->getDBId());
+    REQUIRE(batch.has_value());
+    REQUIRE(batch->count(asset_id) == 1);
+    REQUIRE(batch->at(asset_id)->getDBId() == (*single)->getDBId());
 }
 
 TEST_CASE("db_connection: recordCommandDispatch stores the dispatch id")

--- a/tests/mock_database.hpp
+++ b/tests/mock_database.hpp
@@ -186,9 +186,13 @@ public:
         return newest;
     }
 
-    auto getCommands(const std::vector<uint64_t> &ids)
-        -> std::unordered_map<uint64_t, std::shared_ptr<flight_safety_system::server::asset_command>> override
+    auto getCommands(const std::vector<uint64_t> &ids) -> std::optional<
+        std::unordered_map<uint64_t, std::shared_ptr<flight_safety_system::server::asset_command>>> override
     {
+        if (command_read_fail)
+        {
+            return std::nullopt;
+        }
         /* Reuse getCommand's newest-by-timestamp selection so batched and
          * single reads can never disagree; assets with no command are omitted,
          * matching the production "absent == nullptr" contract. */


### PR DESCRIPTION
## Description

IDatabase::getCommands now returns std::optional<unordered_map>. A mid-cursor failure previously returned the rows read before the error and logged the rest away; pollCommands() then cleared pending_command for every asset absent from that partial map, which includes every asset the read never reached.

In a partial map "absent" cannot be told from "not read", so the partial is discarded rather than returned — the same call getActiveServers makes. pollCommands() returns early on nullopt, leaving every client's pending command as it stands for the next 100 ms tick. The cost of discarding is one tick for the assets that were read; the cost of not discarding was clearing the fleet's commands on the strength of a failed read.

That closes the last of the four reads: no read now reports failure in-band.

## Summary by Sourcery

Refine batched command retrieval semantics so that partial database reads are treated as failures, propagating through the optional-return interface and causing pollers to leave existing pending commands untouched until a successful retry.

Bug Fixes:
- Prevent batched command polling from clearing pending commands when a mid-cursor database read fails by treating partial results as a failed read.

Enhancements:
- Change IDatabase::getCommands to return std::optional to distinguish successful empty results from failed reads and align semantics with getActiveServers.
- Adjust server client polling to no-op on failed batched reads, preserving existing pending commands until the next tick.
- Update mock and stub database implementations and associated tests to reflect the new optional-return contract and explicitly test empty vs failed read cases.

Tests:
- Extend unit tests for db_connection, mock database, and concurrency client to cover the new optional batched command interface and failure handling semantics.