### PR TITLE
docs: record that the read-failure convention is now universal (todo/69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   where a mismatch falls.
 
 ### Fixed
+- **A database read failure is no longer reported as an empty result on the
+  command and SMM paths** (todo/69, extending
+  `docs/decisions/24-database-read-error-control-flow.md`). Two of the four
+  reads never adopted the convention that a read which could only produce a
+  partial or misleading result reports that by status. `getCommand` returned
+  `nullptr` for a failed `SELECT`, which the interface documents as "no pending
+  command" — on the read that carries `TERM` and `DISARM`, so a read outage
+  presented as "this aircraft has nothing waiting". `getSmmSettings` did the
+  same, and `refreshSmmSettings()` wrote that result straight over its cache, so
+  one transient failure on the poller thread wiped an aircraft's SMM settings
+  until a later read succeeded. `getCommands` (the batched poll) did report the
+  error and then discarded it, and `pollCommands()` cleared `pending_command`
+  for every asset absent from the partial map — including every asset the read
+  never reached. All three now return `std::optional`, where `nullopt` is the
+  read having failed and an engaged empty value is the genuinely-absent answer;
+  the callers keep their cached settings, leave pending commands untouched, and
+  retry on the next tick. A row whose command string or credentials were
+  truncated stays a per-row absence rather than a read failure: it is named on
+  stderr and is unusable either way, and failing the batched read there would
+  blind fleet-wide command polling on one bad row. No read now reports failure
+  in-band.
 - Connection teardown no longer closes the socket before the threads that
   might still use it are joined (todo/52). `disconnect()` used to shutdown
   *and* close the descriptor up front, then join the recv thread — so a

--- a/docs/decisions/24-database-read-error-control-flow.md
+++ b/docs/decisions/24-database-read-error-control-flow.md
@@ -28,6 +28,42 @@ production paths' observable behaviour is unchanged.
 The filing named two callers. There turned out to be three — the poller, identify
 on the recv thread, and both of those via `getServersListMsg`.
 
+## The convention is now universal (todo/69, 2026-07-29)
+
+When this was written it described two of the four reads. `getCommand` and
+`getSmmSettings` still had no `error_out` at all in the ECPG layer, so a failed
+`SELECT` returned `NULL` — the same answer as "no pending command" / "no
+settings configured". `getCommands` had `error_out` and discarded it. All four
+now report by status:
+
+| Read | `nullopt` | Engaged |
+|---|---|---|
+| `getAssetId` | lookup failed | `0` = no such asset |
+| `getCommand` | read failed | `nullptr` = nothing pending |
+| `getCommands` | read cut short, partial discarded | map; absent = nothing pending |
+| `getSmmSettings` | read failed | `nullptr` = no settings row |
+| `getActiveServers` | read cut short | vector; empty = no servers |
+
+And the callers honour it: `refreshSmmSettings()` keeps its cached settings on
+`nullopt` (an engaged `nullptr` still clears them, which is a settings row
+genuinely deleted); the identify path leaves `pending_command` alone and lets
+the 100 ms poller retry; `pollCommands()` returns early rather than clearing the
+fleet's pending commands.
+
+**`getCommands` discards its partial rather than returning it.** In a partial
+map, an absent asset cannot be told from one the cursor never reached — the
+exact confusion this decision exists to prevent, reintroduced one level up. The
+cost is one 100 ms tick for the assets that *were* read.
+
+**Truncation is not a read failure here**, deliberately differing from
+`db_active_fss_servers_get` (see Related below). A truncated command string or
+credential is one identified row, named on stderr, and undispatchable whatever
+we report; a truncated address silently *drops* a server from a list with no
+per-row report, which is why that one fails the read. The asymmetry also
+matters operationally: a permanently-truncated command row that failed the
+batched read would blind fleet-wide command polling until an operator fixed
+that row.
+
 ## `database_error` stays, for writes
 
 The [34/45/47](34-45-47-db-failsafe-latch.md) write wrappers still throw


### PR DESCRIPTION
## Description

Decision 24 read as though every database read already reported failure by status; two of the four did not. It now carries the full table of what nullopt and an engaged value mean per read, the callers that honour them, and the two judgement calls the conversion made: getCommands discards its partial batch (in a partial map "absent" and "not read" are the same thing), and truncation stays a per-row absence rather than a read failure, deliberately unlike db_active_fss_servers_get.

## Summary by Sourcery

Document the now-universal database read-failure convention and its impact on command and SMM polling semantics.

Bug Fixes:
- Clarify that command and SMM database read failures are reported out-of-band by status instead of being indistinguishable from empty results, ensuring pending commands and cached settings are preserved across transient read outages.

Documentation:
- Extend the database read error control-flow decision record with a complete table of read outcomes, caller behaviours, and the rationale for treating truncation as per-row absence rather than read failure.
- Update the changelog to describe the corrected handling of command and SMM read failures and the adoption of the universal status-based reporting convention.