### PR TITLE
fix: measure the DB fail-safe's thresholds against a clock, not tick counts

### DIFF
--- a/src/server-failsafe.hpp
+++ b/src/server-failsafe.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
+#include "fss.hpp"
+
 #include <cstddef>
 #include <cstdint>
+#include <memory>
+#include <utility>
 
 namespace flight_safety_system {
 namespace server {
@@ -32,6 +36,17 @@ namespace server {
  * then the health probe — if the fault persists, the next incident latches
  * again rather than flapping on the tick period.
  *
+ * Thresholds are measured against an injectable IClock, not against a count of
+ * tick() calls (todo/70). The caller drives this from a loop whose period is
+ * nominally one second but is really a sleep plus however long the loop body
+ * took, and which a signal can cut short — so counting calls meant "5 seconds
+ * of sustained failure before severing" stretched under load and compressed
+ * under signal traffic. Load is correlated with the database being unwell,
+ * which made the trip late in exactly the conditions it exists for. Measuring
+ * real elapsed time also lets the tests assert the thresholds ("no trip at
+ * 4.9 s, trip at 5.1 s") rather than the call count, which is the whole reason
+ * every other timekeeping class in the tree takes a clock.
+ *
  * Not thread-safe: main-loop tick only, like the tracker it replaces. */
 class db_failsafe {
 public:
@@ -48,33 +63,48 @@ public:
         command_drop,
     };
 private:
-    uint64_t disconnect_age_secs;
-    uint64_t recovery_grace_secs;
-    uint64_t elapsed_secs{0};
-    uint64_t incident_start_secs{0}; // 0 = no active write-failure incident
-    uint64_t last_event_secs{0};     // last tick a new failure or drop arrived
+    static constexpr uint64_t ms_per_sec = 1000;
+    uint64_t disconnect_age_ms;
+    uint64_t recovery_grace_ms;
+    std::shared_ptr<IClock> clock;
+    uint64_t now_ms{0}; // the clock reading taken by the current tick
+    uint64_t incident_start_ms{0};
+    uint64_t last_event_ms{0}; // when a new failure or drop last arrived
     uint64_t last_write_failures{0};
     uint64_t last_command_drops{0};
+    /* An explicit flag rather than incident_start_ms == 0. A monotonic clock
+     * that has just started, and every test clock, legitimately reads 0, so a
+     * zero sentinel would silently discard an incident that began at the
+     * origin. */
+    bool incident_active{false};
     bool degraded_{false};
     trip_reason reason_{trip_reason::none};
 public:
-    db_failsafe(uint64_t t_disconnect_age_secs, uint64_t t_recovery_grace_secs)
-        : disconnect_age_secs(t_disconnect_age_secs), recovery_grace_secs(t_recovery_grace_secs)
+    /* Thresholds are given in seconds, as the config file states them, and held
+     * in milliseconds because that is what IClock reports. A null clock falls
+     * back to MonotonicClock, matching fss_client::setClock. */
+    db_failsafe(uint64_t t_disconnect_age_secs, uint64_t t_recovery_grace_secs,
+                std::shared_ptr<IClock> t_clock = nullptr)
+        : disconnect_age_ms(t_disconnect_age_secs * ms_per_sec), recovery_grace_ms(t_recovery_grace_secs * ms_per_sec),
+          clock(t_clock == nullptr ? std::make_shared<MonotonicClock>() : std::move(t_clock))
     {
     }
-    /* Advance one second with the queue's current cumulative counters and
-     * backlog depth. Counters are cumulative (never reset), so a change since
-     * the previous tick is a new failure/drop in the last second. */
+    /* Advance with the queue's current cumulative counters and backlog depth.
+     * Counters are cumulative (never reset), so a change since the previous
+     * tick is a new failure/drop since then. The caller is expected to tick
+     * about once a second, but nothing here depends on that: every threshold
+     * is measured against the clock, so a slow or interrupted tick changes when
+     * a decision is observed, never when it is due. */
     auto tick(uint64_t write_failures, uint64_t command_drops, std::size_t pending_writes) -> event
     {
-        this->elapsed_secs++;
+        this->now_ms = this->clock->now_ms();
         bool new_write_failure = write_failures != this->last_write_failures;
         bool new_command_drop = command_drops != this->last_command_drops;
         this->last_write_failures = write_failures;
         this->last_command_drops = command_drops;
         if (new_write_failure || new_command_drop)
         {
-            this->last_event_secs = this->elapsed_secs;
+            this->last_event_ms = this->now_ms;
         }
         if (this->degraded_)
         {
@@ -83,12 +113,12 @@ public:
              * they keep producing failures, and a nonempty-but-quiet queue
              * (e.g. a wedged sink) is not health either. */
             bool quiet = !new_write_failure && !new_command_drop &&
-                         (this->elapsed_secs - this->last_event_secs) > this->recovery_grace_secs;
+                         (this->now_ms - this->last_event_ms) > this->recovery_grace_ms;
             if (pending_writes == 0 && quiet)
             {
                 this->degraded_ = false;
                 this->reason_ = trip_reason::none;
-                this->incident_start_secs = 0;
+                this->incident_active = false;
                 return event::recovered;
             }
             return event::none;
@@ -97,40 +127,47 @@ public:
         {
             this->degraded_ = true;
             this->reason_ = trip_reason::command_drop;
-            this->incident_start_secs = 0;
+            /* No write-failure incident is implicated, so do not leave one
+             * standing for incidentAgeSecs() to report against this trip. */
+            this->incident_active = false;
             return event::tripped;
         }
         if (new_write_failure)
         {
-            if (this->incident_start_secs == 0)
+            if (!this->incident_active)
             {
-                this->incident_start_secs = this->elapsed_secs;
+                this->incident_active = true;
+                this->incident_start_ms = this->now_ms;
             }
             /* Not `else`: a disconnect_age_secs of 0 means "sever on any
              * failure", so the incident's first failure must satisfy the age
              * check on its own tick. */
-            if ((this->elapsed_secs - this->incident_start_secs) >= this->disconnect_age_secs)
+            if ((this->now_ms - this->incident_start_ms) >= this->disconnect_age_ms)
             {
                 this->degraded_ = true;
                 this->reason_ = trip_reason::write_failure;
-                this->incident_start_secs = 0;
+                /* Deliberately left active, unlike the command-drop path: the
+                 * caller logs incidentAgeSecs() with the trip, and nothing
+                 * consults the incident while degraded — the branch above
+                 * returns before reaching it. Recovery clears it. */
                 return event::tripped;
             }
         }
-        else if (this->incident_start_secs != 0 &&
-                 (this->elapsed_secs - this->last_event_secs) > this->recovery_grace_secs)
+        else if (this->incident_active && (this->now_ms - this->last_event_ms) > this->recovery_grace_ms)
         {
-            this->incident_start_secs = 0;
+            this->incident_active = false;
         }
         return event::none;
     }
     [[nodiscard]] auto degraded() const -> bool { return this->degraded_; }
     [[nodiscard]] auto reason() const -> trip_reason { return this->reason_; }
-    /* The active write-failure incident's age in seconds (0 if none), for the
-     * caller's trip log. */
+    /* How long the write-failure incident had been running as of the last
+     * tick, in seconds (0 if none is active), for the caller's trip log. Read
+     * against the tick's own clock reading rather than a fresh one, so the
+     * number logged is the one the trip decision was made on. */
     [[nodiscard]] auto incidentAgeSecs() const -> uint64_t
     {
-        return this->incident_start_secs == 0 ? 0 : this->elapsed_secs - this->incident_start_secs;
+        return this->incident_active ? (this->now_ms - this->incident_start_ms) / ms_per_sec : 0;
     }
 };
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -514,14 +514,24 @@ auto main(int argc, char *argv[]) -> int
                     case db_failsafe::event::tripped: {
                         clients->setDegraded(true);
                         auto severed = clients->disconnectAll();
-                        FSS_LOG_ERROR("server", "DB fail-safe tripped ("
-                                                    << (failsafe.reason() == db_failsafe::trip_reason::command_drop
-                                                            ? "a command dispatch/ack DB write was dropped — audit "
-                                                              "state destroyed"
-                                                            : "sustained DB write failures")
-                                                    << "); severed " << severed
-                                                    << " connection(s) and refusing new sessions until the write "
-                                                       "queue drains and stays quiet");
+                        bool dropped = failsafe.reason() == db_failsafe::trip_reason::command_drop;
+                        /* Name how long the incident had been running: with the
+                         * threshold now measured against a clock rather than a
+                         * tick count (todo/70), the operator can tell a
+                         * just-over-threshold trip from one that had been
+                         * failing for a minute. Only meaningful for the
+                         * sustained-failure path — a command drop trips on the
+                         * first occurrence, with no incident to age. */
+                        FSS_LOG_ERROR("server",
+                                      "DB fail-safe tripped ("
+                                          << (dropped ? "a command dispatch/ack DB write was dropped — audit "
+                                                        "state destroyed"
+                                                      : "sustained DB write failures")
+                                          << (dropped ? std::string{}
+                                                      : " over " + std::to_string(failsafe.incidentAgeSecs()) + "s")
+                                          << "); severed " << severed
+                                          << " connection(s) and refusing new sessions until the write "
+                                             "queue drains and stays quiet");
                         break;
                     }
                     case db_failsafe::event::recovered:

--- a/tests/server_failsafe_test.cpp
+++ b/tests/server_failsafe_test.cpp
@@ -22,11 +22,51 @@
 namespace fss = flight_safety_system;
 
 using fss::server::db_failsafe;
+using fss_test::FakeClock;
 
 /* Unit tests for the unified DB fail-safe monitor (todo/45 + todo/47): the
  * write-failure incident semantics carried over from todo/34's tracker, the
  * immediate command-drop trip, and the latched degraded state with its
  * drain-plus-quiet-window recovery rule. */
+
+namespace {
+
+/* Drives db_failsafe on a clock the test owns (todo/70).
+ *
+ * Every case below was written when a tick() call *was* the unit of time, so
+ * tick() here spends one second before each call and the cases read unchanged.
+ * That is also what the caller does: the main loop ticks the fail-safe once a
+ * second. What the clock adds is that the tests can now say how much time a
+ * tick spent — see the threshold-edge and slow-tick cases at the end, which
+ * were not expressible against a call counter. */
+class FailsafeHarness {
+public:
+    FailsafeHarness(uint64_t t_disconnect_age_secs, uint64_t t_recovery_grace_secs)
+        : f(t_disconnect_age_secs, t_recovery_grace_secs, clock)
+    {
+    }
+    /* One nominal second of the caller's loop. */
+    auto tick(uint64_t write_failures, uint64_t command_drops, std::size_t pending_writes) -> db_failsafe::event
+    {
+        return this->tickAfter(1000, write_failures, command_drops, pending_writes);
+    }
+    /* A tick that took `ms` to come round — a slow loop body, a signal-shortened
+     * sleep, or a deliberate step onto one side of a threshold. */
+    auto tickAfter(uint64_t ms, uint64_t write_failures, uint64_t command_drops, std::size_t pending_writes)
+        -> db_failsafe::event
+    {
+        this->clock->advance(ms);
+        return this->f.tick(write_failures, command_drops, pending_writes);
+    }
+    [[nodiscard]] auto degraded() const -> bool { return this->f.degraded(); }
+    [[nodiscard]] auto reason() const -> db_failsafe::trip_reason { return this->f.reason(); }
+    [[nodiscard]] auto incidentAgeSecs() const -> uint64_t { return this->f.incidentAgeSecs(); }
+private:
+    std::shared_ptr<FakeClock> clock{std::make_shared<FakeClock>()};
+    db_failsafe f;
+};
+
+} // namespace
 
 TEST_CASE("db_failsafe: a single transient write failure never trips")
 {
@@ -35,7 +75,7 @@ TEST_CASE("db_failsafe: a single transient write failure never trips")
      * grace exceeded the disconnect threshold — the default configuration —
      * because a lone failure kept the incident 'active' through the grace
      * period and the age check then fired with no further failure. */
-    db_failsafe f(5, 15);
+    FailsafeHarness f(5, 15);
     REQUIRE(f.tick(1, 0, 0) == db_failsafe::event::none);
     for (int i = 0; i < 30; i++)
     {
@@ -46,7 +86,7 @@ TEST_CASE("db_failsafe: a single transient write failure never trips")
 
 TEST_CASE("db_failsafe: sustained write failures trip once they span the age threshold")
 {
-    db_failsafe f(5, 15);
+    FailsafeHarness f(5, 15);
     uint64_t failures = 0;
     /* Failures every tick: the incident starts at the first one; the trip
      * needs a new failure arriving at age >= 5, i.e. the sixth tick. */
@@ -66,7 +106,7 @@ TEST_CASE("db_failsafe: failures recurring within the grace window chain into on
      * ticks between: gaps shorter than the recovery grace must not restart
      * the incident age (the reason todo/34 replaced a consecutive-tick
      * counter with a wall-clock incident). */
-    db_failsafe f(4, 15);
+    FailsafeHarness f(4, 15);
     REQUIRE(f.tick(1, 0, 0) == db_failsafe::event::none); // incident starts
     for (int i = 0; i < 3; i++)
     {
@@ -79,7 +119,7 @@ TEST_CASE("db_failsafe: failures recurring within the grace window chain into on
 
 TEST_CASE("db_failsafe: a gap longer than the grace window starts a fresh incident")
 {
-    db_failsafe f(5, 3);
+    FailsafeHarness f(5, 3);
     REQUIRE(f.tick(1, 0, 0) == db_failsafe::event::none);
     for (int i = 0; i < 6; i++)
     {
@@ -93,7 +133,7 @@ TEST_CASE("db_failsafe: a gap longer than the grace window starts a fresh incide
 
 TEST_CASE("db_failsafe: a disconnect threshold of 0 trips on the first failure")
 {
-    db_failsafe f(0, 15);
+    FailsafeHarness f(0, 15);
     REQUIRE(f.tick(1, 0, 0) == db_failsafe::event::tripped);
     REQUIRE(f.degraded());
     REQUIRE(f.reason() == db_failsafe::trip_reason::write_failure);
@@ -103,7 +143,7 @@ TEST_CASE("db_failsafe: any command drop trips immediately")
 {
     /* todo/45: a dropped command dispatch/ack write is known-destroyed audit
      * state; there is no threshold to age through. */
-    db_failsafe f(5, 15);
+    FailsafeHarness f(5, 15);
     REQUIRE(f.tick(0, 0, 0) == db_failsafe::event::none);
     REQUIRE(f.tick(0, 1, 0) == db_failsafe::event::tripped);
     REQUIRE(f.degraded());
@@ -112,7 +152,7 @@ TEST_CASE("db_failsafe: any command drop trips immediately")
 
 TEST_CASE("db_failsafe: no recovery while the write queue still holds a backlog")
 {
-    db_failsafe f(0, 2);
+    FailsafeHarness f(0, 2);
     REQUIRE(f.tick(1, 0, 5) == db_failsafe::event::tripped);
     /* Quiet, but the backlog never drains: stays degraded no matter how long
      * the quiet window grows (a wedged-but-silent sink is not health). */
@@ -129,7 +169,7 @@ TEST_CASE("db_failsafe: no recovery while the write queue still holds a backlog"
 
 TEST_CASE("db_failsafe: recovery requires the full quiet window after the last failure")
 {
-    db_failsafe f(0, 3);
+    FailsafeHarness f(0, 3);
     REQUIRE(f.tick(1, 0, 0) == db_failsafe::event::tripped);
     /* Quiet, drained ticks: the window must strictly exceed the grace. */
     REQUIRE(f.tick(1, 0, 0) == db_failsafe::event::none); // 1s quiet
@@ -144,7 +184,7 @@ TEST_CASE("db_failsafe: failures during the degraded drain push recovery out")
     /* After the trip severs everything, the queue's backlog keeps draining
      * against the broken sink and keeps producing failures; each one restarts
      * the quiet window, so recovery only follows genuine silence. */
-    db_failsafe f(0, 3);
+    FailsafeHarness f(0, 3);
     REQUIRE(f.tick(1, 0, 3) == db_failsafe::event::tripped);
     REQUIRE(f.tick(2, 0, 2) == db_failsafe::event::none); // drain failure
     REQUIRE(f.tick(2, 0, 1) == db_failsafe::event::none); // quiet 1s
@@ -157,7 +197,7 @@ TEST_CASE("db_failsafe: failures during the degraded drain push recovery out")
 
 TEST_CASE("db_failsafe: a command drop while already degraded does not re-trip")
 {
-    db_failsafe f(0, 2);
+    FailsafeHarness f(0, 2);
     REQUIRE(f.tick(1, 0, 0) == db_failsafe::event::tripped);
     /* Already degraded: the drop extends the quiet window but reports no new
      * transition (the caller has already severed and gated). */
@@ -174,7 +214,7 @@ TEST_CASE("db_failsafe: a fresh incident after recovery trips again")
      * readmitted traffic is the health probe. If the fault persists, the next
      * incident must latch again (one clean severance per incident, on the
      * incident timescale — not a per-tick flap). */
-    db_failsafe f(2, 3);
+    FailsafeHarness f(2, 3);
     uint64_t failures = 0;
     REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::none);
     REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::none);
@@ -226,7 +266,7 @@ TEST_CASE("db_failsafe: telemetry-only drops from a real queue never trip the fa
     REQUIRE(q.dropped_count() == 1);
     REQUIRE(q.command_dropped_count() == 0);
 
-    db_failsafe f(5, 15);
+    FailsafeHarness f(5, 15);
     for (int i = 0; i < 20; i++)
     {
         REQUIRE(f.tick(q.write_failure_count(), q.command_dropped_count(), q.pending_count()) ==
@@ -248,4 +288,111 @@ TEST_CASE("db_failsafe: telemetry-only drops from a real queue never trip the fa
     }
     gate_cv.notify_all();
     q.stop();
+}
+
+/* ── Threshold behaviour, which a call counter could not express ─────────── */
+
+TEST_CASE("db_failsafe: the trip threshold is real time, not tick count (todo/70)")
+{
+    /* The question the class exists to answer and could not previously be
+     * asked: does it fire when the configuration says it fires? The default is
+     * 5 s of sustained failure, so a failure at 4.9 s must not trip and one at
+     * 5.1 s must. */
+    {
+        FailsafeHarness f(5, 15);
+        REQUIRE(f.tickAfter(1000, 1, 0, 0) == db_failsafe::event::none); // incident starts
+        REQUIRE(f.tickAfter(3900, 2, 0, 0) == db_failsafe::event::none); // 4.9s old
+        REQUIRE(!f.degraded());
+    }
+    {
+        FailsafeHarness f(5, 15);
+        REQUIRE(f.tickAfter(1000, 1, 0, 0) == db_failsafe::event::none);
+        REQUIRE(f.tickAfter(5100, 2, 0, 0) == db_failsafe::event::tripped); // 5.1s old
+        REQUIRE(f.reason() == db_failsafe::trip_reason::write_failure);
+    }
+}
+
+TEST_CASE("db_failsafe: the recovery window is real time, not tick count (todo/70)")
+{
+    /* Same question for the other edge. The window is strictly greater than the
+     * grace, so exactly 15.0 s of quiet is not yet recovery. */
+    {
+        FailsafeHarness f(0, 15);
+        REQUIRE(f.tickAfter(1000, 1, 0, 0) == db_failsafe::event::tripped);
+        REQUIRE(f.tickAfter(15000, 1, 0, 0) == db_failsafe::event::none); // exactly 15s
+        REQUIRE(f.degraded());
+    }
+    {
+        FailsafeHarness f(0, 15);
+        REQUIRE(f.tickAfter(1000, 1, 0, 0) == db_failsafe::event::tripped);
+        REQUIRE(f.tickAfter(15001, 1, 0, 0) == db_failsafe::event::recovered);
+        REQUIRE(!f.degraded());
+    }
+}
+
+TEST_CASE("db_failsafe: a slow tick does not move the threshold (todo/70)")
+{
+    /* The defect todo/70 filed. The caller's loop is a 100 ms sleep plus
+     * however long the body took, and a signal can cut the sleep short — so
+     * "5 seconds" used to mean "5 calls", stretching under load and
+     * compressing under signal traffic. Load correlates with the database
+     * being unwell, so the trip ran late in exactly the conditions it exists
+     * for.
+     *
+     * Here one tick takes six seconds. Against a call counter the incident
+     * would be one tick old and would not trip; against the clock it is six
+     * seconds old and does. */
+    FailsafeHarness f(5, 15);
+    REQUIRE(f.tickAfter(1000, 1, 0, 0) == db_failsafe::event::none);
+    REQUIRE(f.tickAfter(6000, 2, 0, 0) == db_failsafe::event::tripped);
+    REQUIRE(f.reason() == db_failsafe::trip_reason::write_failure);
+}
+
+TEST_CASE("db_failsafe: a fast tick does not trip early (todo/70)")
+{
+    /* The other direction, which matters more: a SIGHUP returns the caller's
+     * usleep early, so ticks can arrive far faster than once a second. Thirty
+     * of them inside one second must not add up to a 5 s incident. */
+    FailsafeHarness f(5, 15);
+    uint64_t failures = 0;
+    for (int i = 0; i < 30; i++)
+    {
+        REQUIRE(f.tickAfter(30, ++failures, 0, 0) == db_failsafe::event::none);
+        REQUIRE(!f.degraded());
+    }
+}
+
+TEST_CASE("db_failsafe: the trip reports how long the incident had been running (todo/70)")
+{
+    /* incidentAgeSecs() is documented as existing for the caller's trip log and
+     * had no caller; server.cpp now logs it, so an operator can tell a
+     * just-over-threshold trip from one that had been failing for a minute.
+     * The write-failure path leaves the incident standing for exactly this
+     * read; the command-drop path has no incident to report. */
+    {
+        FailsafeHarness f(5, 15);
+        REQUIRE(f.tickAfter(1000, 1, 0, 0) == db_failsafe::event::none);
+        REQUIRE(f.tickAfter(42000, 2, 0, 0) == db_failsafe::event::tripped);
+        REQUIRE(f.incidentAgeSecs() == 42);
+    }
+    {
+        FailsafeHarness f(5, 15);
+        REQUIRE(f.tickAfter(1000, 0, 1, 0) == db_failsafe::event::tripped);
+        REQUIRE(f.reason() == db_failsafe::trip_reason::command_drop);
+        REQUIRE(f.incidentAgeSecs() == 0);
+    }
+}
+
+TEST_CASE("db_failsafe: an incident starting at clock zero is not discarded (todo/70)")
+{
+    /* Regression guard for the sentinel this conversion removed. The old code
+     * used incident_start == 0 to mean "no incident", which a clock reading
+     * zero — every FakeClock, and a monotonic clock just after boot —
+     * indistinguishably satisfies. With the sentinel, this incident would
+     * silently restart on every failure and never age enough to trip. */
+    FailsafeHarness f(2, 15);
+    REQUIRE(f.tickAfter(0, 1, 0, 0) == db_failsafe::event::none); // incident starts at t=0
+    REQUIRE(f.tickAfter(1000, 2, 0, 0) == db_failsafe::event::none);
+    REQUIRE(f.tickAfter(1000, 3, 0, 0) == db_failsafe::event::tripped); // 2s old
+    REQUIRE(f.reason() == db_failsafe::trip_reason::write_failure);
 }


### PR DESCRIPTION
## Description

`db_failsafe::tick()` opened with `elapsed_secs++` and expressed every threshold against that counter, but its caller advances it on a `usleep(100 ms)` loop plus however long the loop body took — `sendCommand()` fanned out over every client, and once a second `cleanupRemovableClients()` (which joins departing clients' recv threads), `checkTimeouts()` and `sendRTTRequest()`. The handlers install with `sa_flags = 0`, so a SIGHUP or SIGTERM also returns the sleep early.

So "5 seconds of sustained failure before severing" meant five loop iterations. They stretch under load — and load correlates with the database being unwell, since a struggling write queue means more clients backing up — so the trip ran late in exactly the conditions it exists for. This was the only timekeeping class in the tree without an injectable clock, which is why the drift had never been measured: the 12 existing cases tested the counter arithmetic because there was no timing behaviour to test.

`db_failsafe` now takes a `shared_ptr<IClock>` defaulting to `MonotonicClock`, holds its thresholds in milliseconds, and reads the clock once per tick. The comparison semantics are carried over exactly: `>=` for the trip, strict `>` for both grace windows, and the deliberate non-`else` that lets a threshold of 0 trip on the incident's own first failure. The 12 cases keep their text — a test harness spends one nominal second per tick — so the conversion is auditable against them rather than being a rewrite.

One trap worth naming: `incident_start_secs == 0` was the "no active incident" sentinel, and a clock reading zero satisfies it. Every FakeClock starts at 0, so with the sentinel kept, an incident beginning at the origin would restart on every failure and never age enough to trip. It is now an explicit `incident_active` flag, with a regression case pinning it.

`incidentAgeSecs()` was documented as existing "for the caller's trip log" and had no caller anywhere in the tree. The write-failure trip now leaves the incident standing so the accessor can answer, and `server.cpp` logs it: an operator can tell a just-over-threshold trip from one that had been failing for a minute. The command-drop trip clears it instead, since no incident is implicated.

Six new cases assert what the item was filed for and what a call counter could not express: no trip at 4.9 s and a trip at 5.1 s; no recovery at exactly 15.0 s of quiet and recovery at 15.001 s; a single six-second tick trips where five calls would not have; thirty signal-shortened ticks inside one second do not; the trip reports the incident's age; and an incident starting at clock zero survives.

Acceptance criterion met: no change to observed behaviour in `e2e/test_db_disk_full.py`, `test_db_write_only_failure.py` (which pins exactly one latched fail-safe event and a 6 s no-flap window), `test_db_blackhole.py` (which pins that a *frozen* database must not trip it) or `test_schema_check.py` — all four still pass.

The main loop still advances on `usleep` plus work; putting it on a deadline is the next commit. The point of doing the clock first is that the fail-safe no longer depends on the answer.

`src/server-failsafe.hpp` is not an installed header, so there is no ABI cost and no `-version-info` change.

Verified: 439 unit cases green (18 in this file, up from 12); check-code.sh clean; the four fail-safe e2e tests pass.

## Summary by Sourcery

Measure DB fail-safe thresholds against an injectable clock instead of tick counts and expose incident duration in server logging.

New Features:
- Allow db_failsafe to use an injectable clock implementation for time-based threshold evaluation.
- Log the duration of sustained DB write-failure incidents when the fail-safe trips.

Enhancements:
- Represent DB fail-safe thresholds and incident timing in milliseconds to align with clock-based measurement.
- Replace sentinel-based incident tracking with an explicit flag to correctly handle incidents starting at time zero.

Tests:
- Introduce a FailsafeHarness using a controllable FakeClock and extend db_failsafe tests to cover real-time threshold behaviour, slow/fast ticks, incident age reporting, and zero-origin incidents.