### PR TITLE
fix(server): scope the GPS-fix state machine to aircraft clients

### DIFF
--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -846,6 +846,35 @@ void fss::server::fss_client::updateClockOffset(uint64_t client_timestamp, uint6
 
 void fss::server::fss_client::logGpsFixState(bool t_fix_valid, bool t_have_coords)
 {
+    /* Aircraft only. The state machine below holds ONE fix state per
+     * connection, which is only a truth when the connection carries one
+     * aircraft's own GPS. A non-aircraft client does not: an fss-adsb feeder
+     * relays reports for many arbitrary ICAO addresses down a single
+     * connection (todo/28, e2e/test_adsb_forwarding.py), so a mixed stream
+     * would flip the state between vehicles and log a loss/restore pair per
+     * alternation — the throttle only holds while the state is UNCHANGED, so
+     * the edges defeat it entirely — every line naming the feeder rather than
+     * the vehicle the report describes.
+     *
+     * Guarded here rather than at the call site so the invariant lives with
+     * the state it protects: the members are private to this class and this is
+     * their only writer, so one guard covers any future caller instead of each
+     * one having to restate it. The database write stays gated separately at
+     * the call site (`aircraft && asset_id != 0`) — it needs the asset id too,
+     * which the log line does not.
+     *
+     * No known feeder reaches the flip today, on either count: an older build
+     * advertises 0, so flags_meaningful is false and fix_valid just tracks
+     * have_coords; and per decision 76 fss-adsb always sets the coords-valid
+     * bit, because it only builds a report once a message carried a position.
+     * This guard is therefore defence for a relay that does forward an
+     * estimate or a position-less vehicle, not a fix for an observed flood —
+     * the defect being corrected is the scoping error itself, one fix state
+     * asserted over many vehicles. */
+    if (!this->aircraft)
+    {
+        return;
+    }
     /* The row is written for every report; the log is for the human reading
      * stderr, so it names only the edges plus a periodic reminder. An aircraft
      * streams position at up to 5 Hz, so an unthrottled per-report line would

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -321,7 +321,13 @@ private:
     /* Log the edges of this session's GPS-fix state (todo/76). Every report is
      * recorded to the database regardless; this only decides what reaches the
      * log, which is why it is edge-triggered and the storage is not. Recv
-     * thread only. */
+     * thread only.
+     *
+     * A no-op for a non-aircraft client, checked internally: its reports
+     * describe other vehicles (an fss-adsb feeder relays many ICAO addresses
+     * over one connection, todo/28), so a per-connection fix state would be
+     * meaningless and its edges would flood the log. Callers therefore need no
+     * guard of their own. */
     void logGpsFixState(bool gps_fix_valid, bool have_coords);
     uint64_t last_command_send_ts{0};
     uint64_t last_command_dbid{0};
@@ -402,7 +408,16 @@ private:
      * Session-scoped by design: a reconnect mid-outage genuinely has no prior
      * state and re-logs the loss, which is information rather than a duplicate.
      * Drives logging only — every report is recorded either way. Recv thread
-     * only. */
+     * only.
+     *
+     * All three are ALSO aircraft-only, and deliberately so: one fix state per
+     * connection is a truth only while the connection carries one aircraft's
+     * own GPS. An fss-adsb feeder relays reports for many arbitrary ICAO
+     * addresses down a single connection (todo/28), so letting its stream drive
+     * these would flip the state between vehicles and attribute every resulting
+     * log line to the feeder rather than to the vehicle. logGpsFixState() is the
+     * sole writer and holds the guard — see the comment there for why it sits
+     * inside rather than at the call site. */
     bool gps_fix_state_known{false};
     bool gps_fix_valid{true};
     /* Position staleness window in ms (0 disables the check). A report whose

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -2172,6 +2172,110 @@ TEST_CASE("session: a run of no-fix reports is recorded per report but logged on
     REQUIRE(count_occurrences(cap.str(), "no GPS fix") == 1);
 }
 
+namespace {
+/* A position report at fixed, valid coordinates whose only variable is the
+ * coords-valid flag. Alternating that bit is what an fss-adsb feeder's relayed
+ * stream looks like when the vehicles behind it disagree about their fixes. */
+auto make_flagged_position_msg(bool valid_coords) -> std::shared_ptr<fss::transport::fss_message_position_report>
+{
+    return std::make_shared<fss::transport::fss_message_position_report>(
+        -43.5, 172.6, 100U, 0U, 0U, int16_t{0}, 0U, std::string{}, 0U, uint8_t{0},
+        static_cast<uint16_t>(valid_coords ? fss::transport::FSS_POSITION_FLAG_VALID_COORDS : 0U), uint8_t{0},
+        uint8_t{0}, fss::fss_current_timestamp());
+}
+
+constexpr size_t alternating_report_count = 10;
+} // namespace
+
+TEST_CASE("session: a non-aircraft feeder's relayed positions never drive the GPS-fix state machine")
+{
+    /* The fix-state machine keeps one state per connection, which is only a
+     * truth for an aircraft reporting its own GPS. An fss-adsb feeder relays
+     * reports for many arbitrary ICAO addresses over a single connection
+     * (todo/28, e2e/test_adsb_forwarding.py), so a stream mixing vehicles with
+     * and without the coords-valid bit would flip the state on nearly every
+     * report. The throttle only holds while the state is UNCHANGED — the edges
+     * are always logged — so an alternating stream defeats it entirely and
+     * emits a WARN plus an INFO per alternation, each naming the feeder rather
+     * than the vehicle the report describes. */
+    fss_test::MockDatabase mock;
+    /* "adsb-feeder" absent from asset_ids — not an aircraft. */
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("adsb-feeder");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+
+    uint64_t next_id = 1;
+    auto version = std::make_shared<fss::transport::fss_message_version>(fss::transport::FSS_PROTOCOL_VERSION,
+                                                                         fss::transport::FSS_PROTOCOL_MIN_VERSION,
+                                                                         fss::transport::FSS_SUPPORTED_FEATURES);
+    version->setId(next_id++);
+    session->processMessage(version);
+    auto identity = std::make_shared<fss::transport::fss_message_identity_non_aircraft>();
+    identity->setId(next_id++);
+    session->processMessage(identity);
+    REQUIRE_FALSE(session->isAircraft());
+    /* The flags word is meaningful here — this is the rebuilt-feeder case, the
+     * one where the state machine would actually flip. */
+    REQUIRE((conn->getNegotiatedFeatureFlags() & fss::transport::FSS_FEATURE_POSITION_FLAGS) != 0U);
+
+    fss_test::capture_cerr cap;
+    for (size_t i = 0; i < alternating_report_count; ++i)
+    {
+        auto report = make_flagged_position_msg(i % 2 != 0);
+        report->setId(next_id++);
+        session->processMessage(report);
+    }
+
+    /* Not one fix-state line, in either direction. */
+    REQUIRE(count_occurrences(cap.str(), "no GPS fix") == 0);
+    REQUIRE(count_occurrences(cap.str(), "GPS fix restored") == 0);
+    REQUIRE(cap.str().find("dead-reckoned estimate") == std::string::npos);
+    /* Relay is untouched: forwarding a feeder's reports is the whole point of
+     * the non-aircraft client (todo/28), and nothing is stored against the
+     * feeder either — that write was already gated on being an aircraft. */
+    REQUIRE(handler.broadcasts.size() == alternating_report_count);
+    REQUIRE(mock.getPositions().empty());
+}
+
+TEST_CASE("session: an aircraft's alternating fix state still logs every edge")
+{
+    /* The counterpart to the feeder case above: the aircraft-only gate must
+     * narrow the state machine's scope, not disable it. One connection here
+     * really is one GPS, so each transition is a genuine event about that
+     * aircraft and every edge belongs in the log. */
+    fss_test::MockDatabase mock;
+    mock.asset_ids["craft"] = 1;
+
+    auto conn = std::make_shared<FakeConnection>();
+    conn->cert_names.push_back("craft");
+    NullClientHandler handler;
+
+    auto writer = make_mock_writer(mock);
+    auto session = std::make_shared<fss::server::fss_client>(conn, &mock, writer, &handler);
+    uint64_t next_id = 1;
+    establish_v2_session(session, next_id);
+    REQUIRE(session->isAircraft());
+
+    fss_test::capture_cerr cap;
+    for (size_t i = 0; i < alternating_report_count; ++i)
+    {
+        auto report = make_flagged_position_msg(i % 2 != 0);
+        report->setId(next_id++);
+        session->processMessage(report);
+    }
+
+    /* Alternating from cleared: half the reports are loss edges and half are
+     * restores. The first report is a loss, so the unknown-state case (which
+     * logs the loss but no restore) costs neither count anything. */
+    REQUIRE(count_occurrences(cap.str(), "no GPS fix") == alternating_report_count / 2);
+    REQUIRE(count_occurrences(cap.str(), "GPS fix restored") == alternating_report_count / 2);
+    REQUIRE(fss_test::wait_for([&]() { return mock.getPositions().size() == alternating_report_count; }));
+}
+
 TEST_CASE("session: a cleared coords-valid flag records a dead-reckoned estimate without dropping it")
 {
     /* The user-visible gap todo/76 closes on the flags side: a client can send


### PR DESCRIPTION
## Description

`logGpsFixState()` drives one fix state per connection -- `no_fix_reports`, `gps_fix_state_known`, `gps_fix_valid` -- and was called for every position report, including those from a non-aircraft client. That scoping is only a truth when the connection carries one aircraft's own GPS.

An fss-adsb feeder does not: it relays reports for many arbitrary ICAO addresses down a single connection (todo/28, e2e/test_adsb_forwarding.py). A stream mixing vehicles that disagree about their fixes would flip the state on nearly every report, and the throttle only holds while the state is UNCHANGED -- the edges are always logged -- so an alternating stream defeats it entirely and emits a WARN plus an INFO per alternation, each naming the feeder rather than the vehicle the report describes.

No known feeder reaches that flip today, on either count: an older build advertises 0 for FSS_FEATURE_POSITION_FLAGS, so flags_meaningful is false and fix_valid just tracks have_coords; and per decision 76 fss-adsb always sets the coords-valid bit, because it only builds a report once a message carried a position. So this is not a fix for an observed flood -- it corrects the scoping error itself, and is defence for a relay that does forward a dead-reckoned estimate or a position-less vehicle.

The guard sits inside logGpsFixState() rather than at the call site: the three members are private and this is their only writer, so the invariant lives with the state it protects and one guard covers any future caller. The database write stays gated separately at the call site (`aircraft && asset_id != 0`) -- it needs the asset id, which the log line does not. Nothing else moves: the relay of a feeder's reports is untouched, and no position was ever stored against a non-aircraft client.

Two cases in server_session_test.cpp, both driving ten reports with the coords-valid bit alternating: the feeder case asserts not one fix-state line in either direction while all ten are still relayed and none stored, and the aircraft counterpart asserts all five loss and five restore edges still log, so the gate narrows the machine rather than disabling it. The first fails (5 == 0) with the guard stubbed out.

Verified: make check green (455 cases, 423 passed, 32 skipped -- the live-DB cases skip without a database); check-code.sh clean.

## Summary by Sourcery

Scope the server-side GPS-fix logging state machine to aircraft clients only to avoid meaningless per-connection fix state for relay feeders, while keeping aircraft behaviour unchanged.

Bug Fixes:
- Prevent non-aircraft feeder connections from driving the GPS-fix state machine and flooding logs with incorrect fix state transitions attributed to the feeder.

Enhancements:
- Document that GPS-fix state tracking and related session fields are aircraft-only and that callers need no external guards.
- Add focused unit tests covering alternating GPS-fix state for both non-aircraft feeders and aircraft clients to validate the new scoping and logging behaviour.

Tests:
- Introduce tests ensuring non-aircraft feeders relay all position reports without emitting GPS-fix log lines or storing positions, and that aircraft connections still log all fix-loss and restore edges for alternating fix states.