### PR TITLE
fix(server): the DB fail-safe recovers on evidence, not on silence

### DIFF
--- a/docs/decisions/34-45-47-db-failsafe-latch.md
+++ b/docs/decisions/34-45-47-db-failsafe-latch.md
@@ -78,7 +78,7 @@ health probe" — the sentence this section replaces — describes a probe whose
 result arrives only after the fleet has already been let back in.
 
 Path M m05 showed what that costs. A 200 MB Postgres data directory was filled
-until the instance PANICked on its WAL, and its crash recovery could not write
+until the instance hit a `PANIC` on its WAL, and its crash recovery could not write
 either, so the instance was permanently gone:
 
 ```

--- a/docs/decisions/34-45-47-db-failsafe-latch.md
+++ b/docs/decisions/34-45-47-db-failsafe-latch.md
@@ -40,10 +40,10 @@ the gate check shares `lock`'s critical section with list insertion, so no
 connection can slip in between the severance snapshot and the gate. Refused
 clients are severed unactivated.
 
-**Recovery.** The write queue draining to zero *and* more than
-`db_write_failure_recovery_grace_secs` of quiet lowers the gate; readmitted
-traffic is itself the health probe. A persistent fault re-latches on the
-incident timescale rather than flapping.
+**Recovery.** The write queue draining to zero, more than
+`db_write_failure_recovery_grace_secs` of quiet, *and* a successful health probe
+lower the gate. The probe condition was added 2026-08-02; see below for what it
+replaced and why.
 
 ### Both windows are real time (revised 2026-07-31, todo/70)
 
@@ -64,6 +64,165 @@ too.
 The config field `db_write_failure_disconnect_ticks` is renamed
 `db_write_failure_disconnect_secs`, which is what it always meant; the old key
 is still accepted with a deprecation warning.
+
+### Recovery needs positive evidence (revised 2026-08-02, todo/78)
+
+As shipped, recovery was "the write queue has drained *and* nothing has failed
+for the grace window". Both are statements about the **absence** of failure, and
+the trip's own action removes everything that could produce one: `disconnectAll()`
+severs every session and the admission gate refuses new ones, so no telemetry
+arrives, nothing is queued, nothing fails. Drained-and-quiet was therefore
+satisfied **by construction** about `db_write_failure_recovery_grace_secs` after
+every trip, whatever the database was doing. "Readmitted traffic is itself the
+health probe" — the sentence this section replaces — describes a probe whose
+result arrives only after the fleet has already been let back in.
+
+Path M m05 showed what that costs. A 200 MB Postgres data directory was filled
+until the instance PANICked on its WAL, and its crash recovery could not write
+either, so the instance was permanently gone:
+
+```
+08:49:21 DB fail-safe tripped (sustained DB write failures); severed 1 connection(s)
+08:49:28 Refusing new client: DB fail-safe is degraded
+08:49:37 DB fail-safe recovered: write queue drained and quiet for 15s; accepting sessions again
+```
+
+Sixteen seconds. Against a permanently dead database that is a ~20 s cycle
+forever, and each cycle takes a connected aircraft out of and back into its
+comms-loss failsafe — the opposite of the one clean latched event 47 exists to
+produce.
+
+**Decision.** Recovery now also requires a **probe write** to have succeeded
+since the trip:
+
+```
+recovered  ⟺  pending_writes == 0
+           ∧  no new write failure, command drop or probe failure for the grace window
+           ∧  a probe success observed on this very tick
+           ∧  probe_successes != probe_successes_at_trip
+```
+
+The probe **gates** the quiet window, it does not replace it. Since the probe
+runs on the caller's per-second tick and any probe failure restarts the quiet
+window, recovery in the default configuration needs roughly fifteen *consecutive*
+successful probes, not one lucky one.
+
+**The evidence must be fresh, and freshness is edge-triggered.** "A probe has
+succeeded at some point since the trip" is not enough, because a probe that
+**hangs** — a partition, a failover, a frozen host — returns neither answer: no
+success, no failure, no counter movement at all, and `requestProbe()` coalesces
+so nothing queues up behind it either. A failing probe holds the latch by
+restarting the quiet window; a hanging one can only be caught by the absence of
+*new* evidence.
+
+A time-boxed version of that test ("a success within the last
+`recovery_grace_ms`") sounds equivalent and is not, which is worth recording
+because it is the obvious formulation. The quiet window runs from the trip,
+which is itself an event, so recovery is first possible one tick after
+`trip + grace` — and a success landing one tick *after* the trip is at that
+moment almost exactly `grace` old, i.e. still inside such a window. With the
+defaults: trip at t=1 s, one success at t=2 s, database hangs, quiet satisfied
+from t=16.001 s, success age 14.001 s < 15 s → recovered, on the strength of a
+single answer given fourteen seconds earlier. Requiring the success on the
+recovering tick has no constant in it and no boundary to land on.
+`tests/server_failsafe_test.cpp` pins that arithmetic directly.
+
+Cost on a healthy database: none. The caller requests a probe on every degraded
+tick and the write queue is empty while degraded, so every tick observes the
+previous tick's success and recovery lands on the tick it always did — confirmed
+against the e2e timings, which did not move. A database answering *more slowly
+than the tick period* delays recovery by at most one probe round trip; while it
+is answering that slowly, holding the gate up is the safer error.
+
+The probe statement, on the **write** connection, inside a transaction that is
+rolled back:
+
+```sql
+INSERT INTO assets_assetrtt (asset_id, rtt, timestamp)
+    SELECT id, 0, NOW() FROM assets_asset ORDER BY id LIMIT 1;
+```
+
+- Both tables are already in `required_columns[]`, so this adds no table, no
+  column, no fss-web migration and no change to the minimum migration floor.
+- The `SELECT`-driven asset id satisfies the foreign key without the server
+  having to remember an id across a severance that has just discarded every
+  session.
+- A zero-row result (`sqlca.sqlerrd[2] == 0`, i.e. an empty `assets_asset`) is
+  **inconclusive**, not success: a zero-row INSERT fires no row trigger, extends
+  no heap page and writes no tuple, so it proves nothing. It is counted and
+  logged separately, and the fail-safe stays degraded on it.
+
+`db_failsafe` remains a pure state machine that performs no I/O: the probe runs
+on the `db_write_queue` worker thread — which already owns the write connection
+and already blocks on it by design — and its outcome reaches `tick()` as
+cumulative counters, exactly like `write_failure_count()`. The main loop only
+sets a flag (`requestProbe()`), so [46](46-no-statement-timeout.md)'s
+no-synchronous-DB-work-on-the-main-loop contract is untouched. Probes are asked
+for only while degraded (`wantsProbe()`), so healthy operation pays one bool
+read per second.
+
+Operator visibility came with it, because the fix makes silence the *correct*
+outcome against a dead database and silence is exactly what an operator cannot
+act on: a rate-limited (60 s) ERROR while degraded naming the elapsed time, the
+probe failure and inconclusive counts and the last probe error, and a recovery
+line that states the evidence ("drained, quiet for 15s, **and a probe write
+succeeded**").
+
+**Accepted residual — the probe does not prove durability.** A rolled-back
+INSERT exercises parse, plan, permissions, triggers, foreign keys, heap-page
+extension and WAL *generation*, but an aborted transaction never forces a WAL
+fsync. A database that can buffer a write but not flush it can therefore pass
+this probe and still fail a real commit. This is accepted: the failure modes
+that actually produced this defect (a dead instance, a full disk, a write-only
+fault) all fail the probe as it stands, and the upgrade path is named below.
+
+**Rejected, and why:**
+
+- **`SELECT 1` (or any read).** Disproved by an existing test:
+  `e2e/test_db_write_only_failure.py` installs `BEFORE INSERT` triggers that
+  raise on the four telemetry tables — `assets_assetrtt` among them, so the
+  probe's own target is faulted by that test — and reads stay perfectly healthy
+  throughout. A read-only probe would report health while every write failed,
+  which is the exact fault class the fail-safe exists for. (`db_ping`'s
+  `SELECT 1` remains right for what it does: connection liveness for
+  `tryReconnectIfNeeded`.)
+- **Committing the probe row.** It would fabricate an `rtt = 0` telemetry
+  sample, attributed to a real aircraft that is disconnected, in a table the
+  operator reads. This service exists to produce a truthful audit record; a
+  health check must not write fiction into it. ECPG ends an open transaction by
+  COMMITting it when `AUTOCOMMIT` is switched back on, so `db_probe_write`
+  issues an explicit `ROLLBACK` first and leaves the connection transaction-idle.
+- **A dedicated probe table.** The clean answer, and the named upgrade path for
+  the durability residual above — a table FSS owns, written and committed. It is
+  not available today: every table in this schema belongs to fss-web. Adding one
+  to `required_columns[]` would turn a health-check improvement into a
+  fleet-wide startup refusal on any deployment that has not run the new
+  migration (decision 73), and leaving it out of `required_columns[]` means the
+  startup check cannot guarantee the probe works at all. Revisit when fss-web
+  next takes a migration for FSS's sake.
+- **Making the probe a `db_write_task`.** A queued probe makes
+  `pending_count()` non-zero, which the drain check reads as "not drained".
+  Recovery would become unreachable and the fleet would stay severed forever —
+  worse than the defect being fixed. The probe is a separate flag with a
+  separate function, and `pending_count()` is untouched.
+- **Probing from the main loop.** A synchronous round trip on the loop that
+  dispatches TERM and DISARM, which is precisely what decision 46 removed.
+- **Probing from the `command_poller`.** It owns the *read* connection, so it
+  would prove the wrong path — see the `SELECT 1` argument above.
+- **A dedicated probe thread.** Needs either a third connection or contention on
+  `write_lock` with the writer, for no benefit over the worker that already owns
+  the connection and is already allowed to block.
+- **A `statement_timeout` on the probe.** Decision 46 rejected it globally and
+  the same reasoning applies here: `e2e/test_slow_db_does_not_stall.py` holds an
+  `EXCLUSIVE` lock the writer is expected to ride out, and that must present to
+  the probe as "no answer yet", not as a probe failure. A lock wait blocks the
+  probe; it cannot manufacture one. The stall bound stays `PGTCPUSERTIMEOUT`
+  (25 s) at the socket.
+
+**Still open (todo/81):** an *intermittent* write fault can still flap. The
+probe can catch a good moment, recovery readmits the fleet, real traffic fails,
+and the fail-safe re-trips. Closing that needs K-consecutive-successes or a
+grace multiplier that backs off per re-trip within a window.
 
 ## Alternatives deliberately not taken
 

--- a/e2e/test_db_disk_full.py
+++ b/e2e/test_db_disk_full.py
@@ -276,6 +276,21 @@ def test_disk_full_fails_visibly_and_a_fresh_instance_recovers(certs_dir, tmp_pa
             + server["log"].read_text(errors="replace")
         )
 
+        # todo/78, and the m05 field observation verbatim: this Postgres is
+        # gone for good (it PANICked on the full WAL and its crash recovery
+        # could not write either), so the server must stay degraded for the
+        # rest of the run. Before todo/78 recovery needed only "write queue
+        # drained and quiet for 15s" — both of which the severance itself
+        # guarantees — so this instance produced a "DB fail-safe recovered"
+        # line ~16s after the trip and readmitted the aircraft into a database
+        # that could not record a single thing about it. The recovery rule now
+        # also requires a successful probe write, which a dead instance can
+        # never supply. Checked again at the end of the run, below.
+        assert "DB fail-safe recovered" not in server["log"].read_text(errors="replace"), (
+            "fail-safe recovered against a permanently dead Postgres\n"
+            + server["log"].read_text(errors="replace")
+        )
+
         # Fresh instance: a restart restores service (explicitly sanctioned
         # by the todo as an acceptable recovery path once the flooded
         # instance itself cannot recover in place -- see module docstring).
@@ -306,6 +321,15 @@ def test_disk_full_fails_visibly_and_a_fresh_instance_recovers(certs_dir, tmp_pa
             f"-- client log --\n{fresh_client['log'].read_text(errors='replace')}"
         )
         fresh_setup_conn.close()
+
+        # End of run: the server still attached to the dead instance never
+        # announced a recovery, however long the fresh-instance half took
+        # (container start, migration, server + client spawn — comfortably more
+        # than the 15s window that used to be sufficient on its own).
+        assert "DB fail-safe recovered" not in server["log"].read_text(errors="replace"), (
+            "fail-safe recovered against a permanently dead Postgres (todo/78)\n"
+            + server["log"].read_text(errors="replace")
+        )
     finally:
         for proc_dict in (client, fresh_client):
             if proc_dict is not None:

--- a/e2e/test_db_write_only_failure.py
+++ b/e2e/test_db_write_only_failure.py
@@ -1,4 +1,5 @@
-"""e2e: a write-only DB failure latches one fail-safe event, no flap (todo/45+47).
+"""e2e: a write-only DB failure latches the fail-safe until writes actually
+work again (todo/45+47, todo/78).
 
 The shipped todo/34 fail-safe severed every client on sustained DB write
 failure but left the listener ungated. If the failure is write-only — reads
@@ -11,19 +12,28 @@ read side dies too; see test_db_disk_full.py.)
 
 This test manufactures the write-only case with BEFORE INSERT triggers that
 raise on the telemetry tables (the server connects as a superuser here, so
-REVOKE would be bypassed; a trigger fires for any role). Reads are untouched.
-It asserts the todo/47 behaviour: exactly one trip, the reconnecting client
-is refused (never re-identified) while degraded, and once the fault is
-removed the fail-safe recovers on its own — the write queue drains and stays
-quiet for db_write_failure_recovery_grace_secs (15s default) — after which
-the same client is readmitted and telemetry stores again.
+REVOKE would be bypassed; a trigger fires for any role). Reads are untouched,
+which is exactly why a `SELECT 1`-style health check cannot be the fail-safe's
+recovery evidence: it stays green throughout this test.
 
-Timing note: while degraded no writes are attempted (all clients are severed
-and refused), so the quiet window elapses ~15s after the trip even with the
-triggers still installed — recovery deliberately readmits traffic as the
-health probe. The no-flap observation window must therefore stay well inside
-those 15s, and the triggers are dropped immediately after it so the probe
-succeeds; a persistent fault would simply re-latch on the incident timescale.
+What is asserted: exactly one trip; the reconnecting client is refused (never
+re-identified) while degraded; the degraded state HOLDS for as long as writes
+keep failing, not merely until a quiet timer expires; and once the fault is
+removed the fail-safe recovers on its own and the same client is readmitted
+and stores telemetry again.
+
+That middle property is todo/78, and it is what this file used to assert the
+opposite of. Recovery was "the write queue drained and stayed quiet for
+db_write_failure_recovery_grace_secs" — but the trip's own action (sever
+everything, refuse everything) removes all the traffic that could produce a
+failure, so drained-and-quiet was satisfied by construction ~15 s after every
+trip, whatever the database was doing. Against a permanently dead database
+that was a ~20 s flap forever (Path M m05 observed it live). The old version of
+this test could only observe the no-flap window for 6 s, because at ~15 s the
+server would have "recovered" into the still-broken database and the test would
+have been asserting the defect. Recovery now additionally requires a successful
+*probe write* — a real INSERT on the write connection, rolled back — which the
+triggers here fail, so the hold below can be as long as we like.
 """
 from __future__ import annotations
 
@@ -68,9 +78,20 @@ def _remove_write_failure(db_conn: psycopg2.extensions.connection) -> None:
         cur.execute("DROP FUNCTION IF EXISTS e2e_fail_write()")
 
 
+# Worst-case budget for the waits below, so the next person does not have to
+# re-derive it: 25 (baseline row) + 30 (trip) + 15 (first refusal) + 45 (the
+# degraded hold) + 40 (recovery once the fault is removed) + 20 (re-identify)
+# + 25 (telemetry resumes) = 200 s, plus this test's share of fixture setup
+# (postgis container, migration, cert generation, server + client spawn), which
+# pytest-timeout counts because it is not running in func_only mode. 300 s
+# leaves ~100 s of headroom. The hold was 6 s before todo/78: recovery used to
+# arrive on a ~15 s timer regardless of the database's state, so observing for
+# longer would have caught the server "recovering" into a still-broken database
+# — which is the defect, not the behaviour. e2e/pytest.ini's global 60 s default
+# is overridden by this decorator.
 @pytest.mark.requires_docker
 @pytest.mark.slow
-@pytest.mark.timeout(180)
+@pytest.mark.timeout(300)
 def test_write_only_db_failure_latches_one_failsafe_event(db_conn, fake_client, server_proc):
     """Write-only DB failure: one latched severance while degraded, refusal of
     reconnect attempts, autonomous recovery once writes heal, no flap."""
@@ -119,27 +140,41 @@ def test_write_only_db_failure_latches_one_failsafe_event(db_conn, fake_client, 
             "no reconnect attempt was refused while degraded\n" + log_text()
         )
 
-        # No-flap window. Pre-fix, the client re-identified within ~1-2s of
-        # the severance and was severed again ~5s later; 6s of observation
-        # catches that cycle while staying well inside the ~15s quiet window
-        # after which the (deliberate) autonomous recovery would readmit —
-        # see the module docstring.
-        time.sleep(6)
+        # No-flap window, and the todo/78 property: the degraded state must
+        # hold for as long as writes are broken. Three times the 15s recovery
+        # grace, checked continuously rather than only at the end — a recovery
+        # that happened and re-tripped would otherwise be invisible in the final
+        # snapshot. Pre-todo/78 this reached the first assert inside ~16s.
+        hold_secs = 45
+        deadline = time.monotonic() + hold_secs
+        while time.monotonic() < deadline:
+            snapshot = log_text()
+            assert "DB fail-safe recovered" not in snapshot, (
+                "fail-safe recovered while every write to the database was still failing "
+                f"({int(hold_secs - (deadline - time.monotonic()))}s into a {hold_secs}s hold)\n" + snapshot
+            )
+            assert snapshot.count("DB fail-safe tripped") == 1, (
+                "fail-safe tripped more than once while degraded (flap)\n" + snapshot
+            )
+            time.sleep(0.5)
+
         during_degraded = log_text()
-        assert during_degraded.count("DB fail-safe tripped") == 1, (
-            "fail-safe tripped more than once while degraded (flap)\n" + during_degraded
-        )
         assert during_degraded.count("Aircraft client identified: test1") == 1, (
             "client was re-admitted to identified operation while degraded\n" + during_degraded
         )
-        assert "DB fail-safe recovered" not in during_degraded, (
-            "fail-safe recovered while writes were still failing\n" + during_degraded
+        # The probe is what holds the latch shut, so it must be visibly running:
+        # a server that simply stopped probing would pass the asserts above for
+        # the wrong reason.
+        assert "fail-safe probe write failed" in during_degraded, (
+            "no failing probe write was logged while degraded — the fail-safe is holding on "
+            "silence rather than on evidence (todo/78)\n" + during_degraded
         )
     finally:
         _remove_write_failure(db_conn)
 
-    # With the fault removed, the queue is drained and quiet: recovery follows
-    # once the grace window (15s from the last failure) elapses.
+    # With the fault removed the probe succeeds within a cadence or two, and
+    # recovery follows once the grace window (15s from the last failure, which
+    # is the last failing probe) has also elapsed.
     assert _wait_for(lambda: "DB fail-safe recovered" in log_text(), timeout=40.0, poll=0.5), (
         "fail-safe never recovered after the write fault was removed\n" + log_text()
     )

--- a/e2e/test_slow_db_does_not_stall.py
+++ b/e2e/test_slow_db_does_not_stall.py
@@ -74,6 +74,14 @@ def test_slow_db_does_not_stall(db_conn, fake_client, migrated_db, server_proc):
 
     # Hold the lock long enough for the server to buffer several position
     # reports in its write queue.
+    #
+    # Unaffected by todo/78's fail-safe probe, deliberately: no trip happens
+    # here (a lock wait is not a write failure — see decision 46 on why there is
+    # no statement_timeout), so no probe is ever requested. Even if one were,
+    # this EXCLUSIVE lock would *block* it rather than fail it, exactly as it
+    # blocks the position INSERTs — it cannot manufacture a probe failure, and a
+    # blocked probe simply never reports. The stall bound stays PGTCPUSERTIMEOUT
+    # at the socket.
     lock_hold_s = 12
     with hold_table_lock(migrated_db, "assets_assetposition"):
         time.sleep(lock_hold_s)

--- a/src/db-write-queue.cpp
+++ b/src/db-write-queue.cpp
@@ -9,8 +9,8 @@
 
 namespace flight_safety_system::server {
 
-db_write_queue::db_write_queue(std::size_t t_max_depth, db_write_sink t_sink)
-    : max_depth(std::max<std::size_t>(1, t_max_depth)), sink(std::move(t_sink))
+db_write_queue::db_write_queue(std::size_t t_max_depth, db_write_sink t_sink, db_probe_fn t_probe)
+    : max_depth(std::max<std::size_t>(1, t_max_depth)), sink(std::move(t_sink)), probe(std::move(t_probe))
 {
     this->worker = std::thread(&db_write_queue::run, this);
 }
@@ -110,6 +110,21 @@ void db_write_queue::enqueue(db_write_task task)
     }
 }
 
+void db_write_queue::requestProbe()
+{
+    {
+        std::scoped_lock guard(this->mtx);
+        if (this->stopping)
+        {
+            return;
+        }
+        /* Stored under mtx so the flag cannot be set between the worker
+         * evaluating its wait predicate and blocking on the cv. */
+        this->probe_requested.store(true);
+    }
+    this->cv.notify_one();
+}
+
 void db_write_queue::stop()
 {
     {
@@ -154,10 +169,85 @@ auto db_write_queue::write_failure_count() const -> uint64_t
     return this->write_failures.load();
 }
 
+auto db_write_queue::probe_success_count() const -> uint64_t
+{
+    return this->probe_successes.load();
+}
+
+auto db_write_queue::probe_failure_count() const -> uint64_t
+{
+    return this->probe_failures.load();
+}
+
+auto db_write_queue::probe_inconclusive_count() const -> uint64_t
+{
+    return this->probe_inconclusive.load();
+}
+
+auto db_write_queue::last_probe_error() const -> std::string
+{
+    std::scoped_lock guard(this->probe_error_mtx);
+    return this->probe_error;
+}
+
+/* pending_count() deliberately knows nothing about an outstanding probe: it is
+ * the fail-safe's drain check, and a probe must never read as a backlog. */
 auto db_write_queue::pending_count() const -> std::size_t
 {
     std::scoped_lock guard(this->mtx);
     return this->q.size();
+}
+
+void db_write_queue::run_probe()
+{
+    try
+    {
+        if (this->probe())
+        {
+            ++this->probe_successes;
+            return;
+        }
+        uint64_t inconclusive = ++this->probe_inconclusive;
+        constexpr uint64_t log_every = 60;
+        if (inconclusive == 1 || (inconclusive % log_every) == 0)
+        {
+            /* Not an error and not evidence: the fail-safe stays degraded on
+             * it, so say why rather than leaving the operator with a silent
+             * server that never recovers. */
+            FSS_LOG_WARN("db-writer", "fail-safe probe write was inconclusive -- no assets registered, so the probe "
+                                      "statement matched no row and proved nothing (total="
+                                          << inconclusive << ")");
+        }
+    }
+    catch (const std::exception &e)
+    {
+        uint64_t failures = ++this->probe_failures;
+        {
+            std::scoped_lock guard(this->probe_error_mtx);
+            this->probe_error = e.what();
+        }
+        constexpr uint64_t log_every = 60;
+        if (failures == 1 || (failures % log_every) == 0)
+        {
+            /* Rate-limited here and reported again, with elapsed time, by the
+             * caller's degraded-state line; the probe runs about once a second
+             * while degraded and could otherwise flood the log forever. */
+            FSS_LOG_WARN("db-writer", "fail-safe probe write failed (total=" << failures << "): " << e.what());
+        }
+    }
+    catch (...)
+    {
+        uint64_t failures = ++this->probe_failures;
+        {
+            std::scoped_lock guard(this->probe_error_mtx);
+            this->probe_error = "unknown exception";
+        }
+        constexpr uint64_t log_every = 60;
+        if (failures == 1 || (failures % log_every) == 0)
+        {
+            FSS_LOG_WARN("db-writer", "fail-safe probe write failed (total=" << failures << "): unknown exception");
+        }
+    }
 }
 
 void db_write_queue::run()
@@ -165,15 +255,40 @@ void db_write_queue::run()
     for (;;)
     {
         db_write_task task;
+        bool do_probe = false;
         {
             std::unique_lock<std::mutex> lock(this->mtx);
-            this->cv.wait(lock, [this]() -> bool { return this->stopping || !this->q.empty(); });
+            this->cv.wait(
+                lock, [this]() -> bool { return this->stopping || !this->q.empty() || this->probe_requested.load(); });
             if (this->stopping && this->q.empty())
             {
+                /* An outstanding probe is abandoned rather than run: shutdown
+                 * must not wait on the database, and nothing is left to
+                 * recover for. */
                 return;
             }
-            task = this->q.front();
-            this->q.pop_front();
+            if (this->q.empty())
+            {
+                /* Real writes take priority, and the probe only runs once the
+                 * deque is empty, so its result describes the state *after*
+                 * the backlog drained -- which is the state the fail-safe's
+                 * recovery rule asks about. */
+                do_probe = this->probe_requested.exchange(false);
+                if (!do_probe)
+                {
+                    continue;
+                }
+            }
+            else
+            {
+                task = this->q.front();
+                this->q.pop_front();
+            }
+        }
+        if (do_probe)
+        {
+            this->run_probe();
+            continue;
         }
         try
         {

--- a/src/db-write-queue.hpp
+++ b/src/db-write-queue.hpp
@@ -7,6 +7,7 @@
 #include <deque>
 #include <functional>
 #include <mutex>
+#include <string>
 #include <thread>
 #include <variant>
 
@@ -63,6 +64,14 @@ struct command_ack_write {
 using db_write_task = std::variant<rtt_write, position_write, status_write, search_status_write, command_dispatch_write,
                                    command_ack_write>;
 using db_write_sink = std::function<void(const db_write_task &)>;
+/* The DB fail-safe's health probe (todo/78), run on this queue's worker thread
+ * because that thread already owns the write connection and already blocks on
+ * it by design. Same failure contract as the sink: a throw is a failed probe.
+ * The bool distinguishes the two non-throwing outcomes — true is positive
+ * evidence that a write works, false is an inconclusive probe (nothing was
+ * written because there was nothing to write against), which is deliberately
+ * NOT counted as a success: the fail-safe readmits the fleet on a success. */
+using db_probe_fn = std::function<bool()>;
 
 /* Command dispatch/ack writes carry safety/audit state (the link between a sent
  * command and its ack) and must not be silently dropped under telemetry
@@ -82,21 +91,41 @@ class db_write_queue {
 private:
     std::size_t max_depth;
     db_write_sink sink;
+    db_probe_fn probe;
     mutable std::mutex mtx{};
     std::condition_variable cv{};
     std::deque<db_write_task> q{};
     bool stopping{false};
+    /* Set by requestProbe() under mtx, cleared by the worker when it takes the
+     * probe: repeated requests coalesce, so at most one probe is ever
+     * outstanding. Deliberately NOT a db_write_task: a queued probe would make
+     * pending_count() non-zero, which the fail-safe's drain check reads as "not
+     * drained" — recovery would become unreachable and the fleet would stay
+     * severed forever, which is worse than the defect this closes. */
+    std::atomic<bool> probe_requested{false};
     std::atomic<uint64_t> dropped{0};
     std::atomic<uint64_t> command_dropped{0};
     std::atomic<uint64_t> write_failures{0};
+    std::atomic<uint64_t> probe_successes{0};
+    std::atomic<uint64_t> probe_failures{0};
+    std::atomic<uint64_t> probe_inconclusive{0};
+    /* Last probe failure's message, for the caller's degraded-state log. */
+    mutable std::mutex probe_error_mtx{};
+    std::string probe_error{};
     std::thread worker{};
 
     void run();
+    /* Run the probe and account for its outcome. Called on the worker thread
+     * with mtx released. */
+    void run_probe();
     /* Remove the oldest telemetry (non-command) task from the queue, if any.
      * Caller must hold mtx. Returns true if one was evicted. */
     auto evict_oldest_telemetry() -> bool;
 public:
-    db_write_queue(std::size_t t_max_depth, db_write_sink t_sink);
+    /* t_probe is required, not defaulted: a server wired without one could
+     * never leave the degraded state, so an unwired probe is a compile error
+     * rather than a fleet that never comes back. */
+    db_write_queue(std::size_t t_max_depth, db_write_sink t_sink, db_probe_fn t_probe);
     ~db_write_queue();
     db_write_queue(const db_write_queue &) = delete;
     db_write_queue(db_write_queue &&) = delete;
@@ -104,10 +133,22 @@ public:
     auto operator=(db_write_queue &&) -> db_write_queue & = delete;
 
     void enqueue(db_write_task task);
+    /* Ask the worker to run one health probe once the queue has drained. Never
+     * touches the database itself, so the main loop can call it (todo/46's
+     * no-synchronous-DB-work-on-the-main-loop contract). Repeated calls before
+     * the worker wakes coalesce into one probe. */
+    void requestProbe();
     void stop();
     auto dropped_count() const -> uint64_t;
     auto command_dropped_count() const -> uint64_t;
     auto write_failure_count() const -> uint64_t;
+    /* Probes that wrote (and rolled back) a row: the fail-safe's evidence that
+     * the write path is working. */
+    auto probe_success_count() const -> uint64_t;
+    auto probe_failure_count() const -> uint64_t;
+    /* Probes that ran cleanly but proved nothing (no assets registered). */
+    auto probe_inconclusive_count() const -> uint64_t;
+    auto last_probe_error() const -> std::string;
     auto pending_count() const -> std::size_t;
 };
 

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -215,6 +215,23 @@ void flight_safety_system::server::db_connection::recordCommandAck(uint64_t comm
     }
 }
 
+auto flight_safety_system::server::db_connection::probeWrite() -> bool
+{
+    /* Under write_lock like every record* writer: the probe runs on the write
+     * queue's worker thread, which is the only thread that touches the write
+     * connection, but the lock is what that invariant is stated with. */
+    std::scoped_lock guard(this->write_lock);
+    const int result = db_probe_write(write_conn_name);
+    if (result == DB_PROBE_FAILED)
+    {
+        throw database_error("fail-safe probe write failed");
+    }
+    /* DB_PROBE_INCONCLUSIVE (no assets registered) is not a failure and not
+     * evidence: the caller counts it separately and the fail-safe stays
+     * degraded on it. */
+    return result == DB_PROBE_OK;
+}
+
 void flight_safety_system::server::db_connection::recordPosition(uint64_t asset_id, double latitude, double longitude,
                                                                  uint32_t altitude, bool gps_fix_valid)
 {

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -133,6 +133,20 @@ public:
      * fss_command_ack_outcome/fss_command_ack_reason ints. */
     virtual void recordCommandAck(uint64_t command_dbid, uint8_t ack_state, uint64_t ack_timestamp,
                                   uint8_t ack_reason) = 0;
+    /* Positive evidence that the write path works right now, for the DB
+     * fail-safe's recovery rule (todo/78): a real INSERT inside a transaction
+     * that is rolled back, so nothing is stored. Returns true when a row was
+     * written (and discarded), false when the probe was *inconclusive* — the
+     * asset table is empty, so the statement matched no row and exercised
+     * nothing. Throws database_error when the write failed, exactly as the
+     * record* writers do, so the caller counts it as a probe failure.
+     *
+     * "No failures" is not health while every client is severed: the fail-safe's
+     * own trip removes all the traffic that could produce a failure, so before
+     * this existed the degraded state ended ~15 s after every trip regardless of
+     * the database's actual state. Called only while degraded, from the write
+     * queue's worker thread. */
+    virtual auto probeWrite() -> bool = 0;
     /* The asset's newest pending command, or nullopt when the read failed.
      * nullopt is NOT "no pending command": that is an engaged null pointer.
      * The distinction matters most on this read — it carries TERM and DISARM,
@@ -215,6 +229,7 @@ public:
     void recordCommandDispatch(uint64_t command_dbid, uint64_t dispatch_id) override;
     void recordCommandAck(uint64_t command_dbid, uint8_t ack_state, uint64_t ack_timestamp,
                           uint8_t ack_reason) override;
+    auto probeWrite() -> bool override;
     auto getCommand(uint64_t asset_id) -> std::optional<std::shared_ptr<asset_command>> override;
     auto getCommands(const std::vector<uint64_t> &asset_ids)
         -> std::optional<std::unordered_map<uint64_t, std::shared_ptr<asset_command>>> override;

--- a/src/server-db.h
+++ b/src/server-db.h
@@ -8,6 +8,22 @@ int db_connect(const char *conn, const char *host, int port, const char *user, c
 void db_disconnect(const char *conn);
 int db_ping(const char *conn);
 
+/* db_probe_write() results. The three states are distinct on purpose: an
+ * INSERT that matched no row is not a demonstration that writes work (todo/78). */
+#define DB_PROBE_FAILED 0
+#define DB_PROBE_OK 1
+#define DB_PROBE_INCONCLUSIVE (-1)
+
+/* Health probe for the DB fail-safe's recovery evidence: performs a real
+ * INSERT on the given (write) connection inside an explicit transaction and
+ * rolls it back, so nothing is persisted. Returns DB_PROBE_OK when a row was
+ * inserted, DB_PROBE_INCONCLUSIVE when assets_asset is empty (the INSERT ...
+ * SELECT matched nothing, so it exercised no trigger, constraint or heap
+ * write), and DB_PROBE_FAILED on any SQL error. AUTOCOMMIT is restored before
+ * every return. Only called while the fail-safe is degraded, on the
+ * db_write_queue worker thread that owns the write connection. */
+int db_probe_write(const char *conn);
+
 /* Something this file's statements depend on that the database cannot serve.
  * SCHEMA_PROBLEM_MISSING (a column) and SCHEMA_PROBLEM_MISSING_EXTENSION are
  * fatal -- the statements using them can only ever fail.

--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -775,6 +775,89 @@ int db_ping(const char *conn_arg)
     return (sqlca.sqlcode >= 0) ? 1 : 0;
 }
 
+int db_probe_write(const char *conn_arg)
+{
+    EXEC SQL BEGIN DECLARE SECTION;
+    const char *conn = conn_arg;
+    EXEC SQL END DECLARE SECTION;
+    int result = DB_PROBE_FAILED;
+
+    /* The fail-safe's recovery evidence (todo/78): does a *write* work right
+     * now, on the connection that failed? db_ping's SELECT 1 cannot answer
+     * that -- e2e/test_db_write_only_failure.py's BEFORE INSERT triggers leave
+     * reads perfectly healthy while every write raises, which is precisely the
+     * fault the fail-safe exists to latch on.
+     *
+     * The statement targets assets_assetrtt, already in required_columns[]
+     * below, so this adds no table, no column and no fss-web migration; the
+     * SELECT-driven asset id satisfies the FK without the server having to
+     * remember one across a severance (every client is severed while
+     * degraded). Rolled back, never committed: a committed rtt = 0 row would
+     * fabricate a telemetry sample for a disconnected aircraft in a table the
+     * operator reads, and this service exists to produce a truthful audit
+     * record. See docs/decisions/34-45-47-db-failsafe-latch.md for the
+     * alternatives rejected, and for the accepted residual -- an aborted
+     * transaction generates WAL but never forces an fsync, so a database that
+     * can buffer a write but not flush it can still pass this probe. */
+    EXEC SQL AT :conn SET AUTOCOMMIT TO OFF;
+    if (sqlca.sqlcode < 0)
+    {
+        sqlprint();
+        /* AUTOCOMMIT is restored on EVERY exit path, including this one:
+         * leaving the write connection in non-autocommit mode would silently
+         * change the semantics of every subsequent telemetry INSERT (each
+         * would sit in an implicit transaction nothing ever commits). */
+        EXEC SQL AT :conn SET AUTOCOMMIT TO ON;
+        return DB_PROBE_FAILED;
+    }
+
+    EXEC SQL AT :conn INSERT INTO assets_assetrtt (asset_id, rtt, timestamp)
+        SELECT id, 0, NOW() FROM assets_asset ORDER BY id LIMIT 1;
+
+    if (sqlca.sqlcode < 0)
+    {
+        sqlprint();
+        result = DB_PROBE_FAILED;
+    }
+    else if (sqlca.sqlerrd[2] == 0)
+    {
+        /* assets_asset is empty, so the INSERT ... SELECT matched no row. A
+         * zero-row INSERT fires no row trigger, extends no heap page and
+         * writes no tuple: it proves nothing about the write path. Report it
+         * as inconclusive -- no positive evidence -- rather than as success,
+         * which would readmit the fleet on the strength of a statement that
+         * did nothing. */
+        result = DB_PROBE_INCONCLUSIVE;
+    }
+    else
+    {
+        result = DB_PROBE_OK;
+    }
+
+    /* Explicit ROLLBACK before restoring AUTOCOMMIT, not left to the AUTOCOMMIT
+     * transition: ECPG ends an open transaction with COMMIT when it switches
+     * autocommit back on, which would persist the probe row. Rolling back here
+     * leaves the connection transaction-idle, so the switch below has nothing
+     * to commit. */
+    EXEC SQL AT :conn ROLLBACK;
+    if (sqlca.sqlcode < 0)
+    {
+        /* The rollback itself failed: the connection is not in a state this
+         * function can vouch for, so the probe has not demonstrated a healthy
+         * write no matter what the INSERT reported. */
+        sqlprint();
+        result = DB_PROBE_FAILED;
+    }
+
+    EXEC SQL AT :conn SET AUTOCOMMIT TO ON;
+    if (sqlca.sqlcode < 0)
+    {
+        sqlprint();
+        result = DB_PROBE_FAILED;
+    }
+    return result;
+}
+
 /* Postgres caps identifiers at 63 characters; every name in required_columns
  * below is far shorter, and the rows fetched by db_schema_check come back from
  * a VALUES list built out of that same array, so a fetch into these buffers

--- a/src/server-failsafe.hpp
+++ b/src/server-failsafe.hpp
@@ -41,7 +41,7 @@ namespace server {
  * produce a failure: no telemetry arrives, nothing is queued, nothing fails.
  * So they were satisfied by construction about recovery_grace_secs after every
  * trip, whatever the database was doing. Against a permanently dead database
- * (Path M m05: Postgres PANICked on a full disk and its crash recovery failed
+ * (Path M m05: Postgres hit a PANIC on a full disk and its crash recovery failed
  * too) that made a ~20 s flap cycle forever, each cycle taking a connected
  * aircraft out of and back into its comms-loss failsafe. The probe supplies the
  * positive evidence the quiet window cannot: a real write, on the connection
@@ -111,6 +111,12 @@ private:
      * before the trip — from a previous degraded episode — cannot pay for this
      * one. Compared with !=, matching the counter idiom above. */
     uint64_t probe_successes_at_trip{0};
+    /* When the current degraded episode began, for degradedAgeSecs(). Owned
+     * here rather than by the caller because this is the class that knows when
+     * the transition happened, and because reading it against the tick's own
+     * clock keeps the age consistent with the decision it describes — the same
+     * reason incidentAgeSecs() exists. */
+    uint64_t degraded_since_ms{0};
     /* An explicit flag rather than incident_start_ms == 0. A monotonic clock
      * that has just started, and every test clock, legitimately reads 0, so a
      * zero sentinel would silently discard an incident that began at the
@@ -221,6 +227,7 @@ public:
         {
             this->degraded_ = true;
             this->probe_successes_at_trip = counters.probe_successes;
+            this->degraded_since_ms = this->now_ms;
             this->last_probe_successes = counters.probe_successes;
             this->reason_ = trip_reason::command_drop;
             /* No write-failure incident is implicated, so do not leave one
@@ -242,6 +249,7 @@ public:
             {
                 this->degraded_ = true;
                 this->probe_successes_at_trip = counters.probe_successes;
+                this->degraded_since_ms = this->now_ms;
                 this->last_probe_successes = counters.probe_successes;
                 this->reason_ = trip_reason::write_failure;
                 /* Deliberately left active, unlike the command-drop path: the
@@ -272,6 +280,16 @@ public:
     [[nodiscard]] auto incidentAgeSecs() const -> uint64_t
     {
         return this->incident_active ? (this->now_ms - this->incident_start_ms) / ms_per_sec : 0;
+    }
+    /* How long the current degraded episode has been running as of the last
+     * tick, in seconds (0 if not degraded), for the caller's periodic
+     * still-degraded log. Distinct from incidentAgeSecs(): an incident is a run
+     * of write failures, which a command-drop trip does not have at all, while
+     * this measures the severance itself — the number an operator reading
+     * "sessions are still being refused" actually wants. */
+    [[nodiscard]] auto degradedAgeSecs() const -> uint64_t
+    {
+        return this->degraded_ ? (this->now_ms - this->degraded_since_ms) / ms_per_sec : 0;
     }
 };
 

--- a/src/server-failsafe.hpp
+++ b/src/server-failsafe.hpp
@@ -31,10 +31,28 @@ namespace server {
  * A trip latches the degraded state: the caller severs every client
  * *and* gates new admissions (server_clients::setDegraded) so aircraft get one
  * clean comms-loss event instead of a disconnect/reconnect flap into the same
- * unhealthy server. Recovery requires the write queue fully drained AND more
- * than recovery_grace_secs with no new failure or drop; readmitted traffic is
- * then the health probe — if the fault persists, the next incident latches
- * again rather than flapping on the tick period.
+ * unhealthy server. Recovery requires the write queue fully drained, more than
+ * recovery_grace_secs with no new failure, drop or probe failure, AND a
+ * *successful health probe* observed on that very tick (todo/78).
+ *
+ * That last condition is the one field evidence forced. Drain-plus-quiet are
+ * both conditions about the ABSENCE of failure, and the trip's own action —
+ * disconnectAll() plus the admission gate — removes everything that could
+ * produce a failure: no telemetry arrives, nothing is queued, nothing fails.
+ * So they were satisfied by construction about recovery_grace_secs after every
+ * trip, whatever the database was doing. Against a permanently dead database
+ * (Path M m05: Postgres PANICked on a full disk and its crash recovery failed
+ * too) that made a ~20 s flap cycle forever, each cycle taking a connected
+ * aircraft out of and back into its comms-loss failsafe. The probe supplies the
+ * positive evidence the quiet window cannot: a real write, on the connection
+ * that failed, rolled back. It gates the quiet window rather than replacing it,
+ * so with the caller's 1 s cadence and the default 15 s grace, recovery needs a
+ * probe that keeps succeeding across the whole window, not one lucky moment: a
+ * failing probe restarts the quiet window, and the recovering tick must itself
+ * carry a fresh success. That freshness is the only thing that can see a probe
+ * which HANGS rather than fails — against a partitioned or frozen database it
+ * returns neither answer, so no counter moves and there is nothing else to
+ * notice.
  *
  * Thresholds are measured against an injectable IClock, not against a count of
  * tick() calls (todo/70). The caller drives this from a loop whose period is
@@ -62,6 +80,20 @@ public:
         write_failure,
         command_drop,
     };
+    /* One tick's worth of the write queue's cumulative counters plus its
+     * current backlog depth. A struct rather than five positional integers so
+     * a caller cannot silently transpose two of them (and so clang-tidy's
+     * easily-swappable-parameters check stays quiet as the set grows). */
+    struct db_health_counters {
+        uint64_t write_failures;
+        uint64_t command_drops;
+        /* Probes that wrote and rolled back a row. An *inconclusive* probe is
+         * neither counted here nor as a failure: it is the absence of evidence
+         * and must not readmit the fleet. */
+        uint64_t probe_successes;
+        uint64_t probe_failures;
+        std::size_t pending_writes;
+    };
 private:
     static constexpr uint64_t ms_per_sec = 1000;
     uint64_t disconnect_age_ms;
@@ -72,6 +104,13 @@ private:
     uint64_t last_event_ms{0}; // when a new failure or drop last arrived
     uint64_t last_write_failures{0};
     uint64_t last_command_drops{0};
+    uint64_t last_probe_failures{0};
+    uint64_t last_probe_successes{0};
+    /* The probe-success count as of the tick that latched the degraded state.
+     * Recovery requires the live count to differ from it, so successes banked
+     * before the trip — from a previous degraded episode — cannot pay for this
+     * one. Compared with !=, matching the counter idiom above. */
+    uint64_t probe_successes_at_trip{0};
     /* An explicit flag rather than incident_start_ms == 0. A monotonic clock
      * that has just started, and every test clock, legitimately reads 0, so a
      * zero sentinel would silently discard an incident that began at the
@@ -95,14 +134,21 @@ public:
      * about once a second, but nothing here depends on that: every threshold
      * is measured against the clock, so a slow or interrupted tick changes when
      * a decision is observed, never when it is due. */
-    auto tick(uint64_t write_failures, uint64_t command_drops, std::size_t pending_writes) -> event
+    auto tick(const db_health_counters &counters) -> event
     {
         this->now_ms = this->clock->now_ms();
-        bool new_write_failure = write_failures != this->last_write_failures;
-        bool new_command_drop = command_drops != this->last_command_drops;
-        this->last_write_failures = write_failures;
-        this->last_command_drops = command_drops;
-        if (new_write_failure || new_command_drop)
+        bool new_write_failure = counters.write_failures != this->last_write_failures;
+        bool new_command_drop = counters.command_drops != this->last_command_drops;
+        /* A probe failure resets the quiet window exactly like a write
+         * failure — it is a demonstrated write failure, just one this server
+         * provoked deliberately — but it is never a trip trigger: the probe
+         * only runs while already degraded, and re-tripping a latched state
+         * would only churn reason(). */
+        bool new_probe_failure = counters.probe_failures != this->last_probe_failures;
+        this->last_write_failures = counters.write_failures;
+        this->last_command_drops = counters.command_drops;
+        this->last_probe_failures = counters.probe_failures;
+        if (new_write_failure || new_command_drop || new_probe_failure)
         {
             this->last_event_ms = this->now_ms;
         }
@@ -112,9 +158,57 @@ public:
              * anything: while tasks are still draining against a broken sink
              * they keep producing failures, and a nonempty-but-quiet queue
              * (e.g. a wedged sink) is not health either. */
-            bool quiet = !new_write_failure && !new_command_drop &&
+            bool quiet = !new_write_failure && !new_command_drop && !new_probe_failure &&
                          (this->now_ms - this->last_event_ms) > this->recovery_grace_ms;
-            if (pending_writes == 0 && quiet)
+            /* The positive evidence (todo/78). Without it, drain and quiet are
+             * both guaranteed by the severance this state performed, so the
+             * degraded state ended on a timer no matter how dead the database
+             * was.
+             *
+             * The evidence must be FRESH, not merely on record: recovery
+             * happens on a tick that carries a probe success, not on a tick
+             * that remembers one. A probe that HANGS — a partition, a failover,
+             * a frozen host — returns neither answer, so no counter moves at
+             * all: a failing probe holds the latch by restarting the quiet
+             * window, but a hanging one can only be noticed by the absence of
+             * fresh evidence. A "has succeeded at some point since the trip"
+             * test lets a single early success pay for a recovery arbitrarily
+             * later, into a database that has answered nothing since.
+             *
+             * Deliberately edge-triggered rather than "a success within the
+             * last recovery_grace_ms", which sounds equivalent and is not: the
+             * quiet window is measured from the trip, which is itself an event,
+             * so recovery is first possible at trip + grace + one tick — and a
+             * success arriving one tick after the trip is then almost exactly
+             * grace old, i.e. still inside such a window. That formulation
+             * therefore admits the very case it is meant to exclude, by a
+             * margin of one tick. Requiring the success on the tick itself has
+             * no constant in it and no boundary to land on.
+             *
+             * Cost on a healthy database: none. The caller requests a probe on
+             * every degraded tick and the queue is empty while degraded, so
+             * each tick observes the previous tick's success and recovery lands
+             * on the same tick it always did. A database answering more slowly
+             * than the tick period delays recovery by at most one probe round
+             * trip — while it is answering that slowly, holding the gate up is
+             * the safer error.
+             *
+             * The at-trip baseline is implied by freshness (a success observed
+             * this tick is necessarily later than the trip's snapshot) and is
+             * kept because the two state different invariants: this one says
+             * "evidence now", that one says "evidence from THIS episode". A
+             * later change to either must not silently inherit the other's
+             * meaning.
+             *
+             * last_probe_successes is maintained here and at the two trip
+             * sites rather than on every tick: probes are only ever requested
+             * while degraded (wantsProbe()), so the counter cannot move in
+             * between, and keeping the update beside its only reader is what
+             * lets this flag live in the scope that uses it. */
+            bool new_probe_success = counters.probe_successes != this->last_probe_successes;
+            this->last_probe_successes = counters.probe_successes;
+            bool probed_healthy = new_probe_success && counters.probe_successes != this->probe_successes_at_trip;
+            if (counters.pending_writes == 0 && quiet && probed_healthy)
             {
                 this->degraded_ = false;
                 this->reason_ = trip_reason::none;
@@ -126,6 +220,8 @@ public:
         if (new_command_drop)
         {
             this->degraded_ = true;
+            this->probe_successes_at_trip = counters.probe_successes;
+            this->last_probe_successes = counters.probe_successes;
             this->reason_ = trip_reason::command_drop;
             /* No write-failure incident is implicated, so do not leave one
              * standing for incidentAgeSecs() to report against this trip. */
@@ -145,6 +241,8 @@ public:
             if ((this->now_ms - this->incident_start_ms) >= this->disconnect_age_ms)
             {
                 this->degraded_ = true;
+                this->probe_successes_at_trip = counters.probe_successes;
+                this->last_probe_successes = counters.probe_successes;
                 this->reason_ = trip_reason::write_failure;
                 /* Deliberately left active, unlike the command-drop path: the
                  * caller logs incidentAgeSecs() with the trip, and nothing
@@ -160,6 +258,12 @@ public:
         return event::none;
     }
     [[nodiscard]] auto degraded() const -> bool { return this->degraded_; }
+    /* Whether the caller should ask for a health probe this tick. True only
+     * while degraded: in normal operation this is one bool read per second, no
+     * enqueue, no atomic store and no database contact — the probe exists to
+     * end the degraded state, and real traffic is evidence enough while it is
+     * flowing. */
+    [[nodiscard]] auto wantsProbe() const -> bool { return this->degraded_; }
     [[nodiscard]] auto reason() const -> trip_reason { return this->reason_; }
     /* How long the write-failure incident had been running as of the last
      * tick, in seconds (0 if none is active), for the caller's trip log. Read

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -16,6 +16,7 @@
 #include <memory>
 #include <mutex>
 #include <atomic>
+#include <string>
 #include <thread>
 
 #pragma GCC diagnostic push
@@ -379,7 +380,13 @@ auto main(int argc, char *argv[]) -> int
             },
             task);
     };
-    auto writer = std::make_shared<flight_safety_system::server::db_write_queue>(db_queue_depth, sink);
+    /* The fail-safe's recovery evidence (todo/78). Runs on the write queue's
+     * worker thread — the only thread that touches the write connection, and
+     * one that is already allowed to block on it — so the main loop's
+     * no-synchronous-DB contract (decision 46) is untouched: it only ever sets
+     * a flag. */
+    flight_safety_system::server::db_probe_fn probe = [dbc]() -> bool { return dbc->probeWrite(); };
+    auto writer = std::make_shared<flight_safety_system::server::db_write_queue>(db_queue_depth, sink, probe);
 
     auto clients = std::make_shared<server_clients>();
     constexpr int msec_per_sec = 1000;
@@ -560,9 +567,16 @@ auto main(int argc, char *argv[]) -> int
                  * disconnect/reconnect flap into the same unhealthy server.
                  * Recovery logs at ERROR like the trip: supervision watching
                  * for the fail-safe must see both edges at one level. */
-                switch (failsafe.tick(current_failures, current_command_dropped, writer->pending_count()))
+                static uint64_t degraded_since_ms = 0;
+                static uint64_t last_degraded_report_ms = 0;
+                const db_failsafe::db_health_counters counters{current_failures, current_command_dropped,
+                                                               writer->probe_success_count(),
+                                                               writer->probe_failure_count(), writer->pending_count()};
+                switch (failsafe.tick(counters))
                 {
                     case db_failsafe::event::tripped: {
+                        degraded_since_ms = now_ms;
+                        last_degraded_report_ms = now_ms;
                         clients->setDegraded(true);
                         auto severed = clients->disconnectAll();
                         bool dropped = failsafe.reason() == db_failsafe::trip_reason::command_drop;
@@ -587,11 +601,51 @@ auto main(int argc, char *argv[]) -> int
                     }
                     case db_failsafe::event::recovered:
                         clients->setDegraded(false);
-                        FSS_LOG_ERROR("server", "DB fail-safe recovered: write queue drained and quiet for "
+                        /* States the evidence, not just the silence: a probe
+                         * write actually succeeded on the connection that
+                         * failed. The e2e suite matches this line on its
+                         * "DB fail-safe recovered" prefix only. */
+                        FSS_LOG_ERROR("server", "DB fail-safe recovered: write queue drained, quiet for "
                                                     << db_write_failure_recovery_grace_secs
-                                                    << "s; accepting sessions again");
+                                                    << "s, and a probe write succeeded; accepting sessions again");
                         break;
                     case db_failsafe::event::none: break;
+                }
+                if (failsafe.degraded())
+                {
+                    /* A permanently dead database now leaves the server
+                     * degraded indefinitely — correctly, but silently unless
+                     * this says so. Rate-limited to once a minute; the trip
+                     * line above is the loud edge. */
+                    constexpr uint64_t degraded_report_period_ms = 60 * ms_per_sec;
+                    if ((now_ms - last_degraded_report_ms) >= degraded_report_period_ms)
+                    {
+                        last_degraded_report_ms = now_ms;
+                        std::string probe_error = writer->last_probe_error();
+                        /* Reports the counters rather than diagnosing which
+                         * condition is unmet: the fail-safe owns that decision
+                         * and these are the numbers it decided on. */
+                        FSS_LOG_ERROR(
+                            "server",
+                            "DB fail-safe still degraded after "
+                                << (now_ms - degraded_since_ms) / ms_per_sec
+                                << "s; sessions stay refused until the write queue is drained, quiet for "
+                                << db_write_failure_recovery_grace_secs
+                                << "s and a probe write has succeeded (queue depth=" << writer->pending_count()
+                                << ", probe successes=" << writer->probe_success_count()
+                                << ", failures=" << writer->probe_failure_count()
+                                << ", inconclusive=" << writer->probe_inconclusive_count() << ", last probe error: "
+                                << (probe_error.empty() ? std::string{"none"} : probe_error) << ")");
+                    }
+                }
+                /* Ask for the next probe. Nothing happens here but a flag and a
+                 * notify; the write queue's worker runs it once its deque is
+                 * empty, so the answer describes the drained state the recovery
+                 * rule asks about. False whenever the server is healthy, which
+                 * is what keeps this free in normal operation. */
+                if (failsafe.wantsProbe())
+                {
+                    writer->requestProbe();
                 }
             }
             if (do_per_config_period)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -567,7 +567,9 @@ auto main(int argc, char *argv[]) -> int
                  * disconnect/reconnect flap into the same unhealthy server.
                  * Recovery logs at ERROR like the trip: supervision watching
                  * for the fail-safe must see both edges at one level. */
-                static uint64_t degraded_since_ms = 0;
+                /* Only the report throttle lives here; how long the server has
+                 * been degraded is db_failsafe::degradedAgeSecs(), measured
+                 * against the same clock the decision was made on. */
                 static uint64_t last_degraded_report_ms = 0;
                 const db_failsafe::db_health_counters counters{current_failures, current_command_dropped,
                                                                writer->probe_success_count(),
@@ -575,7 +577,6 @@ auto main(int argc, char *argv[]) -> int
                 switch (failsafe.tick(counters))
                 {
                     case db_failsafe::event::tripped: {
-                        degraded_since_ms = now_ms;
                         last_degraded_report_ms = now_ms;
                         clients->setDegraded(true);
                         auto severed = clients->disconnectAll();
@@ -628,7 +629,7 @@ auto main(int argc, char *argv[]) -> int
                         FSS_LOG_ERROR(
                             "server",
                             "DB fail-safe still degraded after "
-                                << (now_ms - degraded_since_ms) / ms_per_sec
+                                << failsafe.degradedAgeSecs()
                                 << "s; sessions stay refused until the write queue is drained, quiet for "
                                 << db_write_failure_recovery_grace_secs
                                 << "s and a probe write has succeeded (queue depth=" << writer->pending_count()

--- a/tests/async_db_write_test.cpp
+++ b/tests/async_db_write_test.cpp
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <thread>
 #include <vector>
 
@@ -87,12 +88,22 @@ struct CapturingSink {
     }
 };
 
+/* Every case that does not exercise the probe itself passes this. The
+ * constructor requires a probe function (todo/78) precisely so a server wired
+ * without one — which could never leave the degraded state — fails to compile
+ * rather than shipping. */
+auto healthy_probe() -> bool
+{
+    return true;
+}
+
 } // namespace
 
 TEST_CASE("db_write_queue: enqueue-then-drain preserves order")
 {
     auto cap = std::make_shared<CapturingSink>();
-    fss::server::db_write_queue q(100, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+    fss::server::db_write_queue q(
+        100, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
 
     for (uint64_t i = 1; i <= 20; ++i)
     {
@@ -118,7 +129,8 @@ TEST_CASE("db_write_queue: bounded queue drops oldest when full")
     cap->delay = std::chrono::milliseconds(50);
 
     constexpr std::size_t depth = 5;
-    fss::server::db_write_queue q(depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+    fss::server::db_write_queue q(
+        depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
 
     /* Worker will pick up task 1 and sleep. Fill 5 slots, then push 10 more;
      * older entries beyond depth must be dropped. */
@@ -147,7 +159,8 @@ TEST_CASE("db_write_queue: stop drains pending work")
     auto cap = std::make_shared<CapturingSink>();
     cap->delay = std::chrono::milliseconds(5);
 
-    fss::server::db_write_queue q(1000, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+    fss::server::db_write_queue q(
+        1000, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
     for (uint64_t i = 1; i <= 50; ++i)
     {
         q.enqueue(fss::server::position_write{i, 0.0, 0.0, 0});
@@ -162,7 +175,8 @@ TEST_CASE("db_write_queue: stop drains pending work")
 TEST_CASE("db_write_queue: stop is idempotent")
 {
     auto cap = std::make_shared<CapturingSink>();
-    fss::server::db_write_queue q(100, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+    fss::server::db_write_queue q(
+        100, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
     q.enqueue(fss::server::rtt_write{1, 1});
     REQUIRE(fss_test::wait_for([&]() -> bool { return cap->count.load() == 1; }));
     q.stop();
@@ -173,7 +187,8 @@ TEST_CASE("db_write_queue: stop is idempotent")
 TEST_CASE("db_write_queue: enqueue after stop is a no-op")
 {
     auto cap = std::make_shared<CapturingSink>();
-    fss::server::db_write_queue q(100, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+    fss::server::db_write_queue q(
+        100, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
 
     q.enqueue(fss::server::rtt_write{1, 10});
     q.enqueue(fss::server::rtt_write{2, 20});
@@ -198,7 +213,8 @@ TEST_CASE("db_write_queue: slow sink does not block producers")
     auto cap = std::make_shared<CapturingSink>();
     cap->delay = std::chrono::milliseconds(200);
 
-    fss::server::db_write_queue q(10000, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+    fss::server::db_write_queue q(
+        10000, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
 
     auto start = std::chrono::steady_clock::now();
     for (uint64_t i = 1; i <= 20; ++i)
@@ -229,7 +245,8 @@ TEST_CASE("db_write_queue: drop log message appears on stderr when queue fills")
     fss_test::capture_cerr cerr_capture;
 
     {
-        fss::server::db_write_queue q(3, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+        fss::server::db_write_queue q(
+            3, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
         for (uint64_t i = 1; i <= 20; ++i)
         {
             q.enqueue(fss::server::rtt_write{i, 0});
@@ -254,7 +271,8 @@ TEST_CASE("db_write_queue: a command dispatch survives a telemetry overflow")
     cap->delay = std::chrono::milliseconds(50); /* slow sink so the queue stays full */
 
     constexpr std::size_t depth = 5;
-    fss::server::db_write_queue q(depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+    fss::server::db_write_queue q(
+        depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
 
     constexpr uint64_t cmd_id = 1000000; /* distinct from any telemetry asset id below */
     for (uint64_t i = 1; i <= depth; ++i)
@@ -282,7 +300,8 @@ TEST_CASE("db_write_queue: a command ack survives a telemetry overflow")
     cap->delay = std::chrono::milliseconds(50);
 
     constexpr std::size_t depth = 5;
-    fss::server::db_write_queue q(depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+    fss::server::db_write_queue q(
+        depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
 
     constexpr uint64_t ack_command_dbid = 2000000;
     for (uint64_t i = 1; i <= depth; ++i)
@@ -316,7 +335,8 @@ TEST_CASE("db_write_queue: command overload drops on a distinct command-specific
 
     {
         constexpr std::size_t depth = 3;
-        fss::server::db_write_queue q(depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+        fss::server::db_write_queue q(
+            depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
         for (uint64_t i = 1; i <= 10; ++i)
         {
             q.enqueue(fss::server::command_dispatch_write{i, i});
@@ -343,7 +363,8 @@ TEST_CASE("db_write_queue: telemetry is rejected without evicting a command when
     cap->gate_open = false; /* the worker will park on the first task */
 
     constexpr std::size_t depth = 3;
-    fss::server::db_write_queue q(depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+    fss::server::db_write_queue q(
+        depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
 
     /* Park the worker on a first command so the remaining slots fill predictably. */
     q.enqueue(fss::server::command_dispatch_write{1, 1});
@@ -381,7 +402,7 @@ TEST_CASE("db_write_queue: write_failure_count tracks sink exceptions")
         throw std::runtime_error("injected sink failure");
     };
 
-    fss::server::db_write_queue q(100, throwing_sink);
+    fss::server::db_write_queue q(100, throwing_sink, healthy_probe);
     for (uint64_t i = 1; i <= task_count; ++i)
     {
         q.enqueue(fss::server::rtt_write{i, 0});
@@ -397,7 +418,7 @@ TEST_CASE("db_write_queue: catch-all handler counts non-exception throws")
 {
     auto weird_sink = [](const fss::server::db_write_task &) -> void { throw 42; };
 
-    fss::server::db_write_queue q(100, weird_sink);
+    fss::server::db_write_queue q(100, weird_sink, healthy_probe);
     q.enqueue(fss::server::rtt_write{1, 0});
 
     REQUIRE(fss_test::wait_for([&]() -> bool { return q.write_failure_count() == 1; }));
@@ -412,7 +433,8 @@ TEST_CASE("db_write_queue: destructor without explicit stop drains pending work"
     cap->delay = std::chrono::milliseconds(5);
 
     {
-        fss::server::db_write_queue q(1000, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); });
+        fss::server::db_write_queue q(
+            1000, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
         for (uint64_t i = 1; i <= 30; ++i)
         {
             q.enqueue(fss::server::search_status_write{i, 0, 0, 0});
@@ -421,4 +443,185 @@ TEST_CASE("db_write_queue: destructor without explicit stop drains pending work"
     }
 
     REQUIRE(cap->count.load() == 30);
+}
+
+/* ── The fail-safe health probe (todo/78) ────────────────────────────────── */
+
+TEST_CASE("db_write_queue: a probe runs only once the queue has drained")
+{
+    /* The probe is the fail-safe's evidence that the write path works *now*,
+     * so it must describe the state after the backlog cleared, not race it.
+     * It is also deliberately not a queued task: a queued probe would make
+     * pending_count() non-zero, which the fail-safe reads as "not drained" —
+     * recovery would become unreachable and the fleet would stay severed. */
+    auto cap = std::make_shared<CapturingSink>();
+    {
+        std::lock_guard<std::mutex> guard(cap->gate_mtx);
+        cap->gate_open = false;
+    }
+    std::atomic<uint64_t> probes{0};
+    std::atomic<uint64_t> writes_seen_by_probe{0};
+    fss::server::db_write_queue q(
+        100, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); },
+        [&]() -> bool {
+            writes_seen_by_probe.store(cap->count.load());
+            probes.fetch_add(1);
+            return true;
+        });
+
+    constexpr uint64_t task_count = 5;
+    for (uint64_t i = 1; i <= task_count; ++i)
+    {
+        q.enqueue(fss::server::rtt_write{i, i});
+    }
+    /* The worker is parked inside the sink on the first task; the rest sit in
+     * the deque. */
+    REQUIRE(fss_test::wait_for([&]() -> bool { return cap->entered.load() >= 1; }));
+    const std::size_t pending_before = q.pending_count();
+    q.requestProbe();
+    /* Asking for a probe must not change the backlog the fail-safe measures. */
+    REQUIRE(q.pending_count() == pending_before);
+    REQUIRE(probes.load() == 0);
+
+    cap->open_gate();
+    REQUIRE(fss_test::wait_for([&]() -> bool { return probes.load() == 1; }));
+    q.stop();
+
+    REQUIRE(q.pending_count() == 0);
+    REQUIRE(writes_seen_by_probe.load() == task_count);
+    REQUIRE(q.probe_success_count() == 1);
+}
+
+TEST_CASE("db_write_queue: repeated probe requests coalesce into one probe")
+{
+    auto cap = std::make_shared<CapturingSink>();
+    {
+        std::lock_guard<std::mutex> guard(cap->gate_mtx);
+        cap->gate_open = false;
+    }
+    std::atomic<uint64_t> probes{0};
+    fss::server::db_write_queue q(
+        100, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); },
+        [&]() -> bool {
+            probes.fetch_add(1);
+            return true;
+        });
+
+    q.enqueue(fss::server::rtt_write{1, 1});
+    REQUIRE(fss_test::wait_for([&]() -> bool { return cap->entered.load() >= 1; }));
+    /* The caller asks once a second while degraded and never waits for an
+     * answer, so requests pile up behind a slow write; at most one probe may
+     * ever be outstanding. */
+    for (int i = 0; i < 20; i++)
+    {
+        q.requestProbe();
+    }
+
+    cap->open_gate();
+    REQUIRE(fss_test::wait_for([&]() -> bool { return probes.load() >= 1; }));
+    q.stop();
+
+    REQUIRE(probes.load() == 1);
+    REQUIRE(q.probe_success_count() == 1);
+}
+
+TEST_CASE("db_write_queue: a successful probe counts as a success, not a write")
+{
+    fss::server::db_write_queue q(100, [](const fss::server::db_write_task &) -> void {}, healthy_probe);
+    q.requestProbe();
+
+    REQUIRE(fss_test::wait_for([&]() -> bool { return q.probe_success_count() == 1; }));
+    q.stop();
+
+    REQUIRE(q.probe_success_count() == 1);
+    REQUIRE(q.probe_failure_count() == 0);
+    REQUIRE(q.probe_inconclusive_count() == 0);
+    REQUIRE(q.write_failure_count() == 0);
+}
+
+TEST_CASE("db_write_queue: a throwing probe counts as a probe failure, not a write failure")
+{
+    /* Kept off write_failure_count() on purpose: the caller logs that counter at
+     * ERROR on every change, so routing probe failures through it would emit one
+     * ERROR per second forever against a permanently dead database. */
+    fss::server::db_write_queue q(
+        100, [](const fss::server::db_write_task &) -> void {},
+        []() -> bool { throw std::runtime_error("probe boom"); });
+    q.requestProbe();
+
+    REQUIRE(fss_test::wait_for([&]() -> bool { return q.probe_failure_count() == 1; }));
+    q.stop();
+
+    REQUIRE(q.probe_failure_count() == 1);
+    REQUIRE(q.probe_success_count() == 0);
+    REQUIRE(q.write_failure_count() == 0);
+    REQUIRE(q.last_probe_error() == "probe boom");
+}
+
+TEST_CASE("db_write_queue: an inconclusive probe is neither a success nor a failure")
+{
+    /* An empty asset table makes the probe statement match no row: it fires no
+     * trigger and extends no heap page, so it proves nothing. Counting it as a
+     * success would readmit the fleet on the strength of a statement that did
+     * nothing. */
+    fss::server::db_write_queue q(
+        100, [](const fss::server::db_write_task &) -> void {}, []() -> bool { return false; });
+    q.requestProbe();
+
+    REQUIRE(fss_test::wait_for([&]() -> bool { return q.probe_inconclusive_count() == 1; }));
+    q.stop();
+
+    REQUIRE(q.probe_inconclusive_count() == 1);
+    REQUIRE(q.probe_success_count() == 0);
+    REQUIRE(q.probe_failure_count() == 0);
+}
+
+TEST_CASE("db_write_queue: stop with a probe outstanding does not hang")
+{
+    /* Shutdown must never wait on the database: an outstanding probe is
+     * abandoned, not run, once stopping is set and the queue is empty. */
+    auto cap = std::make_shared<CapturingSink>();
+    {
+        std::lock_guard<std::mutex> guard(cap->gate_mtx);
+        cap->gate_open = false;
+    }
+    std::atomic<uint64_t> probes{0};
+    {
+        fss::server::db_write_queue q(
+            100, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); },
+            [&]() -> bool {
+                probes.fetch_add(1);
+                return true;
+            });
+
+        q.enqueue(fss::server::rtt_write{1, 1});
+        REQUIRE(fss_test::wait_for([&]() -> bool { return cap->entered.load() >= 1; }));
+        q.requestProbe();
+
+        std::thread releaser([cap]() -> void {
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            cap->open_gate();
+        });
+        q.stop();
+        releaser.join();
+        /* Destructor runs on a stopped queue: stop() is idempotent. */
+    }
+
+    REQUIRE(probes.load() == 0);
+}
+
+TEST_CASE("db_write_queue: a probe requested after stop is ignored")
+{
+    std::atomic<uint64_t> probes{0};
+    fss::server::db_write_queue q(
+        100, [](const fss::server::db_write_task &) -> void {},
+        [&]() -> bool {
+            probes.fetch_add(1);
+            return true;
+        });
+    q.stop();
+    q.requestProbe();
+
+    REQUIRE(probes.load() == 0);
+    REQUIRE(q.probe_success_count() == 0);
 }

--- a/tests/async_db_write_test.cpp
+++ b/tests/async_db_write_test.cpp
@@ -88,22 +88,13 @@ struct CapturingSink {
     }
 };
 
-/* Every case that does not exercise the probe itself passes this. The
- * constructor requires a probe function (todo/78) precisely so a server wired
- * without one — which could never leave the degraded state — fails to compile
- * rather than shipping. */
-auto healthy_probe() -> bool
-{
-    return true;
-}
-
 } // namespace
 
 TEST_CASE("db_write_queue: enqueue-then-drain preserves order")
 {
     auto cap = std::make_shared<CapturingSink>();
     fss::server::db_write_queue q(
-        100, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
+        100, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, fss_test::healthy_probe);
 
     for (uint64_t i = 1; i <= 20; ++i)
     {
@@ -130,7 +121,7 @@ TEST_CASE("db_write_queue: bounded queue drops oldest when full")
 
     constexpr std::size_t depth = 5;
     fss::server::db_write_queue q(
-        depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
+        depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, fss_test::healthy_probe);
 
     /* Worker will pick up task 1 and sleep. Fill 5 slots, then push 10 more;
      * older entries beyond depth must be dropped. */
@@ -160,7 +151,7 @@ TEST_CASE("db_write_queue: stop drains pending work")
     cap->delay = std::chrono::milliseconds(5);
 
     fss::server::db_write_queue q(
-        1000, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
+        1000, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, fss_test::healthy_probe);
     for (uint64_t i = 1; i <= 50; ++i)
     {
         q.enqueue(fss::server::position_write{i, 0.0, 0.0, 0});
@@ -176,7 +167,7 @@ TEST_CASE("db_write_queue: stop is idempotent")
 {
     auto cap = std::make_shared<CapturingSink>();
     fss::server::db_write_queue q(
-        100, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
+        100, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, fss_test::healthy_probe);
     q.enqueue(fss::server::rtt_write{1, 1});
     REQUIRE(fss_test::wait_for([&]() -> bool { return cap->count.load() == 1; }));
     q.stop();
@@ -188,7 +179,7 @@ TEST_CASE("db_write_queue: enqueue after stop is a no-op")
 {
     auto cap = std::make_shared<CapturingSink>();
     fss::server::db_write_queue q(
-        100, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
+        100, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, fss_test::healthy_probe);
 
     q.enqueue(fss::server::rtt_write{1, 10});
     q.enqueue(fss::server::rtt_write{2, 20});
@@ -214,7 +205,7 @@ TEST_CASE("db_write_queue: slow sink does not block producers")
     cap->delay = std::chrono::milliseconds(200);
 
     fss::server::db_write_queue q(
-        10000, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
+        10000, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, fss_test::healthy_probe);
 
     auto start = std::chrono::steady_clock::now();
     for (uint64_t i = 1; i <= 20; ++i)
@@ -246,7 +237,7 @@ TEST_CASE("db_write_queue: drop log message appears on stderr when queue fills")
 
     {
         fss::server::db_write_queue q(
-            3, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
+            3, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, fss_test::healthy_probe);
         for (uint64_t i = 1; i <= 20; ++i)
         {
             q.enqueue(fss::server::rtt_write{i, 0});
@@ -272,7 +263,7 @@ TEST_CASE("db_write_queue: a command dispatch survives a telemetry overflow")
 
     constexpr std::size_t depth = 5;
     fss::server::db_write_queue q(
-        depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
+        depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, fss_test::healthy_probe);
 
     constexpr uint64_t cmd_id = 1000000; /* distinct from any telemetry asset id below */
     for (uint64_t i = 1; i <= depth; ++i)
@@ -301,7 +292,7 @@ TEST_CASE("db_write_queue: a command ack survives a telemetry overflow")
 
     constexpr std::size_t depth = 5;
     fss::server::db_write_queue q(
-        depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
+        depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, fss_test::healthy_probe);
 
     constexpr uint64_t ack_command_dbid = 2000000;
     for (uint64_t i = 1; i <= depth; ++i)
@@ -336,7 +327,7 @@ TEST_CASE("db_write_queue: command overload drops on a distinct command-specific
     {
         constexpr std::size_t depth = 3;
         fss::server::db_write_queue q(
-            depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
+            depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, fss_test::healthy_probe);
         for (uint64_t i = 1; i <= 10; ++i)
         {
             q.enqueue(fss::server::command_dispatch_write{i, i});
@@ -364,7 +355,7 @@ TEST_CASE("db_write_queue: telemetry is rejected without evicting a command when
 
     constexpr std::size_t depth = 3;
     fss::server::db_write_queue q(
-        depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
+        depth, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, fss_test::healthy_probe);
 
     /* Park the worker on a first command so the remaining slots fill predictably. */
     q.enqueue(fss::server::command_dispatch_write{1, 1});
@@ -402,7 +393,7 @@ TEST_CASE("db_write_queue: write_failure_count tracks sink exceptions")
         throw std::runtime_error("injected sink failure");
     };
 
-    fss::server::db_write_queue q(100, throwing_sink, healthy_probe);
+    fss::server::db_write_queue q(100, throwing_sink, fss_test::healthy_probe);
     for (uint64_t i = 1; i <= task_count; ++i)
     {
         q.enqueue(fss::server::rtt_write{i, 0});
@@ -418,7 +409,7 @@ TEST_CASE("db_write_queue: catch-all handler counts non-exception throws")
 {
     auto weird_sink = [](const fss::server::db_write_task &) -> void { throw 42; };
 
-    fss::server::db_write_queue q(100, weird_sink, healthy_probe);
+    fss::server::db_write_queue q(100, weird_sink, fss_test::healthy_probe);
     q.enqueue(fss::server::rtt_write{1, 0});
 
     REQUIRE(fss_test::wait_for([&]() -> bool { return q.write_failure_count() == 1; }));
@@ -434,7 +425,7 @@ TEST_CASE("db_write_queue: destructor without explicit stop drains pending work"
 
     {
         fss::server::db_write_queue q(
-            1000, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, healthy_probe);
+            1000, [cap](const fss::server::db_write_task &t) -> void { (*cap)(t); }, fss_test::healthy_probe);
         for (uint64_t i = 1; i <= 30; ++i)
         {
             q.enqueue(fss::server::search_status_write{i, 0, 0, 0});
@@ -527,7 +518,7 @@ TEST_CASE("db_write_queue: repeated probe requests coalesce into one probe")
 
 TEST_CASE("db_write_queue: a successful probe counts as a success, not a write")
 {
-    fss::server::db_write_queue q(100, [](const fss::server::db_write_task &) -> void {}, healthy_probe);
+    fss::server::db_write_queue q(100, [](const fss::server::db_write_task &) -> void {}, fss_test::healthy_probe);
     q.requestProbe();
 
     REQUIRE(fss_test::wait_for([&]() -> bool { return q.probe_success_count() == 1; }));

--- a/tests/concurrency_client_test.cpp
+++ b/tests/concurrency_client_test.cpp
@@ -24,6 +24,7 @@
 
 #include "fss-transport.hpp"
 #include "fss-server.hpp"
+#include "test_helpers.hpp"
 #include "db-write-queue.hpp"
 
 using flight_safety_system::transport::fss_connection;
@@ -191,7 +192,7 @@ TEST_CASE("tsan: fss_client config precedes handler activation")
 
     stub_database db;
     srv::db_write_sink sink = [](const srv::db_write_task &) -> void {};
-    auto writer = std::make_shared<srv::db_write_queue>(std::size_t{1024}, sink, []() -> bool { return true; });
+    auto writer = std::make_shared<srv::db_write_queue>(std::size_t{1024}, sink, fss_test::healthy_probe);
     null_handler handler;
 
     auto client = std::make_shared<srv::fss_client>(conn, &db, writer, &handler);

--- a/tests/concurrency_client_test.cpp
+++ b/tests/concurrency_client_test.cpp
@@ -108,6 +108,8 @@ public:
     void recordSearchStatus(uint64_t, uint64_t, uint64_t, uint64_t) override {}
     void recordCommandDispatch(uint64_t, uint64_t) override {}
     void recordCommandAck(uint64_t, uint8_t, uint64_t, uint8_t) override {}
+    /* Always healthy: nothing here exercises the fail-safe's probe (todo/78). */
+    auto probeWrite() -> bool override { return true; }
     auto getCommand(uint64_t) -> std::optional<std::shared_ptr<flight_safety_system::server::asset_command>> override
     {
         /* An engaged null pointer: no pending command, not a failed read. */
@@ -189,7 +191,7 @@ TEST_CASE("tsan: fss_client config precedes handler activation")
 
     stub_database db;
     srv::db_write_sink sink = [](const srv::db_write_task &) -> void {};
-    auto writer = std::make_shared<srv::db_write_queue>(std::size_t{1024}, sink);
+    auto writer = std::make_shared<srv::db_write_queue>(std::size_t{1024}, sink, []() -> bool { return true; });
     null_handler handler;
 
     auto client = std::make_shared<srv::fss_client>(conn, &db, writer, &handler);

--- a/tests/crl_revocation_test.cpp
+++ b/tests/crl_revocation_test.cpp
@@ -54,7 +54,8 @@ auto make_writer(fss_test::MockDatabase &mock) -> std::shared_ptr<fss::server::d
                    },
                    task);
     };
-    return std::make_shared<fss::server::db_write_queue>(std::size_t{1024}, sink);
+    return std::make_shared<fss::server::db_write_queue>(std::size_t{1024}, sink,
+                                                         [&mock]() -> bool { return mock.probeWrite(); });
 }
 
 } // namespace

--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -503,6 +503,59 @@ auto get_command_column(uint64_t command_id, const std::string &column) -> std::
 
 } // namespace
 
+TEST_CASE("db_connection: probeWrite proves the write path without storing anything (todo/78)")
+{
+    /* The fail-safe's recovery evidence. Two properties, and the second is the
+     * one that needs a live database to check at all: the probe must exercise a
+     * real INSERT (so a write-only fault -- a BEFORE INSERT trigger, a full
+     * disk, a revoked grant -- fails it, unlike db_ping's SELECT 1), and it must
+     * leave nothing behind. A committed probe row would fabricate an rtt = 0
+     * telemetry sample for a disconnected aircraft in a table the operator
+     * reads. ECPG ends an open transaction by COMMITting it when AUTOCOMMIT is
+     * switched back on, so the explicit ROLLBACK in db_probe_write is what makes
+     * that true; this pins it. */
+    LIVE_DB_OR_SKIP(dbc);
+    const auto rows_before = psql_query("SELECT COUNT(*) FROM assets_assetrtt");
+    REQUIRE(dbc->probeWrite());
+    REQUIRE(psql_query("SELECT COUNT(*) FROM assets_assetrtt") == rows_before);
+}
+
+TEST_CASE("db_connection: probeWrite leaves AUTOCOMMIT restored on the write connection (todo/78)")
+{
+    /* The sharpest hazard in the probe: it is the only statement in
+     * server-db.pgc that turns AUTOCOMMIT off on the *write* connection, and if
+     * any exit path left it off, every subsequent telemetry INSERT would sit in
+     * an implicit transaction nothing ever commits -- telemetry would vanish
+     * with no error anywhere. A write after the probe must therefore be
+     * durable, and remain durable after a *failed* probe too. */
+    LIVE_DB_OR_SKIP(dbc);
+    auto asset_id = get_test_asset_id(*dbc);
+    REQUIRE(dbc->probeWrite());
+
+    const auto rows_before = std::stoull(psql_query("SELECT COUNT(*) FROM assets_assetrtt"));
+    dbc->recordRtt(asset_id, uint64_t{4242});
+    REQUIRE(std::stoull(psql_query("SELECT COUNT(*) FROM assets_assetrtt")) == rows_before + 1);
+}
+
+TEST_CASE("db_connection: probeWrite throws when the write connection is down (todo/78)")
+{
+    /* A failed probe must reach the write queue as an exception, exactly like a
+     * failed record* write, so it is counted as a probe failure and the
+     * fail-safe stays degraded. Recovery on silence is what todo/78 removed. */
+    LIVE_DB_OR_SKIP(dbc);
+    auto asset_id = get_test_asset_id(*dbc);
+    db_disconnect(flight_safety_system::server::db_connection::write_conn_name);
+    REQUIRE_THROWS_AS(dbc->probeWrite(), flight_safety_system::server::database_error);
+
+    /* And the connection is left in a state a reconnect can use: AUTOCOMMIT is
+     * restored on the error path too. */
+    dbc->tryReconnectIfNeeded();
+    REQUIRE(dbc->isConnected());
+    const auto rows_before = std::stoull(psql_query("SELECT COUNT(*) FROM assets_assetrtt"));
+    dbc->recordRtt(asset_id, uint64_t{4243});
+    REQUIRE(std::stoull(psql_query("SELECT COUNT(*) FROM assets_assetrtt")) == rows_before + 1);
+}
+
 TEST_CASE("db_connection: getCommands returns the newest command per asset and omits absent ones")
 {
     /* Exercises the batched read end-to-end: DISTINCT ON must pick the newest

--- a/tests/mock_database.hpp
+++ b/tests/mock_database.hpp
@@ -132,6 +132,23 @@ public:
         acks.push_back({command_dbid, ack_state, ack_timestamp, ack_reason});
     }
 
+    /* Health probe (todo/78). Healthy by default; set probe_write_fail to make
+     * it throw like the real writer does on a failed probe, or
+     * probe_write_inconclusive to return the "nothing to write against"
+     * answer, which is deliberately not a success. */
+    bool probe_write_fail{false};
+    bool probe_write_inconclusive{false};
+    std::atomic<int> probe_writes{0};
+    auto probeWrite() -> bool override
+    {
+        probe_writes++;
+        if (probe_write_fail)
+        {
+            throw flight_safety_system::server::database_error("mock probe write failed");
+        }
+        return !probe_write_inconclusive;
+    }
+
     /* Snapshot accessors: copy the sink under the lock so a test can inspect it
      * without racing the write-queue worker that fills it. */
     auto getPositions() const -> std::vector<recorded_pos>

--- a/tests/server_clients_test.cpp
+++ b/tests/server_clients_test.cpp
@@ -130,7 +130,8 @@ auto count_sent(const std::vector<std::shared_ptr<fss::transport::fss_message>> 
 
 auto make_null_writer() -> std::shared_ptr<fss::server::db_write_queue>
 {
-    return std::make_shared<fss::server::db_write_queue>(std::size_t{16}, [](const fss::server::db_write_task &) {});
+    return std::make_shared<fss::server::db_write_queue>(
+        std::size_t{16}, [](const fss::server::db_write_task &) {}, []() -> bool { return true; });
 }
 
 /* Build a client that has completed the identity handshake as an aircraft. */

--- a/tests/server_clients_test.cpp
+++ b/tests/server_clients_test.cpp
@@ -131,7 +131,7 @@ auto count_sent(const std::vector<std::shared_ptr<fss::transport::fss_message>> 
 auto make_null_writer() -> std::shared_ptr<fss::server::db_write_queue>
 {
     return std::make_shared<fss::server::db_write_queue>(
-        std::size_t{16}, [](const fss::server::db_write_task &) {}, []() -> bool { return true; });
+        std::size_t{16}, [](const fss::server::db_write_task &) {}, fss_test::healthy_probe);
 }
 
 /* Build a client that has completed the identity handshake as an aircraft. */

--- a/tests/server_failsafe_test.cpp
+++ b/tests/server_failsafe_test.cpp
@@ -38,14 +38,23 @@ namespace {
  * That is also what the caller does: the main loop ticks the fail-safe once a
  * second. What the clock adds is that the tests can now say how much time a
  * tick spent — see the threshold-edge and slow-tick cases at the end, which
- * were not expressible against a call counter. */
+ * were not expressible against a call counter.
+ *
+ * The three-argument tick()/tickAfter() also supply a *fresh probe success* on
+ * every call (todo/78), because that is what the world those cases describe
+ * looks like: the database answers writes. Before todo/78 recovery needed no
+ * positive evidence at all, so leaving the probe counter still would silently
+ * rewrite every recovery case here into a no-recovery case. The cases that are
+ * about the probe itself use tickCounters() and drive all five counters
+ * explicitly. */
 class FailsafeHarness {
 public:
     FailsafeHarness(uint64_t t_disconnect_age_secs, uint64_t t_recovery_grace_secs)
         : f(t_disconnect_age_secs, t_recovery_grace_secs, clock)
     {
     }
-    /* One nominal second of the caller's loop. */
+    /* One nominal second of the caller's loop, against a database whose probe
+     * is succeeding. */
     auto tick(uint64_t write_failures, uint64_t command_drops, std::size_t pending_writes) -> db_failsafe::event
     {
         return this->tickAfter(1000, write_failures, command_drops, pending_writes);
@@ -55,15 +64,25 @@ public:
     auto tickAfter(uint64_t ms, uint64_t write_failures, uint64_t command_drops, std::size_t pending_writes)
         -> db_failsafe::event
     {
+        ++this->healthy_probe_successes;
+        return this->tickCounters(
+            ms, {write_failures, command_drops, this->healthy_probe_successes, this->probe_failures, pending_writes});
+    }
+    /* Full control of every counter the monitor reads. */
+    auto tickCounters(uint64_t ms, const db_failsafe::db_health_counters &counters) -> db_failsafe::event
+    {
         this->clock->advance(ms);
-        return this->f.tick(write_failures, command_drops, pending_writes);
+        return this->f.tick(counters);
     }
     [[nodiscard]] auto degraded() const -> bool { return this->f.degraded(); }
+    [[nodiscard]] auto wantsProbe() const -> bool { return this->f.wantsProbe(); }
     [[nodiscard]] auto reason() const -> db_failsafe::trip_reason { return this->f.reason(); }
     [[nodiscard]] auto incidentAgeSecs() const -> uint64_t { return this->f.incidentAgeSecs(); }
 private:
     std::shared_ptr<FakeClock> clock{std::make_shared<FakeClock>()};
     db_failsafe f;
+    uint64_t healthy_probe_successes{0};
+    uint64_t probe_failures{0};
 };
 
 } // namespace
@@ -250,7 +269,7 @@ TEST_CASE("db_failsafe: telemetry-only drops from a real queue never trip the fa
     };
 
     constexpr std::size_t depth = 3;
-    fss::server::db_write_queue q(depth, sink);
+    fss::server::db_write_queue q(depth, sink, []() -> bool { return true; });
     /* Park the worker on a first command so the queue fills predictably. */
     q.enqueue(fss::server::command_dispatch_write{1, 1});
     REQUIRE(fss_test::wait_for([&]() -> bool { return entered.load() >= 1; }));
@@ -395,4 +414,291 @@ TEST_CASE("db_failsafe: an incident starting at clock zero is not discarded (tod
     REQUIRE(f.tickAfter(1000, 2, 0, 0) == db_failsafe::event::none);
     REQUIRE(f.tickAfter(1000, 3, 0, 0) == db_failsafe::event::tripped); // 2s old
     REQUIRE(f.reason() == db_failsafe::trip_reason::write_failure);
+}
+
+/* ── Recovery needs positive evidence, not silence (todo/78) ─────────────── */
+
+TEST_CASE("db_failsafe: silence alone never recovers the degraded state (todo/78)")
+{
+    /* The m05 field regression, distilled. A 200 MB Postgres data directory
+     * filled until the instance PANICked and its crash recovery failed too, so
+     * the database was permanently gone — and the server announced "DB fail-safe
+     * recovered: write queue drained and quiet for 15s" sixteen seconds after
+     * the trip, readmitting the aircraft into a database that could not record
+     * a single thing about it.
+     *
+     * Both of the old conditions are about the ABSENCE of failure, and the
+     * trip's own action removes everything that could produce one: every client
+     * is severed and new ones refused, so nothing is queued and nothing fails.
+     * Drained and quiet were therefore satisfied by construction. Here they are
+     * satisfied for ten times the grace window with the probe never once
+     * succeeding, and the state must hold. */
+    FailsafeHarness f(0, 15);
+    REQUIRE(f.tickCounters(1000, {1, 0, 0, 0, 0}) == db_failsafe::event::tripped);
+    for (int i = 0; i < 150; i++)
+    {
+        REQUIRE(f.tickCounters(1000, {1, 0, 0, 0, 0}) == db_failsafe::event::none);
+        REQUIRE(f.degraded());
+        REQUIRE(f.reason() == db_failsafe::trip_reason::write_failure);
+    }
+}
+
+TEST_CASE("db_failsafe: a probe success after the quiet window recovers (todo/78)")
+{
+    FailsafeHarness f(0, 3);
+    REQUIRE(f.tickCounters(1000, {1, 0, 0, 0, 0}) == db_failsafe::event::tripped);
+    /* Drained and quiet, but no evidence: the window elapsing is not enough. */
+    REQUIRE(f.tickCounters(1000, {1, 0, 0, 0, 0}) == db_failsafe::event::none); // 1s
+    REQUIRE(f.tickCounters(1000, {1, 0, 0, 0, 0}) == db_failsafe::event::none); // 2s
+    REQUIRE(f.tickCounters(1000, {1, 0, 0, 0, 0}) == db_failsafe::event::none); // 3s
+    REQUIRE(f.tickCounters(1000, {1, 0, 0, 0, 0}) == db_failsafe::event::none); // 4s, quiet satisfied
+    REQUIRE(f.degraded());
+    /* The probe wrote a row (and rolled it back): the write path works. */
+    REQUIRE(f.tickCounters(1000, {1, 0, 1, 0, 0}) == db_failsafe::event::recovered);
+    REQUIRE(!f.degraded());
+    REQUIRE(f.reason() == db_failsafe::trip_reason::none);
+}
+
+TEST_CASE("db_failsafe: a probe success does not shortcut the quiet window (todo/78)")
+{
+    /* The probe gates the existing window, it does not replace it. A database
+     * that answers one probe in the middle of a failure burst has not shown it
+     * can carry the fleet's writes. */
+    FailsafeHarness f(0, 3);
+    REQUIRE(f.tickCounters(1000, {1, 0, 0, 0, 0}) == db_failsafe::event::tripped);
+    REQUIRE(f.tickCounters(1000, {1, 0, 1, 0, 0}) == db_failsafe::event::none); // 1s quiet
+    REQUIRE(f.tickCounters(1000, {1, 0, 2, 0, 0}) == db_failsafe::event::none); // 2s
+    REQUIRE(f.tickCounters(1000, {1, 0, 3, 0, 0}) == db_failsafe::event::none); // 3s
+    REQUIRE(f.degraded());
+    REQUIRE(f.tickCounters(1000, {1, 0, 4, 0, 0}) == db_failsafe::event::recovered); // 4s > grace
+}
+
+TEST_CASE("db_failsafe: a probe failure restarts the quiet window (todo/78)")
+{
+    FailsafeHarness f(0, 3);
+    REQUIRE(f.tickCounters(1000, {1, 0, 0, 0, 0}) == db_failsafe::event::tripped);
+    REQUIRE(f.tickCounters(1000, {1, 0, 1, 0, 0}) == db_failsafe::event::none); // a success banked
+    /* A probe failure is a demonstrated write failure, so it resets the window
+     * exactly as a real one does — recovery is deferred a full grace from here,
+     * not from the trip. */
+    REQUIRE(f.tickCounters(1000, {1, 0, 1, 1, 0}) == db_failsafe::event::none);
+    for (int i = 0; i < 3; i++)
+    {
+        REQUIRE(f.tickCounters(1000, {1, 0, 2, 1, 0}) == db_failsafe::event::none);
+        REQUIRE(f.degraded());
+    }
+    REQUIRE(f.tickCounters(1000, {1, 0, 3, 1, 0}) == db_failsafe::event::recovered);
+}
+
+TEST_CASE("db_failsafe: a permanently failing probe never recovers (todo/78)")
+{
+    /* Five simulated minutes against a database that is simply gone. Zero
+     * recovered events — which is what the aircraft in m05 needed: one latched
+     * comms-loss event, not one every twenty seconds. */
+    FailsafeHarness f(0, 15);
+    REQUIRE(f.tickCounters(1000, {1, 0, 0, 0, 0}) == db_failsafe::event::tripped);
+    uint64_t probe_failures = 0;
+    for (int i = 0; i < 300; i++)
+    {
+        REQUIRE(f.tickCounters(1000, {1, 0, 0, ++probe_failures, 0}) == db_failsafe::event::none);
+        REQUIRE(f.degraded());
+    }
+}
+
+TEST_CASE("db_failsafe: wantsProbe is true exactly while degraded (todo/78)")
+{
+    /* The cadence rule. Healthy operation must not pay for the probe at all:
+     * the caller's per-second block reads this one bool and does nothing else. */
+    FailsafeHarness f(0, 3);
+    REQUIRE(!f.wantsProbe());
+    REQUIRE(f.tickCounters(1000, {0, 0, 0, 0, 0}) == db_failsafe::event::none);
+    REQUIRE(!f.wantsProbe());
+    REQUIRE(f.tickCounters(1000, {1, 0, 0, 0, 0}) == db_failsafe::event::tripped);
+    for (int i = 0; i < 4; i++)
+    {
+        REQUIRE(f.wantsProbe());
+        REQUIRE(f.tickCounters(1000, {1, 0, 0, 0, 0}) == db_failsafe::event::none);
+    }
+    REQUIRE(f.wantsProbe());
+    REQUIRE(f.tickCounters(1000, {1, 0, 1, 0, 0}) == db_failsafe::event::recovered);
+    REQUIRE(!f.wantsProbe());
+}
+
+TEST_CASE("db_failsafe: probe successes banked before the trip do not count (todo/78)")
+{
+    /* The baseline is taken from the tick that latches, so a previous degraded
+     * episode's evidence cannot pay for this one — otherwise a server that
+     * recovered once would recover instantly forever after. */
+    FailsafeHarness f(0, 3);
+    REQUIRE(f.tickCounters(1000, {0, 0, 7, 0, 0}) == db_failsafe::event::none);
+    REQUIRE(f.tickCounters(1000, {1, 0, 7, 0, 0}) == db_failsafe::event::tripped);
+    for (int i = 0; i < 10; i++)
+    {
+        REQUIRE(f.tickCounters(1000, {1, 0, 7, 0, 0}) == db_failsafe::event::none);
+        REQUIRE(f.degraded());
+    }
+    REQUIRE(f.tickCounters(1000, {1, 0, 8, 0, 0}) == db_failsafe::event::recovered);
+}
+
+TEST_CASE("db_failsafe: a probe success does not recover while the queue holds a backlog (todo/78)")
+{
+    FailsafeHarness f(0, 2);
+    REQUIRE(f.tickCounters(1000, {1, 0, 0, 0, 5}) == db_failsafe::event::tripped);
+    uint64_t successes = 0;
+    for (int i = 0; i < 10; i++)
+    {
+        REQUIRE(f.tickCounters(1000, {1, 0, ++successes, 0, 5}) == db_failsafe::event::none);
+        REQUIRE(f.degraded());
+    }
+    REQUIRE(f.tickCounters(1000, {1, 0, ++successes, 0, 0}) == db_failsafe::event::recovered);
+}
+
+TEST_CASE("db_failsafe: a probe failure while degraded never re-trips (todo/78)")
+{
+    /* A probe failure feeds the quiet window and nothing else: the state is
+     * already latched, and re-reporting a trip would churn the caller's
+     * severance path and rewrite reason(). Checked with disconnect_age_secs 0,
+     * the setting that trips on any single write failure. */
+    FailsafeHarness f(0, 3);
+    REQUIRE(f.tickCounters(1000, {0, 1, 0, 0, 0}) == db_failsafe::event::tripped);
+    REQUIRE(f.reason() == db_failsafe::trip_reason::command_drop);
+    uint64_t probe_failures = 0;
+    for (int i = 0; i < 10; i++)
+    {
+        REQUIRE(f.tickCounters(1000, {0, 1, 0, ++probe_failures, 0}) == db_failsafe::event::none);
+        REQUIRE(f.degraded());
+        REQUIRE(f.reason() == db_failsafe::trip_reason::command_drop);
+    }
+}
+
+TEST_CASE("db_failsafe: a command-drop trip also requires a probe success (todo/78)")
+{
+    /* Both triggers share the one latch, so both share the one recovery rule.
+     * A dropped command write is known-destroyed audit state; readmitting the
+     * fleet on silence would be no better founded here than for a write
+     * failure. */
+    FailsafeHarness f(5, 3);
+    REQUIRE(f.tickCounters(1000, {0, 1, 0, 0, 0}) == db_failsafe::event::tripped);
+    for (int i = 0; i < 10; i++)
+    {
+        REQUIRE(f.tickCounters(1000, {0, 1, 0, 0, 0}) == db_failsafe::event::none);
+        REQUIRE(f.degraded());
+    }
+    REQUIRE(f.tickCounters(1000, {0, 1, 1, 0, 0}) == db_failsafe::event::recovered);
+    REQUIRE(f.reason() == db_failsafe::trip_reason::none);
+}
+
+TEST_CASE("db_failsafe: a stale probe success does not recover a hung database (todo/78)")
+{
+    /* The gap between "has ever succeeded since the trip" and "is succeeding".
+     * A *failing* probe holds the latch by restarting the quiet window. A
+     * probe that HANGS — a network partition, a failover, a frozen host —
+     * returns neither answer: no success, no failure, no counter movement, and
+     * requestProbe() coalesces so nothing accumulates behind it either. The only
+     * observable is that the last answer keeps getting older.
+     *
+     * Here one probe succeeds a second after the trip and the database then
+     * stops answering entirely. With an evidence test that had no recency
+     * requirement, that single success would still be paying for recovery ten
+     * grace windows later. */
+    FailsafeHarness f(0, 15);
+    REQUIRE(f.tickCounters(1000, {1, 0, 0, 0, 0}) == db_failsafe::event::tripped);
+    REQUIRE(f.tickCounters(1000, {1, 0, 1, 0, 0}) == db_failsafe::event::none); // the last answer ever given
+    for (int i = 0; i < 150; i++)
+    {
+        REQUIRE(f.tickCounters(1000, {1, 0, 1, 0, 0}) == db_failsafe::event::none);
+        REQUIRE(f.degraded());
+        REQUIRE(f.reason() == db_failsafe::trip_reason::write_failure);
+    }
+}
+
+TEST_CASE("db_failsafe: a probe that resumes answering recovers on that tick (todo/78)")
+{
+    /* The other half of the hung-database rule: holding the latch on missing
+     * evidence must not become holding it forever. Once the probe starts
+     * answering again the state ends on the tick that carries the answer —
+     * not before it (no credit for the silence) and not later (no extra
+     * penalty box). */
+    FailsafeHarness f(0, 15);
+    REQUIRE(f.tickCounters(1000, {1, 0, 0, 0, 0}) == db_failsafe::event::tripped);
+    REQUIRE(f.tickCounters(1000, {1, 0, 1, 0, 0}) == db_failsafe::event::none);
+    /* Sixty seconds of a hung probe: quiet has long since elapsed. */
+    for (int i = 0; i < 60; i++)
+    {
+        REQUIRE(f.tickCounters(1000, {1, 0, 1, 0, 0}) == db_failsafe::event::none);
+    }
+    REQUIRE(f.degraded());
+    REQUIRE(f.tickCounters(1000, {1, 0, 2, 0, 0}) == db_failsafe::event::recovered);
+}
+
+TEST_CASE("db_failsafe: an in-window but stale success is not evidence (todo/78)")
+{
+    /* Why the freshness test is edge-triggered rather than "a success within
+     * the last recovery_grace_ms". Those sound equivalent; they are not, and
+     * the difference is exactly the case this rule exists for.
+     *
+     * The quiet window runs from the trip, which is itself an event, so
+     * recovery is first possible one tick after trip + grace. A success
+     * arriving one tick AFTER the trip is, at that moment, almost exactly
+     * grace old — inside a "within the last grace" window by a whole tick. So
+     * that formulation would readmit the fleet here, having had one answer at
+     * t=2s and none since. Written against the clock so the arithmetic is
+     * visible: trip at 1s, sole success at 2s, quiet satisfied from 16.001s. */
+    FailsafeHarness f(0, 15);
+    REQUIRE(f.tickCounters(1000, {1, 0, 0, 0, 0}) == db_failsafe::event::tripped);
+    REQUIRE(f.tickCounters(1000, {1, 0, 1, 0, 0}) == db_failsafe::event::none);
+    REQUIRE(f.tickCounters(14001, {1, 0, 1, 0, 0}) == db_failsafe::event::none); // t=16.001s, quiet
+    REQUIRE(f.degraded());
+    REQUIRE(f.tickCounters(999, {1, 0, 1, 0, 0}) == db_failsafe::event::none); // t=17s
+    REQUIRE(f.degraded());
+}
+
+TEST_CASE("db_failsafe: the freshness rule does not delay a normal recovery (todo/78)")
+{
+    /* The freshness test must be free on a healthy database: the caller
+     * requests a probe on every degraded tick and the write queue is empty
+     * while degraded, so every tick carries the previous tick's success.
+     * Recovery lands on exactly the tick it landed on before the rule existed —
+     * compare with "recovery requires the full quiet window after the last
+     * failure" above, which is this same sequence driven through the harness's
+     * healthy-probe default. */
+    FailsafeHarness f(0, 3);
+    uint64_t successes = 0;
+    REQUIRE(f.tickCounters(1000, {1, 0, successes, 0, 0}) == db_failsafe::event::tripped);
+    REQUIRE(f.tickCounters(1000, {1, 0, ++successes, 0, 0}) == db_failsafe::event::none); // 1s quiet
+    REQUIRE(f.tickCounters(1000, {1, 0, ++successes, 0, 0}) == db_failsafe::event::none); // 2s
+    REQUIRE(f.tickCounters(1000, {1, 0, ++successes, 0, 0}) == db_failsafe::event::none); // 3s
+    REQUIRE(f.tickCounters(1000, {1, 0, ++successes, 0, 0}) == db_failsafe::event::recovered);
+    REQUIRE(!f.degraded());
+}
+
+TEST_CASE("db_failsafe: a probe slower than the tick delays recovery by at most one round trip (todo/78)")
+{
+    /* A database that answers, but slowly (a loaded instance, a long lock
+     * wait): probes complete every ~5s while the caller ticks every second, so
+     * most ticks carry no fresh success. Recovery must wait for one — and must
+     * not wait longer than the next one. The bound the state machine offers is
+     * therefore "quiet window plus at most one probe round trip", which is
+     * worth stating because it is the only case where this rule costs
+     * anything. */
+    FailsafeHarness f(0, 15);
+    uint64_t successes = 0;
+    REQUIRE(f.tickCounters(1000, {1, 0, successes, 0, 0}) == db_failsafe::event::tripped); // t=1s
+    /* Ticks 1..15 (t=2s..16s), an answer landing on every fifth. */
+    for (int i = 1; i <= 15; i++)
+    {
+        if (i % 5 == 0)
+        {
+            ++successes;
+        }
+        REQUIRE(f.tickCounters(1000, {1, 0, successes, 0, 0}) == db_failsafe::event::none);
+    }
+    /* t=17s: quiet is satisfied (16s since the trip) but the last answer landed
+     * at t=16s and this tick carries nothing new. */
+    REQUIRE(f.tickCounters(1000, {1, 0, successes, 0, 0}) == db_failsafe::event::none);
+    REQUIRE(f.degraded());
+    REQUIRE(f.tickCounters(1000, {1, 0, successes, 0, 0}) == db_failsafe::event::none); // t=18s
+    REQUIRE(f.tickCounters(1000, {1, 0, successes, 0, 0}) == db_failsafe::event::none); // t=19s
+    /* t=20s, the next completed probe: recovery, one round trip after quiet. */
+    REQUIRE(f.tickCounters(1000, {1, 0, ++successes, 0, 0}) == db_failsafe::event::recovered);
 }

--- a/tests/server_failsafe_test.cpp
+++ b/tests/server_failsafe_test.cpp
@@ -78,6 +78,7 @@ public:
     [[nodiscard]] auto wantsProbe() const -> bool { return this->f.wantsProbe(); }
     [[nodiscard]] auto reason() const -> db_failsafe::trip_reason { return this->f.reason(); }
     [[nodiscard]] auto incidentAgeSecs() const -> uint64_t { return this->f.incidentAgeSecs(); }
+    [[nodiscard]] auto degradedAgeSecs() const -> uint64_t { return this->f.degradedAgeSecs(); }
 private:
     std::shared_ptr<FakeClock> clock{std::make_shared<FakeClock>()};
     db_failsafe f;
@@ -269,7 +270,7 @@ TEST_CASE("db_failsafe: telemetry-only drops from a real queue never trip the fa
     };
 
     constexpr std::size_t depth = 3;
-    fss::server::db_write_queue q(depth, sink, []() -> bool { return true; });
+    fss::server::db_write_queue q(depth, sink, fss_test::healthy_probe);
     /* Park the worker on a first command so the queue fills predictably. */
     q.enqueue(fss::server::command_dispatch_write{1, 1});
     REQUIRE(fss_test::wait_for([&]() -> bool { return entered.load() >= 1; }));
@@ -701,4 +702,49 @@ TEST_CASE("db_failsafe: a probe slower than the tick delays recovery by at most 
     REQUIRE(f.tickCounters(1000, {1, 0, successes, 0, 0}) == db_failsafe::event::none); // t=19s
     /* t=20s, the next completed probe: recovery, one round trip after quiet. */
     REQUIRE(f.tickCounters(1000, {1, 0, ++successes, 0, 0}) == db_failsafe::event::recovered);
+}
+
+TEST_CASE("db_failsafe: degradedAgeSecs measures the severance, not the incident (todo/78)")
+{
+    /* The periodic still-degraded log reports this, and it is deliberately not
+     * incidentAgeSecs(): an incident is a run of write failures, which the
+     * command-drop path does not have at all, while this measures how long
+     * sessions have actually been refused. Read against the tick's own clock,
+     * for the same reason incidentAgeSecs() is — the number logged is the one
+     * the decision was made on. */
+    SECTION("zero before a trip, and again after recovery")
+    {
+        FailsafeHarness f(0, 15);
+        REQUIRE(f.degradedAgeSecs() == 0);
+        REQUIRE(f.tick(0, 0, 0) == db_failsafe::event::none);
+        REQUIRE(f.degradedAgeSecs() == 0);
+        REQUIRE(f.tick(1, 0, 0) == db_failsafe::event::tripped);
+        for (int i = 0; i < 16; i++)
+        {
+            f.tick(1, 0, 0);
+        }
+        REQUIRE_FALSE(f.degraded());
+        REQUIRE(f.degradedAgeSecs() == 0);
+    }
+    SECTION("counts from the trip while the state is latched")
+    {
+        FailsafeHarness f(0, 15);
+        REQUIRE(f.tickCounters(1000, {1, 0, 0, 0, 0}) == db_failsafe::event::tripped);
+        REQUIRE(f.degradedAgeSecs() == 0);
+        /* A hung probe: no counter moves, so the latch holds and the age runs. */
+        for (int i = 1; i <= 60; i++)
+        {
+            REQUIRE(f.tickCounters(1000, {1, 0, 0, 0, 0}) == db_failsafe::event::none);
+            REQUIRE(f.degradedAgeSecs() == static_cast<uint64_t>(i));
+        }
+    }
+    SECTION("a command-drop trip has no incident but still has a degraded age")
+    {
+        FailsafeHarness f(5, 15);
+        REQUIRE(f.tickCounters(1000, {0, 1, 0, 0, 0}) == db_failsafe::event::tripped);
+        REQUIRE(f.reason() == db_failsafe::trip_reason::command_drop);
+        REQUIRE(f.incidentAgeSecs() == 0);
+        REQUIRE(f.tickCounters(1000, {0, 1, 0, 0, 0}) == db_failsafe::event::none);
+        REQUIRE(f.degradedAgeSecs() == 1);
+    }
 }

--- a/tests/server_session_test.cpp
+++ b/tests/server_session_test.cpp
@@ -215,7 +215,8 @@ auto make_mock_writer(fss_test::MockDatabase &mock) -> std::shared_ptr<fss::serv
                    },
                    task);
     };
-    return std::make_shared<fss::server::db_write_queue>(std::size_t{1024}, sink);
+    return std::make_shared<fss::server::db_write_queue>(std::size_t{1024}, sink,
+                                                         [&mock]() -> bool { return mock.probeWrite(); });
 }
 
 class NullClientHandler : public fss::server::fss_client_handler {

--- a/tests/test_helpers.hpp
+++ b/tests/test_helpers.hpp
@@ -307,4 +307,20 @@ inline auto make_framed_buffer(uint16_t type, uint64_t msg_id, const std::string
     return bl;
 }
 
+/* The probe function for every db_write_queue whose test does not exercise the
+ * probe itself (todo/78). The constructor takes one as a required argument on
+ * purpose — a server wired without a probe could never leave the degraded state,
+ * so that has to be a compile error rather than something to discover in the
+ * field — which means every construction site needs a probe even when the probe
+ * is beside the point. This is that probe, in one place, for the same reason
+ * FakeClock lives here: it was otherwise copy-pasted verbatim across five files.
+ *
+ * Deliberately NOT a default argument on the constructor: a default is exactly
+ * the silent mis-wiring the required parameter exists to prevent, and it would
+ * apply to production callers too, not just tests. */
+inline auto healthy_probe() -> bool
+{
+    return true;
+}
+
 } // namespace fss_test

--- a/tests/timeout_test.cpp
+++ b/tests/timeout_test.cpp
@@ -47,8 +47,8 @@ protected:
  * position_report, system_status, search_status), so a no-op sink suffices. */
 auto make_null_writer() -> std::shared_ptr<fss::server::db_write_queue>
 {
-    return std::make_shared<fss::server::db_write_queue>(std::size_t{64},
-                                                         [](const fss::server::db_write_task &) -> void {});
+    return std::make_shared<fss::server::db_write_queue>(
+        std::size_t{64}, [](const fss::server::db_write_task &) -> void {}, []() -> bool { return true; });
 }
 
 class NullClientHandler : public fss::server::fss_client_handler {

--- a/tests/timeout_test.cpp
+++ b/tests/timeout_test.cpp
@@ -48,7 +48,7 @@ protected:
 auto make_null_writer() -> std::shared_ptr<fss::server::db_write_queue>
 {
     return std::make_shared<fss::server::db_write_queue>(
-        std::size_t{64}, [](const fss::server::db_write_task &) -> void {}, []() -> bool { return true; });
+        std::size_t{64}, [](const fss::server::db_write_task &) -> void {}, fss_test::healthy_probe);
 }
 
 class NullClientHandler : public fss::server::fss_client_handler {


### PR DESCRIPTION
## Description

Recovery was "the write queue has drained AND nothing has failed for the grace window". Both are statements about the ABSENCE of failure, and the trip's own action removes everything that could produce one: disconnectAll() severs every session and the admission gate refuses new ones, so no telemetry arrives, nothing is queued, nothing fails. Drained-and-quiet was therefore satisfied by construction about recovery_grace_secs after every trip, whatever the database was doing. "Readmitted traffic is itself the health probe" -- the claim this commit deletes from server-failsafe.hpp -- describes a probe whose result arrives only after the fleet has been let back in.

Path M m05 caught it: a Postgres that PANICked on a full disk and could not crash-recover, permanently gone, and the server severed at 08:49:21 and declared itself recovered at 08:49:37 into the same dead instance. Against a permanently dead database that is a ~20 s cycle forever, each cycle taking a connected aircraft out of and back into its comms-loss failsafe -- the opposite of the one clean latched event todo/47 exists to produce.

Recovery now also requires a probe write to have succeeded, observed on the recovering tick itself: an INSERT into assets_assetrtt selecting its asset id from assets_asset, inside a transaction that is rolled back. Both tables are already in required_columns[], so this adds no table, no column, no fss-web migration and no change to the minimum migration floor.

The evidence must be fresh, not merely on record. A failing probe holds the latch by restarting the quiet window, but a probe that HANGS -- a partition, a failover, a frozen host -- returns neither answer, so no counter moves at all and requestProbe() coalesces so nothing accumulates behind it. A "has succeeded at some point since the trip" test would let one early success pay for a recovery arbitrarily later. A time-boxed version ("a success within the last grace") sounds equivalent and is not: the quiet window runs from the trip, so a success landing one tick after it is still inside such a window when quiet first elapses, and that formulation admits the very case it excludes, by a margin of one tick. Requiring the success on the recovering tick has no constant in it.

db_failsafe stays a pure state machine performing no I/O. The probe runs on the db_write_queue worker thread, which already owns the write connection and already blocks on it by design; the main loop only sets a flag, so decision 46's no-synchronous-DB-work-on-the-main-loop contract is untouched. Deliberately not a db_write_task: a queued probe makes pending_count() non-zero, which the drain check reads as "not drained", and recovery would become unreachable -- worse than the defect being fixed. Probe failures get their own counter rather than feeding write_failure_count(), which the main loop logs at ERROR on every change and would otherwise emit once a second forever against a dead database.

ECPG ends an open transaction by COMMITting it when AUTOCOMMIT is switched back on, so db_probe_write() issues an explicit ROLLBACK first; without it the probe would have persisted a fabricated rtt=0 sample for a disconnected aircraft into a table the operator reads. AUTOCOMMIT is restored on every exit path including the error paths. A zero-row result (empty assets_asset) is inconclusive, not success -- it fires no trigger and extends no heap page, so it proves nothing.

Because the fix makes silence the correct outcome against a dead database, and silence is what an operator cannot act on, the degraded state now logs a rate-limited ERROR naming elapsed time, probe counts and the last probe error, and the recovery line states the evidence.

Accepted residual, recorded in the decision file: a rolled-back INSERT generates WAL but never forces an fsync, so a database that can buffer a write but not flush it can pass the probe and still fail a real commit. A dedicated committed probe table is the named upgrade path, and needs an fss-web migration. The intermittent-write-fault flap the probe narrows but does not close is filed as todo/81.

Verified: make check green (480 cases, 445 passed, 35 skipped); check-code.sh clean; the four freshness cases fail with the freshness conjunct disabled and pass with it; e2e test_db_write_only_failure, test_db_disk_full, test_db_blackhole and test_slow_db_does_not_stall all pass, in 167s against a 166s baseline -- recovery timing on a healthy database did not move.

## Summary by Sourcery

Require explicit, positive DB write evidence for server fail-safe recovery instead of relying on drained-and-quiet timers, and wire a new health probe through the write queue and database connection with supporting logging and documentation.

New Features:
- Introduce a dedicated DB health probe that performs a non-persistent write on the write connection to serve as recovery evidence for the fail-safe.
- Expose probe controls and counters via the async write queue so the main loop can request probes and observe their outcomes.
- Add an IDatabase::probeWrite API and implement it for the real DB connection and mocks to integrate probing into the server.

Bug Fixes:
- Prevent the DB fail-safe from declaring recovery solely on silence and drained queues, fixing flapping against permanently or write-only broken databases.
- Ensure the DB health probe never persists test rows and always restores AUTOCOMMIT, avoiding silent telemetry loss or bogus data.
- Guarantee that server shutdown does not hang when a probe is outstanding and that probes are ignored after stop.

Enhancements:
- Refine db_failsafe state machine to consume structured health counters, incorporate probe success/failure into recovery logic, and add a wantsProbe cadence signal.
- Improve degraded-state observability with periodic ERROR logs that report elapsed time and probe statistics, and clarify recovery logs to state the positive evidence.
- Update decision documentation to describe the new recovery rule, probe semantics, and accepted residual risks and alternatives.
- Extend unit and e2e test coverage around fail-safe recovery, probe behavior, disk-full and write-only failure scenarios, including timing and flapping constraints.

Documentation:
- Revise the DB fail-safe latch decision document to document the new probe-based recovery condition, rationale from field incidents, and remaining trade-offs.

Tests:
- Add comprehensive tests for db_failsafe probe gating, freshness requirements, wantsProbe behavior, and non-flapping recovery semantics.
- Add tests for the write queue’s probe lifecycle, logging, and counters, including coalescing requests, inconclusive results, and error handling.
- Add live DB tests for probeWrite covering non-persistence, AUTOCOMMIT restoration, and failure behavior on disconnected connections.
- Update and extend e2e tests for write-only failures, disk-full scenarios, and slow databases to validate that recovery only occurs on real write success and that dead instances never trigger recovery.