### PR TITLE
test: cover the read-failure contract end to end (todo/69)

### DIFF
--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -145,6 +145,40 @@ TEST_CASE("db_connection: getAssetId returns nullopt when the read connection is
     REQUIRE_FALSE(dbc->getAssetId("test-asset").has_value());
 }
 
+TEST_CASE("db_connection: getCommand returns nullopt when the read connection is down (todo/69)")
+{
+    /* test-asset has a pending command, so an engaged result here would be a
+     * non-null one. With the read connection forced down the read cannot say
+     * anything: nullopt, never the engaged nullptr that means "nothing
+     * pending" — the caller must not clear a pending command over this. */
+    LIVE_DB_OR_SKIP(dbc);
+    auto asset_id = get_test_asset_id(*dbc);
+    db_disconnect(flight_safety_system::server::db_connection::read_conn_name);
+    REQUIRE_FALSE(dbc->getCommand(asset_id).has_value());
+}
+
+TEST_CASE("db_connection: getSmmSettings returns nullopt when the read connection is down (todo/69)")
+{
+    /* test-asset has SMM settings configured, so this is the case that used to
+     * wipe a good cache: the failure arrived as the same nullptr an asset with
+     * no settings row produces. */
+    LIVE_DB_OR_SKIP(dbc);
+    auto asset_id = get_test_asset_id(*dbc);
+    db_disconnect(flight_safety_system::server::db_connection::read_conn_name);
+    REQUIRE_FALSE(dbc->getSmmSettings(asset_id).has_value());
+}
+
+TEST_CASE("db_connection: getCommands returns nullopt when the read connection is down (todo/69)")
+{
+    /* The batched poll path. A partial map would be indistinguishable from
+     * "these assets have no pending command", so the read reports failure and
+     * the partial is discarded. */
+    LIVE_DB_OR_SKIP(dbc);
+    auto asset_id = get_test_asset_id(*dbc);
+    db_disconnect(flight_safety_system::server::db_connection::read_conn_name);
+    REQUIRE_FALSE(dbc->getCommands({asset_id}).has_value());
+}
+
 TEST_CASE("db_connection: recordRtt writes a row without error")
 {
     LIVE_DB_OR_SKIP(dbc);

--- a/tests/server_clients_test.cpp
+++ b/tests/server_clients_test.cpp
@@ -1163,3 +1163,44 @@ TEST_CASE("server_clients: pollCommands fans the batched read out to the owning 
     REQUIRE(count_sent<fss::transport::fss_message_asset_command>(conn1->sentSnapshot()) == 1);
     REQUIRE(count_sent<fss::transport::fss_message_asset_command>(conn2->sentSnapshot()) == 0);
 }
+
+TEST_CASE("server_clients: a failed batched read leaves pending commands intact (todo/69)")
+{
+    /* A read that fails reports nullopt, and every asset is then absent from
+     * nothing rather than absent from a partial map. pollCommands must leave
+     * each client's staged command alone and wait for the next tick, instead of
+     * clearing the fleet's pending commands on the strength of a failed read. */
+    server_clients sc;
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft1"] = 1;
+
+    auto conn1 = std::make_shared<FakeConnection>();
+    conn1->cert_names.push_back("craft1");
+    auto client1 = std::make_shared<fss::server::fss_client>(conn1, &mock, make_null_writer(), &sc);
+    client1->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft1"));
+    sc.clientConnected(client1);
+
+    mock.pushCommand(
+        1, std::make_shared<fss::server::asset_command>(uint64_t{100}, uint64_t{1000}, "RTL", 0.0, 0.0, uint32_t{0}));
+
+    /* A good poll stages the command. */
+    sc.pollCommands(&mock);
+
+    /* The read now fails. Before todo/69 this cleared the staged command,
+     * because an asset missing from a partial map was read as "no command". */
+    mock.command_read_fail = true;
+    sc.pollCommands(&mock);
+
+    client1->sendCommand();
+    REQUIRE(count_sent<fss::transport::fss_message_asset_command>(conn1->sentSnapshot()) == 1);
+
+    /* A recovered read that finds the command gone does clear it: an engaged
+     * map with the asset absent is the genuinely-no-command answer, and
+     * sendCommand() then has nothing staged to send. */
+    mock.command_read_fail = false;
+    mock.commands.clear();
+    sc.pollCommands(&mock);
+    const std::size_t sent_before = count_sent<fss::transport::fss_message_asset_command>(conn1->sentSnapshot());
+    client1->sendCommand();
+    REQUIRE(count_sent<fss::transport::fss_message_asset_command>(conn1->sentSnapshot()) == sent_before);
+}

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -495,6 +495,40 @@ TEST_CASE("session: getCommand returns newest-timestamp entry")
     REQUIRE(cmd->getTimeStamp() == 500);
 }
 
+TEST_CASE("session: a failed command read at identify dispatches nothing and keeps the client (todo/69)")
+{
+    /* The identify-time getCommand used to record nullptr — "no command
+     * waiting" — for a read that had actually failed, on the path that carries
+     * TERM and DISARM. A failed read must now dispatch nothing and leave
+     * pending_command untouched for the poller, without failing the identify:
+     * the client stays connected and identified. */
+    fss_test::MockDatabase mock;
+    constexpr uint64_t asset_id = 42;
+    mock.asset_ids["craft"] = asset_id;
+    mock.pushCommand(asset_id,
+                     std::make_shared<fss::server::asset_command>(/*dbid*/ 7, /*ts*/ 100, "RTL", 0.0, 0.0, 0));
+    mock.command_read_fail = true;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    REQUIRE(handler.disconnects == 0);
+    REQUIRE(find_sent<fss::transport::fss_message_asset_command>(conn->sent) == nullptr);
+    REQUIRE(mock.getDispatches().empty());
+
+    /* Nothing was staged, so a later successful read is what delivers it. */
+    mock.command_read_fail = false;
+    session->setPendingCommand(*mock.getCommand(asset_id));
+    session->sendCommand();
+    auto cmd = find_sent<fss::transport::fss_message_asset_command>(conn->sent);
+    REQUIRE(cmd != nullptr);
+    REQUIRE(cmd->getTimeStamp() == 100);
+}
+
 TEST_CASE("session: server list sent on identify contains seeded servers")
 {
     fss_test::MockDatabase mock;


### PR DESCRIPTION
## Description

Three live-DB cases force the read connection down and assert getCommand, getSmmSettings and getCommands each return nullopt, using the same db_disconnect(read_conn_name) harness the todo/60 test uses. They sit next to the positive cases, which now assert engaged-and-null explicitly, so the two answers are pinned apart rather than by omission.

server_clients: a batched read that fails leaves an already-staged command intact, and a recovered read that finds the command gone still clears it — the acceptance criterion, and the pair that distinguishes the two nulls.

server_session: a failed command read at identify dispatches nothing, records no dispatch write, and does not fail the identify; the command is delivered by the later successful read instead.

## Summary by Sourcery

Extend test coverage for command-read failure handling across database, client polling, and session identify flows.

Tests:
- Add server_clients test ensuring failed batched reads preserve staged commands and that recovered reads with no commands clear them.
- Add db_connection live-DB tests verifying getCommand, getSmmSettings, and getCommands return nullopt when the read connection is down.
- Add server_session test confirming failed identify-time command reads dispatch nothing, do not record dispatches, and keep the client connected until a later successful read delivers the command.