### PR TITLE
fix: record a command dispatch once per connection, not once per resend

### DIFF
--- a/docs/decisions/48-command-ack-terminal-finality.md
+++ b/docs/decisions/48-command-ack-terminal-finality.md
@@ -22,9 +22,32 @@ cycle**: when it stamps a new dispatch id it clears the three ack columns. The
 ack columns therefore always describe the *latest dispatch*, not the row's
 lifetime.
 
-There is no ordering race in that pairing: an ack for the new delivery can only
-match the row via the new dispatch id, and that dispatch id does not exist on
-the row until the same statement that clears the acks lands.
+### What fences a stale ack (revised by [68](68-command-redelivery-and-ack-keying.md))
+
+As decided here, the fence was the freshly minted dispatch id: an ack for the
+new delivery could only match the row by carrying that id, and the id did not
+exist on the row until the same statement that cleared the acks landed.
+
+**That argument no longer holds, and is not what protects the row today.**
+Decision 68 keys the ack on the command row's primary key rather than on the
+stored `dispatch_id`, and stops writing a dispatch on every resend — so the ack
+no longer reaches the row via the stored id at all, and the clearing statement
+fires once per delivery rather than once per resend.
+
+The replacement fence is narrower and stronger:
+
+- The ack names the **row**, and finality is scoped to that row's current
+  dispatch via the unchanged writable-set guard. There is no id to collide and
+  no subselect to pick the wrong row.
+- Cross-connection staleness is impossible because the translation is
+  in-process: `fss_client` holds the `dispatch_id → command_dbid` map, a
+  server-side session is built per accepted connection and never reused, and
+  the map dies with the session. An ack arriving on a new connection for a
+  delivery made on the old one resolves to nothing and is dropped.
+- Within one connection, the ack cycle is reopened exactly once — at the first
+  delivery of a given command — and every later frame for that command is a
+  resend that writes nothing. So no clear can land between a delivery and its
+  ack.
 
 ## Alternative deliberately not taken: blanket "terminal is final"
 
@@ -33,6 +56,11 @@ legitimate terminal-over-terminal exists and is pinned by
 `e2e/test_server_restart.py`: a command redelivered after a server bounce must
 settle back to `actioned` with a fresh `ack_timestamp`. Blanket finality would
 leave that row stuck at its pre-bounce outcome forever.
+
+Decision 68 does not change this. A server bounce (or an aircraft reconnect)
+builds a new session, whose `last_dispatch_write_dbid` starts at zero, so the
+first delivery on the new connection still records a dispatch, still reopens the
+cycle, and the re-ack still lands.
 
 ## A refused write is not an error
 

--- a/docs/decisions/49-server-command-id-semantics.md
+++ b/docs/decisions/49-server-command-id-semantics.md
@@ -54,9 +54,21 @@ above, at zero infrastructure cost.
 ## Not to be conflated with `dispatch_id`
 
 `dispatch_id` is the per-connection message header id used for command-ack
-correlation. It is scoped to a *single delivery* and is stable across resends of
-that delivery. `server_command_id` is scoped to the *operator action* and
-survives reconnects. They are different values with different lifetimes.
+correlation. It is scoped to a *single delivery*: `fss_connection::sendMsg()`
+stamps the next sequence number unconditionally, so every resend of a command
+goes out under a **new** dispatch id, and the counter restarts at 0 on each
+connection. `server_command_id` is scoped to the *operator action* and survives
+reconnects. They are different values with different lifetimes.
+
+> Corrected 2026-07-31 (todo/68). This section previously said `dispatch_id` was
+> "stable across resends of that delivery", which was never true of the
+> implementation — the same claim was repeated on the field comment in
+> `fss-transport.hpp`. The distinction the section draws is right; only that
+> clause was wrong. Since resends no longer record a dispatch at all, the
+> `dispatch_id` **stored on the command row** is now stable for the life of a
+> connection — but the id on the wire still changes with every frame, which is
+> why the ack is keyed on the row id instead
+> (see [68](68-command-redelivery-and-ack-keying.md)).
 
 ## Implementation trap, found during the work
 

--- a/e2e/test_command_ack.py
+++ b/e2e/test_command_ack.py
@@ -44,21 +44,20 @@ COLLISION_BAND = 20
 
 # Nothing retires a command row, so the newest row for an asset stays pending
 # and sendCommand() re-dispatches it every 10 s (client_session.cpp's
-# `timeout_time`, the resend window). Every redelivery enqueues a
-# command_dispatch_write, and db_command_set_dispatch_id nulls ack_state,
-# ack_timestamp and ack_superseded_by before the fresh ack re-populates them —
-# so each redelivery opens a brief window in which the ack columns read NULL
-# for a command that was acked (todo/68).
+# `timeout_time`, the resend window).
 #
-# Polling with a deadline of exactly the resend window puts every poll on that
-# boundary: a poll that starts just after one redelivery expires just as the
-# next one lands, and can time out inside the null gap, reporting "never acked".
-# Poll for longer than two resend windows instead, so a single null gap can
-# never consume a whole deadline, and pick a value that is not a multiple of the
-# window so the two cadences do not stay phase-locked across a run.
+# A redelivery used to null ack_state, ack_timestamp and ack_superseded_by
+# before the fresh ack re-populated them, so each one opened a brief window in
+# which the ack columns read NULL for a command that had been acked. Polling on
+# exactly the resend window put every poll on that boundary and could time out
+# inside the gap, reporting "never acked" — hence the deliberately off-boundary
+# deadline below.
 #
-# This is a harness-side mitigation, not a fix: the churn itself is todo/68
-# proper. Keep this off the boundary if the resend window ever changes.
+# todo/68 closed the gap at the source: a resend no longer records a dispatch,
+# so the ack columns are written once per delivery and never cleared under a
+# poll. The margin is kept anyway, because it costs nothing on the happy path
+# (every poll returns as soon as its condition holds) and the polls still have
+# to outlast a first delivery that lands just after a poll starts.
 RESEND_WINDOW = 10.0
 ACK_POLL_TIMEOUT = 2.5 * RESEND_WINDOW
 

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -576,16 +576,32 @@ void fss::server::fss_client::sendCommand()
     /* sendMsg stamped the per-connection message id into msg. Remember locally
      * which command row that id delivered, so an ack echoing it as
      * acked_command_id resolves to this exact row (todo/68) rather than being
-     * reconstructed from (asset_id, dispatch_id) in SQL. */
-    this->recordDispatchedCommand(msg->getId(), dbid);
-    /* Record it against the command row too (cached_asset_id is non-zero here —
-     * the early return above guarantees it), so the stored dispatch id says
-     * which delivery the row's ack columns describe. */
-    this->writer->enqueue(command_dispatch_write{dbid, msg->getId()});
+     * reconstructed from (asset_id, dispatch_id) in SQL. Every delivery is
+     * remembered, including a resend — the aircraft acks whichever frame it
+     * actually received. */
+    if (this->recordDispatchedCommand(msg->getId(), dbid))
+    {
+        /* First delivery of this command on this connection, so record the
+         * dispatch against the row (cached_asset_id is non-zero here — the
+         * early return above guarantees it).
+         *
+         * A resend deliberately does NOT write (todo/68). The write is not
+         * free: db_command_set_dispatch_id also clears ack_state,
+         * ack_timestamp and ack_superseded_by to reopen the ack cycle, so
+         * firing it every resend destroyed and rewrote the row's stored
+         * outcome every 10 s for as long as the aircraft stayed connected —
+         * the audit state the todo/45 fail-safe exists to protect, erased on
+         * the healthy path, at a steady cost in non-evictable queue slots.
+         * Nothing needs the stored dispatch_id to track the latest frame now
+         * that the ack is keyed on the row id; it records which delivery the
+         * ack columns describe, and that is the first one until the aircraft
+         * reconnects and a new session dispatches afresh. */
+        this->writer->enqueue(command_dispatch_write{dbid, msg->getId()});
+    }
     FSS_LOG_INFO("server", "dispatched command dbid=" << dbid << " to " << client_name);
 }
 
-void fss::server::fss_client::recordDispatchedCommand(uint64_t dispatch_id, uint64_t command_dbid)
+auto fss::server::fss_client::recordDispatchedCommand(uint64_t dispatch_id, uint64_t command_dbid) -> bool
 {
     std::scoped_lock guard(this->client_lock);
     this->dispatched_commands.emplace_back(dispatch_id, command_dbid);
@@ -593,6 +609,17 @@ void fss::server::fss_client::recordDispatchedCommand(uint64_t dispatch_id, uint
     {
         this->dispatched_commands.pop_front();
     }
+    /* Checked and claimed under the same lock as the insert above, for the
+     * same reason sendCommand() claims its resend window before sending: the
+     * recv thread's identify path and an outbound worker can both be in here
+     * for the same command, and two dispatch writes for one delivery would
+     * null the ack columns twice. */
+    if (command_dbid == this->last_dispatch_write_dbid)
+    {
+        return false;
+    }
+    this->last_dispatch_write_dbid = command_dbid;
+    return true;
 }
 
 auto fss::server::fss_client::lookupDispatchedCommand(uint64_t dispatch_id) -> uint64_t

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -107,10 +107,12 @@ public:
     virtual void recordStatus(uint64_t asset_id, uint8_t bat_percent, uint32_t bat_mah_used, double bat_voltage) = 0;
     virtual void recordSearchStatus(uint64_t asset_id, uint64_t search_id, uint64_t completed, uint64_t total) = 0;
     /* Records the dispatch id (the per-connection message id the server stamped
-     * on the command) against the command row, so a later ack can be matched to
-     * this specific command. Also reopens the row's ack cycle (clears the ack
-     * columns): the stored ack always describes the latest dispatch, and a
-     * terminal outcome is final only within its dispatch — see recordCommandAck. */
+     * on the command) against the command row, and reopens the row's ack cycle
+     * (clears the ack columns): the stored ack always describes the latest
+     * dispatch, and a terminal outcome is final only within its dispatch — see
+     * recordCommandAck. Enqueued once per command per connection, not on every
+     * resend (todo/68): the clear is what made the healthy path destroy and
+     * rewrite a command's stored outcome every resend window. */
     virtual void recordCommandDispatch(uint64_t command_dbid, uint64_t dispatch_id) = 0;
     /* Stores a command ack against the command row named by its primary key.
      * The caller has already translated the wire's per-connection acked id to the
@@ -309,6 +311,12 @@ private:
     void updateClockOffset(uint64_t client_timestamp, uint64_t rtt_ms, uint64_t recv_wall);
     uint64_t last_command_send_ts{0};
     uint64_t last_command_dbid{0};
+    /* The command row this session has already recorded a dispatch write for
+     * (todo/68). Deliberately separate from last_command_dbid, which
+     * sendCommand()'s mark_handled also sets on a permanent validation
+     * refusal — a command that was never sent must not count as dispatched.
+     * Guarded by client_lock. */
+    uint64_t last_dispatch_write_dbid{0};
     /* Guarded by client_lock. Maps a dispatch id (the per-connection message id
      * sendMsg() stamped onto a dispatched command) to the command row it
      * delivered, so an ack echoing that id names an exact row (todo/68). The
@@ -326,8 +334,10 @@ private:
     static constexpr size_t max_tracked_dispatches = 16;
     std::list<std::pair<uint64_t, uint64_t>> dispatched_commands{};
     /* Remember that dispatch_id delivered command_dbid, evicting the oldest
-     * entry once the cap is reached. Takes client_lock. */
-    void recordDispatchedCommand(uint64_t dispatch_id, uint64_t command_dbid);
+     * entry once the cap is reached. Returns true when this is the first
+     * delivery of that command on this connection, i.e. when a dispatch write
+     * is due; a resend returns false. Takes client_lock. */
+    auto recordDispatchedCommand(uint64_t dispatch_id, uint64_t command_dbid) -> bool;
     /* The command row dispatch_id delivered, or 0 if this session never
      * dispatched it (or it has aged out of the FIFO). Takes client_lock. */
     auto lookupDispatchedCommand(uint64_t dispatch_id) -> uint64_t;

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -727,9 +727,9 @@ private:
      *     as an optional trailing wire field, omitted when 0, like
      *     rtt_response's client_timestamp (todo/17 item 3).
      * This is NOT the per-connection header id used for command-ack
-     * correlation (dispatch_id): that one is scoped to a single delivery and
-     * stable across resends of it; this one is scoped to the operator action
-     * and survives reconnects.
+     * correlation (dispatch_id): that one is scoped to a single delivery, is
+     * re-stamped on every resend, and restarts at 0 on each connection; this
+     * one is scoped to the operator action and survives reconnects.
      *
      * The other of the two optional trailing fields the prefix-closed
      * extension rule above (docs/decisions/51-optional-trailing-field-rule.md)

--- a/src/server-db.h
+++ b/src/server-db.h
@@ -64,8 +64,10 @@ int db_position_create_entry(const char *conn, unsigned long long asset_id, doub
 
 /* Records the per-connection message id the server stamped onto the dispatched
  * command, on the assets_assetcommand row identified by its primary key
- * (command_dbid). Lets a later command-ack be matched back to this specific
- * command via dispatch_id == acked_command_id. */
+ * (command_dbid), and reopens the row's ack cycle. Called once per command per
+ * connection, not once per resend (todo/68), so the stored id names the
+ * delivery the row's ack columns describe. The ack itself is matched on the row
+ * id, not on this column. */
 int db_command_set_dispatch_id(const char *conn, unsigned long long command_dbid, unsigned long long dispatch_id);
 
 /* Updates the ack fields on the assets_assetcommand row identified by its primary

--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -207,9 +207,9 @@ int db_command_set_dispatch_id(const char *conn_arg, unsigned long long command_
      * A redelivery (identify resends the newest command on every reconnect)
      * must therefore reopen the ack cycle here, or the re-ack the redelivered
      * command legitimately produces would be refused as a duplicate terminal.
-     * An ack can only match this row by carrying the new dispatch_id, which
-     * does not exist on the row until this statement lands, so no ack for the
-     * new delivery can slip in ahead of the clear. */
+     * Since todo/68 the caller fires this once per command per connection, not
+     * once per resend, so no clear can land between a delivery and its ack —
+     * see docs/decisions/68-command-redelivery-and-ack-keying.md. */
     EXEC SQL AT :conn UPDATE assets_assetcommand
         SET dispatch_id = :dispatch_id, ack_state = NULL, ack_timestamp = NULL, ack_superseded_by = NULL
         WHERE id = :command_dbid;

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -722,6 +722,107 @@ TEST_CASE("session: a successful command send records exactly one dispatch and s
     REQUIRE(mock.getDispatches().front().command_dbid == 88);
 }
 
+TEST_CASE("session: resends across the window do not re-record the dispatch (todo/68)")
+{
+    /* The measurement todo/68's acceptance criterion asks for. Nothing retires
+     * a command row, so the resend fires every 10 s for as long as the aircraft
+     * stays connected. Every resend used to enqueue a command_dispatch_write,
+     * and db_command_set_dispatch_id nulls the three ack columns to reopen the
+     * cycle — so the stored outcome of a command was destroyed and rewritten
+     * every 10 s, forever, on the healthy path.
+     *
+     * Drive several whole resend windows and assert the wire saw a delivery
+     * each time (the aircraft is still being told its commanded state) while
+     * the database saw exactly one dispatch. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 12;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+    auto clock = std::make_shared<FakeClock>();
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->setClock(clock);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    constexpr uint64_t command_dbid = 88;
+    session->setPendingCommand(
+        std::make_shared<fss::server::asset_command>(command_dbid, /*ts*/ 500, "RTL", 0.0, 0.0, 0));
+
+    /* client_session.cpp's resend window, plus a margin so `>` is satisfied. */
+    constexpr uint64_t resend_window_ms = 10 * uint64_t{1000};
+    constexpr int windows = 4;
+    session->sendCommand();
+    for (int i = 0; i < windows; ++i)
+    {
+        clock->advance(resend_window_ms + 1);
+        session->sendCommand();
+    }
+
+    REQUIRE(count_sent<fss::transport::fss_message_asset_command>(conn->sent) == windows + 1);
+    REQUIRE(fss_test::wait_for([&]() -> bool { return !mock.getDispatches().empty(); }));
+    REQUIRE(mock.getDispatches().size() == 1);
+    REQUIRE(mock.getDispatches().front().command_dbid == command_dbid);
+
+    /* A genuinely new command is still recorded: the suppression is per
+     * command row, not a one-dispatch-per-connection cap. */
+    constexpr uint64_t newer_dbid = 89;
+    session->setPendingCommand(
+        std::make_shared<fss::server::asset_command>(newer_dbid, /*ts*/ 600, "HOLD", 0.0, 0.0, 0));
+    session->sendCommand();
+    REQUIRE(fss_test::wait_for([&]() -> bool { return mock.getDispatches().size() == 2; }));
+    REQUIRE(mock.getDispatches().back().command_dbid == newer_dbid);
+}
+
+TEST_CASE("session: every delivery stays ackable even though only the first is recorded (todo/68)")
+{
+    /* The dispatch-write suppression must not narrow what the aircraft can
+     * ack. The translating map is populated on every send, so an ack echoing
+     * the id of a *resent* frame — which is what an aircraft that only acted
+     * on the third delivery would send — still resolves to the command row. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 12;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    conn->setNegotiatedFeatureFlags(fss::transport::FSS_FEATURE_COMMAND_ACK);
+    NullClientHandler handler;
+    auto clock = std::make_shared<FakeClock>();
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->setClock(clock);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    constexpr uint64_t command_dbid = 88;
+    session->setPendingCommand(
+        std::make_shared<fss::server::asset_command>(command_dbid, /*ts*/ 500, "RTL", 0.0, 0.0, 0));
+    session->sendCommand();
+    clock->advance((10 * uint64_t{1000}) + 1);
+    session->sendCommand();
+
+    /* The id of the second (unrecorded) delivery, taken off the wire. */
+    auto sent = conn->sentSnapshot();
+    std::vector<uint64_t> command_ids;
+    for (const auto &msg : sent)
+    {
+        if (msg != nullptr && msg->getType() == fss::transport::message_type_command)
+        {
+            command_ids.push_back(msg->getId());
+        }
+    }
+    REQUIRE(command_ids.size() == 2);
+    REQUIRE(command_ids[0] != command_ids[1]);
+
+    session->processMessage(std::make_shared<fss::transport::fss_message_command_ack>(
+        command_ids[1], fss::transport::asset_command_rtl, fss::transport::command_ack_actioned, uint64_t{1}));
+
+    REQUIRE(fss_test::wait_for([&]() -> bool { return !mock.getAcks().empty(); }));
+    REQUIRE(mock.getAcks().front().command_dbid == command_dbid);
+}
+
 TEST_CASE("session: dispatched command carries the server command id only when negotiated (todo/49)")
 {
     /* The dispatched wire message identifies the operator action by this


### PR DESCRIPTION
## Description

Nothing retires a command row, so `pollCommands()` keeps handing the newest one back and `sendCommand()` re-dispatches it every 10 s for as long as the aircraft stays connected. Every one of those redeliveries enqueued a `command_dispatch_write`, and `db_command_set_dispatch_id` clears `ack_state`, `ack_timestamp` and `ack_superseded_by` to reopen the ack cycle.

So the stored outcome of a command was destroyed and rewritten every 10 s, indefinitely, for a command issued once. An operator or a post-incident investigator reading `assets_assetcommand` saw the ack for the most recent redelivery, never the aircraft's original response — and if the aircraft went quiet between a redelivery and its ack, the columns read NULL, indistinguishable from "never acked". That is the audit state the todo/45 fail-safe exists to protect, erased on the *healthy* path, at ~6 non-evictable queue slots per minute per aircraft forever.

`sendCommand()` now enqueues the dispatch write only on the first delivery of a command on a connection. The check and the claim happen under `client_lock` alongside the map insertion, for the same reason the resend window is claimed before the send: the recv thread's identify path and an outbound worker can both be in there for the same command.

`last_dispatch_write_dbid` is deliberately not `last_command_dbid` — the latter is also set by `mark_handled` on a permanent validation refusal, and a command that was never sent must not count as dispatched.

The wire is unchanged: the aircraft still receives its commanded state every 10 s, and every delivery stays ackable, because the translating map from the previous commit is still populated on every send. Only the DB write is suppressed. A reconnect builds a new session, so the first delivery there records afresh and reopens the cycle — which is what `test_server_restart.py` pins.

Documentation, all of it load-bearing rather than tidying:

- Decision 48's "no ordering race" argument depended on the freshly minted dispatch id being what fenced a stale ack. That premise died with the previous commit and this one; replaced with the actual fence (the ack names the row, and the translating map dies with the session), and the server-bounce re-ack story is now stated explicitly rather than implied.
- Decision 49 and the `server_command_id` field comment both said `dispatch_id` is "stable across resends of that delivery". That was never true — `sendMsg()` stamps a new id on every frame. Corrected in place, with a note saying which half was wrong, since the distinction those passages draw is right and worth keeping.
- The e2e comment block explaining the off-boundary ack poll described the null gap this commit removes. Rewritten to say the gap is closed and why the margin is kept anyway.

Two new unit cases: four resend windows produce four wire deliveries and one dispatch write (todo/68's acceptance criterion, measured), while a genuinely new dbid still records; and an ack echoing the id of a *resent* frame — which is what an aircraft that only acted on the third delivery sends — still resolves to the command row.

Also repairs the previous commit, which did not compile under `-Werror=null-dereference`: `mock.getDispatches().front()` on a temporary is a null deref GCC cannot rule out. `all_test` is a check_PROGRAM, so `make all` silently leaves it stale — the earlier local runs were against a stale binary. Use `make check` to build it.

Verified: 429 unit cases green locally; 429 green with 0 skipped against a live PostgreSQL; check-code.sh clean; e2e test_command_ack, test_server_restart, test_command_identity and test_command_latency all pass.

## Summary by Sourcery

Ensure command dispatch is recorded once per command per connection while preserving ackability of all deliveries and tightening audit semantics around command acknowledgements.

Bug Fixes:
- Prevent repeated resends from continually clearing and rewriting a command row’s ack state by suppressing redundant dispatch writes.
- Avoid potential null-dereference in tests when accessing mock dispatches.

Enhancements:
- Track whether a command’s dispatch has already been recorded for a session so resends only update in-memory correlation and not persistent state.
- Clarify the relationship between per-connection dispatch IDs and server command IDs, and explicitly document how acks are keyed to command rows across reconnects.

Documentation:
- Update decision records to reflect that acks are now keyed on command row IDs, not stored dispatch IDs, and describe the revised fencing of stale acknowledgements.
- Correct documentation that previously claimed dispatch IDs were stable across resends and explain current dispatch and ack semantics.
- Revise e2e ack polling guidance to reflect removal of the resend-induced NULL gap while retaining off-boundary polling rationale.

Tests:
- Add unit tests ensuring multiple resend windows produce multiple wire deliveries but a single dispatch write per command, and that acks for resent frames still resolve to the correct command row.
- Extend e2e tests around command acks and server restart behavior to validate the new dispatch and ack handling semantics.