### PR TITLE
fix: rename db_write_failure_disconnect_ticks to _secs (todo/70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tracked documents; the rest are retargeted as those files are next touched.
 
 ### Changed
+- **The DB fail-safe's thresholds are measured in real time, not in loop
+  iterations** (todo/70). `db_failsafe` opened each tick with `elapsed_secs++`
+  and compared every threshold against that counter, but the caller advances it
+  on a 100 ms sleep *plus* whatever the loop body took — a fan-out over every
+  client, and once a second a pass that joins departing clients' receive
+  threads — and the signal handlers install without `SA_RESTART`, so a SIGHUP or
+  SIGTERM returned the sleep early. "5 seconds of sustained failure before
+  severing the fleet" therefore meant five loop iterations: stretched under
+  load, compressed under signal traffic. Load correlates with the database being
+  unwell, so the trip ran late in exactly the conditions it exists for. This was
+  also the only timekeeping class in the tree without an injectable clock, which
+  is why the drift had never been measured — its tests could only assert the
+  counter arithmetic. It now takes an `IClock`, and the main loop runs every
+  periodic task on its own deadline, so `checkTimeouts()` and the RTT sweep keep
+  honest time as well. No threshold or transition changed; the existing twelve
+  cases are unchanged and six new ones pin the edges (no trip at 4.9 s, trip at
+  5.1 s; recovery at 15.001 s but not at 15.000 s; one six-second tick trips
+  where five calls would not have; thirty signal-shortened ticks inside a second
+  do not). The trip log now names how long the incident had been running.
+  **The config field `db_write_failure_disconnect_ticks` is renamed
+  `db_write_failure_disconnect_secs`** — which is what it always meant, and what
+  its sibling was already called; the old key is still accepted and warns.
 - **A command issued once no longer destroys and rewrites its own stored
   acknowledgement every 10 seconds** (todo/68,
   `docs/decisions/68-command-redelivery-and-ack-keying.md`). Nothing retires a

--- a/docs/decisions/34-45-47-db-failsafe-latch.md
+++ b/docs/decisions/34-45-47-db-failsafe-latch.md
@@ -26,7 +26,7 @@ One state machine owning both triggers and the latch.
 **Triggers.** A `command_dropped_count()` increase trips *immediately* — a
 dropped dispatch or ack write is known-destroyed audit state, with no threshold
 to age through. A write-*failure* incident trips only when a **new** failure
-arrives while the incident is already `db_write_failure_disconnect_ticks` old.
+arrives while the incident is already `db_write_failure_disconnect_secs` old.
 
 That second condition also fixed a defect in the shipped 34 tracker: a *single*
 transient failure kept the incident active through the recovery grace and
@@ -44,6 +44,26 @@ clients are severed unactivated.
 `db_write_failure_recovery_grace_secs` of quiet lowers the gate; readmitted
 traffic is itself the health probe. A persistent fault re-latches on the
 incident timescale rather than flapping.
+
+### Both windows are real time (revised 2026-07-31, todo/70)
+
+As shipped, `db_failsafe` counted `tick()` calls and both thresholds were
+expressed against that counter. The caller drove it from a loop whose period was
+a 100 ms sleep plus the loop body's work, and which a signal could cut short, so
+the windows above stretched under load and compressed under signal traffic —
+load being correlated with the database being unwell, the trip ran late in
+exactly the conditions it exists for.
+
+`db_failsafe` now takes an injectable `IClock` and measures elapsed milliseconds.
+No threshold, comparison or transition changed; what changed is that they are
+now measured rather than counted, and can be asserted at the edge. The main loop
+also runs its periodic tasks on deadlines rather than an iteration count, so the
+other per-second work (`checkTimeouts()`, `sendRTTRequest()`) keeps honest time
+too.
+
+The config field `db_write_failure_disconnect_ticks` is renamed
+`db_write_failure_disconnect_secs`, which is what it always meant; the old key
+is still accepted with a deprecation warning.
 
 ## Alternatives deliberately not taken
 

--- a/e2e/test_db_disk_full.py
+++ b/e2e/test_db_disk_full.py
@@ -24,7 +24,7 @@ Two confirmed defects, both fixed alongside this test:
    quiet tick could never reach its threshold. Fixed by tracking a
    wall-clock failure *incident* (started at the first new failure, only
    cleared after a 15s quiet recovery window) instead of a per-tick streak;
-   once the incident has lasted db_write_failure_disconnect_ticks (default
+   once the incident has lasted db_write_failure_disconnect_secs (default
    5s), every connected client is severed via
    server_clients::disconnectAll() -- matching Tier-3 Path M m05's
    expectation that the server "sever connections cleanly ... rather than
@@ -263,7 +263,7 @@ def test_disk_full_fails_visibly_and_a_fresh_instance_recovers(certs_dir, tmp_pa
 
         # The failure must escalate to visibly severing the session, not
         # stay a silently-kept-alive one -- give the streak/incident guard
-        # its own window (db_write_failure_disconnect_ticks, default 5s,
+        # its own window (db_write_failure_disconnect_secs, default 5s,
         # plus margin) *after* the first failure was already observed
         # above, rather than checking instantly. (todo/45+47 unified the
         # severance into the "DB fail-safe tripped ... severed N

--- a/e2e/test_db_write_only_failure.py
+++ b/e2e/test_db_write_only_failure.py
@@ -4,7 +4,7 @@ The shipped todo/34 fail-safe severed every client on sustained DB write
 failure but left the listener ungated. If the failure is write-only — reads
 still succeed, so re-identify works — every severed aircraft reconnected
 straight back into the same unhealthy server, failed writes again, and was
-severed again ~db_write_failure_disconnect_ticks later: a sustained
+severed again ~db_write_failure_disconnect_secs later: a sustained
 disconnect/reconnect flap oscillating aircraft in and out of comms-loss RTL.
 (The pure disk-full case never showed this because Postgres PANICs and the
 read side dies too; see test_db_disk_full.py.)
@@ -107,7 +107,7 @@ def test_write_only_db_failure_latches_one_failsafe_event(db_conn, fake_client, 
             cur.execute("SELECT id FROM assets_asset WHERE name = 'test1'")
             assert cur.fetchone()[0] == asset_id
 
-        # The incident must span db_write_failure_disconnect_ticks (5s) of
+        # The incident must span db_write_failure_disconnect_secs (5s) of
         # recurring failures before tripping; RTT writes recur ~1s.
         assert _wait_for(lambda: "DB fail-safe tripped" in log_text(), timeout=30.0, poll=0.2), (
             "server never tripped the fail-safe on sustained write-only failure\n" + log_text()

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -93,7 +93,7 @@ auto main(int argc, char *argv[]) -> int
      * arriving once the incident spans the threshold, so only sustained
      * failure -- what disk-full looks like -- can fire it. Command
      * dispatch/ack drops trip unconditionally, with no threshold (todo/45). */
-    constexpr uint64_t default_db_write_failure_disconnect_ticks = 5;
+    constexpr uint64_t default_db_write_failure_disconnect_secs = 5;
     /* Two roles (same meaning: how long with no new failure before the
      * incident is considered over). Outside a trip: how long failures may
      * pause and still chain into one incident (PR #327 review: configurable
@@ -119,7 +119,7 @@ auto main(int argc, char *argv[]) -> int
     uint64_t rate_capacity = default_rate_capacity;
     uint64_t rate_refill = default_rate_refill_per_s;
     auto duplicate_identity_policy = default_duplicate_identity_policy;
-    uint64_t db_write_failure_disconnect_ticks = default_db_write_failure_disconnect_ticks;
+    uint64_t db_write_failure_disconnect_secs = default_db_write_failure_disconnect_secs;
     uint64_t db_write_failure_recovery_grace_secs = default_db_write_failure_recovery_grace_secs;
     unsigned int tls_handshake_timeout_ms = default_tls_handshake_timeout_ms;
     std::size_t max_concurrent_handshakes = default_max_concurrent_handshakes;
@@ -270,9 +270,29 @@ auto main(int argc, char *argv[]) -> int
                                                                               << "'; using default (reject_newcomer)");
             }
         }
-        if (config.isMember("db_write_failure_disconnect_ticks"))
+        /* Renamed from db_write_failure_disconnect_ticks (todo/70): the value
+         * always meant seconds — it is documented in seconds and its sibling
+         * has always been named _secs — but until the threshold was measured
+         * against a clock it was really counting loop iterations, and the old
+         * name was the only place the tree admitted that. The old key is still
+         * accepted so an existing deployment's config keeps working; the new
+         * one wins if both are present. */
+        if (config.isMember("db_write_failure_disconnect_secs"))
         {
-            db_write_failure_disconnect_ticks = config["db_write_failure_disconnect_ticks"].asUInt64();
+            db_write_failure_disconnect_secs = config["db_write_failure_disconnect_secs"].asUInt64();
+            if (config.isMember("db_write_failure_disconnect_ticks"))
+            {
+                FSS_LOG_WARN("server", "both db_write_failure_disconnect_secs and the deprecated "
+                                       "db_write_failure_disconnect_ticks are set; using the former ("
+                                           << db_write_failure_disconnect_secs << ")");
+            }
+        }
+        else if (config.isMember("db_write_failure_disconnect_ticks"))
+        {
+            db_write_failure_disconnect_secs = config["db_write_failure_disconnect_ticks"].asUInt64();
+            FSS_LOG_WARN("server", "db_write_failure_disconnect_ticks is deprecated; rename it to "
+                                   "db_write_failure_disconnect_secs (the value is unchanged: "
+                                       << db_write_failure_disconnect_secs << "s)");
         }
         if (config.isMember("db_write_failure_recovery_grace_secs"))
         {
@@ -516,7 +536,7 @@ auto main(int argc, char *argv[]) -> int
                 using flight_safety_system::server::db_failsafe;
                 static uint64_t last_failure_count = 0;
                 static uint64_t last_command_dropped = 0;
-                static db_failsafe failsafe(db_write_failure_disconnect_ticks, db_write_failure_recovery_grace_secs);
+                static db_failsafe failsafe(db_write_failure_disconnect_secs, db_write_failure_recovery_grace_secs);
                 uint64_t current_failures = writer->write_failure_count();
                 if (current_failures != last_failure_count)
                 {


### PR DESCRIPTION
## Description

The value always meant seconds — it is documented in seconds, its sibling has always been `db_write_failure_recovery_grace_secs`, and the fail-safe's own constructor parameter is `disconnect_age_secs`. The `_ticks` name was the single place the tree admitted that the threshold was really counting loop iterations. The previous two commits made that untrue, so the name is now simply wrong.

The old key is still read, so an existing deployment's config keeps working. It warns and names the replacement; if both are set the new one wins and says so. Exercised by hand across all four cases (old only, new only, both, neither).

Neither `examples/server.json` nor `e2e/fixtures/server.json.tmpl` sets either key — both run on the defaults — so no shipped or test config changes.

Decision 34/45/47 gains a subsection recording the todo/70 revision: the thresholds are unchanged, but they are now measured rather than counted, and the field is renamed. The 1.2.0 CHANGELOG entry keeps the old name, since that was the field's name in that release.

Verified: 439 unit cases green; check-code.sh clean; test_db_disk_full and test_db_write_only_failure — the two whose docstrings name the field — pass.

## Summary by Sourcery

Rename the DB fail-safe disconnect threshold configuration from a tick-based name to a seconds-based one while preserving backwards compatibility and updating documentation and tests accordingly.

Bug Fixes:
- Ensure configs using the deprecated db_write_failure_disconnect_ticks key continue to work with warnings and prefer the new db_write_failure_disconnect_secs key when both are present.

Enhancements:
- Rename internal variables and configuration handling from db_write_failure_disconnect_ticks to db_write_failure_disconnect_secs to reflect the time-based measurement of the fail-safe threshold.

Documentation:
- Update decision record and CHANGELOG to document that DB fail-safe windows are now measured in real time and that the disconnect threshold config field is renamed to db_write_failure_disconnect_secs.

Tests:
- Adjust e2e tests for DB disk-full and write-only failure scenarios to refer to the renamed db_write_failure_disconnect_secs threshold.