### PR TITLE
ci: publish the combined coverage number, captured correctly (todo/11)

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -84,9 +84,35 @@ jobs:
           .libs/all_test
 
   # ─── 3. Coverage collection and upload ───────────────────────────────────
+  #
+  # This job measures the *combined* number: the unit suite against a live
+  # database plus the e2e suite against the instrumented server. Both are
+  # needed for the figure to mean anything — without a database the 30
+  # live-DB unit cases skip (db.cpp reads 13 % instead of 96 %), and without
+  # e2e nothing exercises server.cpp at all.
+  #
+  # The e2e run is duplicated here rather than instrumenting job 5: that job
+  # is the gate, and gcov-instrumented binaries change the timing its resend
+  # windows and 120 s cap depend on. It is `continue-on-error` here for the
+  # same reason — a flake in the instrumented copy must not fail the pipeline
+  # or block the upload, because job 5 remains the real verdict.
   coverage:
     runs-on: ubuntu-latest
     needs: build-and-check
+
+    services:
+      postgres:
+        image: postgis/postgis:18-3.6-alpine
+        env:
+          POSTGRES_PASSWORD: e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
     steps:
     - uses: actions/checkout@v7
 
@@ -94,30 +120,76 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get install -y \
-          libjsoncpp-dev libecpg-dev catch2 libgnutls28-dev gnutls-bin lcov
+          libjsoncpp-dev libecpg-dev catch2 libgnutls28-dev gnutls-bin lcov \
+          postgresql-client python3-pip python3-venv
 
     - name: autogen
       run: ./autogen.sh
 
+    # --enable-server and --enable-fake-client are what the e2e step below
+    # needs; instrumenting them is also the only way server.cpp is measured.
     - name: configure with coverage
-      run: ./configure --enable-tests --enable-coverage
+      run: ./configure --enable-tests --enable-server --enable-fake-client --enable-coverage
 
     - name: make
       run: make -j$(nproc)
 
+    # Two databases: `unit` carries the schema plus the fixtures the live-DB
+    # unit cases expect, `e2e` is left empty for the suite's own migrated_db
+    # fixture to populate.
+    - name: Provision databases
+      env:
+        PGPASSWORD: e2e
+      run: |
+        psql -h 127.0.0.1 -U postgres -c 'CREATE DATABASE unit;'
+        psql -h 127.0.0.1 -U postgres -c 'CREATE DATABASE e2e;'
+        psql -h 127.0.0.1 -U postgres -d unit -f e2e/schema/001_init.sql
+        psql -h 127.0.0.1 -U postgres -d unit -f tests/db-fixtures.sql
+
     - name: make check
+      env:
+        TEST_DB_HOST: 127.0.0.1
+        TEST_DB_PORT: "5432"
+        TEST_DB_USER: postgres
+        TEST_DB_PASS: e2e
+        TEST_DB_NAME: unit
       run: make check
 
+    - name: Install Python deps
+      run: |
+        python3 -m venv e2e/.venv
+        e2e/.venv/bin/pip install -q -r e2e/requirements.txt
+
+    - name: Run E2E tests (instrumented)
+      continue-on-error: true
+      env:
+        PGHOST: 127.0.0.1
+        PGPORT: 5432
+        PGPASSWORD: e2e
+        FSS_E2E_EXTERNAL_DB: "host=127.0.0.1 port=5432 user=postgres password=e2e dbname=e2e"
+      run: |
+        cd e2e
+        .venv/bin/pytest -q --timeout=120
+
+    # Capture src/ *and* tests/: the inline bodies in src/*.hpp are attributed
+    # to whichever translation unit instantiated them, and for headers like
+    # server-failsafe.hpp that is only ever a test TU. Capturing src/ alone
+    # reported the whole db_failsafe class as unreachable while
+    # server_failsafe_test.cpp covered every line of it.
+    #
+    # The removal patterns therefore drop the test *sources* rather than the
+    # tests/ directory, so those header records survive the filter.
     - name: Capture coverage
       run: |
         lcov --capture \
              --directory src \
+             --directory tests \
              --output-file cov.info \
-             --ignore-errors mismatch,empty
+             --ignore-errors mismatch,empty,inconsistent
         lcov --remove cov.info \
-             '/usr/*' '*/tests/*' \
+             '/usr/*' '*/tests/*.cpp' '*/tests/*.hpp' \
              --output-file cov.info \
-             --ignore-errors unused
+             --ignore-errors unused,inconsistent
 
     - name: Upload to Codecov
       uses: codecov/codecov-action@v7

--- a/docker/db-unit-test-entrypoint.sh
+++ b/docker/db-unit-test-entrypoint.sh
@@ -5,6 +5,10 @@
 # expect to find, then runs the full test binary.  The Docker healthcheck
 # on the db service guarantees Postgres is accepting connections before
 # this script runs, so no additional wait loop is needed.
+#
+# The fixtures live in tests/db-fixtures.sql rather than inline here because
+# CI's coverage job seeds the same rows to run this suite against a service
+# container; two copies would drift.
 set -euo pipefail
 
 PGPASSWORD="${TEST_DB_PASS:-password}" psql \
@@ -12,32 +16,6 @@ PGPASSWORD="${TEST_DB_PASS:-password}" psql \
     -p "${TEST_DB_PORT:-5432}" \
     -U "${TEST_DB_USER:-postgres}" \
     -d "${TEST_DB_NAME:-postgres}" \
-    <<'SQL'
-INSERT INTO assets_asset (name) VALUES ('test-asset');
-
-INSERT INTO config_smmconfig (address, port, https)
-    VALUES ('smm.example.com', 80, false);
-
-INSERT INTO config_assetconfig (asset_id, smm_id, smm_login, smm_password)
-    SELECT a.id, s.id, 'testuser', 'testpass'
-    FROM   assets_asset a, config_smmconfig s
-    WHERE  a.name = 'test-asset';
-
-INSERT INTO config_serverconfig (address, client_port, active, name, config_port, https)
-    VALUES ('fss.example.com', 20202, true, 'test-server', 8090, false);
-
--- todo/41 fixture: an address of 255 two-byte UTF-8 characters (510 bytes)
--- fits VARCHAR(255) (which counts characters, not bytes) but overflows the
--- 256-byte ECPG host variable server_address is fetched into, triggering a
--- truncation warning. Seeded inactive so it is invisible to every other
--- getActiveServers() test; the todo/41 regression test flips it active for
--- the duration of that one test only.
-INSERT INTO config_serverconfig (address, client_port, active, name, config_port, https)
-    VALUES (repeat('é', 255), 20203, false, 'test-server-truncated', 8091, false);
-
--- A pending command for test-asset, so the getCommand DB test finds a row.
-INSERT INTO assets_assetcommand (asset_id, command)
-    SELECT a.id, 'RTL' FROM assets_asset a WHERE a.name = 'test-asset';
-SQL
+    -f /code/tests/db-fixtures.sql
 
 exec /code/tests/all_test "$@"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -29,7 +29,7 @@ AM_LDFLAGS += $(TSAN_LDFLAGS)
 # ran `make dist`, and the release tarball must carry these files regardless
 # of that tree's configure flags (tsan.supp was silently dropped from the
 # 1.2.0 tarball this way).
-EXTRA_DIST = test_helpers.hpp mock_database.hpp tsan.supp
+EXTRA_DIST = test_helpers.hpp mock_database.hpp tsan.supp db-fixtures.sql
 
 if ENABLE_TSAN
 # Under --enable-tsan the whole suite runs instrumented, so `make check` needs

--- a/tests/db-fixtures.sql
+++ b/tests/db-fixtures.sql
@@ -1,0 +1,34 @@
+-- Fixtures the live-database unit tests (db_connection_test.cpp) expect to
+-- find. Apply to a database that already carries e2e/schema/001_init.sql.
+--
+-- Kept in one file because two harnesses need exactly the same rows: the
+-- docker-compose db-unit-test runner (docker/db-unit-test-entrypoint.sh) and
+-- CI's coverage job, which runs the same suite against a service container so
+-- the published number includes the DB layer. Seeded once, before the suite;
+-- the tests that mutate these rows restore them.
+
+INSERT INTO assets_asset (name) VALUES ('test-asset');
+
+INSERT INTO config_smmconfig (address, port, https)
+    VALUES ('smm.example.com', 80, false);
+
+INSERT INTO config_assetconfig (asset_id, smm_id, smm_login, smm_password)
+    SELECT a.id, s.id, 'testuser', 'testpass'
+    FROM   assets_asset a, config_smmconfig s
+    WHERE  a.name = 'test-asset';
+
+INSERT INTO config_serverconfig (address, client_port, active, name, config_port, https)
+    VALUES ('fss.example.com', 20202, true, 'test-server', 8090, false);
+
+-- todo/41 fixture: an address of 255 two-byte UTF-8 characters (510 bytes)
+-- fits VARCHAR(255) (which counts characters, not bytes) but overflows the
+-- 256-byte ECPG host variable server_address is fetched into, triggering a
+-- truncation warning. Seeded inactive so it is invisible to every other
+-- getActiveServers() test; the todo/41 regression test flips it active for
+-- the duration of that one test only.
+INSERT INTO config_serverconfig (address, client_port, active, name, config_port, https)
+    VALUES (repeat('é', 255), 20203, false, 'test-server-truncated', 8091, false);
+
+-- A pending command for test-asset, so the getCommand DB test finds a row.
+INSERT INTO assets_assetcommand (asset_id, command)
+    SELECT a.id, 'RTL' FROM assets_asset a WHERE a.name = 'test-asset';


### PR DESCRIPTION
## Description

The coverage job measured the unit suite alone, with no database, and captured with `lcov --capture --directory src` followed by
`lcov --remove ... '*/tests/*'`. Three things were wrong with that, all found while re-baselining todo/coverage-to-95-percent.md:

- With no database the 30 live-DB unit cases skip, so db.cpp read 13 % covered where it is really 96 %.
- With no server run, server.cpp (269 lines) was absent from the measurement entirely, as was the whole ECPG layer once `*/tests/*` had removed it.
- Inline bodies in src/*.hpp are attributed to whichever translation unit instantiated them, and for some headers that is only ever a test TU. Capturing src/ alone reported server-failsafe.hpp as unreachable while server_failsafe_test.cpp covers all 36 of its lines, and fss-log.hpp as 17/49 rather than 51/59.

So the job now provisions two databases from the service container, seeds the live-DB fixtures, runs `make check` against them, runs the e2e suite against the instrumented server, and captures both src/ and tests/ while removing only the test *sources*. Measured locally, that moves the figure from 87.1 % (2832/3252) to 92.6 % (3764/4066) with no new tests.

The e2e run is duplicated here rather than instrumenting the e2e job: that job is the gate and gcov changes the timing its resend windows depend on. Here it is continue-on-error for the same reason — one instrumented run in two saw test_db_write_only_failure miss its recovery window — so a flake cannot fail the pipeline or block the upload.

The unit fixtures move to tests/db-fixtures.sql, shared with docker/db-unit-test-entrypoint.sh, so CI and the docker-compose runner cannot drift apart. Verified with
`docker compose -f docker-compose.db-unit-tests.yaml up --build`: 418 cases, 0 skipped, green.

## Summary by Sourcery

Measure and publish a more accurate combined coverage figure by running unit tests against a live database and instrumented end-to-end tests, and sharing DB fixtures between CI and the docker-based test runner.

Enhancements:
- Update coverage collection to capture both src and test translation units while filtering out only test source files so inline header code is correctly attributed.
- Configure the coverage build to include server and fake client binaries so server-side code participates in coverage measurements.

Build:
- Install additional CI dependencies (Postgres client and Python/venv tooling) required for database provisioning and running the e2e test suite.

CI:
- Extend the coverage workflow to start a Postgres service, provision unit and e2e databases, run make check against the live DB, execute instrumented e2e pytest, and upload the resulting combined coverage.

Tests:
- Centralize live-database test fixtures in tests/db-fixtures.sql and reuse them from both CI and the db-unit-test docker entrypoint to keep test setups aligned.