### PR TITLE
test(e2e): drive a real GPS-fix outage through the whole stack

### DIFF
--- a/e2e/test_gps_fix.py
+++ b/e2e/test_gps_fix.py
@@ -1,0 +1,63 @@
+"""A client that loses its GPS fix is recorded as such, not silently dropped.
+
+Before todo/76 a no-fix report was discarded, so the operator saw a position
+that stopped advancing while RTT kept the asset connected -- indistinguishable
+from a dropout or a wedged FMU. The rows now carry gps_fix_valid, and a report
+with no coordinates at all stores NULL geometry rather than nothing.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+
+@pytest.mark.satisfies("TC-FS-002")
+@pytest.mark.requires_docker
+def test_no_fix_reports_are_recorded_with_null_position(db_conn, fake_client):
+    """Drive good -> no fix -> good and assert the transition is visible.
+
+    The fake client clears the coords-valid flag and NaNs the coordinates
+    together, exactly as cap-fmu does, so this exercises the whole signal.
+    """
+    with db_conn.cursor() as cur:
+        cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
+        asset_id = cur.fetchone()[0]
+
+    fake_client(
+        "test1",
+        extra_args=[
+            "--position-interval-ms=1000",
+            "--no-fix-start-ms=6000",
+            "--no-fix-stop-ms=12000",
+        ],
+    )
+
+    time.sleep(18)
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT gps_fix_valid, position IS NULL FROM assets_assetposition "
+            "WHERE asset_id = %s ORDER BY timestamp",
+            (asset_id,),
+        )
+        rows = cur.fetchall()
+
+    assert len(rows) >= 6, f"expected several position rows, got {len(rows)}"
+
+    fix_states = [valid for valid, _ in rows]
+    assert True in fix_states, "no GPS-backed rows were recorded"
+    assert False in fix_states, "the no-fix window left no record at all"
+
+    # Every no-fix row here has NULL geometry: the client sent the sentinel
+    # rather than a dead-reckoned estimate, and NULL must not decay to (0,0) --
+    # Null Island is a legal coordinate that would render as a real position.
+    for valid, position_is_null in rows:
+        assert position_is_null == (not valid), (
+            f"gps_fix_valid={valid} paired with position_is_null={position_is_null}"
+        )
+
+    # The outage is bounded: the fix comes back, and the run of no-fix rows sits
+    # between GPS-backed ones rather than running to the end of the session.
+    assert fix_states[0] is True, "session did not start with a GPS-backed row"
+    assert fix_states[-1] is True, "fix never recovered"

--- a/examples/fake_client.cpp
+++ b/examples/fake_client.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdlib>
 #include <csignal>
+#include <limits>
 #include <iostream>
 #include <optional>
 #include <sstream>
@@ -97,6 +98,12 @@ struct cli_options {
     std::string callsign{"example"};
     int position_interval_ms{5000};
     int64_t clock_offset_ms{0};
+    /* Window, in ms since start, during which position reports are sent with
+     * no GPS fix (todo/76). Both halves of the signal are driven together, as
+     * cap-fmu does: the coords-valid flag is cleared and the coordinates are
+     * NaN'd. Inactive while stop <= start. */
+    int no_fix_start_ms{0};
+    int no_fix_stop_ms{0};
 };
 
 /* Parses `text` as a base-10 integer via strtoul/strtol, requiring the
@@ -149,6 +156,8 @@ auto parse_args(int argc, char *argv[]) -> std::optional<cli_options>
     constexpr std::string_view callsign_prefix = "--callsign=";
     constexpr std::string_view interval_prefix = "--position-interval-ms=";
     constexpr std::string_view clock_offset_prefix = "--clock-offset-ms=";
+    constexpr std::string_view no_fix_start_prefix = "--no-fix-start-ms=";
+    constexpr std::string_view no_fix_stop_prefix = "--no-fix-stop-ms=";
     for (int i = 2; i < argc; i++)
     {
         std::string_view arg = argv[i];
@@ -174,6 +183,20 @@ auto parse_args(int argc, char *argv[]) -> std::optional<cli_options>
         {
             opts.clock_offset_ms =
                 std::strtoll(std::string(arg.substr(clock_offset_prefix.size())).c_str(), nullptr, 10);
+        }
+        else if (arg.substr(0, no_fix_start_prefix.size()) == no_fix_start_prefix)
+        {
+            if (!parse_int_arg(no_fix_start_prefix, arg.substr(no_fix_start_prefix.size()), opts.no_fix_start_ms))
+            {
+                return std::nullopt;
+            }
+        }
+        else if (arg.substr(0, no_fix_stop_prefix.size()) == no_fix_stop_prefix)
+        {
+            if (!parse_int_arg(no_fix_stop_prefix, arg.substr(no_fix_stop_prefix.size()), opts.no_fix_stop_ms))
+            {
+                return std::nullopt;
+            }
         }
         else
         {
@@ -274,8 +297,14 @@ auto main(int argc, char *argv[]) -> int
         }
         if (opts.position_interval_ms > 0 && elapsed_ms >= next_position_ms)
         {
-            constexpr double lat = -43.5;
-            constexpr double lng = 172.5;
+            /* Inside the no-fix window, report exactly as cap-fmu does when
+             * the autopilot drops below a 2D fix: clear the coords-valid bit
+             * and send NaN coordinates. The two are one signal and must not
+             * diverge. */
+            const bool no_fix = opts.no_fix_stop_ms > opts.no_fix_start_ms && elapsed_ms >= opts.no_fix_start_ms &&
+                                elapsed_ms < opts.no_fix_stop_ms;
+            const double lat = no_fix ? std::numeric_limits<double>::quiet_NaN() : -43.5;
+            const double lng = no_fix ? std::numeric_limits<double>::quiet_NaN() : 172.5;
             constexpr int alt = 300;
             constexpr int heading_cdeg = 1800;
             constexpr int hor_vel = 200;
@@ -285,7 +314,8 @@ auto main(int argc, char *argv[]) -> int
             /* ADS-B style validity bits: coords, altitude, heading, velocity,
              * callsign, squawk. Only the coords bit has a name here because it
              * is the only one the server reads (todo/76). */
-            constexpr int flags = fss::transport::FSS_POSITION_FLAG_VALID_COORDS | 2 | 4 | 8 | 16 | 32;
+            constexpr int other_valid_fields = 2 | 4 | 8 | 16 | 32;
+            const int flags = other_valid_fields | (no_fix ? 0 : int{fss::transport::FSS_POSITION_FLAG_VALID_COORDS});
             constexpr int alt_type = 1;
             constexpr int emitter_type = 14;
             /* getSkewedTimestamp() (todo/33) rather than fss_current_timestamp()


### PR DESCRIPTION
## Description

fake_client gains --no-fix-start-ms/--no-fix-stop-ms, which clear the coords-valid flag and NaN the coordinates together for a window -- the same pairing cap-fmu uses, so the two halves of the signal cannot drift apart in the test the way they could if the flag were faked alone.

The new e2e case drives good -> no fix -> good and asserts the outage is visible in assets_assetposition: rows appear throughout, the no-fix ones carry gps_fix_valid false with NULL geometry, and the fix recovers. The NULL is the point of the last assertion -- decaying it to (0,0) would put the aircraft at Null Island, a legal coordinate that renders as a real position.

## Summary by Sourcery

Simulate and validate GPS fix outages end-to-end, ensuring they are recorded with explicit no-fix state rather than silently dropped.

New Features:
- Add CLI options to fake_client to generate a configurable no-GPS-fix window by clearing coordinate validity and sending NaN coordinates.

Tests:
- Introduce an end-to-end test that drives a good → no-fix → good GPS scenario and asserts asset positions record gps_fix_valid with NULL geometry during outages and recovery afterward.