### PR TITLE
build: give ecpg an absolute input path so coverage merges (todo/11)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,8 +47,20 @@ libfss_client_ssl_la_LIBADD = $(GNUTLS_LIBS) $(JSONCPP_LIBS) -L. libfss.la libfs
 include_HEADERS += fss-client-ssl.hpp
 pkgconfig_DATA += fss-client-ssl.pc
 
+# ecpg copies its input path verbatim into the #line directives of the generated
+# C, so the path must be absolute: server-db.c is compiled twice, once from src/
+# (fss-server) and once from tests/ (all_test, which lists ../src/server-db.c).
+# With a bare relative "server-db.pgc" each compile resolves it against its own
+# directory, so gcov attributes the two objects to src/server-db.pgc and
+# tests/server-db.pgc — the latter a path that does not exist. Coverage then
+# reports the file twice, never merges the two halves, and any filter that drops
+# tests/ discards the unit tests' share of it outright.
+#
+# $(<F) rather than a shell `basename` (no subshell) or GNU make's
+# $(notdir $<): the F-suffixed internal macros are POSIX, and no other
+# Makefile.am in the tree uses a GNU-only make function.
 .pgc.c:
-	ecpg -o $@ $< $(ECPGFLAGS)
+	ecpg -o $@ $(abs_srcdir)/$(<F) $(ECPGFLAGS)
 
 # server-db.c is generated from server-db.pgc, by either the server build or
 # the tests (when the server is disabled). Clean it unconditionally so it is


### PR DESCRIPTION
## Description

server-db.c is compiled twice — once from src/ into fss-server, once from tests/ into all_test (which lists ../src/server-db.c). ecpg copies its input path verbatim into the generated #line directives, and a bare relative "server-db.pgc" resolves against each compile's own directory, so gcov attributed the two objects to two different source files: src/server-db.pgc and tests/server-db.pgc, the latter a path that does not exist.

The consequences were all in the measurement rather than the binary. The file was reported twice, so its 414 lines were double-counted in any total; the two halves never merged, so a line covered only by the unit tests read as uncovered in the server's copy and vice versa; and CI's `lcov --remove ... '*/tests/*'` discarded the unit tests' half outright — which is why 544d42e's fix (compiling server-db.c instrumented at all) never showed up in the published number.

Passing $(abs_srcdir)/`basename $<` makes both compiles agree on one absolute path that exists, so the two objects merge into a single record and genhtml can render the source. No change to the compiled output.

## Summary by Sourcery

Build:
- Update the src Makefile ecpg rule to invoke ecpg with $(abs_srcdir)/`basename $<` instead of a relative input path to unify coverage attribution for server-db.pgc.