### PR TITLE
test: give the copy-pasted FakeClock one home in test_helpers.hpp

### DIFF
--- a/tests/client_server_list_test.cpp
+++ b/tests/client_server_list_test.cpp
@@ -20,6 +20,10 @@
 
 #include "fss-client-ssl.hpp"
 #include "fss-transport.hpp"
+#include "test_helpers.hpp"
+
+/* Shared controllable clock (tests/test_helpers.hpp). */
+using fss_test::FakeClock;
 
 /* todo/67: updateServers() only ever ADDED. There was no removal path anywhere
  * in client-ssl.cpp — entries migrated between `servers` and
@@ -32,12 +36,6 @@
 namespace {
 
 namespace fss = flight_safety_system;
-
-struct FakeClock : public fss::IClock {
-    uint64_t t{0};
-    auto now_ms() const -> uint64_t override { return t; }
-    void advance(uint64_t ms) { t += ms; }
-};
 
 /* Exposes the configuration setters, which are protected because they are meant
  * to be driven from a config file. Nothing here ever dials, so every server

--- a/tests/reconnect_test.cpp
+++ b/tests/reconnect_test.cpp
@@ -26,6 +26,9 @@
 #include "fss-client-ssl.hpp"
 #include "test_helpers.hpp"
 
+/* Shared controllable clock (tests/test_helpers.hpp). */
+using fss_test::FakeClock;
+
 /* The client-ssl reconnect path needs TLS fixtures; the test Makefile
  * generates these under certs/ at build time and they're reused by
  * tests/client.cpp. */
@@ -47,12 +50,6 @@ auto make_listener(uint16_t port)
     return std::make_shared<flight_safety_system::transport_ssl::fss_listen>(port, handoff.callback(), CA_PUBLIC_FILE,
                                                                              SERVER_PRIVATE_FILE, SERVER_PUBLIC_FILE);
 }
-
-struct FakeClock : public flight_safety_system::IClock {
-    uint64_t t{0};
-    auto now_ms() const -> uint64_t override { return t; }
-    void advance(uint64_t ms) { t += ms; }
-};
 
 class CountingServer : public flight_safety_system::client_ssl::fss_server {
 public:

--- a/tests/server_clients_test.cpp
+++ b/tests/server_clients_test.cpp
@@ -31,6 +31,9 @@
 #include "server-clients.hpp"
 #include "test_helpers.hpp"
 
+/* Shared controllable clock (tests/test_helpers.hpp). */
+using fss_test::FakeClock;
+
 namespace fss = flight_safety_system;
 
 namespace {
@@ -124,12 +127,6 @@ auto count_sent(const std::vector<std::shared_ptr<fss::transport::fss_message>> 
     }
     return count;
 }
-
-struct FakeClock : public fss::IClock {
-    uint64_t t{0};
-    auto now_ms() const -> uint64_t override { return t; }
-    void advance(uint64_t ms) { t += ms; }
-};
 
 auto make_null_writer() -> std::shared_ptr<fss::server::db_write_queue>
 {

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -28,6 +28,9 @@
 #include "db-write-queue.hpp"
 #include "test_helpers.hpp"
 
+/* Shared controllable clock (tests/test_helpers.hpp). */
+using fss_test::FakeClock;
+
 namespace fss = flight_safety_system;
 
 namespace flight_safety_system::server {
@@ -186,12 +189,6 @@ auto count_sent(const std::vector<std::shared_ptr<fss::transport::fss_message>> 
     }
     return count;
 }
-
-struct FakeClock : public fss::IClock {
-    uint64_t t{0};
-    auto now_ms() const -> uint64_t override { return t; }
-    void advance(uint64_t ms) { t += ms; }
-};
 
 /* Builds a db_write_queue that forwards to the mock — tests that don't care
  * about telemetry still need a non-null writer for the fss_client ctor. */

--- a/tests/test_helpers.hpp
+++ b/tests/test_helpers.hpp
@@ -19,10 +19,24 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "fss.hpp"
 #include "fss-log.hpp"
 #include "fss-transport.hpp"
 
 namespace fss_test {
+
+/* A clock the test drives by hand. Every timekeeping class in the tree takes an
+ * injectable IClock so its timing behaviour can be asserted at the threshold
+ * ("no trip at 4.9 s, trip at 5.1 s") instead of by sleeping and hoping.
+ *
+ * Starts at 0, which is a real value rather than a sentinel: a class that uses
+ * 0 to mean "no timestamp recorded" will silently misbehave here, so use an
+ * explicit flag for that rather than advancing the clock past it. */
+struct FakeClock : public flight_safety_system::IClock {
+    uint64_t t{0};
+    [[nodiscard]] auto now_ms() const -> uint64_t override { return t; }
+    void advance(uint64_t ms) { t += ms; }
+};
 
 inline auto wait_for(const std::function<bool()> &pred,
                      std::chrono::milliseconds timeout = std::chrono::milliseconds(2000),

--- a/tests/timeout_test.cpp
+++ b/tests/timeout_test.cpp
@@ -20,17 +20,14 @@
 #include "db-write-queue.hpp"
 #include "test_helpers.hpp"
 
+/* Shared controllable clock (tests/test_helpers.hpp). */
+using fss_test::FakeClock;
+
 namespace fss = flight_safety_system;
 
 namespace {
 
 /* ── shared test doubles ─────────────────────────────────── */
-
-struct FakeClock : public fss::IClock {
-    uint64_t t{0};
-    auto now_ms() const -> uint64_t override { return t; }
-    void advance(uint64_t ms) { t += ms; }
-};
 
 class FakeConnection : public fss::transport::fss_connection {
 public:


### PR DESCRIPTION
## Description

The same five-line struct was defined independently in timeout_test.cpp, reconnect_test.cpp, client_server_list_test.cpp, server_clients_test.cpp and server_session_test.cpp — identical in every one, differing only in whether it spelled the base class `fss::IClock` or `flight_safety_system::IClock`. server_failsafe_test.cpp is about to become the sixth user, so it moves to tests/test_helpers.hpp beside the other shared doubles first, as its own no-behaviour-change commit.

The shared copy documents the one thing a caller can get wrong, which none of the five copies mentioned: it starts at 0, and 0 is a real reading rather than a spare value. A class that uses 0 as a "no timestamp yet" sentinel misbehaves silently under it — which is precisely the trap in db_failsafe's incident_start, dealt with in the next commit.

client_server_list_test.cpp did not previously include test_helpers.hpp and now does.

Verified: 433 cases green, unchanged from before the move.

## Summary by Sourcery

Centralize the FakeClock test double in test_helpers.hpp and update tests to use the shared implementation.

Enhancements:
- Add a documented FakeClock implementation to test_helpers.hpp for use across time-dependent tests.
- Replace per-test FakeClock structs in timeout, reconnect, client_server_list, server_clients, and server_session tests with the shared helper.

Tests:
- Update client_server_list_test to include test_helpers.hpp and reference the shared FakeClock helper.