### PR TITLE
fix: key command acks on the command row id, not the dispatch id

### DIFF
--- a/e2e/test_command_ack.py
+++ b/e2e/test_command_ack.py
@@ -67,12 +67,12 @@ ACK_POLL_TIMEOUT = 2.5 * RESEND_WINDOW
 CLIENT_READY_TIMEOUT = 15.0
 
 # pytest.ini caps every test at 60 s, which is the reason the poll deadline used
-# to be exactly the resend window: the two dispatch_id-collision tests make four
+# to be exactly the resend window: the dispatch_id-collision test makes four
 # sequential polls, and 15 + 4x10 = 55 s just fit under the cap. Raising the
 # polls off the boundary breaks that fit, and a pytest-timeout kill is a strictly
 # worse failure than a poll timeout — it loses the assertion messages, which
-# carry the server log. So give those tests a budget derived from the polls they
-# actually make. Only the worst case is longer; the happy path is unchanged,
+# carry the server log. So give that test a budget derived from the polls it
+# actually makes. Only the worst case is longer; the happy path is unchanged,
 # since every poll returns as soon as its condition holds.
 COLLISION_TEST_TIMEOUT = CLIENT_READY_TIMEOUT + 4 * ACK_POLL_TIMEOUT + 30.0
 
@@ -241,150 +241,49 @@ def _dispatch_rtl(db_conn, asset_id: int) -> int:
     return new_dbid
 
 
+
+
 @pytest.mark.satisfies("TC-SRV-004")
 @pytest.mark.requires_docker
 @pytest.mark.timeout(COLLISION_TEST_TIMEOUT)
-def test_ack_does_not_cross_assets_on_dispatch_id_collision(
+def test_ack_lands_only_on_the_dispatched_row_despite_dispatch_id_collisions(
     db_conn, fake_client, server_proc
 ):
-    """An ack from one asset must not touch another asset's command row, even
-    when the two rows share a dispatch_id.
+    """An ack must reach only the command row it was dispatched for, whatever
+    else shares its dispatch_id.
 
-    dispatch_id is a per-connection monotonic id, not globally unique, so two
-    assets routinely have commands stamped with the same dispatch_id. The ack
-    UPDATE is scoped by asset_id (not dispatch_id alone); without that scoping an
-    ack for asset B would overwrite asset A's same-dispatch_id row and show the
-    operator a false confirmation on A. This is the regression the single-asset
-    test could not catch.
+    dispatch_id is the connection's last_msg_id: it is unique to neither the
+    asset nor the session (it restarts at 0 on every connection), so rows
+    sharing one are routine in both directions — another asset's row, and this
+    asset's own older row from a previous session.
 
-    Construction (no hard-coded dispatch_id): only asset B has a live client.
-    We dispatch one command to B to learn where its connection's dispatch_id
-    currently sits, then pre-seed asset A with a *band* of database-only command
-    rows spanning the dispatch_ids B's next command might use, each carrying a
-    distinct terminal ack (superseded). dispatch_id is the connection's
-    last_msg_id, bumped by every server->client message — not just commands —
-    so the once-a-second RTT request can land between B's two commands and B's
-    next command is not reliably the very next id. Seeding a band rather than a
-    single guessed id makes the collision deterministic: B's second command
-    lands on one row in the band, and the asset scoping must leave every seeded
-    A row untouched while B's own row advances to actioned.
+    Since todo/68 the ack is keyed on the command row's primary key, which the
+    dispatching session resolved locally, so a collision cannot reach the wrong
+    row. This test replaces the two that pinned the older reconstruction (an
+    (asset_id, dispatch_id) match plus an `ORDER BY timestamp DESC LIMIT 1`
+    subselect); it covers both of their regressions in one pass and, unlike
+    them, keeps holding if the row-id keying is ever reverted.
+
+    Construction (no hard-coded dispatch_id): dispatch one command to the live
+    asset to learn where its connection's dispatch_id sits, then seed a *band*
+    spanning the ids the next command might use — the once-a-second RTT request
+    also bumps last_msg_id, so the next command is not reliably +1. Each seeded
+    row carries a terminal `superseded` sentinel the fake client never produces,
+    so any change to one is unambiguously attributable to the code under test.
     """
     with db_conn.cursor() as cur:
         cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
-        asset_a = cur.fetchone()[0]
+        live_asset = cur.fetchone()[0]
         cur.execute("INSERT INTO assets_asset (name) VALUES ('test2') RETURNING id")
-        asset_b = cur.fetchone()[0]
-    db_conn.commit()
-
-    # Only asset B gets a live client; asset A is a database-only asset whose
-    # command row we craft to collide with B's dispatch_id.
-    fake_client("test2")
-    _wait_for_client_ready(server_proc, "test2")
-
-    # First dispatch to B: learn the dispatch_id its connection is currently at.
-    b_first = _dispatch_rtl(db_conn, asset_b)
-    b_first_dispatch = _poll_field(db_conn, b_first, "dispatch_id", timeout=ACK_POLL_TIMEOUT)
-    assert b_first_dispatch is not None, (
-        f"B's first command dbid={b_first} never recorded a dispatch_id; server log:\n"
-        + server_proc["log"].read_text(errors="replace")
-    )
-    # Let B's own ack for this first command settle so it can't interfere later.
-    _poll_field(db_conn, b_first, "ack_state", timeout=ACK_POLL_TIMEOUT)
-
-    # Pre-seed asset A with a band of database-only rows spanning the
-    # dispatch_ids B's next command might use, each with a terminal superseded
-    # ack the fake client never produces — so any change is unambiguous. The
-    # band absorbs RTT/other server->client messages that bump B's id between
-    # commands by an unpredictable (small) amount; B's second command lands on
-    # exactly one of these. The band is wide enough to cover many seconds of
-    # intervening once-a-second RTT traffic.
-    sentinel_ts = SENTINEL_ACK_TIMESTAMP
-    sentinel_reason = SENTINEL_SUPERSEDE_REASON
-    collision_band = range(b_first_dispatch + 1, b_first_dispatch + 1 + COLLISION_BAND)
-    a_dbids: dict[int, int] = {}  # dispatch_id -> asset A command row id
-    with db_conn.cursor() as cur:
-        for dispatch_id in collision_band:
-            cur.execute(
-                "INSERT INTO assets_assetcommand "
-                "(asset_id, command, position, altitude, dispatch_id, "
-                " ack_state, ack_timestamp, ack_superseded_by) "
-                "VALUES (%s, 'RTL', ST_SetSRID(ST_MakePoint(0, 0), 4326)::geography, 0, "
-                "        %s, %s, %s, %s) RETURNING id",
-                (asset_a, dispatch_id, ACK_STATE_SUPERSEDED, sentinel_ts, sentinel_reason),
-            )
-            a_dbids[dispatch_id] = cur.fetchone()[0]
-    db_conn.commit()
-
-    # Second dispatch to B: lands on one dispatch_id in the band and is acked.
-    b_second = _dispatch_rtl(db_conn, asset_b)
-    b_second_dispatch = _poll_field(db_conn, b_second, "dispatch_id", timeout=ACK_POLL_TIMEOUT)
-    b_second_state = _poll_ack_state(db_conn, b_second, ACK_STATE_ACTIONED, timeout=ACK_POLL_TIMEOUT)
-
-    # Guard the construction itself: if B's command did not collide with a seeded
-    # row the test proves nothing, so fail loudly rather than pass vacuously.
-    assert b_second_dispatch in collision_band, (
-        f"setup failed to collide: B's second command got dispatch_id="
-        f"{b_second_dispatch}, outside the seeded band "
-        f"{collision_band.start}..{collision_band.stop - 1}; server log:\n"
-        + server_proc["log"].read_text(errors="replace")
-    )
-    assert b_second_state == ACK_STATE_ACTIONED, (
-        f"B's own command should have been acked actioned, got {b_second_state}"
-    )
-
-    # The real assertion: none of asset A's rows are touched by B's ack — above
-    # all the one sharing B's dispatch_id. With the bug (match on dispatch_id
-    # alone) B's actioned ack would overwrite that row's superseded sentinel and
-    # stamp it with B's ack_timestamp.
-    db_conn.rollback()
-    with db_conn.cursor() as cur:
-        cur.execute(
-            "SELECT dispatch_id, ack_state, ack_timestamp, ack_superseded_by "
-            "FROM assets_assetcommand WHERE asset_id = %s ORDER BY dispatch_id",
-            (asset_a,),
-        )
-        a_rows = cur.fetchall()
-    for dispatch_id, a_state, a_ts, a_reason in a_rows:
-        assert (a_state, a_ts, a_reason) == (ACK_STATE_SUPERSEDED, sentinel_ts, sentinel_reason), (
-            f"asset A's command row at dispatch_id={dispatch_id} was mutated by asset B's "
-            f"ack (B collided at dispatch_id={b_second_dispatch}): got ack_state={a_state}, "
-            f"ack_timestamp={a_ts}, ack_superseded_by={a_reason}; server log:\n"
-            + server_proc["log"].read_text(errors="replace")
-        )
-
-
-@pytest.mark.satisfies("TC-SRV-004")
-@pytest.mark.requires_docker
-@pytest.mark.timeout(COLLISION_TEST_TIMEOUT)
-def test_ack_updates_only_the_latest_row_on_cross_session_dispatch_id_reuse(
-    db_conn, fake_client, server_proc
-):
-    """Within a single asset, an ack must update only the newest command sharing
-    a dispatch_id, not an old already-settled one from a prior session.
-
-    dispatch_id is the connection's last_msg_id, which resets to 0 on every
-    reconnect, so the same asset accumulates several historical command rows that
-    share a dispatch_id across sessions. The ack is for the command just
-    dispatched on the current connection — the latest row — so the UPDATE targets
-    the newest match. An ack must never reach back and rewrite a long-settled
-    historical row that happens to carry the same dispatch_id.
-
-    We give the asset one live client, seed an OLD command row with a terminal
-    "superseded" sentinel and an old timestamp at the dispatch_id the next live
-    command will use, then dispatch a NEW command that lands on that same
-    dispatch_id. The client's ack must advance only the NEW row and leave the OLD
-    sentinel untouched.
-    """
-    with db_conn.cursor() as cur:
-        cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
-        asset = cur.fetchone()[0]
+        other_asset = cur.fetchone()[0]
     db_conn.commit()
 
     fake_client("test1")
     _wait_for_client_ready(server_proc, "test1")
 
-    # First dispatch: learn the connection's current dispatch_id.
-    first = _dispatch_rtl(db_conn, asset)
+    # First dispatch: learn the connection's current dispatch_id, and let its
+    # own ack settle so it cannot interfere with the assertions below.
+    first = _dispatch_rtl(db_conn, live_asset)
     first_dispatch = _poll_field(db_conn, first, "dispatch_id", timeout=ACK_POLL_TIMEOUT)
     assert first_dispatch is not None, (
         f"first command dbid={first} never recorded a dispatch_id; server log:\n"
@@ -392,59 +291,63 @@ def test_ack_updates_only_the_latest_row_on_cross_session_dispatch_id_reuse(
     )
     _poll_field(db_conn, first, "ack_state", timeout=ACK_POLL_TIMEOUT)
 
-    # Seed OLD already-acked rows for the SAME asset across the band of
-    # dispatch_ids the next live command might land on — the connection's
-    # last_msg_id is bumped by RTT and other server->client traffic, so it is
-    # not reliably first_dispatch + 1. Each carries an explicitly older timestamp
-    # so the newest-row subselect must prefer the live command's row, never these.
+    # Seed both collision shapes across the band: a *different asset's* row
+    # (which an unscoped match would clobber) and this asset's own *older*
+    # row from a notional earlier session (which a newest-row subselect could
+    # reach back to if it picked wrong).
     sentinel_ts = SENTINEL_ACK_TIMESTAMP
     sentinel_reason = SENTINEL_SUPERSEDE_REASON
     collision_band = range(first_dispatch + 1, first_dispatch + 1 + COLLISION_BAND)
-    old_dbids: dict[int, int] = {}  # dispatch_id -> seeded historical row id
+    seeded: list[int] = []
     with db_conn.cursor() as cur:
         for dispatch_id in collision_band:
-            cur.execute(
-                "INSERT INTO assets_assetcommand "
-                "(asset_id, command, position, altitude, timestamp, dispatch_id, "
-                " ack_state, ack_timestamp, ack_superseded_by) "
-                "VALUES (%s, 'RTL', ST_SetSRID(ST_MakePoint(0, 0), 4326)::geography, 0, "
-                "        NOW() - INTERVAL '1 hour', %s, %s, %s, %s) RETURNING id",
-                (asset, dispatch_id, ACK_STATE_SUPERSEDED, sentinel_ts, sentinel_reason),
-            )
-            old_dbids[dispatch_id] = cur.fetchone()[0]
+            # Both are timestamped an hour ago: the same-asset row has to be
+            # older than the live dispatch for the historical-row case to mean
+            # anything, and the other asset's age is immaterial.
+            for asset_id in (other_asset, live_asset):
+                cur.execute(
+                    "INSERT INTO assets_assetcommand "
+                    "(asset_id, command, position, altitude, timestamp, dispatch_id, "
+                    " ack_state, ack_timestamp, ack_superseded_by) "
+                    "VALUES (%s, 'RTL', ST_SetSRID(ST_MakePoint(0, 0), 4326)::geography, 0, "
+                    "        NOW() - INTERVAL '1 hour', %s, %s, %s, %s) RETURNING id",
+                    (asset_id, dispatch_id, ACK_STATE_SUPERSEDED, sentinel_ts, sentinel_reason),
+                )
+                seeded.append(cur.fetchone()[0])
     db_conn.commit()
 
-    # New dispatch: lands on one dispatch_id in the band with a fresh timestamp.
-    new_dbid = _dispatch_rtl(db_conn, asset)
+    # The live dispatch: lands on one dispatch_id in the band, colliding with
+    # two seeded rows, and is acked by the client.
+    new_dbid = _dispatch_rtl(db_conn, live_asset)
     new_dispatch = _poll_field(db_conn, new_dbid, "dispatch_id", timeout=ACK_POLL_TIMEOUT)
     new_state = _poll_ack_state(db_conn, new_dbid, ACK_STATE_ACTIONED, timeout=ACK_POLL_TIMEOUT)
 
+    # Guard the construction itself: without a collision the test proves
+    # nothing, so fail loudly rather than pass vacuously.
     assert new_dispatch in collision_band, (
-        f"setup failed to reuse dispatch_id: the new command got dispatch_id="
-        f"{new_dispatch}, outside the seeded band "
-        f"{collision_band.start}..{collision_band.stop - 1}; server log:\n"
-        + server_proc["log"].read_text(errors="replace")
+        f"setup failed to collide: the new command got dispatch_id={new_dispatch}, "
+        f"outside the seeded band {collision_band.start}..{collision_band.stop - 1}; "
+        "server log:\n" + server_proc["log"].read_text(errors="replace")
     )
-    # The new (latest) row is the one the ack must land on.
     assert new_state == ACK_STATE_ACTIONED, (
-        f"the new command should have been acked actioned, got {new_state}"
+        f"the dispatched command should have been acked actioned, got {new_state}"
     )
 
-    # The old, already-settled rows must all be untouched — above all the one
-    # sharing the new command's dispatch_id, which the newest-row subselect must
-    # not reach back to.
+    # The real assertion: every seeded row still carries its sentinel.
     db_conn.rollback()
     with db_conn.cursor() as cur:
         cur.execute(
-            "SELECT dispatch_id, ack_state, ack_timestamp, ack_superseded_by "
-            "FROM assets_assetcommand WHERE id = ANY(%s) ORDER BY dispatch_id",
-            (list(old_dbids.values()),),
+            "SELECT id, asset_id, dispatch_id, ack_state, ack_timestamp, ack_superseded_by "
+            "FROM assets_assetcommand WHERE id = ANY(%s) ORDER BY id",
+            (seeded,),
         )
-        old_rows = cur.fetchall()
-    for dispatch_id, old_state, old_ts, old_reason in old_rows:
-        assert (old_state, old_ts, old_reason) == (ACK_STATE_SUPERSEDED, sentinel_ts, sentinel_reason), (
-            f"the old already-acked row at dispatch_id={dispatch_id} was rewritten by an ack "
-            f"meant for the newer command (which landed at dispatch_id={new_dispatch}): got "
-            f"ack_state={old_state}, ack_timestamp={old_ts}, ack_superseded_by={old_reason}; "
+        rows = cur.fetchall()
+    assert len(rows) == len(seeded), f"expected {len(seeded)} seeded rows, read {len(rows)}"
+    for row_id, asset_id, dispatch_id, state, ack_ts, reason in rows:
+        which = "the other asset's" if asset_id == other_asset else "this asset's older"
+        assert (state, ack_ts, reason) == (ACK_STATE_SUPERSEDED, sentinel_ts, sentinel_reason), (
+            f"{which} command row id={row_id} at dispatch_id={dispatch_id} was mutated by an "
+            f"ack meant for dbid={new_dbid} (which landed at dispatch_id={new_dispatch}): got "
+            f"ack_state={state}, ack_timestamp={ack_ts}, ack_superseded_by={reason}; "
             "server log:\n" + server_proc["log"].read_text(errors="replace")
         )

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -573,12 +573,37 @@ void fss::server::fss_client::sendCommand()
                      "Failed to send command dbid=" << dbid << " to " << client_name << "; will retry on next tick");
         return;
     }
-    /* sendMsg stamped the per-connection message id into msg; record it against
-     * the command row (cached_asset_id is non-zero here — the early return above
-     * guarantees it) so a later ack, which echoes this id as acked_command_id,
-     * can be matched back to this specific command. */
+    /* sendMsg stamped the per-connection message id into msg. Remember locally
+     * which command row that id delivered, so an ack echoing it as
+     * acked_command_id resolves to this exact row (todo/68) rather than being
+     * reconstructed from (asset_id, dispatch_id) in SQL. */
+    this->recordDispatchedCommand(msg->getId(), dbid);
+    /* Record it against the command row too (cached_asset_id is non-zero here —
+     * the early return above guarantees it), so the stored dispatch id says
+     * which delivery the row's ack columns describe. */
     this->writer->enqueue(command_dispatch_write{dbid, msg->getId()});
     FSS_LOG_INFO("server", "dispatched command dbid=" << dbid << " to " << client_name);
+}
+
+void fss::server::fss_client::recordDispatchedCommand(uint64_t dispatch_id, uint64_t command_dbid)
+{
+    std::scoped_lock guard(this->client_lock);
+    this->dispatched_commands.emplace_back(dispatch_id, command_dbid);
+    while (this->dispatched_commands.size() > max_tracked_dispatches)
+    {
+        this->dispatched_commands.pop_front();
+    }
+}
+
+auto fss::server::fss_client::lookupDispatchedCommand(uint64_t dispatch_id) -> uint64_t
+{
+    std::scoped_lock guard(this->client_lock);
+    /* Newest first: a resend of the same command adds a fresh entry, and the
+     * aircraft is acking the delivery it most recently received. */
+    auto entry =
+        std::find_if(this->dispatched_commands.rbegin(), this->dispatched_commands.rend(),
+                     [dispatch_id](const std::pair<uint64_t, uint64_t> &e) -> bool { return e.first == dispatch_id; });
+    return entry == this->dispatched_commands.rend() ? 0 : entry->second;
 }
 
 void fss::server::fss_client::setClock(std::shared_ptr<fss::IClock> t_clock)
@@ -1367,26 +1392,31 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                     break;
                 }
                 auto ack_msg = std::dynamic_pointer_cast<fss::transport::fss_message_command_ack>(msg);
-                /* Scope the stored ack to the acking asset: dispatch_id is only
-                 * per-connection unique, so without asset_id the DB update could
-                 * land on a different asset's same-dispatch_id command row. An
-                 * ack from a connection with no identified asset (asset_id == 0)
-                 * cannot be scoped, so it is dropped. */
-                if (ack_msg != nullptr && asset_id != 0)
+                /* Resolve the acked id against what this session actually
+                 * dispatched (todo/68). The wire id is only per-connection
+                 * unique, so it names a row only in combination with the session
+                 * that sent it; translating here means the write that reaches the
+                 * database names one row outright, and an ack for a dispatch this
+                 * session never sent is dropped rather than being turned into a
+                 * plausible-looking update to somebody else's row. */
+                uint64_t acked_dbid =
+                    ack_msg == nullptr ? 0 : this->lookupDispatchedCommand(ack_msg->getAckedCommandId());
+                if (ack_msg != nullptr && acked_dbid != 0)
                 {
-                    this->writer->enqueue(command_ack_write{
-                        asset_id, ack_msg->getAckedCommandId(), static_cast<uint8_t>(ack_msg->getOutcome()),
-                        ack_msg->getTimeStamp(), static_cast<uint8_t>(ack_msg->getReason())});
+                    this->writer->enqueue(command_ack_write{acked_dbid, static_cast<uint8_t>(ack_msg->getOutcome()),
+                                                            ack_msg->getTimeStamp(),
+                                                            static_cast<uint8_t>(ack_msg->getReason())});
                 }
                 else if (ack_msg != nullptr)
                 {
-                    /* asset_id == 0: the connection has no identified asset, so the
-                     * ack cannot be scoped and is dropped. A conforming client only
-                     * acks after identifying, so this is unexpected — log it so an
-                     * unscoped ack can be investigated rather than vanishing. */
+                    /* Either the connection has no identified asset (so it can
+                     * never have been sent a command), or the id does not match
+                     * any dispatch this session made. A conforming client only
+                     * acks a command it was just sent, so log it rather than
+                     * letting it vanish. */
                     FSS_LOG_WARN("server", "Dropping command-ack for acked-command "
-                                               << ack_msg->getAckedCommandId()
-                                               << " from connection with no identified asset (asset_id==0)");
+                                               << ack_msg->getAckedCommandId() << " from " << this->name
+                                               << ": no matching dispatch on this connection");
                 }
             }
             break;

--- a/src/db-write-queue.hpp
+++ b/src/db-write-queue.hpp
@@ -41,14 +41,14 @@ struct command_dispatch_write {
     uint64_t command_dbid;
     uint64_t dispatch_id;
 };
-/* A command ack to store against the row whose (asset_id, dispatch_id) matches.
- * dispatch_id is only per-connection unique (see transport::getMessageId), so the
- * ack must be scoped to the acking asset or it could clobber another asset's row
- * that happened to be stamped with the same dispatch_id. ack_state is the
+/* A command ack to store against the command row identified by its primary key
+ * (todo/68). The acked id on the wire is the per-connection dispatch id, which is
+ * unique to neither the asset nor the session; the acking session translates it to
+ * the row id it dispatched before enqueueing, so what reaches the DB names exactly
+ * one row and needs no scoping of its own. ack_state is the
  * fss_command_ack_outcome int, ack_reason the fss_command_ack_reason int. */
 struct command_ack_write {
-    uint64_t asset_id;
-    uint64_t dispatch_id;
+    uint64_t command_dbid;
     uint8_t ack_state;
     uint64_t ack_timestamp;
     uint8_t ack_reason;

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -204,15 +204,14 @@ void flight_safety_system::server::db_connection::recordCommandDispatch(uint64_t
     }
 }
 
-void flight_safety_system::server::db_connection::recordCommandAck(uint64_t asset_id, uint64_t dispatch_id,
-                                                                   uint8_t ack_state, uint64_t ack_timestamp,
-                                                                   uint8_t ack_reason)
+void flight_safety_system::server::db_connection::recordCommandAck(uint64_t command_dbid, uint8_t ack_state,
+                                                                   uint64_t ack_timestamp, uint8_t ack_reason)
 {
     std::scoped_lock guard(this->write_lock);
-    if (db_command_record_ack(write_conn_name, asset_id, dispatch_id, static_cast<int>(ack_state), ack_timestamp,
+    if (db_command_record_ack(write_conn_name, command_dbid, static_cast<int>(ack_state), ack_timestamp,
                               static_cast<int>(ack_reason)) == 0)
     {
-        throw database_error("command ack write failed for asset " + std::to_string(asset_id));
+        throw database_error("command ack write failed for command " + std::to_string(command_dbid));
     }
 }
 

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -16,6 +16,7 @@
 #include <mutex>
 #include <thread>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace flight_safety_system {
@@ -111,15 +112,16 @@ public:
      * columns): the stored ack always describes the latest dispatch, and a
      * terminal outcome is final only within its dispatch — see recordCommandAck. */
     virtual void recordCommandDispatch(uint64_t command_dbid, uint64_t dispatch_id) = 0;
-    /* Stores a command ack against the row whose (asset_id, dispatch_id) matches.
-     * Terminal-transition policy (todo/48): a terminal outcome (actioned/
-     * superseded/rejected/noop) is final for its dispatch — the write is refused
-     * unless the stored state is empty or received, so neither a late "received"
-     * nor a second terminal can rewrite a settled outcome; a redispatch reopens
-     * the cycle. dispatch_id is only per-connection unique, so asset_id scopes
-     * the match to the acking asset. ack_state/ack_reason are the
+    /* Stores a command ack against the command row named by its primary key.
+     * The caller has already translated the wire's per-connection acked id to the
+     * row it dispatched (todo/68), so this names exactly one row and carries no
+     * scoping of its own. Terminal-transition policy (todo/48): a terminal outcome
+     * (actioned/superseded/rejected/noop) is final for its dispatch — the write is
+     * refused unless the stored state is empty or received, so neither a late
+     * "received" nor a second terminal can rewrite a settled outcome; a redispatch
+     * reopens the cycle. ack_state/ack_reason are the
      * fss_command_ack_outcome/fss_command_ack_reason ints. */
-    virtual void recordCommandAck(uint64_t asset_id, uint64_t dispatch_id, uint8_t ack_state, uint64_t ack_timestamp,
+    virtual void recordCommandAck(uint64_t command_dbid, uint8_t ack_state, uint64_t ack_timestamp,
                                   uint8_t ack_reason) = 0;
     /* The asset's newest pending command, or nullopt when the read failed.
      * nullopt is NOT "no pending command": that is an engaged null pointer.
@@ -200,7 +202,7 @@ public:
     void recordStatus(uint64_t asset_id, uint8_t bat_percent, uint32_t bat_mah_used, double bat_voltage) override;
     void recordSearchStatus(uint64_t asset_id, uint64_t search_id, uint64_t completed, uint64_t total) override;
     void recordCommandDispatch(uint64_t command_dbid, uint64_t dispatch_id) override;
-    void recordCommandAck(uint64_t asset_id, uint64_t dispatch_id, uint8_t ack_state, uint64_t ack_timestamp,
+    void recordCommandAck(uint64_t command_dbid, uint8_t ack_state, uint64_t ack_timestamp,
                           uint8_t ack_reason) override;
     auto getCommand(uint64_t asset_id) -> std::optional<std::shared_ptr<asset_command>> override;
     auto getCommands(const std::vector<uint64_t> &asset_ids)
@@ -307,6 +309,28 @@ private:
     void updateClockOffset(uint64_t client_timestamp, uint64_t rtt_ms, uint64_t recv_wall);
     uint64_t last_command_send_ts{0};
     uint64_t last_command_dbid{0};
+    /* Guarded by client_lock. Maps a dispatch id (the per-connection message id
+     * sendMsg() stamped onto a dispatched command) to the command row it
+     * delivered, so an ack echoing that id names an exact row (todo/68). The
+     * wire id alone cannot: it restarts at 0 on every connection and is unique
+     * to neither the asset nor the session. Translating here rather than in SQL
+     * also means an ack for a dispatch this session never sent is dropped
+     * instead of reaching the database as a plausible-looking update.
+     *
+     * A server-side session is built per accepted connection and never reused,
+     * so this starts empty for every new connection by construction. Bounded
+     * FIFO, like stray_rtt_responses above: a session holds one entry per
+     * delivery, and the cap stops a peer that never acks from growing it
+     * without limit. Oldest-first eviction is the right direction — an
+     * unacked dispatch that old has been superseded by the ones behind it. */
+    static constexpr size_t max_tracked_dispatches = 16;
+    std::list<std::pair<uint64_t, uint64_t>> dispatched_commands{};
+    /* Remember that dispatch_id delivered command_dbid, evicting the oldest
+     * entry once the cap is reached. Takes client_lock. */
+    void recordDispatchedCommand(uint64_t dispatch_id, uint64_t command_dbid);
+    /* The command row dispatch_id delivered, or 0 if this session never
+     * dispatched it (or it has aged out of the FIFO). Takes client_lock. */
+    auto lookupDispatchedCommand(uint64_t dispatch_id) -> uint64_t;
     bool liveness_active{false};
     uint64_t last_rtt_response_time{0};
     uint64_t client_timeout_ms{30000};

--- a/src/server-db.h
+++ b/src/server-db.h
@@ -68,14 +68,14 @@ int db_position_create_entry(const char *conn, unsigned long long asset_id, doub
  * command via dispatch_id == acked_command_id. */
 int db_command_set_dispatch_id(const char *conn, unsigned long long command_dbid, unsigned long long dispatch_id);
 
-/* Updates the ack fields on the assets_assetcommand row whose (asset_id,
- * dispatch_id) matches the acking asset and the acked id. dispatch_id is only
- * per-connection unique, so asset_id scopes the match to avoid clobbering another
- * asset's same-dispatch_id row. ack_state is the fss_command_ack_outcome int,
+/* Updates the ack fields on the assets_assetcommand row identified by its primary
+ * key (command_dbid). The caller translates the wire's per-connection acked id to
+ * the row it dispatched before calling (todo/68), so this names one row outright
+ * and needs no asset scoping. ack_state is the fss_command_ack_outcome int,
  * ack_superseded_by the fss_command_ack_reason int, ack_timestamp the FMU
  * wall-clock ms. The update never lowers an already-terminal ack_state back to a
  * non-terminal one (a late "received" cannot clobber a settled outcome). */
-int db_command_record_ack(const char *conn, unsigned long long asset_id, unsigned long long dispatch_id, int ack_state,
+int db_command_record_ack(const char *conn, unsigned long long command_dbid, int ack_state,
                           unsigned long long ack_timestamp, int ack_superseded_by);
 
 struct asset_command_s {

--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -222,31 +222,30 @@ int db_command_set_dispatch_id(const char *conn_arg, unsigned long long command_
     return 1;
 }
 
-int db_command_record_ack(const char *conn_arg, unsigned long long asset_id_arg, unsigned long long dispatch_id_arg, int ack_state_arg, unsigned long long ack_timestamp_arg, int ack_superseded_by_arg)
+int db_command_record_ack(const char *conn_arg, unsigned long long command_dbid_arg, int ack_state_arg, unsigned long long ack_timestamp_arg, int ack_superseded_by_arg)
 {
     EXEC SQL BEGIN DECLARE SECTION;
     const char *conn = conn_arg;
-    unsigned long long asset_id = asset_id_arg;
-    unsigned long long dispatch_id = dispatch_id_arg;
+    unsigned long long command_dbid = command_dbid_arg;
     int ack_state = ack_state_arg;
     unsigned long long ack_timestamp = ack_timestamp_arg;
     int ack_superseded_by = ack_superseded_by_arg;
     EXEC SQL END DECLARE SECTION;
 
-    /* Match the dispatched row by the acking asset and its stamped id, and
-     * update only the NEWEST such row. dispatch_id is the per-connection
-     * last_msg_id: it is not globally unique (so asset_id is needed to avoid a
-     * different asset's row) AND it resets to 0 on every reconnect, so one asset
-     * accumulates several historical command rows sharing a dispatch_id across
-     * sessions. An ack is always for the command just dispatched on the current
-     * connection — the latest such row — so target it alone via a subselect
-     * ordered by timestamp; matching all of them would let this ack rewrite a
-     * long-settled historical row.
+    /* Match the acked row by its primary key (todo/68). What the aircraft echoes
+     * on the wire is the per-connection dispatch id, which identifies a row only
+     * in combination with the session that sent it: it is not globally unique,
+     * and it restarts at 0 on every connection, so one asset accumulates several
+     * historical rows sharing a dispatch_id. This function used to reconstruct
+     * the intended row from (asset_id, dispatch_id) plus a newest-row subselect;
+     * the acking session now translates the id to the row it dispatched, which
+     * is exact rather than reconstructed, so neither the asset scoping nor the
+     * subselect is needed. An ack naming a dispatch this session never sent is
+     * dropped before it reaches the queue and never arrives here.
      * Terminal-transition policy (todo/48): a terminal outcome is final for
      * its dispatch. The row is writable only while unsettled — stored state
      * NULL (no ack yet) or received (0) — so neither a late "received" nor a
-     * second terminal outcome (from a buggy, misordered or forged peer; acks
-     * are not validated in-session against a dispatched command) can rewrite
+     * second terminal outcome (from a buggy or misordered peer) can rewrite
      * a settled actioned/superseded/rejected/noop. The conforming two-phase
      * flow (received, then exactly one terminal) is unaffected, and a
      * REDELIVERED command still re-acks normally: db_command_set_dispatch_id()
@@ -259,9 +258,7 @@ int db_command_record_ack(const char *conn_arg, unsigned long long asset_id_arg,
      * ack_superseded_by is only meaningful for the superseded state. */
     EXEC SQL AT :conn UPDATE assets_assetcommand
         SET ack_state = :ack_state, ack_timestamp = :ack_timestamp, ack_superseded_by = :ack_superseded_by
-        WHERE id = (SELECT id FROM assets_assetcommand
-                    WHERE asset_id = :asset_id AND dispatch_id = :dispatch_id
-                    ORDER BY timestamp DESC LIMIT 1)
+        WHERE id = :command_dbid
           AND (ack_state IS NULL OR ack_state = 0);
 
     if (sqlca.sqlcode < 0)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -354,7 +354,7 @@ auto main(int argc, char *argv[]) -> int
                     dbc->recordCommandDispatch(w.command_dbid, w.dispatch_id);
                 },
                 [&](const flight_safety_system::server::command_ack_write &w) -> void {
-                    dbc->recordCommandAck(w.asset_id, w.dispatch_id, w.ack_state, w.ack_timestamp, w.ack_reason);
+                    dbc->recordCommandAck(w.command_dbid, w.ack_state, w.ack_timestamp, w.ack_reason);
                 },
             },
             task);

--- a/tests/async_db_write_test.cpp
+++ b/tests/async_db_write_test.cpp
@@ -70,11 +70,11 @@ struct CapturingSink {
                 [&](const fss::server::position_write &w) -> void { asset_ids.push_back(w.asset_id); },
                 [&](const fss::server::status_write &w) -> void { asset_ids.push_back(w.asset_id); },
                 [&](const fss::server::search_status_write &w) -> void { asset_ids.push_back(w.asset_id); },
-                /* Command writes are keyed by command/dispatch id, not
-                 * asset id; these tests don't enqueue them, but the visit
-                 * must cover every alternative, so record the id present. */
+                /* Command writes are keyed by the command row id, not asset
+                 * id; these tests don't enqueue them, but the visit must
+                 * cover every alternative, so record the id present. */
                 [&](const fss::server::command_dispatch_write &w) -> void { asset_ids.push_back(w.command_dbid); },
-                [&](const fss::server::command_ack_write &w) -> void { asset_ids.push_back(w.dispatch_id); },
+                [&](const fss::server::command_ack_write &w) -> void { asset_ids.push_back(w.command_dbid); },
             },
             task);
         count.fetch_add(1);
@@ -284,12 +284,12 @@ TEST_CASE("db_write_queue: a command ack survives a telemetry overflow")
     constexpr std::size_t depth = 5;
     fss::server::db_write_queue q(depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
 
-    constexpr uint64_t ack_dispatch_id = 2000000;
+    constexpr uint64_t ack_command_dbid = 2000000;
     for (uint64_t i = 1; i <= depth; ++i)
     {
         q.enqueue(fss::server::position_write{i, 0.0, 0.0, 0});
     }
-    q.enqueue(fss::server::command_ack_write{42, ack_dispatch_id, 0, 0, 0});
+    q.enqueue(fss::server::command_ack_write{ack_command_dbid, 0, 0, 0});
     for (uint64_t i = 100; i < 200; ++i)
     {
         q.enqueue(fss::server::position_write{i, 0.0, 0.0, 0});
@@ -298,7 +298,7 @@ TEST_CASE("db_write_queue: a command ack survives a telemetry overflow")
     q.stop();
 
     auto seen = cap->snapshot();
-    REQUIRE(std::find(seen.begin(), seen.end(), ack_dispatch_id) != seen.end());
+    REQUIRE(std::find(seen.begin(), seen.end(), ack_command_dbid) != seen.end());
     REQUIRE(q.command_dropped_count() == 0);
 }
 

--- a/tests/concurrency_client_test.cpp
+++ b/tests/concurrency_client_test.cpp
@@ -107,7 +107,7 @@ public:
     void recordStatus(uint64_t, uint8_t, uint32_t, double) override {}
     void recordSearchStatus(uint64_t, uint64_t, uint64_t, uint64_t) override {}
     void recordCommandDispatch(uint64_t, uint64_t) override {}
-    void recordCommandAck(uint64_t, uint64_t, uint8_t, uint64_t, uint8_t) override {}
+    void recordCommandAck(uint64_t, uint8_t, uint64_t, uint8_t) override {}
     auto getCommand(uint64_t) -> std::optional<std::shared_ptr<flight_safety_system::server::asset_command>> override
     {
         /* An engaged null pointer: no pending command, not a failed read. */

--- a/tests/crl_revocation_test.cpp
+++ b/tests/crl_revocation_test.cpp
@@ -49,7 +49,7 @@ auto make_writer(fss_test::MockDatabase &mock) -> std::shared_ptr<fss::server::d
                            mock.recordCommandDispatch(w.command_dbid, w.dispatch_id);
                        },
                        [&](const fss::server::command_ack_write &w) -> void {
-                           mock.recordCommandAck(w.asset_id, w.dispatch_id, w.ack_state, w.ack_timestamp, w.ack_reason);
+                           mock.recordCommandAck(w.command_dbid, w.ack_state, w.ack_timestamp, w.ack_reason);
                        },
                    },
                    task);

--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -244,8 +244,7 @@ TEST_CASE("db_connection: write methods throw database_error when the write conn
     REQUIRE(threw_database_error([&] { dbc->recordStatus(asset_id, uint8_t{80}, uint32_t{1000}, 12.4); }));
     REQUIRE(threw_database_error([&] { dbc->recordSearchStatus(asset_id, uint64_t{1}, uint64_t{50}, uint64_t{100}); }));
     REQUIRE(threw_database_error([&] { dbc->recordCommandDispatch(uint64_t{1}, uint64_t{1}); }));
-    REQUIRE(threw_database_error(
-        [&] { dbc->recordCommandAck(asset_id, uint64_t{1}, uint8_t{1}, uint64_t{1}, uint8_t{0}); }));
+    REQUIRE(threw_database_error([&] { dbc->recordCommandAck(uint64_t{1}, uint8_t{1}, uint64_t{1}, uint8_t{0}); }));
 }
 
 TEST_CASE("db_connection: getSmmSettings returns non-null for configured asset")
@@ -544,9 +543,9 @@ TEST_CASE("db_connection: recordCommandAck stores ack_state, ack_timestamp and a
     auto command_id = insert_test_command(asset_id);
     dbc->recordCommandDispatch(command_id, uint64_t{5555});
 
-    dbc->recordCommandAck(
-        asset_id, uint64_t{5555}, static_cast<uint8_t>(flight_safety_system::transport::command_ack_superseded),
-        uint64_t{1700000000000}, static_cast<uint8_t>(flight_safety_system::transport::supersede_low_battery));
+    dbc->recordCommandAck(command_id, static_cast<uint8_t>(flight_safety_system::transport::command_ack_superseded),
+                          uint64_t{1700000000000},
+                          static_cast<uint8_t>(flight_safety_system::transport::supersede_low_battery));
 
     REQUIRE(get_command_column(command_id, "ack_state") == "2");
     REQUIRE(get_command_column(command_id, "ack_timestamp") == "1700000000000");
@@ -563,12 +562,10 @@ TEST_CASE("db_connection: recordCommandAck does not regress an already-terminal 
     auto command_id = insert_test_command(asset_id);
     dbc->recordCommandDispatch(command_id, uint64_t{6666});
 
-    dbc->recordCommandAck(asset_id, uint64_t{6666},
-                          static_cast<uint8_t>(flight_safety_system::transport::command_ack_actioned), uint64_t{100},
-                          static_cast<uint8_t>(flight_safety_system::transport::supersede_none));
-    dbc->recordCommandAck(asset_id, uint64_t{6666},
-                          static_cast<uint8_t>(flight_safety_system::transport::command_ack_received), uint64_t{200},
-                          static_cast<uint8_t>(flight_safety_system::transport::supersede_none));
+    dbc->recordCommandAck(command_id, static_cast<uint8_t>(flight_safety_system::transport::command_ack_actioned),
+                          uint64_t{100}, static_cast<uint8_t>(flight_safety_system::transport::supersede_none));
+    dbc->recordCommandAck(command_id, static_cast<uint8_t>(flight_safety_system::transport::command_ack_received),
+                          uint64_t{200}, static_cast<uint8_t>(flight_safety_system::transport::supersede_none));
 
     REQUIRE(get_command_column(command_id, "ack_state") == "1");
     REQUIRE(get_command_column(command_id, "ack_timestamp") == "100");
@@ -594,10 +591,9 @@ TEST_CASE("db_connection: recordCommandAck refuses a second terminal outcome")
         auto command_id = insert_test_command(asset_id);
         dbc->recordCommandDispatch(command_id, dispatch_id);
 
-        dbc->recordCommandAck(asset_id, dispatch_id,
-                              static_cast<uint8_t>(flight_safety_system::transport::command_ack_actioned),
+        dbc->recordCommandAck(command_id, static_cast<uint8_t>(flight_safety_system::transport::command_ack_actioned),
                               uint64_t{100}, static_cast<uint8_t>(flight_safety_system::transport::supersede_none));
-        dbc->recordCommandAck(asset_id, dispatch_id, later_state, uint64_t{200},
+        dbc->recordCommandAck(command_id, later_state, uint64_t{200},
                               static_cast<uint8_t>(flight_safety_system::transport::supersede_low_battery));
 
         REQUIRE(get_command_column(command_id, "ack_state") == "1");
@@ -616,14 +612,12 @@ TEST_CASE("db_connection: recordCommandAck admits the conforming received-then-t
     auto command_id = insert_test_command(asset_id);
     dbc->recordCommandDispatch(command_id, uint64_t{7780});
 
-    dbc->recordCommandAck(asset_id, uint64_t{7780},
-                          static_cast<uint8_t>(flight_safety_system::transport::command_ack_received), uint64_t{100},
-                          static_cast<uint8_t>(flight_safety_system::transport::supersede_none));
+    dbc->recordCommandAck(command_id, static_cast<uint8_t>(flight_safety_system::transport::command_ack_received),
+                          uint64_t{100}, static_cast<uint8_t>(flight_safety_system::transport::supersede_none));
     REQUIRE(get_command_column(command_id, "ack_state") == "0");
 
-    dbc->recordCommandAck(asset_id, uint64_t{7780},
-                          static_cast<uint8_t>(flight_safety_system::transport::command_ack_actioned), uint64_t{200},
-                          static_cast<uint8_t>(flight_safety_system::transport::supersede_none));
+    dbc->recordCommandAck(command_id, static_cast<uint8_t>(flight_safety_system::transport::command_ack_actioned),
+                          uint64_t{200}, static_cast<uint8_t>(flight_safety_system::transport::supersede_none));
     REQUIRE(get_command_column(command_id, "ack_state") == "1");
     REQUIRE(get_command_column(command_id, "ack_timestamp") == "200");
 }
@@ -640,9 +634,8 @@ TEST_CASE("db_connection: recordCommandDispatch reopens the ack cycle")
     auto asset_id = get_test_asset_id(*dbc);
     auto command_id = insert_test_command(asset_id);
     dbc->recordCommandDispatch(command_id, uint64_t{7790});
-    dbc->recordCommandAck(asset_id, uint64_t{7790},
-                          static_cast<uint8_t>(flight_safety_system::transport::command_ack_actioned), uint64_t{100},
-                          static_cast<uint8_t>(flight_safety_system::transport::supersede_none));
+    dbc->recordCommandAck(command_id, static_cast<uint8_t>(flight_safety_system::transport::command_ack_actioned),
+                          uint64_t{100}, static_cast<uint8_t>(flight_safety_system::transport::supersede_none));
     REQUIRE(get_command_column(command_id, "ack_state") == "1");
 
     /* Redispatch (e.g. after a reconnect, with the new connection's id). */
@@ -652,12 +645,40 @@ TEST_CASE("db_connection: recordCommandDispatch reopens the ack cycle")
     REQUIRE(get_command_column(command_id, "ack_superseded_by").empty());
 
     /* The re-ack for the new delivery lands, terminal over the reopened row. */
-    dbc->recordCommandAck(asset_id, uint64_t{7791},
-                          static_cast<uint8_t>(flight_safety_system::transport::command_ack_superseded), uint64_t{200},
-                          static_cast<uint8_t>(flight_safety_system::transport::supersede_comms_loss));
+    dbc->recordCommandAck(command_id, static_cast<uint8_t>(flight_safety_system::transport::command_ack_superseded),
+                          uint64_t{200}, static_cast<uint8_t>(flight_safety_system::transport::supersede_comms_loss));
     REQUIRE(get_command_column(command_id, "ack_state") == "2");
     REQUIRE(get_command_column(command_id, "ack_timestamp") == "200");
     REQUIRE(get_command_column(command_id, "ack_superseded_by") == "2");
+}
+
+TEST_CASE("db_connection: recordCommandAck updates only the row it names")
+{
+    /* todo/68: the ack is keyed on the command row's primary key, which the
+     * acking session resolved from the id it dispatched. Two commands for the
+     * same asset -- the shape that used to force an (asset_id, dispatch_id)
+     * match plus a newest-row subselect, and the shape a colliding dispatch id
+     * could land on the wrong one of -- must now be independent. Ack the OLDER
+     * row and confirm the newer one is untouched: under the old newest-row
+     * reconstruction this was not expressible at all. */
+    LIVE_DB_OR_SKIP(dbc);
+    auto asset_id = get_test_asset_id(*dbc);
+    auto older_command = insert_test_command(asset_id);
+    auto newer_command = insert_test_command(asset_id);
+    REQUIRE(older_command != newer_command);
+
+    /* The same dispatch id on both, which is realistic: it restarts at 0 on
+     * every connection, so two deliveries across two sessions collide. */
+    dbc->recordCommandDispatch(older_command, uint64_t{8800});
+    dbc->recordCommandDispatch(newer_command, uint64_t{8800});
+
+    dbc->recordCommandAck(older_command, static_cast<uint8_t>(flight_safety_system::transport::command_ack_actioned),
+                          uint64_t{100}, static_cast<uint8_t>(flight_safety_system::transport::supersede_none));
+
+    REQUIRE(get_command_column(older_command, "ack_state") == "1");
+    REQUIRE(get_command_column(older_command, "ack_timestamp") == "100");
+    REQUIRE(get_command_column(newer_command, "ack_state").empty());
+    REQUIRE(get_command_column(newer_command, "ack_timestamp").empty());
 }
 
 TEST_CASE("db_connection: verifySchema accepts the provisioned schema")

--- a/tests/mock_database.hpp
+++ b/tests/mock_database.hpp
@@ -69,8 +69,7 @@ public:
         uint64_t dispatch_id;
     };
     struct recorded_ack {
-        uint64_t asset_id;
-        uint64_t dispatch_id;
+        uint64_t command_dbid;
         uint8_t ack_state;
         uint64_t ack_timestamp;
         uint8_t ack_reason;
@@ -123,11 +122,10 @@ public:
         dispatches.push_back({command_dbid, dispatch_id});
     }
 
-    void recordCommandAck(uint64_t asset_id, uint64_t dispatch_id, uint8_t ack_state, uint64_t ack_timestamp,
-                          uint8_t ack_reason) override
+    void recordCommandAck(uint64_t command_dbid, uint8_t ack_state, uint64_t ack_timestamp, uint8_t ack_reason) override
     {
         const std::scoped_lock lock(records_lock);
-        acks.push_back({asset_id, dispatch_id, ack_state, ack_timestamp, ack_reason});
+        acks.push_back({command_dbid, ack_state, ack_timestamp, ack_reason});
     }
 
     /* Snapshot accessors: copy the sink under the lock so a test can inspect it

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -213,7 +213,7 @@ auto make_mock_writer(fss_test::MockDatabase &mock) -> std::shared_ptr<fss::serv
                            mock.recordCommandDispatch(w.command_dbid, w.dispatch_id);
                        },
                        [&](const fss::server::command_ack_write &w) -> void {
-                           mock.recordCommandAck(w.asset_id, w.dispatch_id, w.ack_state, w.ack_timestamp, w.ack_reason);
+                           mock.recordCommandAck(w.command_dbid, w.ack_state, w.ack_timestamp, w.ack_reason);
                        },
                    },
                    task);
@@ -1342,7 +1342,17 @@ TEST_CASE("rate limiter: rtt_response and command_ack are exempt (todo/37)")
 
     session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
 
-    /* A real outstanding request to reconcile the response against. */
+    /* A real dispatch to ack, and a real outstanding request to reconcile the
+     * response against. Both are outbound, so neither spends inbound budget. */
+    constexpr uint64_t command_dbid = 4242;
+    session->setPendingCommand(
+        std::make_shared<fss::server::asset_command>(command_dbid, /*ts*/ 500, "RTL", 0.0, 0.0, 0));
+    session->sendCommand();
+    REQUIRE(fss_test::wait_for([&]() -> bool { return mock.getDispatches().size() == 1; }));
+    const auto dispatched = mock.getDispatches();
+    REQUIRE_FALSE(dispatched.empty());
+    const uint64_t dispatched_id = dispatched.front().dispatch_id;
+
     auto rtt_req = std::make_shared<fss::transport::fss_message_rtt_request>();
     session->sendRTTRequest(rtt_req);
     uint64_t assigned_id = rtt_req->getId();
@@ -1367,26 +1377,26 @@ TEST_CASE("rate limiter: rtt_response and command_ack are exempt (todo/37)")
 
     /* Bucket is still drained: without the fix this ack would be silently
      * dropped before ever reaching the writer. */
-    constexpr uint64_t acked_id = 42;
-    auto ack = std::make_shared<fss::transport::fss_message_command_ack>(acked_id, fss::transport::asset_command_hold,
-                                                                         fss::transport::command_ack_actioned,
-                                                                         fss::transport::supersede_none, uint64_t{500});
+    auto ack = std::make_shared<fss::transport::fss_message_command_ack>(
+        dispatched_id, fss::transport::asset_command_hold, fss::transport::command_ack_actioned,
+        fss::transport::supersede_none, uint64_t{500});
     session->processMessage(ack);
     REQUIRE(fss_test::wait_for([&]() -> bool { return !mock.getAcks().empty(); }));
-    REQUIRE(mock.getAcks().front().dispatch_id == acked_id);
+    REQUIRE(mock.getAcks().front().command_dbid == command_dbid);
 }
 
 TEST_CASE("rate limiter: a command_ack flood is capped, not exempted outright (todo/37)")
 {
-    /* Unlike rtt_response, a command_ack is not naturally bounded: nothing
-     * in-session validates it against a command this server actually
-     * dispatched before enqueueing, and command_ack_write is a protected task
-     * in the shared db_write_queue that can evict other assets' telemetry
+    /* Unlike rtt_response, a command_ack is not naturally bounded. Since
+     * todo/68 an ack must name a dispatch this session made, which stops a peer
+     * inventing ids — but nothing stops it re-acking a command it was
+     * legitimately sent, over and over, and command_ack_write is a protected
+     * task in the shared db_write_queue that can evict other assets' telemetry
      * and even other command writes under sustained pressure. A blanket
      * exemption would let one identified peer flood that queue at line rate,
      * so command_ack gets its own small bucket (10 burst, 5/s refill in
-     * fss-server.hpp) instead. Flood well past that cap and assert only the
-     * bucket's worth land. */
+     * fss-server.hpp) instead. Flood well past that cap with a valid acked id
+     * and assert only the bucket's worth land. */
     fss_test::MockDatabase mock;
     mock.asset_ids["craft"] = 1;
 
@@ -1402,11 +1412,19 @@ TEST_CASE("rate limiter: a command_ack flood is capped, not exempted outright (t
 
     session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
 
+    session->setPendingCommand(
+        std::make_shared<fss::server::asset_command>(/*dbid*/ 4242, /*ts*/ 500, "RTL", 0.0, 0.0, 0));
+    session->sendCommand();
+    REQUIRE(fss_test::wait_for([&]() -> bool { return mock.getDispatches().size() == 1; }));
+    const auto dispatched = mock.getDispatches();
+    REQUIRE_FALSE(dispatched.empty());
+    const uint64_t dispatched_id = dispatched.front().dispatch_id;
+
     constexpr int acks_sent = 30;
     for (int i = 0; i < acks_sent; ++i)
     {
         auto ack = std::make_shared<fss::transport::fss_message_command_ack>(
-            static_cast<uint64_t>(i), fss::transport::asset_command_hold, fss::transport::command_ack_actioned,
+            dispatched_id, fss::transport::asset_command_hold, fss::transport::command_ack_actioned,
             fss::transport::supersede_none, uint64_t{500});
         session->processMessage(ack);
     }
@@ -2318,22 +2336,66 @@ TEST_CASE("session: command_ack is stored when the capability is negotiated")
     auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
     session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
 
-    constexpr uint64_t acked_id = 0xABCDEF;
+    /* The ack has to name a command this session actually dispatched (todo/68),
+     * so dispatch one and ack the id that went out on the wire. */
+    constexpr uint64_t command_dbid = 4242;
+    session->setPendingCommand(
+        std::make_shared<fss::server::asset_command>(command_dbid, /*ts*/ 500, "RTL", 0.0, 0.0, 0));
+    session->sendCommand();
+    REQUIRE(fss_test::wait_for([&]() -> bool { return mock.getDispatches().size() == 1; }));
+    const auto dispatched = mock.getDispatches();
+    REQUIRE_FALSE(dispatched.empty());
+    const uint64_t dispatched_id = dispatched.front().dispatch_id;
+
     constexpr uint64_t ack_ts = 1750000000000ULL;
-    auto ack = std::make_shared<fss::transport::fss_message_command_ack>(acked_id, fss::transport::asset_command_manual,
-                                                                         fss::transport::command_ack_superseded,
-                                                                         fss::transport::supersede_low_battery, ack_ts);
+    auto ack = std::make_shared<fss::transport::fss_message_command_ack>(
+        dispatched_id, fss::transport::asset_command_manual, fss::transport::command_ack_superseded,
+        fss::transport::supersede_low_battery, ack_ts);
     session->processMessage(ack);
 
     REQUIRE(fss_test::wait_for([&]() { return !mock.getAcks().empty(); }));
-    /* The ack is scoped to the acking asset (the one this connection identified
-     * as), not just the per-connection dispatch_id. */
+    /* The stored ack names the command ROW, translated from the wire's
+     * per-connection id by the session that dispatched it. */
     auto acks = mock.getAcks();
-    REQUIRE(acks.front().asset_id == 13);
-    REQUIRE(acks.front().dispatch_id == acked_id);
+    REQUIRE(acks.front().command_dbid == command_dbid);
     REQUIRE(acks.front().ack_state == static_cast<uint8_t>(fss::transport::command_ack_superseded));
     REQUIRE(acks.front().ack_timestamp == ack_ts);
     REQUIRE(acks.front().ack_reason == static_cast<uint8_t>(fss::transport::supersede_low_battery));
+}
+
+TEST_CASE("session: an ack naming a dispatch this session never made is dropped")
+{
+    /* todo/68: the wire's acked id is only per-connection unique, so it names a
+     * command row only in combination with the session that sent it. An id this
+     * session never dispatched must not reach the database — before the
+     * translation it was forwarded raw, and the DB reconstructed a plausible
+     * row from (asset_id, dispatch_id), which is how a colliding id could land
+     * an ack on the wrong command. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 13;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    conn->setNegotiatedFeatureFlags(fss::transport::FSS_FEATURE_COMMAND_ACK);
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    session->setPendingCommand(
+        std::make_shared<fss::server::asset_command>(/*dbid*/ 4242, /*ts*/ 500, "RTL", 0.0, 0.0, 0));
+    session->sendCommand();
+    REQUIRE(fss_test::wait_for([&]() -> bool { return mock.getDispatches().size() == 1; }));
+    const auto dispatched = mock.getDispatches();
+    REQUIRE_FALSE(dispatched.empty());
+    const uint64_t dispatched_id = dispatched.front().dispatch_id;
+
+    auto ack = std::make_shared<fss::transport::fss_message_command_ack>(
+        dispatched_id + 1000, fss::transport::asset_command_rtl, fss::transport::command_ack_actioned, uint64_t{1});
+    session->processMessage(ack);
+
+    REQUIRE_FALSE(fss_test::wait_for([&]() { return !mock.getAcks().empty(); }, std::chrono::milliseconds(200)));
 }
 
 TEST_CASE("session: command_ack is dropped when the capability is not negotiated")


### PR DESCRIPTION
## Description

An ack echoes `acked_command_id`, which is the per-connection message id the server stamped on the dispatched command. That id names a command row only in combination with the session that sent it: `fss_connection::getMessageId()` is a per-connection counter that restarts at 0 on every connection, so it is unique to neither the asset nor the session.

`db_command_record_ack` therefore reconstructed the intended row from (asset_id, dispatch_id) plus an `ORDER BY timestamp DESC LIMIT 1` subselect — asset scoping to avoid another asset's row, newest-row selection to avoid this asset's own historical rows from earlier sessions. Two e2e tests existed solely to pin that reconstruction against deliberately seeded collisions.

The session that dispatched the command knows the answer outright, so it now translates before enqueueing: `fss_client` keeps a bounded FIFO of dispatch_id -> command_dbid, `command_ack_write` carries the row id, and the UPDATE is `WHERE id = :command_dbid AND (ack_state IS NULL OR ack_state = 0)`. The todo/48 finality guard is untouched.

Two things fall out that the todo did not name:

- An ack for a dispatch this session never made is now dropped with a WARN instead of being turned into a plausible-looking update. Nothing validated that before — the rate-limit comment at the command_ack arm says so explicitly, as the reason acks get their own bucket. That bucket is still needed and its comment now says why: a peer can still re-ack a command it was legitimately sent, without limit.
- The map is empty by construction on every new connection, because a server-side session is built per accepted connection and never reused. That is what makes "cleared on connection change" free rather than a thing to remember.

This is the enabling step for the rest of todo/68: a resend cannot reuse a recorded dispatch id (`sendMsg` stamps unconditionally), so suppressing the per-resend dispatch write is only safe once acks stop depending on the stored `dispatch_id` matching the last frame sent.

The two collision e2e tests are replaced by one covering both of their regressions — a foreign asset's row and this asset's own older row, seeded across the same band — which unlike them keeps holding if the row-id keying is ever reverted. Two new cases at the seams: an ack naming an un-dispatched id reaches no write (unit), and an ack updates only the row it names when two rows share a dispatch_id (live DB).

Verified: 425 unit cases green; 427 green with 0 skipped against a live PostgreSQL via docker-compose.db-unit-tests.yaml; e2e test_command_ack, test_server_restart, test_command_identity, test_command_latency and test_command_read_under_write_stall all pass.

## Summary by Sourcery

Key command acknowledgements off the command row ID instead of the per-connection dispatch ID, and update the session, database, and queue plumbing plus tests to reflect the new keying and reject acks for commands this session never dispatched.

Bug Fixes:
- Prevent command acks from incorrectly updating rows for other assets or historical sessions when dispatch IDs collide by translating acks to the concrete command row ID in-session before writing to the database.
- Drop command acks that reference a dispatch ID the current session never sent instead of forwarding them as plausible database updates.

Enhancements:
- Track a bounded, per-session FIFO mapping from dispatch IDs to command row IDs so that acks can be resolved locally and resend behaviour can evolve independently of dispatch ID reuse.
- Simplify the command ack write path and async DB write queue to operate directly on command row IDs, removing asset/dispatch scoping from lower layers.

Tests:
- Replace and consolidate the previous dispatch_id collision end-to-end tests with a single test that covers both cross-asset and cross-session collisions under the new row-ID keying.
- Extend server session tests to verify that command acks are only enqueued for commands actually dispatched on that session and that acks still bypass rate limiting while floods are capped using valid IDs.
- Update database tests to exercise recordCommandAck by command row ID, add coverage that acks only affect the named row even when dispatch IDs collide, and refresh async write queue tests to track command_dbid in ack writes.