### PR TITLE
test: cover the queue-after-stop guards and two client config fields

### DIFF
--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -121,22 +121,52 @@ TEST_CASE("client: malformed JSON config leaves client unconfigured")
 TEST_CASE("client: config file skips server entries with invalid ports")
 {
     const char *tmppath = "/tmp/fss_test_client_bad_port.json";
+
+    /* read_json_tcp_port rejects on two independent grounds and both must skip
+     * the entry rather than coerce it: an out-of-range integer, and a value that
+     * is not an integer at all. The second is the likelier hand-editing mistake
+     * ("port": "9999") and was the untested one; jsoncpp would happily hand back
+     * 0 from asInt() on a string, which is a port the connect path cannot use. */
+    SECTION("port above the 16-bit range")
     {
-        std::ofstream f(tmppath);
-        f << R"({
-            "name": "test-asset",
-            "ssl": {
-                "ca_public_key": "ca.pem",
-                "client_private_key": "client.key",
-                "client_public_key": "client.pem"
-            },
-            "servers": [
-                {"address": "localhost", "port": 70000}
-            ]
-        })";
+        {
+            std::ofstream f(tmppath);
+            f << R"({
+                "name": "test-asset",
+                "ssl": {
+                    "ca_public_key": "ca.pem",
+                    "client_private_key": "client.key",
+                    "client_public_key": "client.pem"
+                },
+                "servers": [
+                    {"address": "localhost", "port": 70000}
+                ]
+            })";
+        }
+        fss::client_ssl::fss_client client(tmppath);
+        REQUIRE_FALSE(client.isConfigured());
     }
-    fss::client_ssl::fss_client client(tmppath);
-    REQUIRE_FALSE(client.isConfigured());
+
+    SECTION("port quoted as a string")
+    {
+        {
+            std::ofstream f(tmppath);
+            f << R"({
+                "name": "test-asset",
+                "ssl": {
+                    "ca_public_key": "ca.pem",
+                    "client_private_key": "client.key",
+                    "client_public_key": "client.pem"
+                },
+                "servers": [
+                    {"address": "localhost", "port": "9999"}
+                ]
+            })";
+        }
+        fss::client_ssl::fss_client client(tmppath);
+        REQUIRE_FALSE(client.isConfigured());
+    }
+
     std::remove(tmppath);
 }
 
@@ -380,6 +410,56 @@ TEST_CASE("client: JSON config tcp_user_timeout_ms sets the per-connection send 
         }
         fss::client_ssl::fss_client client(tmppath);
         REQUIRE(client.getTcpUserTimeoutMs() == fss::transport::default_tcp_user_timeout_ms);
+    }
+
+    std::remove(tmppath);
+}
+
+TEST_CASE("client: JSON config clock_offset_ms is exposed to the RTT reply path (todo/33)")
+{
+    /* The deliberate clock skew the e2e clock-skew harness relies on
+     * (test_clock_skew.py, TC-MAV-017) enters through this config field and
+     * leaves through getClockOffsetMs(), which is what stamps the RTT reply and
+     * every position report. The e2e suite pins the behaviour end to end but
+     * cannot say which of parse or accessor is wrong when it breaks; the accessor
+     * had no unit coverage at all. Negative values matter as much as positive —
+     * a client behind the server is the same defect in the other direction. */
+    const char *tmppath = "/tmp/fss_test_client_clock_offset.json";
+
+    SECTION("a positive offset round-trips")
+    {
+        {
+            std::ofstream f(tmppath);
+            f << R"({"name":"test-asset","clock_offset_ms":300000,)"
+              << R"("ssl":{"ca_public_key":"ca.pem","client_private_key":"key.pem","client_public_key":"cert.pem"},)"
+              << R"("servers":[{"address":"127.0.0.1","port":9999}]})";
+        }
+        fss::client_ssl::fss_client client(tmppath);
+        REQUIRE(client.getClockOffsetMs() == 300000);
+    }
+
+    SECTION("a negative offset round-trips")
+    {
+        {
+            std::ofstream f(tmppath);
+            f << R"({"name":"test-asset","clock_offset_ms":-300000,)"
+              << R"("ssl":{"ca_public_key":"ca.pem","client_private_key":"key.pem","client_public_key":"cert.pem"},)"
+              << R"("servers":[{"address":"127.0.0.1","port":9999}]})";
+        }
+        fss::client_ssl::fss_client client(tmppath);
+        REQUIRE(client.getClockOffsetMs() == -300000);
+    }
+
+    SECTION("absent field means no skew")
+    {
+        {
+            std::ofstream f(tmppath);
+            f << R"({"name":"test-asset",)"
+              << R"("ssl":{"ca_public_key":"ca.pem","client_private_key":"key.pem","client_public_key":"cert.pem"},)"
+              << R"("servers":[{"address":"127.0.0.1","port":9999}]})";
+        }
+        fss::client_ssl::fss_client client(tmppath);
+        REQUIRE(client.getClockOffsetMs() == 0);
     }
 
     std::remove(tmppath);

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -792,6 +792,49 @@ TEST_CASE("session: queueCommandSend dispatches a command on the outbound worker
     session->disconnect();
 }
 
+TEST_CASE("session: every queue* is a no-op once the writer has stopped")
+{
+    /* All five schedulers are called from threads that do not own the client's
+     * lifetime — the main loop, the command poller, another client's recv thread
+     * — so each races a disconnect by construction. Every one of them documents
+     * itself as a no-op once disconnecting, and each carries its own copy of the
+     * check; a missed one would either resurrect a stopped worker's flags or
+     * queue a frame nothing will ever drain. Pinned together so a sixth
+     * scheduler cannot be added without the guard. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+    session->activate();
+    session->disconnect(); /* stops and joins the outbound worker */
+
+    const auto sent_before = conn->sentSnapshot().size();
+
+    auto packed = std::make_shared<fss::transport::fss_message_rtt_request>();
+    packed->setId(1);
+    auto frame = packed->getPacked();
+    REQUIRE(frame != nullptr);
+
+    session->setPendingCommand(
+        std::make_shared<fss::server::asset_command>(/*dbid*/ 1, /*ts*/ 500, "RTL", 0.0, 0.0, 0));
+    session->queueCommandSend();
+    session->queueRTTRequest();
+    session->queueSMMSettings();
+    session->queueServerListBroadcast(frame);
+    session->queuePositionRelay(frame);
+
+    /* Nothing was sent, and in particular the dropped-relay counter did not
+     * move: a rejected relay is not a dropped one, and conflating them would
+     * make getPositionRelayDropped() report loss that never happened. */
+    REQUIRE(conn->sentSnapshot().size() == sent_before);
+    REQUIRE(session->getPositionRelayDropped() == 0);
+}
+
 TEST_CASE("session: a blocked client's writer does not stall command dispatch for another client")
 {
     /* todo/21 Done-when: a black-holed socket on one client must not delay


### PR DESCRIPTION
## Description

Second tranche commit, same rule: no new fixtures.

fss_client's five queue* schedulers are each called from a thread that does not own the client's lifetime — the main loop, the command poller, another client's recv thread — so each races a disconnect by construction, and each carries its own copy of the outbound_stopping check. None of those five early returns was covered. They are pinned together, so a sixth scheduler cannot be added without the guard, and the case also asserts a rejected position relay does not increment getPositionRelayDropped(): a refused relay is not a dropped one, and conflating them would report loss that never happened.

On the client side, clock_offset_ms's accessor had no unit coverage — the e2e clock-skew harness (TC-MAV-017) drives it end to end but cannot say whether parse or accessor is at fault when it breaks — and read_json_tcp_port's not-an-integer rejection was untested, though a quoted "port": "9999" is the likelier hand-editing mistake and jsoncpp's asInt() would hand back 0 for it.

Deliberately left out of this tranche: the two join()-threw-system_error detach paths (db-write-queue.cpp, client_session.cpp). Reaching them needs join() called from the worker thread itself, which leaves the queue holding a detached thread it can no longer join — so the object would be destroyed while that thread may still be running it. That is a real use-after-free under the valgrind and TSan jobs, for five lines; the path needs a seam, not a clever test. Recorded in todo/coverage-to-95-percent.md.

## Summary by Sourcery

Extend test coverage for client configuration parsing and server session outbound queue guards after writer shutdown.

Tests:
- Add separate client config tests to verify invalid TCP port entries are rejected for both out-of-range integers and non-integer values.
- Add client config tests to validate clock_offset_ms parsing, including positive, negative, and absent values exposed via getClockOffsetMs().
- Add server session tests to ensure all queue* schedulers are no-ops after the outbound worker stops and that rejected position relays do not increment the dropped-relay counter.