### PR TITLE
feat(transport): name the position-report GPS-fix flag bit (todo/76)

### DIFF
--- a/examples/fake_client.cpp
+++ b/examples/fake_client.cpp
@@ -282,7 +282,10 @@ auto main(int argc, char *argv[]) -> int
             constexpr int vert_vel = 0;
             constexpr int squawk_code = 01200;
             constexpr int time_since_last_contact = 0;
-            constexpr int flags = 1 | 2 | 4 | 8 | 16 | 32;
+            /* ADS-B style validity bits: coords, altitude, heading, velocity,
+             * callsign, squawk. Only the coords bit has a name here because it
+             * is the only one the server reads (todo/76). */
+            constexpr int flags = fss::transport::FSS_POSITION_FLAG_VALID_COORDS | 2 | 4 | 8 | 16 | 32;
             constexpr int alt_type = 1;
             constexpr int emitter_type = 14;
             /* getSkewedTimestamp() (todo/33) rather than fss_current_timestamp()

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -53,6 +53,7 @@ static constexpr uint32_t FSS_FEATURE_RTT_OFFSET = 0x1U;        /* todo/17 item 
 static constexpr uint32_t FSS_FEATURE_COMMAND_ACK = 0x2U;       /* todo/17 item 1 */
 static constexpr uint32_t FSS_FEATURE_SYSTEM_HEALTH = 0x4U;     /* todo/17 item 2 */
 static constexpr uint32_t FSS_FEATURE_SERVER_COMMAND_ID = 0x8U; /* todo/49 */
+static constexpr uint32_t FSS_FEATURE_POSITION_FLAGS = 0x10U;   /* todo/76 */
 static constexpr uint32_t FSS_SUPPORTED_FEATURES =
     FSS_FEATURE_RTT_OFFSET | FSS_FEATURE_COMMAND_ACK | FSS_FEATURE_SERVER_COMMAND_ID;
 
@@ -626,6 +627,18 @@ public:
     virtual auto getRequestId() -> uint64_t;
     virtual auto getClientTimestamp() -> uint64_t;
 };
+
+/* Bit 0 of fss_message_position_report's flags word: the coordinates are
+ * backed by a real GPS fix rather than being the autopilot's dead-reckoned
+ * estimate. Numbered to match MAVLink's ADSB_FLAGS_VALID_COORDS, which is
+ * where the whole flags word comes from, and cap-fmu's POSITION_FLAG_VALID_
+ * COORDS / valid_fields_no_fix.
+ *
+ * A receiver may only act on this bit when the peer negotiated
+ * FSS_FEATURE_POSITION_FLAGS: a peer that predates the capability leaves the
+ * word at 0, and reading that as "no fix" would mark every one of its reports
+ * as dead-reckoned. */
+static constexpr uint16_t FSS_POSITION_FLAG_VALID_COORDS = 0x1U;
 
 class fss_message_position_report : public fss_message {
 private:


### PR DESCRIPTION
## Description

The position report has always carried a MAVLink ADSB_FLAGS-style flags word whose bit 0 marks the coordinates as GPS-backed, but the bit had no name on this side and no reader: getFlags() was called only by the round-trip tests, and fake_client set the whole word as a bare literal.

Name the bit, and reserve FSS_FEATURE_POSITION_FLAGS for the capability that will let a server act on it. The capability is deliberately NOT in FSS_SUPPORTED_FEATURES yet -- a bit joins that set only once the build implements it, as FSS_FEATURE_SYSTEM_HEALTH already shows -- so this commit changes no behaviour on or off the wire.

## Summary by Sourcery

Introduce a named GPS-fix validity flag for position reports and reserve a corresponding transport capability without changing wire behaviour.

New Features:
- Add FSS_FEATURE_POSITION_FLAGS capability constant for negotiating position-report flag handling.
- Expose FSS_POSITION_FLAG_VALID_COORDS as a named bit for GPS-backed coordinates in position-report messages.

Enhancements:
- Update fake_client example to use the named GPS coordinate validity flag and document the ADS-B style flags layout.