### PR TITLE
docs: record the GPS-fix decisions and raise the migration floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **A position report now records whether its coordinates are backed by a GPS
+  fix** (todo/76, `docs/decisions/76-gps-fix-recording.md`). An aircraft that
+  loses GPS keeps reporting and says so — cap-fmu clears the position report's
+  coords-valid flag and sends the wire no-fix sentinel — but the server
+  discarded those reports with a throttled log line and never read the flags
+  word at all. The operator saw a position that stopped advancing while RTT kept
+  the asset `connected`, which is also what a MAVLink dropout, a stalled
+  position stream and a wedged FMU look like; only one of those means an RTL
+  cannot be relied on to navigate home. Every report is now stored with its
+  validity: a dead-reckoned estimate keeps its coordinates and is marked, a
+  report carrying no coordinates stores NULL geometry, and neither is silently
+  dropped. A NaN is still never relayed to another aircraft. Reading the flags
+  word is gated on the negotiated `FSS_FEATURE_POSITION_FLAGS`, so a client that
+  predates the capability is unaffected rather than latching a permanent false
+  GPS warning. **Deployments now require `fss-web`'s `assets` migration 0016 or
+  later** (`gps_fix_valid` and a nullable `position` on
+  `assets_assetposition`); the startup schema check refuses to run without it.
 - **The server verifies the database schema at startup and refuses to run
   without it** (todo/73,
   `docs/decisions/73-startup-schema-verification.md`). The tables FSS reads and

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The flight-safety-system server uses a [postgresql](https://www.postgresql.org/)
 
 The [web frontend](https://github.com/canterbury-air-patrol/flight-safety-system-web/) is a separate project and will need to be set up and connected to the database before the server is run.
 
-The tables belong to that project, and its migrations must be applied first. This release requires its `assets` migration **0008 or later**, which provides the command-acknowledgement columns (`dispatch_id`, `ack_state`, `ack_timestamp`, `ack_superseded_by`) on `assets_assetcommand`. The server checks the schema when it starts and refuses to run against a database that is missing anything it needs, naming what is absent — so an un-migrated database is a startup failure you can read, rather than a fleet-wide disconnection some minutes later. See [docs/decisions/73](docs/decisions/73-startup-schema-verification.md).
+The tables belong to that project, and its migrations must be applied first. This release requires its `assets` migration **0016 or later**, which provides the command-acknowledgement columns (`dispatch_id`, `ack_state`, `ack_timestamp`, `ack_superseded_by`) on `assets_assetcommand`, and `gps_fix_valid` plus a nullable `position` on `assets_assetposition`. The server checks the schema when it starts and refuses to run against a database that is missing anything it needs, naming what is absent — so an un-migrated database is a startup failure you can read, rather than a fleet-wide disconnection some minutes later. See [docs/decisions/73](docs/decisions/73-startup-schema-verification.md).
 
 Create a [server.json](examples/server.json) file with the correct port and database settings.
 

--- a/docs/decisions/73-startup-schema-verification.md
+++ b/docs/decisions/73-startup-schema-verification.md
@@ -119,3 +119,26 @@ enforced by a test.
   (`VARCHAR(15)` against a 16-byte buffer warns not at all, `VARCHAR(32)` warns
   and still starts), a dropped table reports each of its columns, and an empty
   database reports the missing PostGIS extension followed by all 40 columns.
+
+## Amendment: the first deliberate change to the mirror (todo/76)
+
+`gps_fix_valid` on `assets_assetposition` is the first column added to
+`required_columns[]` since this check landed, and so the first test of the
+process it implies. Three things had to move in one commit: the entry in
+`required_columns[]`, the table definition in the hand-written mirror
+`e2e/schema/001_init.sql`, and the stated migration floor in the README and
+`docs/release-checklist.md` (0008 → 0016).
+
+What enforces the pairing is the *positive* case in
+`tests/db_connection_test.cpp` — "verifySchema accepts the provisioned schema".
+Adding a required column without adding it to the mirror fails that test
+immediately, which is the intended tripwire and is why the negative
+column-dropped case is not the important one here.
+
+The same commit made `position` nullable in the mirror. The check only tests
+for a column's presence, so a nullability change is invisible to it: had the
+mirror kept `NOT NULL`, the server would have started cleanly and then failed
+every no-fix write at runtime. Both open options above (provisioning from
+fss-web's real migrations, or diffing an `information_schema` dump) would have
+caught that; the presence check alone cannot, and the e2e no-fix test is what
+covers it today. See [decision 76](76-gps-fix-recording.md).

--- a/docs/decisions/76-gps-fix-recording.md
+++ b/docs/decisions/76-gps-fix-recording.md
@@ -1,0 +1,127 @@
+# 76 — Recording whether a reported position is GPS-backed
+
+Status: implemented. Supersedes the transition-table shape sketched in
+`todo/76`; fss-web chose to carry the state on the position row instead.
+
+## The problem
+
+An aircraft that loses its GPS fix does not go quiet. cap-fmu keeps reporting
+at its normal cadence and marks the reports: it clears bit 0 (`VALID_COORDS`)
+of the position report's MAVLink-style flags word, and sends the coordinates as
+the wire no-fix sentinel (`INT32_MIN`, decoded back to `NaN`).
+
+The server recognised the sentinel and discarded the report, incrementing a
+counter and logging every hundredth. It never read the flags word at all. So a
+GPS outage reached the operator as a position that stopped advancing — while
+RTT kept the asset marked `connected` throughout. A MAVLink dropout, a stalled
+position stream and a wedged FMU all look exactly the same. The four call for
+different responses, and losing GPS is the one where a GOTO cannot be flown
+accurately and an RTL cannot be relied on to navigate home.
+
+The information was in the process. It just never left it.
+
+## What is stored
+
+fss-web owns the schema and chose to put the state on the position row
+(migration 0016) rather than in a separate transition table:
+
+- `assets_assetposition.gps_fix_valid BOOLEAN NOT NULL DEFAULT TRUE`
+- `assets_assetposition.position` made nullable
+
+Their API then serves the latest `gps_fix_valid = true` row as `position` (the
+last trusted location) and the latest row overall as the `gps` block, with a
+`position_estimate` when the newest report is a dead-reckoned one. That shape
+decides ours: the row must exist per report, because the display ages the
+latest row to judge whether the no-fix state is *current*. A transition table
+would have stored two rows per outage but left nothing to age.
+
+## The three cases
+
+| Report | Stored | Broadcast |
+| --- | --- | --- |
+| Finite coordinates, fix valid | position, `gps_fix_valid = true` | yes |
+| Finite coordinates, coords-valid bit clear | position, `gps_fix_valid = false` | yes |
+| No coordinates (NaN sentinel) | NULL geometry, `gps_fix_valid = false` | **no** |
+| Out of range or infinite | nothing | no |
+
+A NaN is still never relayed: delivered to another aircraft it is a hazard, not
+information. A dead-reckoned coordinate *is* relayed, flags word intact, so the
+receiver applies its own policy.
+
+An out-of-range coordinate is discarded and deliberately leaves **no** fix
+record. It is a malformed report, not a report about the GPS; recording it as a
+no-fix would make a buggy client read as an aircraft that had lost its fix.
+
+NULL geometry rather than `(0, 0)`: Null Island is a legal coordinate that
+renders as a real position. This is the same `NaN` ↔ `NULL` convention the
+command read path already uses, carried through `position_write`, `IDatabase::
+recordPosition` and ECPG indicator variables.
+
+## Why a cleared flag never discards a position
+
+A client can send finite coordinates with the coords-valid bit clear — that is
+the estimator's dead-reckoned guess, which drifts but stays plausible-looking.
+The obvious reading is to treat it like the NaN case and drop it.
+
+It is stored instead. A safety system must not discard a real coordinate on the
+strength of a metadata bit, and a drifting estimate that says so is strictly
+more information than either storing it silently (the old bug) or storing
+nothing. fss-web renders it as an annotated estimate beside the last trusted
+fix, with the interval between them, rather than hiding the aircraft.
+
+## Why the flags word is capability-gated
+
+Reading the bit is gated on `FSS_FEATURE_POSITION_FLAGS` (0x10), negotiated
+through the existing version handshake.
+
+A peer that predates the capability leaves the flags word at 0. Read
+unconditionally, that means "no fix" — so every position such a client ever
+sends would be marked dead-reckoned, `position` would never populate in
+fss-web, and the operator would get a permanent GPS warning on a perfectly
+healthy aircraft. Alarm fatigue is a real harm and this would have been a
+guaranteed one.
+
+The gate bounds the blast radius the other way too. The library advertises
+`FSS_SUPPORTED_FEATURES` on the application's behalf, so an app that relinks
+without populating flags claims the capability it does not honour. That is
+accepted: the cost is that its reports read as dead-reckoned, and the two known
+client implementations both set the bit correctly — cap-fmu drives it from
+`GPS_RAW_INT.fix_type`, and fss-adsb always sets `valid_coords` because it only
+builds a report once a message carried a position.
+
+## Session scope and logging
+
+Storage is per report; logging is edge-triggered — loss, restore, and a
+reminder every hundredth report so a long outage does not go silent between the
+edges. An aircraft streams position at up to 5 Hz, so an unthrottled line per
+report would bury every other message for the length of the outage.
+
+The fix-state memory (`gps_fix_state_known` / `gps_fix_valid` on the session) is
+session-scoped, so a reconnect mid-outage re-logs the loss. That is correct
+rather than a duplicate: a new session genuinely has no prior state, and the
+stored rows — which are what fss-web reads — are unaffected either way.
+
+The restore edge is new. Previously the log said an aircraft had lost its fix
+and then never mentioned it again.
+
+## Deployment
+
+fss-web migration 0016 must be applied before this server release starts;
+`required_columns[]` now includes `gps_fix_valid`, so the startup schema check
+refuses to run without it (see
+[decision 73](73-startup-schema-verification.md)). The e2e mirror
+`e2e/schema/001_init.sql` moved in the same commit.
+
+cap-fmu needs no matching change (`cap-fmu` todo/107, closed 2026-08-01). It
+sends the estimator's finite coordinates with the coords-valid bit clear, and
+always has; a change to NaN them was written and reverted once the
+peer-broadcast cost surfaced. So the flag-only row — stored, relayed, marked —
+is the case a real GPS outage produces, and the NULL-geometry row is for a
+client with no estimate to offer at all.
+
+What cap-fmu does need is a rebuild against a client library that advertises
+`FSS_FEATURE_POSITION_FLAGS`: the flags word is only read once the capability
+is negotiated, so a deployment that updates the server but not the aircraft
+keeps reporting a blind aircraft as GPS-backed. `CAP/test-plan`'s Tier-3 Path M
+`m03` holds a strict xfail on the operator-visible end state and will XPASS
+once both ends are deployed.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -62,9 +62,10 @@ migrated is not a degraded deployment — it severs the fleet on the first comma
 and cannot recover, because the schema stays wrong
 (see [decision 73](decisions/73-startup-schema-verification.md)).
 
-**As of this release, FSS requires fss-web's `assets` migration 0008 or later**,
+**As of this release, FSS requires fss-web's `assets` migration 0016 or later**,
 which provides `dispatch_id`, `ack_state`, `ack_timestamp` and
-`ack_superseded_by` on `assets_assetcommand`. The server verifies this at
+`ack_superseded_by` on `assets_assetcommand` (0008), and `gps_fix_valid` with a
+nullable `position` on `assets_assetposition` (0016). The server verifies this at
 startup and refuses to run against a database without them, so the failure is a
 restart rather than an outage — but the requirement still has to reach whoever
 does the deploy, in the release notes, ahead of it.


### PR DESCRIPTION
## Description

Decision 76 covers the parts not recoverable from the code: why fss-web's row-level shape ruled out the transition table todo/76 sketched, why a cleared coords-valid bit never discards a real coordinate, why reading the flags word is capability-gated at all, and the NULL-not-Null-Island rule.

Decision 73 gains an amendment: this was the first deliberate change to required_columns[] and the hand-written e2e mirror since the startup check landed, and it exposed the check's blind spot -- making `position` nullable is invisible to a presence-only check, so a mirror that kept NOT NULL would have started cleanly and failed every no-fix write at runtime.

## Summary by Sourcery

Document recording of GPS-backed position state and raise the required database migration level for deployments.

New Features:
- Record whether each stored position report is backed by a GPS fix, including handling of dead-reckoned estimates and NULL geometry instead of silently dropping reports.

Enhancements:
- Clarify how the startup schema verification relies on the hand-written mirror and tests when adding new required columns such as gps_fix_valid and making position nullable.

Documentation:
- Add decision 76 describing GPS-fix recording semantics, storage rules, capability gating, logging behaviour, and deployment expectations.
- Update decision 73 with an amendment explaining the first deliberate change to the schema mirror and its implications for the startup check.
- Update CHANGELOG, README, and release checklist to state that deployments now require fss-web assets migration 0016, including gps_fix_valid and a nullable position column.