### PR TITLE
feat(server): record whether a position is GPS-backed (todo/76)

### DIFF
--- a/e2e/schema/001_init.sql
+++ b/e2e/schema/001_init.sql
@@ -13,12 +13,17 @@ CREATE TABLE assets_asset (
     name        VARCHAR(64) NOT NULL UNIQUE
 );
 
+-- position is nullable and gps_fix_valid exists as of fss-web migration 0016:
+-- a report whose coordinates are not GPS-backed is still stored (the autopilot's
+-- dead-reckoned estimate is worth showing, labelled), and a report carrying no
+-- coordinates at all stores NULL geometry rather than being discarded.
 CREATE TABLE assets_assetposition (
-    id          BIGSERIAL PRIMARY KEY,
-    asset_id    BIGINT NOT NULL REFERENCES assets_asset(id),
-    position    GEOMETRY(POINT, 4326) NOT NULL,
-    altitude    INTEGER NOT NULL,
-    timestamp   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+    id             BIGSERIAL PRIMARY KEY,
+    asset_id       BIGINT NOT NULL REFERENCES assets_asset(id),
+    position       GEOMETRY(POINT, 4326),
+    altitude       INTEGER NOT NULL,
+    gps_fix_valid  BOOLEAN NOT NULL DEFAULT TRUE,
+    timestamp      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 
 CREATE TABLE assets_assetrtt (

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -27,6 +27,10 @@ constexpr uint64_t rtt_retry_interval = 10 * sec_to_msec;
  * persistently skewed client is unmistakable without a per-message WARN drip. */
 constexpr uint64_t staleness_escalation_threshold = 10;
 constexpr uint64_t staleness_escalation_interval = 100;
+/* How often to repeat the "still no GPS fix" warning while an outage lasts.
+ * The edges are always logged; this only stops a long outage from going silent
+ * between them. */
+constexpr uint64_t no_fix_log_interval = 100;
 /* RTT clock-offset smoothing (todo/17 item 3). A sample's error is bounded by
  * half the round trip, so a link slower than this yields an estimate too coarse
  * to trust for the staleness window — drop it rather than poison the average. */
@@ -840,6 +844,46 @@ void fss::server::fss_client::updateClockOffset(uint64_t client_timestamp, uint6
     }
 }
 
+void fss::server::fss_client::logGpsFixState(bool t_fix_valid, bool t_have_coords)
+{
+    /* The row is written for every report; the log is for the human reading
+     * stderr, so it names only the edges plus a periodic reminder. An aircraft
+     * streams position at up to 5 Hz, so an unthrottled per-report line would
+     * bury every other message in the log for the length of the outage. */
+    if (this->gps_fix_state_known && this->gps_fix_valid == t_fix_valid)
+    {
+        if (!t_fix_valid)
+        {
+            uint64_t no_fix = ++this->no_fix_reports;
+            if (no_fix % no_fix_log_interval == 0)
+            {
+                FSS_LOG_WARN("server",
+                             "Client " << this->name << " still reporting no GPS fix (count=" << no_fix << ")");
+            }
+        }
+        return;
+    }
+    const bool first = !this->gps_fix_state_known;
+    this->gps_fix_state_known = true;
+    this->gps_fix_valid = t_fix_valid;
+    if (!t_fix_valid)
+    {
+        this->no_fix_reports = 1;
+        FSS_LOG_WARN("server", "Position report with no GPS fix from "
+                                   << this->name
+                                   << (t_have_coords ? " (dead-reckoned estimate)" : " (no coordinates)"));
+        return;
+    }
+    if (!first)
+    {
+        /* The restore edge was invisible before todo/76: the log said an
+         * aircraft had lost its fix and then never mentioned it again. */
+        FSS_LOG_INFO("server",
+                     "GPS fix restored for " << this->name << " after " << this->no_fix_reports << " no-fix reports");
+    }
+    this->no_fix_reports = 0;
+}
+
 void fss::server::fss_client::refreshSmmSettings()
 {
     uint64_t asset_id = this->cached_asset_id.load();
@@ -1382,34 +1426,51 @@ void fss::server::fss_client::processMessage(std::shared_ptr<fss::transport::fss
                      * even if the coordinate below is later rejected. */
                     this->staleness_discards = 0;
                 }
-                if (std::isnan(msg->getLatitude()) || std::isnan(msg->getLongitude()))
+                /* NaN coordinates are the wire sentinel for "no GPS fix" (see
+                 * pack_scaled_coord): the report carries no position at all. */
+                const bool have_coords = !std::isnan(msg->getLatitude()) && !std::isnan(msg->getLongitude());
+                if (have_coords && !is_valid_coordinate(msg->getLatitude(), msg->getLongitude()))
                 {
-                    /* NaN coordinates are the wire sentinel for "no GPS fix"
-                     * (see pack_scaled_coord). This is operationally distinct
-                     * from a malformed coordinate, so log it as such — but a
-                     * persistent no-fix arrives every report, so throttle to
-                     * first + every 100th to avoid flooding the log. */
-                    uint64_t no_fix = ++this->no_fix_reports;
-                    if (no_fix == 1 || (no_fix % 100) == 0)
-                    {
-                        FSS_LOG_WARN("server", "Position report with no GPS fix from "
-                                                   << this->name << " (count=" << no_fix << "), discarding");
-                    }
-                    return;
-                }
-                if (!is_valid_coordinate(msg->getLatitude(), msg->getLongitude()))
-                {
+                    /* Out of range or infinite: a malformed report, not a fix
+                     * report. It says nothing about the GPS, so it is discarded
+                     * outright and leaves no record. */
                     FSS_LOG_WARN("server", "Invalid position report coordinates (lat=" << msg->getLatitude()
                                                                                        << " lon=" << msg->getLongitude()
                                                                                        << "), discarding");
                     return;
                 }
+                /* The flags word's coords-valid bit is only meaningful from a
+                 * peer that negotiated the capability: one that predates it
+                 * leaves the word at 0, and reading that as "no fix" would mark
+                 * every report it ever sends as dead-reckoned. Without coords
+                 * there is nothing for a fix to back, so the bit cannot make
+                 * such a report valid. */
+                auto pos_msg = std::dynamic_pointer_cast<fss::transport::fss_message_position_report>(msg);
+                const bool flags_meaningful = pos_msg != nullptr && (active_conn->getNegotiatedFeatureFlags() &
+                                                                     fss::transport::FSS_FEATURE_POSITION_FLAGS) != 0;
+                const bool fix_valid =
+                    have_coords &&
+                    (!flags_meaningful || (pos_msg->getFlags() & fss::transport::FSS_POSITION_FLAG_VALID_COORDS) != 0);
+                this->logGpsFixState(fix_valid, have_coords);
                 if (this->aircraft && asset_id != 0)
                 {
-                    this->writer->enqueue(
-                        position_write{asset_id, msg->getLatitude(), msg->getLongitude(), msg->getAltitude()});
+                    /* Recorded whether or not there is a fix, carrying the
+                     * validity with it (todo/76). An aircraft reporting itself
+                     * blind is exactly what the operator cannot otherwise see:
+                     * a position that stops advancing looks identical to a
+                     * dropout, and RTT keeps the asset marked connected
+                     * throughout. */
+                    this->writer->enqueue(position_write{asset_id, msg->getLatitude(), msg->getLongitude(),
+                                                         msg->getAltitude(), fix_valid});
                 }
-                this->client_handler->broadcastMsg(msg, this);
+                if (have_coords)
+                {
+                    /* A NaN coordinate is never relayed: to a receiving
+                     * aircraft it is a hazard, not information. A dead-reckoned
+                     * coordinate is relayed unchanged, flags word included, so
+                     * the receiver applies its own policy to it. */
+                    this->client_handler->broadcastMsg(msg, this);
+                }
             }
             break;
             case fss::transport::message_type_system_status: {

--- a/src/db-write-queue.hpp
+++ b/src/db-write-queue.hpp
@@ -19,9 +19,15 @@ struct rtt_write {
 };
 struct position_write {
     uint64_t asset_id;
+    /* NaN when the report carried no coordinates -- the wire no-fix sentinel.
+     * The row is still written, with NULL geometry, so the operator can see
+     * that the aircraft reported itself blind (todo/76). */
     double latitude;
     double longitude;
     uint32_t altitude;
+    /* False when the coordinates are the autopilot's dead-reckoned estimate
+     * rather than a GPS fix, or when there are no coordinates at all. */
+    bool gps_fix_valid;
 };
 struct status_write {
     uint64_t asset_id;

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -216,7 +216,7 @@ void flight_safety_system::server::db_connection::recordCommandAck(uint64_t comm
 }
 
 void flight_safety_system::server::db_connection::recordPosition(uint64_t asset_id, double latitude, double longitude,
-                                                                 uint32_t altitude)
+                                                                 uint32_t altitude, bool gps_fix_valid)
 {
     std::scoped_lock guard(this->write_lock);
     if (altitude > static_cast<uint32_t>(std::numeric_limits<int>::max()))
@@ -225,7 +225,8 @@ void flight_safety_system::server::db_connection::recordPosition(uint64_t asset_
                                         << asset_id);
         return;
     }
-    if (db_position_create_entry(write_conn_name, asset_id, latitude, longitude, static_cast<int>(altitude)) == 0)
+    if (db_position_create_entry(write_conn_name, asset_id, latitude, longitude, static_cast<int>(altitude),
+                                 gps_fix_valid ? 1 : 0) == 0)
     {
         throw database_error("position write failed for asset " + std::to_string(asset_id));
     }

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -102,7 +102,15 @@ public:
      * indistinguishable from a fleet of unregistered assets (todo/60,
      * matches the getActiveServers() convention below). */
     virtual auto getAssetId(const std::string &name) -> std::optional<uint64_t> = 0;
-    virtual void recordPosition(uint64_t asset_id, double latitude, double longitude, uint32_t altitude) = 0;
+    /* gps_fix_valid false marks the coordinates as the autopilot's
+     * dead-reckoned estimate rather than a GPS-backed position, so fss-web can
+     * label them instead of ageing them as if they were a fix. A NaN latitude
+     * or longitude means the report carried no coordinates at all and stores
+     * NULL geometry; a no-fix report is recorded either way, because "the
+     * aircraft says it is blind" is what the operator needs and it is not
+     * inferable from a position that merely stops advancing (todo/76). */
+    virtual void recordPosition(uint64_t asset_id, double latitude, double longitude, uint32_t altitude,
+                                bool gps_fix_valid) = 0;
     virtual void recordRtt(uint64_t asset_id, uint64_t rtt_ms) = 0;
     virtual void recordStatus(uint64_t asset_id, uint8_t bat_percent, uint32_t bat_mah_used, double bat_voltage) = 0;
     virtual void recordSearchStatus(uint64_t asset_id, uint64_t search_id, uint64_t completed, uint64_t total) = 0;
@@ -199,7 +207,8 @@ public:
     auto operator=(db_connection &&) -> db_connection & = delete;
     ~db_connection() override;
     auto getAssetId(const std::string &name) -> std::optional<uint64_t> override;
-    void recordPosition(uint64_t asset_id, double latitude, double longitude, uint32_t altitude) override;
+    void recordPosition(uint64_t asset_id, double latitude, double longitude, uint32_t altitude,
+                        bool gps_fix_valid) override;
     void recordRtt(uint64_t asset_id, uint64_t rtt_ms) override;
     void recordStatus(uint64_t asset_id, uint8_t bat_percent, uint32_t bat_mah_used, double bat_voltage) override;
     void recordSearchStatus(uint64_t asset_id, uint64_t search_id, uint64_t completed, uint64_t total) override;
@@ -309,6 +318,11 @@ private:
      * from an authenticated peer — this is a healthy-link correction, not an
      * adversarial defence (see todo/17). Recv thread only. */
     void updateClockOffset(uint64_t client_timestamp, uint64_t rtt_ms, uint64_t recv_wall);
+    /* Log the edges of this session's GPS-fix state (todo/76). Every report is
+     * recorded to the database regardless; this only decides what reaches the
+     * log, which is why it is edge-triggered and the storage is not. Recv
+     * thread only. */
+    void logGpsFixState(bool gps_fix_valid, bool have_coords);
     uint64_t last_command_send_ts{0};
     uint64_t last_command_dbid{0};
     /* The command row this session has already recorded a dispatch write for
@@ -380,10 +394,17 @@ private:
     rate_limiter command_ack_rate{10, 5};
     uint64_t ack_rate_limit_rejects{0};
     uint64_t last_ack_rate_limit_log_ms{0};
-    /* Cumulative position reports discarded for having no GPS fix (NaN
-     * coordinates) this session; touched only on the recv thread
-     * (processMessage), used to throttle the warning. */
+    /* Position reports in the CURRENT no-fix run — reset when the fix returns,
+     * so the restore log can name how long the outage ran. Touched only on the
+     * recv thread (processMessage), used to throttle the warning. */
     uint64_t no_fix_reports{0};
+    /* Last GPS-fix state seen this session, and whether any has been seen yet.
+     * Session-scoped by design: a reconnect mid-outage genuinely has no prior
+     * state and re-logs the loss, which is information rather than a duplicate.
+     * Drives logging only — every report is recorded either way. Recv thread
+     * only. */
+    bool gps_fix_state_known{false};
+    bool gps_fix_valid{true};
     /* Position staleness window in ms (0 disables the check). A report whose
      * timestamp is further than this from the (offset-corrected) server clock
      * is discarded. Configurable via server.json position_staleness_ms. */

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -55,7 +55,7 @@ static constexpr uint32_t FSS_FEATURE_SYSTEM_HEALTH = 0x4U;     /* todo/17 item 
 static constexpr uint32_t FSS_FEATURE_SERVER_COMMAND_ID = 0x8U; /* todo/49 */
 static constexpr uint32_t FSS_FEATURE_POSITION_FLAGS = 0x10U;   /* todo/76 */
 static constexpr uint32_t FSS_SUPPORTED_FEATURES =
-    FSS_FEATURE_RTT_OFFSET | FSS_FEATURE_COMMAND_ACK | FSS_FEATURE_SERVER_COMMAND_ID;
+    FSS_FEATURE_RTT_OFFSET | FSS_FEATURE_COMMAND_ACK | FSS_FEATURE_SERVER_COMMAND_ID | FSS_FEATURE_POSITION_FLAGS;
 
 /* The capability set to adopt for a peer that advertised peer_flags: the
  * intersection with what this build implements, so a peer can never enable a

--- a/src/server-db.h
+++ b/src/server-db.h
@@ -59,8 +59,13 @@ int db_status_create_entry(const char *conn, unsigned long long asset_id, unsign
                            unsigned int bat_mah_used, double bat_voltage);
 int db_search_status_create_entry(const char *conn, unsigned long long asset_id, unsigned long long search_id,
                                   unsigned long long search_completed, unsigned long long search_total);
+/* gps_fix_valid is the wire flags word's coords-valid bit, stored so fss-web
+ * can tell a GPS-backed position from the autopilot's dead-reckoned estimate.
+ * A non-finite latitude or longitude means the report carried no coordinates
+ * at all (the wire no-fix sentinel) and writes NULL geometry -- the same
+ * NaN<->NULL convention asset_command_s already uses in the read direction. */
 int db_position_create_entry(const char *conn, unsigned long long asset_id, double latitude, double longitude,
-                             int altitude);
+                             int altitude, int gps_fix_valid);
 
 /* Records the per-connection message id the server stamped onto the dispatched
  * command, on the assets_assetcommand row identified by its primary key

--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -173,7 +173,7 @@ int db_search_status_create_entry(const char *conn_arg, unsigned long long asset
     return 1;
 }
 
-int db_position_create_entry(const char *conn_arg, unsigned long long asset_id_arg, double latitude, double longitude, int altitude)
+int db_position_create_entry(const char *conn_arg, unsigned long long asset_id_arg, double latitude, double longitude, int altitude, int gps_fix_valid_arg)
 {
     EXEC SQL BEGIN DECLARE SECTION;
     const char *conn = conn_arg;
@@ -181,9 +181,17 @@ int db_position_create_entry(const char *conn_arg, unsigned long long asset_id_a
     double lat = latitude;
     double lng = longitude;
     int alt = altitude;
+    bool fix_valid = gps_fix_valid_arg != 0;
+    /* Negative indicator == SQL NULL. A report with no coordinates (the wire
+     * no-fix sentinel, decoded to NaN) must store NULL geometry rather than
+     * (0,0) -- Null Island is a real place. ST_MakePoint of a NULL argument is
+     * NULL, and ST_SetSRID of NULL is NULL, so the whole expression collapses
+     * to the NULL the column now permits (fss-web migration 0016). */
+    int lat_ind = isnan(latitude) ? -1 : 0;
+    int lng_ind = isnan(longitude) ? -1 : 0;
     EXEC SQL END DECLARE SECTION;
 
-    EXEC SQL AT :conn INSERT INTO assets_assetposition (asset_id, position, altitude, timestamp) VALUES (:asset_id, ST_SetSRID(ST_MakePoint(:lng, :lat), 4326), :alt, NOW());
+    EXEC SQL AT :conn INSERT INTO assets_assetposition (asset_id, position, altitude, gps_fix_valid, timestamp) VALUES (:asset_id, ST_SetSRID(ST_MakePoint(:lng :lng_ind, :lat :lat_ind), 4326), :alt, :fix_valid, NOW());
 
     if (sqlca.sqlcode < 0)
     {
@@ -802,6 +810,7 @@ static const struct required_column_s required_columns[] = {
     {"assets_assetposition", "asset_id", 0},
     {"assets_assetposition", "position", 0},
     {"assets_assetposition", "altitude", 0},
+    {"assets_assetposition", "gps_fix_valid", 0},
     {"assets_assetposition", "timestamp", 0},
     {"assets_assetrtt", "asset_id", 0},
     {"assets_assetrtt", "rtt", 0},

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -362,7 +362,7 @@ auto main(int argc, char *argv[]) -> int
             flight_safety_system::server::overloaded{
                 [&](const flight_safety_system::server::rtt_write &w) -> void { dbc->recordRtt(w.asset_id, w.rtt_ms); },
                 [&](const flight_safety_system::server::position_write &w) -> void {
-                    dbc->recordPosition(w.asset_id, w.latitude, w.longitude, w.altitude);
+                    dbc->recordPosition(w.asset_id, w.latitude, w.longitude, w.altitude, w.gps_fix_valid);
                 },
                 [&](const flight_safety_system::server::status_write &w) -> void {
                     dbc->recordStatus(w.asset_id, w.bat_percent, w.bat_mah_used, w.bat_voltage);

--- a/tests/concurrency_client_test.cpp
+++ b/tests/concurrency_client_test.cpp
@@ -102,7 +102,7 @@ public:
     {
         return uint64_t{name == "craft" ? 1U : 0U};
     }
-    void recordPosition(uint64_t, double, double, uint32_t) override {}
+    void recordPosition(uint64_t, double, double, uint32_t, bool) override {}
     void recordRtt(uint64_t, uint64_t) override {}
     void recordStatus(uint64_t, uint8_t, uint32_t, double) override {}
     void recordSearchStatus(uint64_t, uint64_t, uint64_t, uint64_t) override {}

--- a/tests/crl_revocation_test.cpp
+++ b/tests/crl_revocation_test.cpp
@@ -37,7 +37,7 @@ auto make_writer(fss_test::MockDatabase &mock) -> std::shared_ptr<fss::server::d
         std::visit(fss::server::overloaded{
                        [&](const fss::server::rtt_write &w) -> void { mock.recordRtt(w.asset_id, w.rtt_ms); },
                        [&](const fss::server::position_write &w) -> void {
-                           mock.recordPosition(w.asset_id, w.latitude, w.longitude, w.altitude);
+                           mock.recordPosition(w.asset_id, w.latitude, w.longitude, w.altitude, w.gps_fix_valid);
                        },
                        [&](const fss::server::status_write &w) -> void {
                            mock.recordStatus(w.asset_id, w.bat_percent, w.bat_mah_used, w.bat_voltage);

--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -204,7 +204,22 @@ TEST_CASE("db_connection: recordPosition with valid altitude inserts row")
 {
     LIVE_DB_OR_SKIP(dbc);
     auto asset_id = get_test_asset_id(*dbc);
-    dbc->recordPosition(asset_id, -43.5, 172.6, uint32_t{100});
+    dbc->recordPosition(asset_id, -43.5, 172.6, uint32_t{100}, true);
+}
+
+TEST_CASE("db_connection: recordPosition without a GPS fix inserts a row")
+{
+    /* todo/76: a no-fix report is stored, not discarded. Both shapes must
+     * reach the database -- a dead-reckoned estimate (finite coordinates,
+     * gps_fix_valid false) and a report with no coordinates at all, which
+     * writes NULL geometry via the ECPG indicator variables. The column and
+     * the nullable geometry both arrive with fss-web migration 0016, so this
+     * also proves the e2e schema mirror matches. */
+    LIVE_DB_OR_SKIP(dbc);
+    auto asset_id = get_test_asset_id(*dbc);
+    dbc->recordPosition(asset_id, -43.5, 172.6, uint32_t{100}, false);
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    dbc->recordPosition(asset_id, nan, nan, uint32_t{100}, false);
 }
 
 TEST_CASE("db_connection: recordPosition with overflow altitude is discarded")
@@ -212,7 +227,7 @@ TEST_CASE("db_connection: recordPosition with overflow altitude is discarded")
     LIVE_DB_OR_SKIP(dbc);
     auto asset_id = get_test_asset_id(*dbc);
     constexpr auto huge_alt = static_cast<uint32_t>(std::numeric_limits<int>::max()) + uint32_t{1};
-    dbc->recordPosition(asset_id, -43.5, 172.6, huge_alt);
+    dbc->recordPosition(asset_id, -43.5, 172.6, huge_alt, true);
 }
 
 TEST_CASE("db_connection: write methods throw database_error when the write connection is down (todo/34)")
@@ -239,7 +254,7 @@ TEST_CASE("db_connection: write methods throw database_error when the write conn
         return false;
     };
 
-    REQUIRE(threw_database_error([&] { dbc->recordPosition(asset_id, -43.5, 172.6, uint32_t{100}); }));
+    REQUIRE(threw_database_error([&] { dbc->recordPosition(asset_id, -43.5, 172.6, uint32_t{100}, true); }));
     REQUIRE(threw_database_error([&] { dbc->recordRtt(asset_id, uint64_t{42}); }));
     REQUIRE(threw_database_error([&] { dbc->recordStatus(asset_id, uint8_t{80}, uint32_t{1000}, 12.4); }));
     REQUIRE(threw_database_error([&] { dbc->recordSearchStatus(asset_id, uint64_t{1}, uint64_t{50}, uint64_t{100}); }));

--- a/tests/mock_database.hpp
+++ b/tests/mock_database.hpp
@@ -48,9 +48,12 @@ public:
     };
     struct recorded_pos {
         uint64_t asset_id;
+        /* NaN when the report carried no coordinates; the production layer
+         * stores NULL geometry for that row. */
         double latitude;
         double longitude;
         uint32_t altitude;
+        bool gps_fix_valid;
     };
     struct recorded_status {
         uint64_t asset_id;
@@ -92,10 +95,11 @@ public:
         return it == asset_ids.end() ? uint64_t{0} : it->second;
     }
 
-    void recordPosition(uint64_t asset_id, double latitude, double longitude, uint32_t altitude) override
+    void recordPosition(uint64_t asset_id, double latitude, double longitude, uint32_t altitude,
+                        bool gps_fix_valid) override
     {
         const std::scoped_lock lock(records_lock);
-        positions.push_back({asset_id, latitude, longitude, altitude});
+        positions.push_back({asset_id, latitude, longitude, altitude, gps_fix_valid});
     }
 
     void recordRtt(uint64_t asset_id, uint64_t rtt_ms) override

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -198,7 +198,7 @@ auto make_mock_writer(fss_test::MockDatabase &mock) -> std::shared_ptr<fss::serv
         std::visit(fss::server::overloaded{
                        [&](const fss::server::rtt_write &w) -> void { mock.recordRtt(w.asset_id, w.rtt_ms); },
                        [&](const fss::server::position_write &w) -> void {
-                           mock.recordPosition(w.asset_id, w.latitude, w.longitude, w.altitude);
+                           mock.recordPosition(w.asset_id, w.latitude, w.longitude, w.altitude, w.gps_fix_valid);
                        },
                        [&](const fss::server::status_write &w) -> void {
                            mock.recordStatus(w.asset_id, w.bat_percent, w.bat_mah_used, w.bat_voltage);
@@ -1795,8 +1795,24 @@ TEST_CASE("session: legacy client (no version handshake) is accepted")
 namespace {
 auto make_position_msg(uint64_t ts) -> std::shared_ptr<fss::transport::fss_message_position_report>
 {
+    /* The coords-valid flag is set: these stand for ordinary healthy reports,
+     * and establish_v2_session negotiates the capability that makes the flags
+     * word meaningful (todo/76). */
     return std::make_shared<fss::transport::fss_message_position_report>(
-        0.0, 0.0, 0U, 0U, 0U, int16_t{0}, 0U, std::string{}, 0U, uint8_t{0}, 0U, uint8_t{0}, uint8_t{0}, ts);
+        0.0, 0.0, 0U, 0U, 0U, int16_t{0}, 0U, std::string{}, 0U, uint8_t{0},
+        fss::transport::FSS_POSITION_FLAG_VALID_COORDS, uint8_t{0}, uint8_t{0}, ts);
+}
+
+/* Number of non-overlapping occurrences of `needle` in `haystack`. Used to
+ * assert that a log line fires once per event rather than once per report. */
+auto count_occurrences(const std::string &haystack, const std::string &needle) -> size_t
+{
+    size_t count = 0;
+    for (size_t pos = haystack.find(needle); pos != std::string::npos; pos = haystack.find(needle, pos + needle.size()))
+    {
+        ++count;
+    }
+    return count;
 }
 
 /* Drive a version + identity exchange over a v2 connection.
@@ -2097,8 +2113,18 @@ TEST_CASE("session: no-fix (NaN) position report is discarded, not stored or bro
         std::string{}, 0U, uint8_t{0}, 0U, uint8_t{0}, uint8_t{0}, fss::fss_current_timestamp());
     session->processMessage(no_fix);
 
-    REQUIRE(mock.getPositions().empty()); // not stored
-    REQUIRE(handler.broadcasts.empty());  // not broadcast
+    /* Recorded, not discarded (todo/76): the operator cannot otherwise tell a
+     * blind aircraft from a silent one, because RTT keeps the asset connected
+     * either way. The coordinates stay NaN so the DB layer writes NULL
+     * geometry rather than Null Island. */
+    REQUIRE(fss_test::wait_for([&]() { return mock.getPositions().size() == 1; }));
+    auto stored = mock.getPositions();
+    REQUIRE_FALSE(stored[0].gps_fix_valid);
+    REQUIRE(std::isnan(stored[0].latitude));
+    REQUIRE(std::isnan(stored[0].longitude));
+    /* Still never relayed: a NaN coordinate is a hazard to a receiving
+     * aircraft, not information. */
+    REQUIRE(handler.broadcasts.empty());
     /* Logged distinctly as a no-fix, not the generic invalid-coordinate path. */
     REQUIRE(cap.str().find("no GPS fix") != std::string::npos);
 
@@ -2106,6 +2132,177 @@ TEST_CASE("session: no-fix (NaN) position report is discarded, not stored or bro
     auto fresh = make_position_msg(fss::fss_current_timestamp());
     session->processMessage(fresh);
     REQUIRE(handler.broadcasts.size() == 1);
+    REQUIRE(fss_test::wait_for([&]() { return mock.getPositions().size() == 2; }));
+    stored = mock.getPositions();
+    REQUIRE(stored[1].gps_fix_valid);
+    /* The restore edge is logged too -- before todo/76 the log said an
+     * aircraft had lost its fix and then never mentioned it again. */
+    REQUIRE(cap.str().find("GPS fix restored") != std::string::npos);
+}
+
+TEST_CASE("session: a run of no-fix reports is recorded per report but logged on the edges")
+{
+    /* The storage is per-report because fss-web ages the latest row to decide
+     * whether the no-fix state is current; the log is edge-triggered because an
+     * aircraft streams position at up to 5 Hz and an unthrottled line per
+     * report would bury every other message for the length of the outage. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    fss_test::capture_cerr cap;
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    constexpr size_t no_fix_count = 20;
+    for (size_t i = 0; i < no_fix_count; ++i)
+    {
+        session->processMessage(std::make_shared<fss::transport::fss_message_position_report>(
+            nan, nan, 0U, 0U, 0U, int16_t{0}, 0U, std::string{}, 0U, uint8_t{0}, 0U, uint8_t{0}, uint8_t{0},
+            fss::fss_current_timestamp()));
+    }
+
+    REQUIRE(fss_test::wait_for([&]() { return mock.getPositions().size() == no_fix_count; }));
+    /* One loss line for the run, not twenty. */
+    REQUIRE(count_occurrences(cap.str(), "no GPS fix") == 1);
+}
+
+TEST_CASE("session: a cleared coords-valid flag records a dead-reckoned estimate without dropping it")
+{
+    /* The user-visible gap todo/76 closes on the flags side: a client can send
+     * finite coordinates while clearing the flags word's coords-valid bit,
+     * meaning "this is the estimator's guess, not a GPS fix". The position is
+     * still stored and still relayed -- a safety system must not discard a real
+     * coordinate on the strength of a metadata bit -- but it is marked, so
+     * fss-web labels it instead of ageing it as if it were a fix. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    uint64_t next_id = 1;
+    establish_v2_session(session, next_id);
+
+    fss_test::capture_cerr cap;
+    auto estimate = std::make_shared<fss::transport::fss_message_position_report>(
+        -43.5, 172.6, 100U, 0U, 0U, int16_t{0}, 0U, std::string{}, 0U, uint8_t{0}, uint16_t{0}, uint8_t{0}, uint8_t{0},
+        fss::fss_current_timestamp());
+    estimate->setId(next_id++);
+    session->processMessage(estimate);
+
+    REQUIRE(fss_test::wait_for([&]() { return mock.getPositions().size() == 1; }));
+    auto stored = mock.getPositions();
+    REQUIRE(stored[0].latitude == -43.5);
+    REQUIRE(stored[0].longitude == 172.6);
+    REQUIRE_FALSE(stored[0].gps_fix_valid);
+    REQUIRE(handler.broadcasts.size() == 1);
+    REQUIRE(cap.str().find("dead-reckoned estimate") != std::string::npos);
+
+    /* Setting the bit again restores the fix state. */
+    auto fixed = std::make_shared<fss::transport::fss_message_position_report>(
+        -43.5, 172.6, 100U, 0U, 0U, int16_t{0}, 0U, std::string{}, 0U, uint8_t{0},
+        fss::transport::FSS_POSITION_FLAG_VALID_COORDS, uint8_t{0}, uint8_t{0}, fss::fss_current_timestamp());
+    fixed->setId(next_id++);
+    session->processMessage(fixed);
+    REQUIRE(fss_test::wait_for([&]() { return mock.getPositions().size() == 2; }));
+    stored = mock.getPositions();
+    REQUIRE(stored[1].gps_fix_valid);
+}
+
+TEST_CASE("session: a peer that never negotiated the capability keeps its flags word ignored")
+{
+    /* Compat: a client predating FSS_FEATURE_POSITION_FLAGS leaves the flags
+     * word at 0. Reading that as "no fix" would mark every position it ever
+     * sends as dead-reckoned and, in fss-web, latch a permanent no-fix warning
+     * on a perfectly healthy aircraft. Without the negotiated capability the
+     * word says nothing and the report is a normal fix. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    /* Identity only -- no version handshake, so nothing is negotiated. */
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+    REQUIRE(conn->getNegotiatedFeatureFlags() == 0U);
+
+    session->processMessage(std::make_shared<fss::transport::fss_message_position_report>(
+        -43.5, 172.6, 100U, 0U, 0U, int16_t{0}, 0U, std::string{}, 0U, uint8_t{0}, uint16_t{0}, uint8_t{0}, uint8_t{0},
+        fss::fss_current_timestamp()));
+
+    REQUIRE(fss_test::wait_for([&]() { return mock.getPositions().size() == 1; }));
+    auto stored = mock.getPositions();
+    REQUIRE(stored[0].gps_fix_valid);
+    REQUIRE(handler.broadcasts.size() == 1);
+}
+
+TEST_CASE("session: a no-coordinate report outranks a flags word claiming a valid fix")
+{
+    /* cap-fmu drives both halves of the signal from one bool, but they can
+     * disagree if a client is wrong or malicious. NaN coordinates win: there is
+     * no position for a fix to back, so no flag can make the report valid. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    uint64_t next_id = 1;
+    establish_v2_session(session, next_id);
+
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    auto claimed_fix = std::make_shared<fss::transport::fss_message_position_report>(
+        nan, nan, 0U, 0U, 0U, int16_t{0}, 0U, std::string{}, 0U, uint8_t{0},
+        fss::transport::FSS_POSITION_FLAG_VALID_COORDS, uint8_t{0}, uint8_t{0}, fss::fss_current_timestamp());
+    claimed_fix->setId(next_id++);
+    session->processMessage(claimed_fix);
+
+    REQUIRE(fss_test::wait_for([&]() { return mock.getPositions().size() == 1; }));
+    auto stored = mock.getPositions();
+    REQUIRE_FALSE(stored[0].gps_fix_valid);
+    REQUIRE(handler.broadcasts.empty());
+}
+
+TEST_CASE("session: a malformed coordinate is discarded and leaves no fix record")
+{
+    /* An out-of-range coordinate is a broken report, not a report about the
+     * GPS. It must not masquerade as a no-fix row, or a buggy client would
+     * read as an aircraft that had lost its fix. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    session->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft"));
+
+    fss_test::capture_cerr cap;
+    session->processMessage(std::make_shared<fss::transport::fss_message_position_report>(
+        91.0, 172.6, 100U, 0U, 0U, int16_t{0}, 0U, std::string{}, 0U, uint8_t{0}, uint16_t{0}, uint8_t{0}, uint8_t{0},
+        fss::fss_current_timestamp()));
+
+    REQUIRE(mock.getPositions().empty());
+    REQUIRE(handler.broadcasts.empty());
+    REQUIRE(cap.str().find("Invalid position report coordinates") != std::string::npos);
+    REQUIRE(cap.str().find("no GPS fix") == std::string::npos);
 }
 
 TEST_CASE("session: future-dated position report is discarded (symmetric window)")
@@ -2775,10 +2972,13 @@ TEST_CASE("session: position report with out-of-range latitude is rejected")
     REQUIRE(mock.getPositions().front().asset_id == asset_id);
 }
 
-TEST_CASE("session: position report with invalid longitude or non-finite coords is rejected")
+TEST_CASE("session: position report with invalid longitude or infinite coords is rejected")
 {
-    /* is_valid_coordinate also rejects out-of-range longitude and non-finite
-     * lat/long; each such report must be neither stored nor broadcast. */
+    /* is_valid_coordinate also rejects out-of-range longitude and infinite
+     * lat/long; each such report must be neither stored nor broadcast. NaN is
+     * deliberately absent here -- it is not a malformed coordinate but the
+     * wire's no-fix sentinel, and since todo/76 it is recorded rather than
+     * discarded (see the no-fix cases above). */
     fss_test::MockDatabase mock;
     constexpr uint64_t asset_id = 22;
     mock.asset_ids["craft"] = asset_id;
@@ -2796,12 +2996,11 @@ TEST_CASE("session: position report with invalid longitude or non-finite coords 
             fss::fss_current_timestamp());
     };
 
-    const double nan = std::numeric_limits<double>::quiet_NaN();
     const double inf = std::numeric_limits<double>::infinity();
     for (const auto &bad : {make_pos(0.0, 200.0),  // longitude > 180
                             make_pos(0.0, -181.0), // longitude < -180
-                            make_pos(nan, 0.0),    // non-finite latitude
-                            make_pos(0.0, inf)})   // non-finite longitude
+                            make_pos(-inf, 0.0),   // infinite latitude
+                            make_pos(0.0, inf)})   // infinite longitude
     {
         session->processMessage(bad);
     }


### PR DESCRIPTION
## Description

An aircraft that loses its GPS fix keeps reporting position and says so: cap-fmu clears the flags word's coords-valid bit and NaNs the coordinates (the wire no-fix sentinel). The server recognised the sentinel and threw the report away with a throttled log line, and ignored the flags word entirely. Nothing downstream could tell that the aircraft had reported itself blind -- the operator saw a position that stopped advancing while RTT kept the asset marked connected, which is also what a MAVLink dropout, a stalled position stream and a wedged FMU look like.

Store every report instead, carrying its validity:

- No coordinates at all -> row with NULL geometry, gps_fix_valid false. Still not broadcast: a NaN delivered to another aircraft is a hazard.
- Finite coordinates with the coords-valid bit clear -> stored and broadcast as before, gps_fix_valid false. The estimator's dead-reckoned guess is worth showing, labelled; a safety system must not discard a real coordinate on the strength of a metadata bit.
- Anything out of range or infinite -> discarded as before, and it leaves no fix record. That is a broken report, not a report about the GPS.

Reading the flags word is gated on FSS_FEATURE_POSITION_FLAGS, now implemented and advertised. A peer predating the capability leaves the word at 0, and treating that as "no fix" would mark every report it ever sends as dead-reckoned and latch a permanent warning in fss-web on a healthy aircraft.

Storage is per report because fss-web ages the latest row to decide whether the state is current; the log stays edge-triggered, and now names the restore edge too, which was previously invisible.

Requires fss-web migration 0016 (assets_assetposition.gps_fix_valid, and position made nullable), which the startup schema check now demands.

## Summary by Sourcery

Record GPS fix validity with each position report, storing no-fix events in the database while refining server-side validation, logging, and feature negotiation around GPS-backed coordinates.

New Features:
- Add support for FSS_FEATURE_POSITION_FLAGS to track whether reported coordinates are GPS-backed and expose this state downstream via gps_fix_valid.

Enhancements:
- Persist position reports that indicate loss of GPS fix, including NaN coordinate sentinels, while keeping NaN coordinates out of broadcasts.
- Extend database schema and write path so asset positions store nullable geometry and a gps_fix_valid flag for operator-facing tooling.
- Adjust server logging to treat GPS-fix state as an edge-triggered signal with periodic reminders, and to distinguish dead-reckoned estimates, no-coordinate reports, and malformed coordinates.
- Update feature negotiation and message handling so legacy clients without position flag support remain compatible and are treated as providing valid fixes when coordinates are sane.

Tests:
- Expand server, database, and concurrency tests to cover GPS fix validity propagation, NaN vs malformed coordinates, edge-triggered no-fix logging, and legacy client behaviour.