### PR TITLE
test: cover the transport decode arms and exception_guard's catch-all

### DIFF
--- a/tests/log_test.cpp
+++ b/tests/log_test.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "fss-log.hpp"
+#include "fss.hpp"
 #include "test_helpers.hpp"
 
 TEST_CASE("log: level filter suppresses lower-severity lines")
@@ -157,4 +158,47 @@ TEST_CASE("log: level_str returns expected tag for each level")
     REQUIRE(std::string(fss_log::detail::level_str(fss_log::level::Debug)) == "DEBUG");
     /* Unreachable in normal usage but exercises the default return path. */
     REQUIRE(std::string(fss_log::detail::level_str(static_cast<fss_log::level>(999))) == "?????");
+}
+
+TEST_CASE("log: exception_guard isolates a non-std::exception throw")
+{
+    /* The guard exists so one failed unit of work cannot tear down a loop that
+     * must keep running — the recv loop, the command poller, the main loop tick.
+     * Its std::exception arm is exercised by every in-tree thrower, but the
+     * catch-all arm is what stands between a stray `throw 42` (or a foreign
+     * library's own exception type) and a terminate() that takes the server with
+     * it, so it needs its own case. */
+    namespace fss_log = flight_safety_system::log;
+    flight_safety_system::exception_guard guard("test", "non-std throw");
+
+    fss_test::capture_cerr cap;
+    guard.run([]() -> void { throw 42; });
+
+    /* Reported as an exception, with a wording that says the type was unknown
+     * rather than pretending to have a what() string. */
+    auto out = cap.str();
+    REQUIRE(out.find("Exception in non-std throw") != std::string::npos);
+    REQUIRE(out.find("unknown exception") != std::string::npos);
+
+    /* And the guard is reusable afterwards: a later success logs the recovery,
+     * which is only reachable if the throw left the failure counter consistent. */
+    guard.run([]() -> void {});
+    REQUIRE(cap.str().find("recovered after 1 consecutive failure(s)") != std::string::npos);
+}
+
+TEST_CASE("clock: WallClock reports the real time of day")
+{
+    /* Every timekeeping class in the tree takes an injectable IClock, so the
+     * production implementations are the one part the unit suite never touches
+     * by accident. WallClock is what feeds every stored telemetry timestamp;
+     * that it returns a plausible epoch-millisecond value is worth one case. */
+    flight_safety_system::WallClock clock;
+    const uint64_t before = flight_safety_system::fss_current_timestamp();
+    const uint64_t now = clock.now_ms();
+
+    REQUIRE(now >= before);
+    /* Sanity-check the unit rather than the value: seconds would be ~1000x
+     * smaller and microseconds ~1000x larger than this window. */
+    REQUIRE(now > 1'700'000'000'000ULL);
+    REQUIRE(now < 4'000'000'000'000ULL);
 }

--- a/tests/messages.cpp
+++ b/tests/messages.cpp
@@ -1152,6 +1152,73 @@ TEST_CASE("messages: unknown command_ack reason degrades to supersede_none")
     REQUIRE(decoded->getReason() == flight_safety_system::transport::supersede_none);
 }
 
+TEST_CASE("messages: comms-loss supersede reason survives the round trip")
+{
+    auto msg_id = static_cast<uint64_t>(random());
+    auto acked_command_id = static_cast<uint64_t>(random());
+    auto timestamp = static_cast<uint64_t>(random());
+
+    /* The fourth supersede reason. It is the one the operator most needs told
+     * apart from the others: a comms-loss RTL means the FMU acted on its own
+     * because it lost the link, not that a battery latch or a newer command
+     * displaced what was asked for. Each reason has its own decode arm, so each
+     * needs its own round trip or a swapped arm would go unnoticed. */
+    auto msg = std::make_shared<flight_safety_system::transport::fss_message_command_ack>(
+        acked_command_id, flight_safety_system::transport::asset_command_rtl,
+        flight_safety_system::transport::command_ack_superseded, flight_safety_system::transport::supersede_comms_loss,
+        timestamp);
+    REQUIRE(msg->getReason() == flight_safety_system::transport::supersede_comms_loss);
+
+    msg->setId(msg_id);
+    auto bl = msg->getPacked();
+    REQUIRE(bl != nullptr);
+    auto decoded = std::make_shared<flight_safety_system::transport::fss_message_command_ack>(msg_id, bl);
+    REQUIRE(decoded->getAckedCommandId() == acked_command_id);
+    REQUIRE(decoded->getOutcome() == flight_safety_system::transport::command_ack_superseded);
+    REQUIRE(decoded->getReason() == flight_safety_system::transport::supersede_comms_loss);
+    REQUIRE(decoded->getTimeStamp() == timestamp);
+}
+
+TEST_CASE("messages: out-of-range capability ids are ignored, not shifted")
+{
+    /* The capability bitmap is a uint64_t, so a shift by 64 or more is undefined
+     * behaviour. Ids come off the wire and from callers, so both entry points
+     * bounds-check; this pins that they no-op rather than corrupting the bitmap
+     * (or, on the query side, reading a neighbouring bit). */
+    auto msg = std::make_shared<flight_safety_system::transport::fss_message_identity_non_aircraft>();
+    msg->addCapability(63); // the highest legal id
+    REQUIRE(msg->getCapability(63));
+
+    msg->addCapability(64);
+    msg->addCapability(255);
+    REQUIRE_FALSE(msg->getCapability(64));
+    REQUIRE_FALSE(msg->getCapability(255));
+    /* The legal bit is untouched by the rejected ones. */
+    REQUIRE(msg->getCapability(63));
+}
+
+TEST_CASE("messages: a string longer than the 16-bit length prefix is clamped")
+{
+    /* The on-wire length prefix is 16 bits. A longer string can only arrive from
+     * an upstream programming error, and the danger is not the loss of the tail:
+     * a prefix disagreeing with the bytes written desyncs the decoder for every
+     * later message on the connection. Pin that pack clamps both together. */
+    const size_t over = static_cast<size_t>(std::numeric_limits<uint16_t>::max()) + 100;
+    auto msg = std::make_shared<flight_safety_system::transport::fss_message_smm_settings>(
+        std::string(over, 'a'), flight_safety_system::secure_string{std::string_view{"user"}},
+        flight_safety_system::secure_string{std::string_view{"pass"}});
+    msg->setId(1);
+    auto bl = msg->getPacked();
+    REQUIRE(bl != nullptr);
+
+    /* The address field is packed first, immediately after the framed header:
+     * its big-endian length prefix must be the clamped 0xFFFF, not the
+     * truncated low 16 bits of the real length (which would have been 99). */
+    const char *prefix = bl->getData() + framed_header_len;
+    REQUIRE(static_cast<unsigned char>(prefix[0]) == 0xFF);
+    REQUIRE(static_cast<unsigned char>(prefix[1]) == 0xFF);
+}
+
 /* readUint32 failure (line 129): version message truncated after the two
  * uint16 version fields, so the uint32_t feature_flags read fails. */
 TEST_CASE("messages: BufferReader readUint32 short-read returns false")


### PR DESCRIPTION
## Description

First tranche of the re-baselined coverage ladder: gaps that need no new fixture. Each is a branch the suite could reach and did not.

- The comms-loss supersede reason had no round trip, though the other three did. Every reason has its own decode arm and the operator distinguishes an autonomous comms-loss RTL from a battery latch by exactly this field.
- addCapability/getCapability bounds-check their id because a shift of 64 or more is undefined behaviour, and ids arrive off the wire. Neither guard was exercised.
- packStringRaw clamps a string longer than its 16-bit length prefix. The hazard is not the lost tail: a prefix that disagrees with the bytes written desyncs the decoder for every later message on the connection, so the test asserts the emitted prefix is 0xFFFF rather than the truncated low bits.
- exception_guard's catch (...) arm stood between a stray non-std throw and a terminate() taking the server down, with no test on it; the std::exception arm is exercised by every in-tree thrower. The case also re-runs the guard afterwards, since the recovery log is only reachable if the catch-all left the failure counter consistent.
- WallClock::now_ms had no coverage at all: everything else in the tree takes an injectable IClock, so the production implementation that stamps stored telemetry timestamps was the one clock nothing touched.

## Summary by Sourcery

Extend test coverage for transport message edge cases, exception_guard’s catch-all behaviour, and the WallClock time source.

Tests:
- Add round-trip coverage for the comms-loss command acknowledgment supersede reason.
- Verify capability bitmap ignores out-of-range IDs rather than performing undefined shifts.
- Assert that oversized strings are clamped to the 16-bit on-wire length prefix to keep encoder/decoder in sync.
- Add a test ensuring exception_guard handles non-std exceptions and remains reusable after recovery.
- Add coverage for WallClock::now_ms returning plausible epoch-millisecond timestamps.