### PR TITLE
feat: stop redelivering a command the aircraft has terminally acked

### DIFF
--- a/e2e/test_command_ack.py
+++ b/e2e/test_command_ack.py
@@ -350,3 +350,165 @@ def test_ack_lands_only_on_the_dispatched_row_despite_dispatch_id_collisions(
             f"ack_state={state}, ack_timestamp={ack_ts}, ack_superseded_by={reason}; "
             "server log:\n" + server_proc["log"].read_text(errors="replace")
         )
+
+
+@pytest.mark.satisfies("TC-SRV-004")
+@pytest.mark.requires_docker
+@pytest.mark.timeout(COLLISION_TEST_TIMEOUT)
+def test_restarted_client_is_dispatched_to_again(db_conn, fake_client, server_proc):
+    """An aircraft that restarts is re-sent its pending command, even though it
+    already acked that command terminally before the restart.
+
+    This is the invariant the todo/68 redelivery stop rests on. The server now
+    stops re-sending a command once the aircraft reports a terminal outcome —
+    but cap-fmu has no persistent storage, so an aircraft that restarts has
+    forgotten its commanded state and must be told again.
+
+    What makes that safe is that the stop is scoped to the *connection*: the
+    server holds it in the per-session object and builds a new session for
+    every accepted connection, so a restart resets it by construction. This
+    test proves it end to end rather than by inspection — kill the client
+    outright (no graceful shutdown, no chance to persist anything), let it come
+    back, and require a second dispatch and a second ack.
+
+    Distinct from test_server_restart.py, which bounces the *server*.
+    """
+    with db_conn.cursor() as cur:
+        cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
+        asset_id = cur.fetchone()[0]
+    db_conn.commit()
+
+    first = fake_client("test1", client_id="before-restart")
+    _wait_for_client_ready(server_proc, "test1")
+
+    dbid = _dispatch_rtl(db_conn, asset_id)
+    row = _poll_row(db_conn, dbid, timeout=ACK_POLL_TIMEOUT)
+    assert row is not None, (
+        f"command dbid={dbid} never got an ack before the restart; server log:\n"
+        + server_proc["log"].read_text(errors="replace")
+    )
+    _, _, first_ack_timestamp = row
+    assert first_ack_timestamp is not None
+
+    # Exactly one delivery so far: the terminal ack stopped the resend. Without
+    # that stop this count would keep climbing every 10 s and the assertion
+    # after the restart would prove nothing.
+    dispatch_line = f"dispatched command dbid={dbid} to test1"
+    log_path = server_proc["log"]
+    assert log_path.read_text(errors="replace").count(dispatch_line) == 1
+
+    # Kill it the way a crash or power cycle would: no signal handler, no
+    # graceful close, nothing carried across.
+    first["proc"].kill()
+    first["proc"].wait(timeout=10)
+
+    fake_client("test1", client_id="after-restart")
+    # The readiness helper tails from the start of the log, so it would match
+    # the *first* identify line. Wait for the second one instead.
+    deadline = time.monotonic() + CLIENT_READY_TIMEOUT
+    needle = "Aircraft client identified: test1"
+    while time.monotonic() < deadline:
+        if log_path.read_text(errors="replace").count(needle) >= 2:
+            break
+        time.sleep(0.05)
+    else:
+        raise AssertionError(
+            "the restarted client never identified; server log:\n"
+            + log_path.read_text(errors="replace")
+        )
+
+    # The new session re-dispatches the still-pending command...
+    deadline = time.monotonic() + ACK_POLL_TIMEOUT
+    while time.monotonic() < deadline:
+        if log_path.read_text(errors="replace").count(dispatch_line) >= 2:
+            break
+        time.sleep(0.05)
+    else:
+        raise AssertionError(
+            f"command dbid={dbid} was not re-dispatched to the restarted client; server log:\n"
+            + log_path.read_text(errors="replace")
+        )
+
+    # ...and the re-ack lands. A fresh ack_timestamp is what distinguishes it
+    # from the pre-restart one still sitting in the row: the redispatch clears
+    # the ack columns, so this can only be the new connection's ack.
+    reacked = _poll(
+        db_conn,
+        "SELECT ack_state, ack_timestamp FROM assets_assetcommand WHERE id = %s",
+        (dbid,),
+        lambda r: r[0] == ACK_STATE_ACTIONED and r[1] is not None and r[1] != first_ack_timestamp,
+        timeout=ACK_POLL_TIMEOUT,
+        poll=0.02,
+    )
+    assert reacked is not None, f"row for dbid={dbid} vanished"
+    failure = (
+        f"the restarted client did not re-ack: got ack_state={reacked[0]}, "
+        f"ack_timestamp={reacked[1]} (pre-restart was {first_ack_timestamp}); server log:\n"
+        + log_path.read_text(errors="replace")
+    )
+    assert reacked[0] == ACK_STATE_ACTIONED, failure
+    assert reacked[1] != first_ack_timestamp, failure
+
+
+@pytest.mark.satisfies("TC-SRV-004")
+@pytest.mark.requires_docker
+@pytest.mark.timeout(CLIENT_READY_TIMEOUT + 3 * RESEND_WINDOW + ACK_POLL_TIMEOUT + 20.0)
+def test_acked_command_stops_churning_the_row(db_conn, fake_client, server_proc):
+    """todo/68's acceptance criterion, measured end to end.
+
+    An aircraft that acks a command terminally must not cause a new dispatch
+    write every 10 s, and the stored ack must survive rather than being nulled
+    and rewritten on each redelivery.
+
+    Watch a steady state spanning several resend windows: exactly one dispatch
+    is logged, and the row's ack columns never move once they settle.
+    """
+    with db_conn.cursor() as cur:
+        cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
+        asset_id = cur.fetchone()[0]
+    db_conn.commit()
+
+    fake_client("test1")
+    _wait_for_client_ready(server_proc, "test1")
+
+    dbid = _dispatch_rtl(db_conn, asset_id)
+    settled = _poll_row(db_conn, dbid, timeout=ACK_POLL_TIMEOUT)
+    assert settled is not None, (
+        f"command dbid={dbid} never got an ack stored; server log:\n"
+        + server_proc["log"].read_text(errors="replace")
+    )
+
+    # Sample the row across more than two resend windows. Before todo/68 each
+    # window enqueued a dispatch write that nulled all three ack columns, so a
+    # sample would eventually catch NULLs and the dispatch count would climb.
+    deadline = time.monotonic() + (2 * RESEND_WINDOW) + 5.0
+    samples = []
+    while time.monotonic() < deadline:
+        db_conn.rollback()
+        with db_conn.cursor() as cur:
+            cur.execute(
+                "SELECT dispatch_id, ack_state, ack_timestamp, ack_superseded_by "
+                "FROM assets_assetcommand WHERE id = %s",
+                (dbid,),
+            )
+            samples.append(cur.fetchone())
+        time.sleep(0.25)
+
+    assert len(set(samples)) == 1, (
+        f"the ack columns changed while the command sat acked and pending: "
+        f"saw {sorted(set(samples))}; server log:\n"
+        + server_proc["log"].read_text(errors="replace")
+    )
+    # The sampled values are the ones _poll_row already saw settle. (The fourth
+    # column, ack_superseded_by, is 0 = supersede_none for a plain actioned ack,
+    # not NULL — _poll_row does not select it.)
+    assert samples[0][:3] == settled, (
+        f"the settled row changed under the samples: {samples[0][:3]} vs {settled}"
+    )
+
+    log_text = server_proc["log"].read_text(errors="replace")
+    dispatches = log_text.count(f"dispatched command dbid={dbid} to test1")
+    assert dispatches == 1, (
+        f"expected exactly one dispatch across {2 * RESEND_WINDOW + 5:.0f}s of steady state, "
+        f"got {dispatches}; server log:\n" + log_text
+    )

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -475,6 +475,22 @@ void fss::server::fss_client::sendCommand()
             /* Same command we last handled and still inside the resend window. */
             return;
         }
+        if (!is_new_command && dbid == this->terminally_acked_dbid)
+        {
+            /* The aircraft has told us what it did with this command on this
+             * connection, so there is nothing left to say (todo/68). Redelivery
+             * exists to cover a delivery the aircraft never acted on; once it
+             * has reported actioned/superseded/rejected/noop, resending every
+             * 10 s for the rest of the flight only produces command_ack_noop
+             * traffic and keeps a protected DB write in flight.
+             *
+             * This does NOT assume the aircraft still holds the command later:
+             * terminally_acked_dbid lives in the session, and an FMU that
+             * restarts arrives on a new connection with a new session, where
+             * identify-time dispatch delivers again and the resend loop runs
+             * until that connection acks for itself. */
+            return;
+        }
         /* Mark a command as handled for the current resend window: applied on a
          * permanent validation rejection below (which can never succeed, so
          * re-evaluating it every tick would only spam the log). Deliberately
@@ -620,6 +636,12 @@ auto fss::server::fss_client::recordDispatchedCommand(uint64_t dispatch_id, uint
     }
     this->last_dispatch_write_dbid = command_dbid;
     return true;
+}
+
+void fss::server::fss_client::markCommandTerminallyAcked(uint64_t command_dbid)
+{
+    std::scoped_lock guard(this->client_lock);
+    this->terminally_acked_dbid = command_dbid;
 }
 
 auto fss::server::fss_client::lookupDispatchedCommand(uint64_t dispatch_id) -> uint64_t
@@ -1433,6 +1455,16 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                     this->writer->enqueue(command_ack_write{acked_dbid, static_cast<uint8_t>(ack_msg->getOutcome()),
                                                             ack_msg->getTimeStamp(),
                                                             static_cast<uint8_t>(ack_msg->getReason())});
+                    /* A terminal outcome ends the redelivery of that command on
+                     * this connection (todo/68). "received" is not terminal —
+                     * it means the frame arrived, not that the aircraft acted —
+                     * so the resend must keep running until it says what it
+                     * did. Matches db_command_record_ack's writable set, which
+                     * treats NULL and received as unsettled. */
+                    if (ack_msg->getOutcome() != fss::transport::command_ack_received)
+                    {
+                        this->markCommandTerminallyAcked(acked_dbid);
+                    }
                 }
                 else if (ack_msg != nullptr)
                 {

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -317,6 +317,22 @@ private:
      * refusal — a command that was never sent must not count as dispatched.
      * Guarded by client_lock. */
     uint64_t last_dispatch_write_dbid{0};
+    /* The command row this connection's aircraft has reported a terminal
+     * outcome for, which ends its redelivery (todo/68). 0 = none.
+     *
+     * Scoped to the connection, and that is load-bearing rather than
+     * incidental: an FMU has no persistent storage, so the server must never
+     * assume an aircraft still holds a command it acked on an earlier
+     * connection. A session is built per accepted connection and never reused,
+     * so an aircraft that restarts arrives with this at 0, is dispatched at
+     * identify time, and is resent to until *that* connection acks terminally.
+     * Storing it on the command row instead would wrongly survive the
+     * reconnect. See docs/decisions/68-command-redelivery-and-ack-keying.md.
+     * Guarded by client_lock. */
+    uint64_t terminally_acked_dbid{0};
+    /* Record a terminal ack for command_dbid, ending its resend on this
+     * connection. Takes client_lock. */
+    void markCommandTerminallyAcked(uint64_t command_dbid);
     /* Guarded by client_lock. Maps a dispatch id (the per-connection message id
      * sendMsg() stamped onto a dispatched command) to the command row it
      * delivered, so an ack echoing that id names an exact row (todo/68). The

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -823,6 +823,171 @@ TEST_CASE("session: every delivery stays ackable even though only the first is r
     REQUIRE(mock.getAcks().front().command_dbid == command_dbid);
 }
 
+namespace {
+
+/* Build an identified, ack-capable session with one pending command, dispatch
+ * it once, and hand back the id that went out on the wire. The terminal-ack
+ * cases below all need exactly this preamble. */
+struct AckableSession {
+    std::shared_ptr<FakeConnection> conn{nullptr};
+    std::shared_ptr<fss::server::fss_client> session{nullptr};
+    std::shared_ptr<FakeClock> clock{nullptr};
+    uint64_t dispatched_id{0};
+};
+
+auto make_dispatched_session(fss_test::MockDatabase &mock, fss::server::fss_client_handler *handler,
+                             const std::shared_ptr<fss::server::db_write_queue> &writer, uint64_t command_dbid)
+    -> AckableSession
+{
+    AckableSession out;
+    out.conn = std::make_shared<FakeConnection>();
+    out.conn->cert_names.push_back("craft");
+    out.conn->setNegotiatedFeatureFlags(fss::transport::FSS_FEATURE_COMMAND_ACK);
+    out.clock = std::make_shared<FakeClock>();
+    out.session = std::make_shared<fss::server::fss_client>(out.conn, &mock, writer, handler);
+    out.session->setClock(out.clock);
+    out.session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+    out.session->setPendingCommand(
+        std::make_shared<fss::server::asset_command>(command_dbid, /*ts*/ 500, "RTL", 0.0, 0.0, 0));
+    out.session->sendCommand();
+    const auto sent = out.conn->sentSnapshot();
+    out.dispatched_id = 0;
+    for (const auto &msg : sent)
+    {
+        if (msg != nullptr && msg->getType() == fss::transport::message_type_command)
+        {
+            out.dispatched_id = msg->getId();
+        }
+    }
+    return out;
+}
+
+auto ack_for(uint64_t acked_id, fss::transport::fss_command_ack_outcome outcome)
+    -> std::shared_ptr<fss::transport::fss_message_command_ack>
+{
+    return std::make_shared<fss::transport::fss_message_command_ack>(acked_id, fss::transport::asset_command_rtl,
+                                                                     outcome, uint64_t{1});
+}
+
+} // namespace
+
+TEST_CASE("session: a terminal ack ends the command's redelivery (todo/68)")
+{
+    /* Redelivery covers a delivery the aircraft never acted on. Once it has
+     * reported what it did, resending every 10 s for the rest of the flight
+     * only produces command_ack_noop traffic. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 12;
+    NullClientHandler handler;
+    auto writer = make_mock_writer(mock);
+    constexpr uint64_t command_dbid = 88;
+    auto s = make_dispatched_session(mock, &handler, writer, command_dbid);
+    REQUIRE(s.dispatched_id != 0);
+
+    s.session->processMessage(ack_for(s.dispatched_id, fss::transport::command_ack_actioned));
+    REQUIRE(fss_test::wait_for([&]() -> bool { return !mock.getAcks().empty(); }));
+
+    for (int i = 0; i < 4; ++i)
+    {
+        s.clock->advance((10 * uint64_t{1000}) + 1);
+        s.session->sendCommand();
+    }
+    REQUIRE(count_sent<fss::transport::fss_message_asset_command>(s.conn->sent) == 1);
+}
+
+TEST_CASE("session: a non-terminal 'received' ack does not end the redelivery (todo/68)")
+{
+    /* "received" means the frame arrived, not that the aircraft acted on it —
+     * the same distinction db_command_record_ack's writable set draws. An
+     * aircraft that acknowledges receipt and then goes quiet must keep being
+     * told its commanded state. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 12;
+    NullClientHandler handler;
+    auto writer = make_mock_writer(mock);
+    auto s = make_dispatched_session(mock, &handler, writer, /*command_dbid*/ 88);
+    REQUIRE(s.dispatched_id != 0);
+
+    s.session->processMessage(ack_for(s.dispatched_id, fss::transport::command_ack_received));
+    REQUIRE(fss_test::wait_for([&]() -> bool { return !mock.getAcks().empty(); }));
+
+    for (int i = 0; i < 4; ++i)
+    {
+        s.clock->advance((10 * uint64_t{1000}) + 1);
+        s.session->sendCommand();
+    }
+    REQUIRE(count_sent<fss::transport::fss_message_asset_command>(s.conn->sent) == 5);
+}
+
+TEST_CASE("session: a newer command dispatches despite an earlier terminal ack (todo/68)")
+{
+    /* The stop is scoped to the command that was acked, not to the session. An
+     * operator issuing a new command after the aircraft actioned the last one
+     * must still reach it — this is the DISARM/TERM path. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 12;
+    NullClientHandler handler;
+    auto writer = make_mock_writer(mock);
+    auto s = make_dispatched_session(mock, &handler, writer, /*command_dbid*/ 88);
+    REQUIRE(s.dispatched_id != 0);
+
+    s.session->processMessage(ack_for(s.dispatched_id, fss::transport::command_ack_actioned));
+    REQUIRE(fss_test::wait_for([&]() -> bool { return !mock.getAcks().empty(); }));
+
+    constexpr uint64_t newer_dbid = 89;
+    s.session->setPendingCommand(
+        std::make_shared<fss::server::asset_command>(newer_dbid, /*ts*/ 600, "TERM", 0.0, 0.0, 0));
+    s.session->sendCommand();
+
+    REQUIRE(count_sent<fss::transport::fss_message_asset_command>(s.conn->sent) == 2);
+    REQUIRE(fss_test::wait_for([&]() -> bool { return mock.getDispatches().size() == 2; }));
+    REQUIRE(mock.getDispatches().back().command_dbid == newer_dbid);
+}
+
+TEST_CASE("session: a restarted aircraft is dispatched to again despite the old session's terminal ack (todo/68)")
+{
+    /* The invariant the whole redelivery stop rests on. cap-fmu has no
+     * persistent storage, so an aircraft that restarts has forgotten its
+     * commanded state — and the server must not treat an ack from the previous
+     * connection as evidence that it still holds the command.
+     *
+     * terminally_acked_dbid lives in the per-connection session, and the server
+     * builds a new session for every accepted connection, so a restart resets
+     * it by construction. Model the restart the way the server sees one: the
+     * old session ends and a new session for the same asset and the same
+     * command row takes over. It must dispatch, and must keep resending until
+     * it gets an ack of its own. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 12;
+    NullClientHandler handler;
+    auto writer = make_mock_writer(mock);
+    constexpr uint64_t command_dbid = 88;
+
+    auto first = make_dispatched_session(mock, &handler, writer, command_dbid);
+    REQUIRE(first.dispatched_id != 0);
+    first.session->processMessage(ack_for(first.dispatched_id, fss::transport::command_ack_actioned));
+    REQUIRE(fss_test::wait_for([&]() -> bool { return !mock.getAcks().empty(); }));
+    /* Confirm the precondition: the old session really has stopped resending,
+     * so the assertions below cannot pass just because nothing was suppressed. */
+    first.clock->advance((10 * uint64_t{1000}) + 1);
+    first.session->sendCommand();
+    REQUIRE(count_sent<fss::transport::fss_message_asset_command>(first.conn->sent) == 1);
+    first.session->disconnect();
+
+    /* The aircraft comes back: same asset, same pending command row. */
+    auto second = make_dispatched_session(mock, &handler, writer, command_dbid);
+    REQUIRE(second.dispatched_id != 0);
+    REQUIRE(count_sent<fss::transport::fss_message_asset_command>(second.conn->sent) == 1);
+    /* And the new connection keeps resending until it acks for itself. */
+    for (int i = 0; i < 3; ++i)
+    {
+        second.clock->advance((10 * uint64_t{1000}) + 1);
+        second.session->sendCommand();
+    }
+    REQUIRE(count_sent<fss::transport::fss_message_asset_command>(second.conn->sent) == 4);
+    second.session->disconnect();
+}
+
 TEST_CASE("session: dispatched command carries the server command id only when negotiated (todo/49)")
 {
     /* The dispatched wire message identifies the operator action by this


### PR DESCRIPTION
## Description

Redelivery exists to cover a delivery the aircraft never acted on. Once it has reported actioned/superseded/rejected/noop, re-sending the same command every 10 s for the rest of the flight produces nothing but `command_ack_noop` traffic and a protected DB write to carry each one.

`sendCommand()` now returns early when the pending command is the one this connection has already been terminally acked for. `received` deliberately does not count: it says the frame arrived, not that the aircraft acted, which is the same distinction `db_command_record_ack`'s writable set draws.

**The stop is scoped to the connection, and that is the load-bearing part.** cap-fmu has no persistent storage, so the server must never assume an aircraft still holds a command it acked on some earlier connection. `terminally_acked_dbid` lives in the per-session `fss_client`, and the server builds a new session for every accepted connection — so an aircraft that restarts, or a link that drops, arrives with it at 0, gets the identify-time dispatch immediately, and is resent to until *that* connection acks for itself. Holding the state on the command row instead (the other option todo/68 offers) would wrongly survive the reconnect, which is why it was not taken.

That invariant is pinned rather than asserted in prose: a unit case drives a second session for the same asset and command row after the first acked terminally and requires it to dispatch and keep resending, and an e2e case kills the client outright — no signal handler, no graceful close, nothing carried across — then requires a second dispatch and a re-ack with a fresh ack_timestamp. That is distinct from test_server_restart.py, which bounces the server rather than the aircraft.

Also adds the measurement todo/68's acceptance criterion actually asks for: an e2e steady state spanning two resend windows in which the row's four ack columns never move and exactly one dispatch is logged. Before this series that test would have seen the columns cycle through NULL and the count climb.

The one restart shape this does not cover is an autopilot rebooting *underneath* a live cap-fmu connection: the server sees no connection change and has nothing to re-dispatch on. It cannot observe that event, so it is cap-fmu's to handle — raised as ../cap-fmu/todo/108, along with the question of whether the FMU relies on redelivery as a keep-alive within a connection. If it does, a slow re-assert can go back on top of this.

Verified: 433 unit cases green locally and against a live PostgreSQL with 0 skipped; check-code.sh clean; e2e test_command_ack (4 cases), test_server_restart and test_command_identity all pass.

## Summary by Sourcery

Stop command redelivery on a per-connection basis once the aircraft reports a terminal ack, while preserving redelivery behaviour for non-terminal acknowledgements and reconnections.

New Features:
- Add per-session tracking of the terminally acked command to suppress further redelivery for that command on the same connection.

Enhancements:
- Adjust command sending logic to consult terminal ack state so that only unsettled or new commands are re-dispatched.

Tests:
- Add unit tests validating redelivery stop after terminal ack, continued redelivery after a non-terminal 'received' ack, dispatch of newer commands, and behaviour across client restarts.
- Add end-to-end tests verifying redispatch and re-ack after an aircraft restart and ensuring an acked command no longer churns its database row or dispatch log over multiple resend windows.