### PR TITLE
fix(client): count a server as service only once it has admitted us

### DIFF
--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -563,6 +563,36 @@ static auto status_for_server_count(size_t count) -> flight_safety_system::clien
     }
 }
 
+auto flight_safety_system::client_ssl::fss_client::countAdmittedLocked() const -> size_t
+{
+    return static_cast<size_t>(std::count_if(this->servers.begin(), this->servers.end(),
+                                             [](const auto &server) -> bool { return server->isAdmitted(); }));
+}
+
+void flight_safety_system::client_ssl::fss_client::serverAdmitted(flight_safety_system::client_ssl::fss_server *server)
+{
+    if (server == nullptr)
+    {
+        return;
+    }
+    /* Same shape as serverRequiresReconnect below: mutate and count under the
+     * lock, notify outside it. Notify only on the false->true edge — the
+     * signals that establish admission are ordinary traffic and keep arriving,
+     * and re-reporting an unchanged status on every one of them would be a
+     * callback storm for the application. */
+    size_t count = 0;
+    {
+        std::scoped_lock lock(this->servers_lock);
+        if (server->isAdmitted())
+        {
+            return;
+        }
+        server->setAdmitted(true);
+        count = this->countAdmittedLocked();
+    }
+    this->connectionStatusChange(status_for_server_count(count));
+}
+
 void flight_safety_system::client_ssl::fss_client::serverRequiresReconnect(
     flight_safety_system::client_ssl::fss_server *server)
 {
@@ -585,7 +615,15 @@ void flight_safety_system::client_ssl::fss_client::serverRequiresReconnect(
                 break;
             }
         }
-        count = this->servers.size();
+        /* The connection is over, so the admission it earned is over with it
+         * (todo/79). Cleared for the not-found case too: that server is still
+         * in reconnect_servers, and the connection it was admitted on is just
+         * as dead. */
+        if (server != nullptr)
+        {
+            server->setAdmitted(false);
+        }
+        count = this->countAdmittedLocked();
     }
     if (!found && server != nullptr)
     {
@@ -610,7 +648,7 @@ void flight_safety_system::client_ssl::fss_client::notifyConnectionStatus()
     size_t count = 0;
     {
         std::scoped_lock lock(this->servers_lock);
-        count = this->servers.size();
+        count = this->countAdmittedLocked();
     }
     this->connectionStatusChange(status_for_server_count(count));
 }
@@ -1132,6 +1170,42 @@ void flight_safety_system::client_ssl::fss_server::processMessage(
          * spurious timeout. */
         this->last_message_received_time.store(this->clock->now_ms(), std::memory_order_relaxed);
         this->liveness_active.store(true, std::memory_order_release);
+        /* todo/79: connecting to a server is not the same as being admitted by
+         * one, and only the latter is service. These three are the messages a
+         * server sends *only* to a client it has identified and admitted, so
+         * the first of them to arrive is proof of admission — no new message
+         * type, and nothing to negotiate.
+         *
+         * Deliberately not keyed on the server list alone, as the item
+         * proposed: the identify path skips that send when the active-server
+         * read fails (client_session.cpp) and leaves the client to the 15 s
+         * periodic broadcast, so a server list on its own would report an
+         * admitted aircraft as DISCONNECTED for up to 15 s during exactly the
+         * database trouble this exists for.
+         *
+         * Deliberately NOT including RTT requests, which the server sends to
+         * every client in its list rather than to identified ones only: a
+         * rejected duplicate identity (todo/31) is admitted at the transport
+         * layer and can receive one in the window before its identify is
+         * refused. Counting that as service would reopen the flap for the
+         * duplicate case while closing it for the fail-safe case.
+         *
+         * If all three are missed the client under-reports connectivity until
+         * the next broadcast, which leaves the aircraft in its comms-loss
+         * failsafe — the conservative direction, and the correct one to fail
+         * in. Do not "fix" that by widening the signal to RTT. */
+        switch (msg->getType())
+        {
+            case flight_safety_system::transport::message_type_command:
+            case flight_safety_system::transport::message_type_server_list:
+            case flight_safety_system::transport::message_type_smm_settings:
+                /* Before the handlers below run: admission is established the
+                 * moment the message arrives, and an aircraft acting on a
+                 * command should have seen comms come back first. */
+                this->getClient()->serverAdmitted(this);
+                break;
+            default: break;
+        }
         switch (msg->getType())
         {
             case flight_safety_system::transport::message_type_unknown:

--- a/src/client-ssl.cpp
+++ b/src/client-ssl.cpp
@@ -553,6 +553,60 @@ void flight_safety_system::client_ssl::fss_client::updateServers(
     }
 }
 
+/* Does receiving this message prove the server has admitted us (todo/79)?
+ *
+ * Connecting to a server is not the same as being admitted by one, and only the
+ * latter is service: the server refuses a client while its DB fail-safe is
+ * degraded, and refuses a duplicate identity, both after the handshake the
+ * connect already counted as success. The three types below are the ones a
+ * server sends *only* to a client it has identified and admitted, so the first
+ * of them to arrive is proof — no new message type, and nothing to negotiate.
+ *
+ * Deliberately not keyed on the server list alone, as todo/79 proposed: the
+ * identify path skips that send when the active-server read fails
+ * (client_session.cpp) and leaves the client to the 15 s periodic broadcast, so
+ * a server list on its own would report an admitted aircraft as DISCONNECTED
+ * for up to 15 s during exactly the database trouble this exists for.
+ *
+ * Deliberately NOT including rtt_request, which the server sends to every client
+ * in its list rather than to identified ones only: a rejected duplicate identity
+ * (todo/31) is admitted at the transport layer and can receive one in the window
+ * before its identify is refused. Counting that as service would reopen the flap
+ * for the duplicate case while closing it for the fail-safe case.
+ *
+ * If all three are missed the client under-reports connectivity until the next
+ * broadcast, which leaves the aircraft in its comms-loss failsafe — the
+ * conservative direction, and the correct one to fail in. Do not "fix" that by
+ * widening the signal to rtt_request.
+ *
+ * Every type is enumerated and there is no `default`, deliberately: under -Wall
+ * -Werror that makes a new message type fail to build until someone decides
+ * which side of this line it falls on. A `default: return false` would classify
+ * every future message as "not admission" silently, which is how a rule like
+ * this decays. */
+static auto admits_client(flight_safety_system::transport::fss_message_type type) -> bool
+{
+    switch (type)
+    {
+        case flight_safety_system::transport::message_type_command:
+        case flight_safety_system::transport::message_type_server_list:
+        case flight_safety_system::transport::message_type_smm_settings: return true;
+        case flight_safety_system::transport::message_type_unknown:
+        case flight_safety_system::transport::message_type_closed:
+        case flight_safety_system::transport::message_type_identity:
+        case flight_safety_system::transport::message_type_identity_non_aircraft:
+        case flight_safety_system::transport::message_type_identity_required:
+        case flight_safety_system::transport::message_type_version:
+        case flight_safety_system::transport::message_type_rtt_request:
+        case flight_safety_system::transport::message_type_rtt_response:
+        case flight_safety_system::transport::message_type_position_report:
+        case flight_safety_system::transport::message_type_system_status:
+        case flight_safety_system::transport::message_type_search_status:
+        case flight_safety_system::transport::message_type_command_ack: return false;
+    }
+    return false;
+}
+
 static auto status_for_server_count(size_t count) -> flight_safety_system::client_ssl::connection_status
 {
     switch (count)
@@ -1170,41 +1224,12 @@ void flight_safety_system::client_ssl::fss_server::processMessage(
          * spurious timeout. */
         this->last_message_received_time.store(this->clock->now_ms(), std::memory_order_relaxed);
         this->liveness_active.store(true, std::memory_order_release);
-        /* todo/79: connecting to a server is not the same as being admitted by
-         * one, and only the latter is service. These three are the messages a
-         * server sends *only* to a client it has identified and admitted, so
-         * the first of them to arrive is proof of admission — no new message
-         * type, and nothing to negotiate.
-         *
-         * Deliberately not keyed on the server list alone, as the item
-         * proposed: the identify path skips that send when the active-server
-         * read fails (client_session.cpp) and leaves the client to the 15 s
-         * periodic broadcast, so a server list on its own would report an
-         * admitted aircraft as DISCONNECTED for up to 15 s during exactly the
-         * database trouble this exists for.
-         *
-         * Deliberately NOT including RTT requests, which the server sends to
-         * every client in its list rather than to identified ones only: a
-         * rejected duplicate identity (todo/31) is admitted at the transport
-         * layer and can receive one in the window before its identify is
-         * refused. Counting that as service would reopen the flap for the
-         * duplicate case while closing it for the fail-safe case.
-         *
-         * If all three are missed the client under-reports connectivity until
-         * the next broadcast, which leaves the aircraft in its comms-loss
-         * failsafe — the conservative direction, and the correct one to fail
-         * in. Do not "fix" that by widening the signal to RTT. */
-        switch (msg->getType())
+        /* Before the handlers below run (see admits_client): admission is
+         * established the moment the message arrives, and an aircraft acting on
+         * a command should have seen comms come back first. */
+        if (admits_client(msg->getType()))
         {
-            case flight_safety_system::transport::message_type_command:
-            case flight_safety_system::transport::message_type_server_list:
-            case flight_safety_system::transport::message_type_smm_settings:
-                /* Before the handlers below run: admission is established the
-                 * moment the message arrives, and an aircraft acting on a
-                 * command should have seen comms come back first. */
-                this->getClient()->serverAdmitted(this);
-                break;
-            default: break;
+            this->getClient()->serverAdmitted(this);
         }
         switch (msg->getType())
         {

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -97,7 +97,19 @@ private:
     void notifyConnectionStatus();
     /* How many live servers have actually admitted this client (todo/79).
      * Precondition: servers_lock held. This — not servers.size() — is what
-     * connectionStatusChange() reports; see serverAdmitted(). */
+     * connectionStatusChange() reports; see serverAdmitted().
+     *
+     * Derived on demand, and a cached admitted_count member was considered and
+     * REJECTED (PR 418 review). serverRequiresReconnect() is not the only way a
+     * server leaves the live list: updateServers() splices expired entries
+     * straight out of `servers` into `expired_servers` under this same lock,
+     * bypassing it. A counter would need updating there too, and missing it
+     * would leave the count permanently high — the client reporting CONNECTED
+     * for a server that no longer exists, which is the very failure todo/79
+     * removes, let back in by another door. The scan it avoids is over a list
+     * bounded by max_learned_servers (16) plus the configured entries, and runs
+     * only on status-change edges: serverAdmitted() returns before counting
+     * once a server is already admitted, so this is not a per-message cost. */
     auto countAdmittedLocked() const -> size_t;
     virtual void connectionStatusChange(flight_safety_system::client_ssl::connection_status status);
 protected:

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -95,6 +95,10 @@ private:
      * Takes servers_lock itself, so callers must not already hold it. */
     void updateConfigured();
     void notifyConnectionStatus();
+    /* How many live servers have actually admitted this client (todo/79).
+     * Precondition: servers_lock held. This — not servers.size() — is what
+     * connectionStatusChange() reports; see serverAdmitted(). */
+    auto countAdmittedLocked() const -> size_t;
     virtual void connectionStatusChange(flight_safety_system::client_ssl::connection_status status);
 protected:
     void setAssetName(std::string t_asset_name);
@@ -183,6 +187,22 @@ public:
     virtual auto getSkewedTimestamp() const -> uint64_t;
     virtual auto isConfigured() const -> bool;
     virtual void serverRequiresReconnect(fss_server *server);
+    /* Record that `server` has admitted this client, and report the resulting
+     * connection status if that changed the admitted count (todo/79).
+     * Idempotent: only the first call for a given connection notifies.
+     *
+     * A server joins the live list when its TCP/TLS connect succeeds, but
+     * admission is a *later*, server-side decision — the server refuses a
+     * client while its DB fail-safe is degraded, and refuses a duplicate
+     * identity, both after the handshake the connect already counted as
+     * success. Reporting a connection the server severs milliseconds later as
+     * service made an aircraft leave its comms-loss failsafe and resume the
+     * previous command, then re-enter it when the drop landed. Counting
+     * admitted servers rather than connected ones is what stops that.
+     *
+     * Called from fss_server::processMessage() on the first message of a type
+     * the server sends only to a client it has admitted. */
+    void serverAdmitted(fss_server *server);
     virtual void updateServers(const std::shared_ptr<flight_safety_system::transport::fss_message_server_list> &msg);
     /* Called for every command, with the originating server (the connection the
      * command arrived on). A subclass that needs to reply to that specific
@@ -253,6 +273,13 @@ private:
      * therefore never expired. */
     bool learned{false};
     uint64_t last_seen_ms{0};
+    /* True once this connection has been admitted by the server, as distinct
+     * from merely connected to it (todo/79). Owned by the fss_client under
+     * servers_lock, like `learned` above. Cleared whenever the connection ends,
+     * so each new connection has to earn it again — a reconnect into a server
+     * that refuses the client must not inherit the previous session's
+     * admission. */
+    bool admitted{false};
     /* Per-server outbound writer
      * (docs/decisions/66-67-client-outbound-fanout.md). The caller's thread
      * schedules *what* to send; this worker performs the blocking socket
@@ -399,6 +426,11 @@ public:
      * into either list. */
     auto isLearned() const -> bool { return this->learned; }
     void setLearned(bool t_learned) { this->learned = t_learned; }
+    /* Admission state (todo/79). Same locking rule as the learned accessors
+     * above: fss_client::serverAdmitted() and the paths that end a connection
+     * are the only callers, and each holds servers_lock. */
+    auto isAdmitted() const -> bool { return this->admitted; }
+    void setAdmitted(bool t_admitted) { this->admitted = t_admitted; }
     auto getLastSeenMs() const -> uint64_t { return this->last_seen_ms; }
     void setLastSeenMs(uint64_t t_now_ms) { this->last_seen_ms = t_now_ms; }
     void setServerTimeoutMs(uint64_t ms) { this->server_timeout_ms = ms; }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -53,6 +53,7 @@ all_test_SOURCES = main.cpp messages.cpp connection.cpp client.cpp \
 	reconnect_test.cpp \
 	client_server_list_test.cpp \
 	client_fanout_test.cpp \
+	client_admission_test.cpp \
 	connection_negative_test.cpp \
 	oversized_message_test.cpp \
 	fd_lifecycle_test.cpp \

--- a/tests/client_admission_test.cpp
+++ b/tests/client_admission_test.cpp
@@ -1,0 +1,315 @@
+#ifdef HAVE_CATCH2_CATCH_ALL_HPP
+#include <catch2/catch_all.hpp>
+#elif HAVE_CATCH2_CATCH_HPP
+#include <catch2/catch.hpp>
+#elif HAVE_CATCH_CATCH_HPP
+#include <catch/catch.hpp>
+#elif HAVE_CATCH_HPP
+#include <catch.hpp>
+#else
+#error No catch header
+#endif
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "fss-client-ssl.hpp"
+#include "fss-transport.hpp"
+#include "test_helpers.hpp"
+
+/* todo/79: the client derived its connection status from the size of the live
+ * server list, and a server joined that list the moment its TCP/TLS connect
+ * succeeded. Admission is a later, server-side decision — the server refuses a
+ * client while its DB fail-safe is degraded, and refuses a duplicate identity,
+ * both after the handshake the client already counted as success. So a
+ * connection the server severed milliseconds later was reported as
+ * CONNECTED_1_SERVER and then immediately as DISCONNECTED, which cap-fmu reads
+ * as comms-restored: it left its comms-loss failsafe, resumed the previous
+ * command, and re-entered the failsafe when the drop landed (CAP/test-plan
+ * Path M m05 — the aircraft left its safety state twice in seventeen seconds).
+ *
+ * These cases pin that a server counts as service only once it has admitted
+ * the client, that each of the three admission signals works on its own, that
+ * RTT is deliberately not one of them, and that admission does not survive the
+ * connection that earned it. */
+
+namespace {
+
+namespace fss = flight_safety_system;
+
+/* A connection that swallows whatever is written to it. The tests here care
+ * about what the client reports, not what it sends. */
+class SilentConnection : public fss::transport::fss_connection {
+public:
+    SilentConnection() = default;
+    SilentConnection(const SilentConnection &) = delete;
+    SilentConnection(SilentConnection &&) = delete;
+    auto operator=(const SilentConnection &) -> SilentConnection & = delete;
+    auto operator=(SilentConnection &&) -> SilentConnection & = delete;
+    ~SilentConnection() override = default;
+protected:
+    auto sendMsg(const std::shared_ptr<fss::transport::buf_len> &) -> bool override { return true; }
+};
+
+/* fss_server with setConnection exposed, so a test can present a server that
+ * is connected without a real socket — which is exactly the state todo/79 is
+ * about: connected, not yet admitted. */
+class AdmissionServer : public fss::client_ssl::fss_server {
+public:
+    using fss_server::fss_server;
+    using fss::transport::fss_message_cb::setConnection;
+    AdmissionServer(const AdmissionServer &) = delete;
+    AdmissionServer(AdmissionServer &&) = delete;
+    auto operator=(const AdmissionServer &) -> AdmissionServer & = delete;
+    auto operator=(AdmissionServer &&) -> AdmissionServer & = delete;
+    ~AdmissionServer() override = default;
+};
+
+/* Records every status the client reports, in order, so a case can assert the
+ * *sequence* of transitions rather than just the final state. The flap this
+ * fixes is a sequence: CONNECTED then DISCONNECTED 1 ms apart. */
+class AdmissionClient : public fss::client_ssl::fss_client {
+    mutable std::mutex status_lock{};
+    std::vector<fss::client_ssl::connection_status> statuses{};
+public:
+    using fss_client::fss_client;
+    AdmissionClient(const AdmissionClient &) = delete;
+    AdmissionClient(AdmissionClient &&) = delete;
+    auto operator=(const AdmissionClient &) -> AdmissionClient & = delete;
+    auto operator=(AdmissionClient &&) -> AdmissionClient & = delete;
+    ~AdmissionClient() override = default;
+
+    void add(const std::shared_ptr<fss::client_ssl::fss_server> &server) { this->addServer(server); }
+    auto count() const -> size_t
+    {
+        std::scoped_lock guard(this->status_lock);
+        return this->statuses.size();
+    }
+    auto at(size_t idx) const -> fss::client_ssl::connection_status
+    {
+        std::scoped_lock guard(this->status_lock);
+        return idx < this->statuses.size() ? this->statuses[idx] : fss::client_ssl::CLIENT_CONNECTION_STATUS_UNKNOWN;
+    }
+private:
+    void connectionStatusChange(fss::client_ssl::connection_status status) override
+    {
+        std::scoped_lock guard(this->status_lock);
+        this->statuses.push_back(status);
+    }
+};
+
+/* A server that is connected — the state a successful dial leaves it in. */
+auto make_connected_server(AdmissionClient *client, uint16_t port) -> std::shared_ptr<AdmissionServer>
+{
+    auto server = std::make_shared<AdmissionServer>(client, "server.example", port, "", "", "");
+    server->setConnection(std::make_shared<SilentConnection>());
+    return server;
+}
+
+/* A server whose dial succeeds immediately. Reaching the live list by the
+ * reconnect path rather than by addServer() matters for the m05 case below:
+ * attemptReconnect()'s final phase is what reports the status after a
+ * successful dial, and that report — made on the strength of the dial alone —
+ * is the spurious comms-restored edge todo/79 removes. */
+class DiallingServer : public fss::client_ssl::fss_server {
+public:
+    using fss_server::fss_server;
+    DiallingServer(const DiallingServer &) = delete;
+    DiallingServer(DiallingServer &&) = delete;
+    auto operator=(const DiallingServer &) -> DiallingServer & = delete;
+    auto operator=(DiallingServer &&) -> DiallingServer & = delete;
+    ~DiallingServer() override = default;
+
+    std::atomic<int> dials{0};
+protected:
+    auto reconnect_to() -> bool override
+    {
+        this->dials++;
+        this->setConnection(std::make_shared<SilentConnection>());
+        return true;
+    }
+};
+
+auto make_server_list() -> std::shared_ptr<fss::transport::fss_message>
+{
+    return std::make_shared<fss::transport::fss_message_server_list>();
+}
+
+auto make_command() -> std::shared_ptr<fss::transport::fss_message>
+{
+    return std::make_shared<fss::transport::fss_message_asset_command>(fss::transport::asset_command_rtl, uint64_t{0});
+}
+
+auto make_smm_settings() -> std::shared_ptr<fss::transport::fss_message>
+{
+    return std::make_shared<fss::transport::fss_message_smm_settings>("smm.example", fss::secure_string{"user"},
+                                                                      fss::secure_string{"pass"});
+}
+
+} // namespace
+
+TEST_CASE("client: a connection the server never admits is never reported as service (todo/79)")
+{
+    /* The m05 regression, by the path that actually produced it. The dial
+     * succeeds, attemptReconnect() harvests it into the live list and reports
+     * the resulting status; the server then refuses the client at admission
+     * (DB fail-safe degraded, or duplicate identity) and severs, having sent
+     * nothing at all in between — the fail-safe refusal returns before the
+     * client is ever activated, so it receives no message.
+     *
+     * Pre-fix the harvest reported CONNECTED_1_SERVER on the strength of the
+     * dial, and the sever reported DISCONNECTED milliseconds later. cap-fmu
+     * reads that pair as comms-restored: it left its comms-loss failsafe,
+     * resumed the previous command, and re-entered the failsafe when the drop
+     * landed. */
+    auto client = std::make_shared<AdmissionClient>();
+    auto server = std::make_shared<DiallingServer>(client.get(), "server.example", uint16_t{20301}, "", "", "");
+    client->add(server);
+
+    client->attemptReconnect();
+    REQUIRE(fss_test::wait_for([&]() -> bool { return server->dials.load() == 1; }));
+    client->attemptReconnect();
+    REQUIRE(server->connected());
+
+    /* Connected and harvested, but the server has said nothing. Whatever was
+     * reported, none of it may be service. */
+    for (size_t i = 0; i < client->count(); i++)
+    {
+        REQUIRE(client->at(i) == fss::client_ssl::CLIENT_CONNECTION_STATUS_DISCONNECTED);
+    }
+
+    /* The refusal lands. */
+    server->processMessage(std::make_shared<fss::transport::fss_message_closed>());
+
+    /* Still nothing but DISCONNECTED: no spurious comms-restored edge for the
+     * aircraft to act on (CAP/test-plan TC-FS-003). */
+    REQUIRE(client->count() > 0);
+    for (size_t i = 0; i < client->count(); i++)
+    {
+        REQUIRE(client->at(i) == fss::client_ssl::CLIENT_CONNECTION_STATUS_DISCONNECTED);
+    }
+}
+
+TEST_CASE("client: a server list admits the connection (todo/79)")
+{
+    auto client = std::make_shared<AdmissionClient>();
+    auto server = make_connected_server(client.get(), uint16_t{20302});
+    client->add(server);
+
+    server->processMessage(make_server_list());
+    REQUIRE(client->count() == 1);
+    REQUIRE(client->at(0) == fss::client_ssl::CLIENT_CONNECTION_STATUS_CONNECTED_1_SERVER);
+
+    server->processMessage(std::make_shared<fss::transport::fss_message_closed>());
+    REQUIRE(client->count() == 2);
+    REQUIRE(client->at(1) == fss::client_ssl::CLIENT_CONNECTION_STATUS_DISCONNECTED);
+}
+
+TEST_CASE("client: a command admits the connection (todo/79)")
+{
+    /* Independently sufficient: the identify path skips the server-list send
+     * when the active-server read fails, so the command an aircraft is
+     * carrying can be the first thing that proves admission. */
+    auto client = std::make_shared<AdmissionClient>();
+    auto server = make_connected_server(client.get(), uint16_t{20303});
+    client->add(server);
+
+    server->processMessage(make_command());
+    REQUIRE(client->count() == 1);
+    REQUIRE(client->at(0) == fss::client_ssl::CLIENT_CONNECTION_STATUS_CONNECTED_1_SERVER);
+}
+
+TEST_CASE("client: SMM settings admit the connection (todo/79)")
+{
+    auto client = std::make_shared<AdmissionClient>();
+    auto server = make_connected_server(client.get(), uint16_t{20304});
+    client->add(server);
+
+    server->processMessage(make_smm_settings());
+    REQUIRE(client->count() == 1);
+    REQUIRE(client->at(0) == fss::client_ssl::CLIENT_CONNECTION_STATUS_CONNECTED_1_SERVER);
+}
+
+TEST_CASE("client: an RTT request alone does not admit the connection (todo/79)")
+{
+    /* Deliberate, and the reason the signal is not simply "any message". The
+     * server sends RTT requests to every client in its list, not to identified
+     * ones only, so a client whose identify is about to be refused as a
+     * duplicate (todo/31) can receive one first. Counting that as service would
+     * close the flap for the fail-safe case and leave it open for the duplicate
+     * case. */
+    auto client = std::make_shared<AdmissionClient>();
+    auto server = make_connected_server(client.get(), uint16_t{20305});
+    client->add(server);
+
+    server->processMessage(std::make_shared<fss::transport::fss_message_rtt_request>());
+    REQUIRE(client->count() == 0);
+
+    server->processMessage(std::make_shared<fss::transport::fss_message_closed>());
+    REQUIRE(client->count() == 1);
+    REQUIRE(client->at(0) == fss::client_ssl::CLIENT_CONNECTION_STATUS_DISCONNECTED);
+}
+
+TEST_CASE("client: repeated admission signals report the status once (todo/79)")
+{
+    /* The signals are ordinary traffic and keep arriving; only the false->true
+     * edge is a status change. */
+    auto client = std::make_shared<AdmissionClient>();
+    auto server = make_connected_server(client.get(), uint16_t{20306});
+    client->add(server);
+
+    for (int i = 0; i < 5; i++)
+    {
+        server->processMessage(make_server_list());
+        server->processMessage(make_command());
+    }
+    REQUIRE(client->count() == 1);
+    REQUIRE(client->at(0) == fss::client_ssl::CLIENT_CONNECTION_STATUS_CONNECTED_1_SERVER);
+}
+
+TEST_CASE("client: only admitted servers count towards the status (todo/79)")
+{
+    /* Two servers connected, one admitted: one server's worth of service. */
+    auto client = std::make_shared<AdmissionClient>();
+    auto admitted = make_connected_server(client.get(), uint16_t{20307});
+    auto silent = make_connected_server(client.get(), uint16_t{20308});
+    client->add(admitted);
+    client->add(silent);
+
+    admitted->processMessage(make_server_list());
+    REQUIRE(client->count() == 1);
+    REQUIRE(client->at(0) == fss::client_ssl::CLIENT_CONNECTION_STATUS_CONNECTED_1_SERVER);
+
+    silent->processMessage(make_server_list());
+    REQUIRE(client->count() == 2);
+    REQUIRE(client->at(1) == fss::client_ssl::CLIENT_CONNECTION_STATUS_CONNECTED_2_OR_MORE);
+}
+
+TEST_CASE("client: admission does not survive the connection that earned it (todo/79)")
+{
+    /* A reconnect into a server that now refuses the client must not inherit
+     * the previous session's admission — that would restore exactly the
+     * behaviour this removes. */
+    auto client = std::make_shared<AdmissionClient>();
+    auto server = make_connected_server(client.get(), uint16_t{20309});
+    client->add(server);
+
+    server->processMessage(make_server_list());
+    REQUIRE(client->at(0) == fss::client_ssl::CLIENT_CONNECTION_STATUS_CONNECTED_1_SERVER);
+    server->processMessage(std::make_shared<fss::transport::fss_message_closed>());
+    REQUIRE(client->at(1) == fss::client_ssl::CLIENT_CONNECTION_STATUS_DISCONNECTED);
+    const size_t after_drop = client->count();
+
+    /* The server is back in reconnect_servers with a live connection again,
+     * and this time it says nothing before severing. */
+    server->setConnection(std::make_shared<SilentConnection>());
+    server->processMessage(std::make_shared<fss::transport::fss_message_closed>());
+    for (size_t i = after_drop; i < client->count(); i++)
+    {
+        REQUIRE(client->at(i) == fss::client_ssl::CLIENT_CONNECTION_STATUS_DISCONNECTED);
+    }
+}

--- a/tests/client_fanout_test.cpp
+++ b/tests/client_fanout_test.cpp
@@ -337,9 +337,15 @@ TEST_CASE("client: an unreachable server does not delay reconnection to a health
     REQUIRE(fss_test::wait_for([&]() -> bool { return stalling->dials_entered.load() == 1; }));
     REQUIRE(healthy->connected());
 
-    /* The pass after the dial lands harvests it into the live server list. */
+    /* The pass after the dial lands harvests it into the live server list. The
+     * server list stands in for the admitting server: since todo/79 a
+     * connected server is reported as service only once it has admitted the
+     * client, so the harvest alone no longer moves the status. Feeding it each
+     * pass is harmless — admission is idempotent — and lets the status stay the
+     * observable for "harvested AND admitted". */
     REQUIRE(fss_test::wait_for([&]() -> bool {
         client->attemptReconnect();
+        healthy->processMessage(std::make_shared<fss::transport::fss_message_server_list>());
         return client->last_status.load() == fss::client_ssl::CLIENT_CONNECTION_STATUS_CONNECTED_1_SERVER;
     }));
 

--- a/tests/timeout_test.cpp
+++ b/tests/timeout_test.cpp
@@ -362,7 +362,12 @@ TEST_CASE("timeout: successful reconnect restores cold-start liveness")
     client->attemptReconnect();
     REQUIRE(fss_test::wait_for([&]() -> bool { return server->reconnects.load() == 1; }));
     client->attemptReconnect();
-    REQUIRE(client->last_status == fss::client_ssl::CLIENT_CONNECTION_STATUS_CONNECTED_1_SERVER);
+    /* Harvested into the live list, but not yet reported as service: since
+     * todo/79 that needs the server to admit the client, and this case
+     * deliberately has nothing arrive on the new connection (see below), so
+     * there is no admission signal to have observed. The redial itself is
+     * asserted above. */
+    REQUIRE(client->last_status == fss::client_ssl::CLIENT_CONNECTION_STATUS_DISCONNECTED);
 
     /* Nothing has been received on the new connection: however long it stays
      * quiet, it must not be timed out on the old connection's stale clock. */


### PR DESCRIPTION
## Description

`status_for_server_count()` derived the client's connection status from `servers.size()`, and a server joined that list the moment its TCP/TLS connect succeeded — at `addServer()`, or when `attemptReconnect()`'s phase (d) promoted it. Admission is a *later*, server-side decision: `server_clients:: clientConnected()` refuses a client while the DB fail-safe is degraded, and `client_session` refuses a duplicate identity, both after the handshake the client had already counted as success.

So a connection the server accepted at the transport layer and severed milliseconds later was reported to the application as `CLIENT_CONNECTION_STATUS_CONNECTED_1_SERVER` and then immediately as `DISCONNECTED`. cap-fmu reads that pair as comms-restored: it leaves its comms-loss failsafe and resumes the previous command, then re-enters the failsafe when the drop lands. `CAP/test-plan` Path M m05 caught it against a server whose database had died — the aircraft left its safety state twice in seventeen seconds, once on a connection the server had refused in the same millisecond. That defeats the stated purpose of the degraded gate, which exists so aircraft get "one latched comms-loss event instead of a disconnect/reconnect flap into the same unhealthy server".

`fss_server` gains an `admitted` flag, owned by `fss_client` under `servers_lock` like `learned`, and the status now counts admitted servers. `getServerCount()` is untouched — it is configuration bookkeeping, not connectivity — and the fan-out still uses the whole list, since an unadmitted server must receive the identify that gets it admitted. The flag is cleared in `serverRequiresReconnect()`, so each new connection re-earns it and a reconnect into a server that now refuses the client cannot inherit the last session's admission.

Two departures from the item as filed, both deliberate:

The signal is not the server list alone, which is what todo/79 proposed. That send is conditional: `client_session.cpp` skips it when `getActiveServers()` fails and falls back to the 15 s periodic broadcast, so keying on it would report an admitted aircraft as DISCONNECTED for up to 15 s during exactly the database trouble this exists for. Any of server list, command, or SMM settings now proves admission — the three the server sends only to an identified client.

RTT requests are excluded. `sendRTTRequest()` iterates `snapshotClients()` rather than identified clients, so a client whose identify is about to be refused as a duplicate (todo/31) can receive one first; counting that as service would close the flap for the fail-safe case and leave it open for the duplicate case. The fail-safe refusal itself is clean either way — `clientConnected()` disconnects and returns before `activate()`, so a refused client is never in the list and receives nothing at all.

If all three signals are missed the client under-reports connectivity until the next broadcast, leaving the aircraft in its comms-loss failsafe. That is the conservative direction and is documented as such in the header, so nobody "fixes" it later by widening the signal to RTT.

This is the client half of the m05 flap. The server half (todo/78 — the fail-safe recovers on silence rather than on evidence of a healthy database) is untouched here; either fix narrows the flap, both close it. `CAP/test-plan` Tier-3 `test_m05_no_reconnect_flap` stays a strict xfail until 78 lands.

Two existing cases asserted the old behaviour and were updated, not deleted: `client_fanout_test`'s harvest loop now feeds a server list (admission is idempotent, so the status stays the observable for "harvested AND admitted"), and `timeout_test`'s cold-start-liveness case now expects DISCONNECTED, since it deliberately has nothing arrive on the new connection.

Eight new cases in `tests/client_admission_test.cpp`. Seven of them fail with this commit's `src/` changes reverted, including the m05 regression itself; the eighth pins that RTT alone does not admit, which is a guard against a future widening rather than a regression.

`fss-client-ssl.hpp` is an installed header, but this only adds members and methods — no `-version-info` change here; the soname is measured against the last tag at release time.

Verified: full unit suite green (`make check`); the 8 new cases pass and 7 fail without the fix; check-code.sh clean.

## Summary by Sourcery

Report client connection status based on servers that have explicitly admitted the client, rather than all successful TCP/TLS connections, to eliminate spurious connect/disconnect flaps when the server later refuses the client.

New Features:
- Track per-connection admission state on servers and expose it to the client for connection status reporting.
- Treat receipt of server list, command, or SMM settings messages as proof of server admission, while explicitly excluding RTT-only traffic from counting as service.

Bug Fixes:
- Prevent transient connections that are later refused by the server from being reported as restored service, avoiding comms-loss failsafe flapping in degraded-database and duplicate-identity scenarios.

Enhancements:
- Align connection status notifications with admitted-server count, including status recomputation on reconnect and connection closure.
- Add targeted client admission tests and update existing fanout and timeout tests to validate the new admission-based status semantics and guard against future regressions.