### PR TITLE
feat(server): enforce fss-web asset retirement (todo/80)

### DIFF
--- a/e2e/schema/001_init.sql
+++ b/e2e/schema/001_init.sql
@@ -8,10 +8,18 @@
 
 CREATE EXTENSION IF NOT EXISTS postgis;
 
+-- retired_at exists as of fss-web migration 0013: retirement replaces deletion,
+-- so an asset keeps its identity and audit history while ceasing to be flyable.
+-- Nullable and indexed, exactly as 0013 declares it. A non-NULL value makes the
+-- asset an unknown identity to FSS (todo/80); clearing it returns the asset to
+-- service under the same id.
 CREATE TABLE assets_asset (
     id          BIGSERIAL PRIMARY KEY,
-    name        VARCHAR(64) NOT NULL UNIQUE
+    name        VARCHAR(64) NOT NULL UNIQUE,
+    retired_at  TIMESTAMP WITH TIME ZONE
 );
+
+CREATE INDEX assets_asset_retired_at_idx ON assets_asset (retired_at);
 
 -- position is nullable and gps_fix_valid exists as of fss-web migration 0016:
 -- a report whose coordinates are not GPS-backed is still stored (the autopilot's

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -333,6 +333,46 @@ auto flight_safety_system::server::db_connection::getCommands(const std::vector<
     return res;
 }
 
+auto flight_safety_system::server::db_connection::getRetiredAssets(const std::vector<uint64_t> &asset_ids)
+    -> std::optional<std::unordered_set<uint64_t>>
+{
+    std::unordered_set<uint64_t> res;
+    if (asset_ids.empty())
+    {
+        return res;
+    }
+    /* Same host-type copy as getCommands: uint64_t may be a distinct type from
+     * the unsigned long long server-db.h uses, and the pointers do not convert. */
+    std::vector<unsigned long long> ids(asset_ids.begin(), asset_ids.end());
+    unsigned long long *retired = nullptr;
+    size_t retired_count = 0;
+    int fetch_error = 0;
+    {
+        std::scoped_lock guard(this->read_lock);
+        retired = db_asset_retired_get(read_conn_name, ids.data(), ids.size(), &retired_count, &fetch_error);
+    }
+    /* The C layer already discards a partial read rather than returning one, so
+     * there is nothing half-built to clean up here — but the array still has to
+     * be freed on both paths, since a successful read of zero retired assets
+     * also returns an allocation. */
+    if (fetch_error != 0)
+    {
+        db_free_retired_assets(retired);
+        FSS_LOG_ERROR("db", "retired-asset read failed; severing nobody this pass (todo/80)");
+        return std::nullopt;
+    }
+    if (retired != nullptr)
+    {
+        res.reserve(retired_count);
+        for (size_t i = 0; i < retired_count; i++)
+        {
+            res.insert(retired[i]);
+        }
+        db_free_retired_assets(retired);
+    }
+    return res;
+}
+
 auto flight_safety_system::server::db_connection::getSmmSettings(uint64_t asset_id)
     -> std::optional<std::shared_ptr<smm_settings>>
 {

--- a/src/fss-server.hpp
+++ b/src/fss-server.hpp
@@ -16,6 +16,7 @@
 #include <mutex>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -167,6 +168,21 @@ public:
      * and wait for the next tick (todo/69). */
     virtual auto getCommands(const std::vector<uint64_t> &asset_ids)
         -> std::optional<std::unordered_map<uint64_t, std::shared_ptr<asset_command>>> = 0;
+    /* Which of the given assets have been retired in fss-web (todo/80), so a
+     * session that identified while its asset was still active can be severed
+     * rather than flying on. An id absent from the set is active.
+     *
+     * nullopt is the read failing, and it is NOT an empty set: an empty set
+     * says "every one of these is active", which is the answer that keeps a
+     * retired aircraft connected. On nullopt the caller must sever nobody and
+     * retry on the next pass — the same leave-it-alone rule getCommands uses,
+     * for the sharper reason that here the misread direction is unsafe.
+     *
+     * Called from the command poller, off the session hot path: enforcement is
+     * eventually consistent within one poll interval by design, and that bound
+     * is stated in docs/decisions/80-retired-asset-enforcement.md. */
+    virtual auto getRetiredAssets(const std::vector<uint64_t> &asset_ids)
+        -> std::optional<std::unordered_set<uint64_t>> = 0;
     /* The complete set of active servers, or nullopt when the read was cut
      * short (mid-cursor error, truncated row) and could only produce a
      * partial, misleading list. nullopt is NOT an empty list: the caller must
@@ -191,8 +207,8 @@ private:
      * block a command/config read. Each connection is guarded by its own
      * mutex and therefore only ever used by one thread at a time — the
      * thread-safe usage pattern ECPG documents. read_lock covers getAssetId,
-     * getCommand, getCommands, getActiveServers and getSmmSettings; write_lock
-     * covers the record* telemetry inserts. */
+     * getCommand, getCommands, getRetiredAssets, getActiveServers and
+     * getSmmSettings; write_lock covers the record* telemetry inserts. */
     std::mutex read_lock;
     std::mutex write_lock;
     /* Read without holding either mutex by isConnected(), and written from
@@ -233,6 +249,8 @@ public:
     auto getCommand(uint64_t asset_id) -> std::optional<std::shared_ptr<asset_command>> override;
     auto getCommands(const std::vector<uint64_t> &asset_ids)
         -> std::optional<std::unordered_map<uint64_t, std::shared_ptr<asset_command>>> override;
+    auto getRetiredAssets(const std::vector<uint64_t> &asset_ids)
+        -> std::optional<std::unordered_set<uint64_t>> override;
     auto getActiveServers() -> std::optional<std::vector<fss_server_details>> override;
     auto getSmmSettings(uint64_t asset_id) -> std::optional<std::shared_ptr<smm_settings>> override;
     auto isConnected() const -> bool override;

--- a/src/server-clients.cpp
+++ b/src/server-clients.cpp
@@ -292,6 +292,43 @@ auto server_clients::disconnectRevokedClients(const std::string &crl_file) -> st
     return disconnected_count;
 }
 
+/* docs/decisions/80-retired-asset-enforcement.md: severs the sessions
+ * pollRetiredAssets() observed to belong to a retired asset. Detection ran on
+ * the command poller (it is a DB read); this runs on the main loop, because
+ * disconnect() blocks on socket I/O and joins the recv thread and must not sit
+ * on the thread that dispatches commands to everyone else.
+ *
+ * Same disconnect()+clientDisconnected() pattern as disconnectRevokedClients()
+ * and disconnectAll(), and safe by the same reasoning: both calls are
+ * idempotent, so a client racing its own concurrent teardown between the poll
+ * and this drain is handled harmlessly. clientDisconnected() is what releases
+ * the asset_owners claim (see its todo/44 comment), which is what lets the
+ * asset identify again after reactivation without a server restart.
+ *
+ * The list is drained under `lock` and acted on outside it, like every other
+ * severing path in this class. */
+auto server_clients::disconnectRetiredClients() -> std::size_t
+{
+    std::vector<std::shared_ptr<flight_safety_system::server::fss_client>> retired{};
+    {
+        std::scoped_lock guard(this->lock);
+        retired.swap(this->pending_retirement);
+    }
+    std::size_t disconnected_count = 0;
+    for (const auto &client : retired)
+    {
+        /* Logged per session rather than as a count: retirement is an
+         * administrative act on one aircraft, and an operator who retires the
+         * wrong asset needs to see which session went. */
+        FSS_LOG_WARN("server", "Disconnecting session for retired asset_id " << client->getCachedAssetId()
+                                                                             << " (fss-web retired_at is set)");
+        client->disconnect();
+        this->clientDisconnected(client.get());
+        disconnected_count++;
+    }
+    return disconnected_count;
+}
+
 /* docs/decisions/34-45-47-db-failsafe-latch.md: unconditional version of
  * disconnectRevokedClients above, for the main loop's sustained-DB-write-
  * failure guard — every currently live session gets severed (CAP/test-plan's

--- a/src/server-clients.hpp
+++ b/src/server-clients.hpp
@@ -2,6 +2,7 @@
 
 #include "fss-server.hpp"
 
+#include <algorithm>
 #include <atomic>
 #include <list>
 #include <map>
@@ -46,6 +47,18 @@ private:
      * allowed to read the DB for it); broadcast by the main loop, which must
      * never perform a synchronous DB read. */
     std::shared_ptr<flight_safety_system::transport::fss_message_server_list> cached_server_list{};
+    /* Sessions the poller has observed to be retired, waiting for the main loop
+     * to sever them (todo/80). Guarded by lock.
+     *
+     * The hand-off exists because the two halves belong on different threads.
+     * Detection is a DB read, which may only happen on the command poller; the
+     * severing is disconnect(), which blocks on socket I/O and joins the recv
+     * thread, and running that on the poller would let one black-holed peer
+     * stall command polling for the whole fleet — the hazard todo/46 moved
+     * db_ping off that thread to avoid. The main loop already severs clients
+     * this way for CRL reloads and for the fail-safe, so this list is drained
+     * where that work already lives. */
+    std::vector<std::shared_ptr<flight_safety_system::server::fss_client>> pending_retirement{};
     /* Copy the client list under the lock so the caller can act on it
      * outside the lock: sends block on sockets and disconnect() joins recv
      * threads, and neither may ever run while holding it.  A client that is
@@ -178,6 +191,56 @@ public:
             client->setPendingCommand(found != commands->end() ? found->second : nullptr);
         }
     };
+    void pollRetiredAssets(flight_safety_system::server::IDatabase *dbc)
+    {
+        /* Same (client, asset_id) snapshot discipline as pollCommands above: a
+         * client that identifies mid-pass must not be queried under one id and
+         * severed under another. */
+        std::vector<std::pair<std::shared_ptr<flight_safety_system::server::fss_client>, uint64_t>> identified;
+        std::vector<uint64_t> asset_ids;
+        for (const auto &client : this->snapshotClients())
+        {
+            uint64_t asset_id = client->getCachedAssetId(); /* atomic */
+            if (asset_id != 0)
+            {
+                identified.emplace_back(client, asset_id);
+                asset_ids.push_back(asset_id);
+            }
+        }
+        if (identified.empty())
+        {
+            return;
+        }
+        auto retired = dbc->getRetiredAssets(asset_ids);
+        /* nullopt is the read failing. Sever nobody and retry next pass: an
+         * empty set would say "all active", and acting on a failed read in that
+         * direction is how a retired aircraft keeps flying (todo/80). The
+         * opposite direction — severing the fleet on a failed read — is worse
+         * still, which is why the failure is silent here beyond db.cpp's log. */
+        if (!retired.has_value() || retired->empty())
+        {
+            return;
+        }
+        std::scoped_lock guard(this->lock);
+        for (const auto &[client, asset_id] : identified)
+        {
+            if (retired->count(asset_id) == 0)
+            {
+                continue;
+            }
+            /* Deduplicate against a hand-off the main loop has not drained yet:
+             * the poller can observe the same retirement on consecutive passes.
+             * disconnect() is idempotent so a double entry would be harmless,
+             * but the log line it produces is not — an operator reading two
+             * severance warnings for one retirement would reasonably look for a
+             * second session that never existed. */
+            auto already = std::find(this->pending_retirement.begin(), this->pending_retirement.end(), client);
+            if (already == this->pending_retirement.end())
+            {
+                this->pending_retirement.push_back(client);
+            }
+        }
+    };
     void sendCommand()
     {
         /* Schedule on each client's outbound writer thread rather than sending
@@ -191,5 +254,6 @@ public:
     auto resolveDuplicateIdentity(flight_safety_system::server::fss_client *newcomer, uint64_t asset_id)
         -> bool override;
     auto disconnectRevokedClients(const std::string &crl_file) -> std::size_t;
+    auto disconnectRetiredClients() -> std::size_t;
     auto disconnectAll() -> std::size_t;
 };

--- a/src/server-db.h
+++ b/src/server-db.h
@@ -163,6 +163,29 @@ struct asset_command_row_s **db_asset_commands_get(const char *conn, const unsig
  * the rows or their command strings -- free those first (see Ownership above). */
 void db_free_asset_commands(struct asset_command_row_s **commands);
 
+/* Which of the given assets are retired (assets_asset.retired_at IS NOT NULL,
+ * fss-web migration 0013), in a single round-trip -- the batched read behind
+ * FSS's enforcement of retirement against sessions that identified while still
+ * active (todo/80). Writes the number of ids found to *out_count.
+ *
+ * The result is a SUBSET of asset_ids, ordered by id, so it is not positionally
+ * aligned with the input: an id absent from the result is active.
+ *
+ * error_out (may be NULL) is set to 1 on an allocation failure or a mid-cursor
+ * read error. Unlike db_asset_commands_get, a partial read is discarded here
+ * rather than returned: a retired asset missing from a truncated list reads as
+ * active, and this is the one query where failing that way keeps a retired
+ * aircraft flying. On failure the caller must change nothing and retry.
+ *
+ * NULL with *error_out == 0 means no id in the batch is retired. Ownership is
+ * whole: pass the array to db_free_retired_assets. count == 0 answers without
+ * querying. */
+unsigned long long *db_asset_retired_get(const char *conn, const unsigned long long *asset_ids, size_t count,
+                                         size_t *out_count, int *error_out);
+/* Frees the array returned by db_asset_retired_get, in full (no split
+ * ownership: the array holds scalars, not rows the caller took out of it). */
+void db_free_retired_assets(unsigned long long *asset_ids);
+
 struct smm_settings_s {
     char *address;
     char *username;

--- a/src/server-db.pgc
+++ b/src/server-db.pgc
@@ -96,14 +96,26 @@ unsigned long long db_get_asset_id(const char *conn_arg, const char *asset_name_
     unsigned long long asset_id = 0;
     EXEC SQL END DECLARE SECTION;
 
-    EXEC SQL AT :conn SELECT id INTO :asset_id FROM assets_asset WHERE name = :asset_name;
+    /* retired_at IS NULL makes a retired asset an unknown identity rather than
+     * a recognised one that happens to be out of service (todo/80): fss-web
+     * migration 0013 retires assets instead of deleting them, so the row (and
+     * its history) stays behind, and without this clause a retired aircraft
+     * would still identify, still write telemetry and still be handed the
+     * newest command. Retirement is reversible -- clearing retired_at returns
+     * the same id to service on the next identify, with no state here to
+     * unwind. */
+    EXEC SQL AT :conn SELECT id INTO :asset_id FROM assets_asset
+        WHERE name = :asset_name AND retired_at IS NULL;
 
     if (sqlca.sqlcode < 0)
     {
         /* A query failure (connection down, etc.) still returns 0 for the id
          * like an unknown asset, but error_out lets the caller (todo/60) tell
          * the two apart instead of treating every read outage as a fleet of
-         * unregistered assets. Print the SQL error so the log tells the truth
+         * unregistered assets. A retired asset is deliberately NOT an error:
+         * it takes the unknown-asset path above (0 with *error_out left 0),
+         * because it is a policy answer the database gave successfully, not a
+         * failure to read one. Print the SQL error so the log tells the truth
          * about why identification failed. */
         sqlprint();
         if (error_out != NULL)
@@ -532,6 +544,135 @@ db_asset_commands_get(const char *conn_arg, const unsigned long long *asset_ids,
     return res;
 }
 
+unsigned long long *
+db_asset_retired_get(const char *conn_arg, const unsigned long long *asset_ids, size_t count, size_t *out_count,
+                     int *error_out)
+{
+    size_t len = 0;
+    if (error_out != NULL)
+    {
+        *error_out = 0;
+    }
+    if (out_count != NULL)
+    {
+        *out_count = 0;
+    }
+
+    /* No assets means nothing to ask about, and an empty set would build an
+     * invalid "IN ()" clause -- answer without touching the DB. NULL with
+     * *error_out == 0 is the empty answer; NULL with *error_out == 1 is a
+     * failure, which is the distinction the caller acts on. */
+    if (count == 0)
+    {
+        return NULL;
+    }
+
+    /* The result is a subset of the ids asked about, so the exact worst case is
+     * known up front: allocate once and never grow. That is the whole reason
+     * this function does not carry db_asset_commands_get's realloc-per-row
+     * dance -- there is no row payload to own, only ids we already hold. */
+    unsigned long long *res = (unsigned long long *)malloc(sizeof(unsigned long long) * count);
+    if (res == NULL)
+    {
+        if (error_out != NULL)
+        {
+            *error_out = 1;
+        }
+        return NULL;
+    }
+
+    /* Same id-concatenation as db_asset_commands_get above, and safe for the
+     * same reason: these are uint64s the server holds, never text from a
+     * client. Each id is at most 20 decimal digits plus a separator. */
+    static const char *sql_prefix = "SELECT id FROM assets_asset WHERE retired_at IS NOT NULL AND id IN (";
+    static const char *sql_suffix = ") ORDER BY id";
+    const size_t id_max = 21; /* up to 20 digits + ',' */
+    size_t buf_size = strlen(sql_prefix) + strlen(sql_suffix) + (count * id_max) + 1;
+    char *query_buf = (char *)malloc(buf_size);
+    if (query_buf == NULL)
+    {
+        free(res);
+        if (error_out != NULL)
+        {
+            *error_out = 1;
+        }
+        return NULL;
+    }
+    int written = snprintf(query_buf, buf_size, "%s", sql_prefix);
+    size_t off = (written < 0) ? 0 : (size_t)written;
+    for (size_t i = 0; i < count; i++)
+    {
+        written = snprintf(query_buf + off, buf_size - off, "%s%llu", (i == 0) ? "" : ",", asset_ids[i]);
+        off += (written < 0) ? 0 : (size_t)written;
+    }
+    snprintf(query_buf + off, buf_size - off, "%s", sql_suffix);
+
+    EXEC SQL BEGIN DECLARE SECTION;
+    const char *conn = conn_arg;
+    const char *query = query_buf;
+    unsigned long long r_asset_id = 0;
+    EXEC SQL END DECLARE SECTION;
+
+    /* Cursor over a dynamically-prepared statement, the same AUTOCOMMIT OFF /
+     * DECLARE / OPEN / FETCH / CLOSE idiom as db_asset_commands_get. Distinct
+     * statement and cursor names so the two can never collide on a tick that
+     * runs both. */
+    EXEC SQL AT :conn SET AUTOCOMMIT TO OFF;
+    EXEC SQL AT :conn PREPARE retstmt FROM :query;
+    EXEC SQL AT :conn DECLARE retcur CURSOR FOR retstmt;
+    EXEC SQL AT :conn OPEN retcur;
+
+    EXEC SQL WHENEVER NOT FOUND DO BREAK;
+    EXEC SQL WHENEVER SQLERROR DO BREAK;
+    while (1)
+    {
+        EXEC SQL AT :conn FETCH FROM retcur INTO :r_asset_id;
+        /* Cannot overrun: the server asked about `count` distinct ids and id is
+         * the primary key, so at most `count` rows can come back. The guard is
+         * here anyway because the allocation's safety depends on a property of
+         * the query text several lines away. */
+        if (len < count)
+        {
+            res[len] = r_asset_id;
+            len++;
+        }
+    }
+    EXEC SQL WHENEVER NOT FOUND CONTINUE;
+    EXEC SQL WHENEVER SQLERROR CONTINUE;
+
+    /* sqlca still reflects the FETCH that ended the loop; a negative sqlcode is
+     * a mid-cursor error rather than the normal NOT FOUND (100). Capture it
+     * before CLOSE / SET AUTOCOMMIT overwrite sqlca.
+     *
+     * A partial read here is worse than a partial command read: a retired asset
+     * missing from a truncated list reads as "still active", which is exactly
+     * the wrong way to fail for a safety boundary. Discard the whole thing and
+     * report failure -- the caller then changes nothing and retries next tick,
+     * leaving the fleet as it stands rather than acting on a list that cannot
+     * be told apart from a complete one. */
+    if (sqlca.sqlcode < 0)
+    {
+        if (error_out != NULL)
+        {
+            *error_out = 1;
+        }
+        free(res);
+        res = NULL;
+        len = 0;
+    }
+
+    EXEC SQL AT :conn CLOSE retcur;
+    EXEC SQL AT :conn DEALLOCATE PREPARE retstmt;
+    EXEC SQL AT :conn SET AUTOCOMMIT TO ON;
+
+    free(query_buf);
+    if (out_count != NULL)
+    {
+        *out_count = len;
+    }
+    return res;
+}
+
 #define HTTP_PORT 80
 #define HTTPS_PORT 443
 
@@ -882,6 +1023,14 @@ struct required_column_s {
  * that actually bite: they arrived with fss-web's assets migration 0008, and a
  * deployment missing it severs the whole fleet on the first command.
  *
+ * assets_asset.retired_at is the second such gate (fss-web migration 0013,
+ * todo/80). Listing it here is deliberate and load-bearing: retirement is a
+ * safety boundary, and a release that enforces it must refuse to start against
+ * a schema that cannot express it rather than run on happily and keep flying
+ * retired aircraft. An operator who upgrades FSS ahead of fss-web therefore
+ * gets a server that will not start and names the missing column -- which is
+ * the intended outcome, and is why the release note has to say so.
+ *
  * buffer_len is the sizeof() of the fixed host variable the column is fetched
  * into, so the widest value that survives is buffer_len - 1: ECPG fills the
  * buffer to capacity and leaves no room for a terminator, and the truncation
@@ -890,6 +1039,7 @@ struct required_column_s {
 static const struct required_column_s required_columns[] = {
     {"assets_asset", "id", 0},
     {"assets_asset", "name", 0},
+    {"assets_asset", "retired_at", 0},
     {"assets_assetposition", "asset_id", 0},
     {"assets_assetposition", "position", 0},
     {"assets_assetposition", "altitude", 0},
@@ -1164,4 +1314,11 @@ void db_free_asset_commands(struct asset_command_row_s **commands)
     /* Frees only the array; the caller frees each row (and its command string)
      * as it consumes them, as getActiveServers does for db_free_fss_servers. */
     free(commands);
+}
+
+void db_free_retired_assets(unsigned long long *asset_ids)
+{
+    /* One flat block of scalars, so unlike db_free_asset_commands there is no
+     * split ownership here: this frees everything the caller was given. */
+    free(asset_ids);
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -456,6 +456,19 @@ auto main(int argc, char *argv[]) -> int
                     dbc->tryReconnectIfNeeded();
                 }
                 clients->pollCommands(dbc.get());
+                /* Retirement enforcement for already-identified sessions
+                 * (todo/80). Once a second, not every tick: retirement is an
+                 * administrative act, so a second of latency costs nothing,
+                 * and at 100 ms it would double this poller's query rate to
+                 * chase an event that happens a handful of times a year. The
+                 * severing itself is the main loop's job — pollRetiredAssets
+                 * only records who to sever, because disconnect() blocks.
+                 * Worst case observed-to-severed is therefore this second plus
+                 * the main loop's next 100 ms tick. */
+                if ((poll_counter % ticks_per_sec) == 0)
+                {
+                    clients->pollRetiredAssets(dbc.get());
+                }
                 /* Config reads share the poller so the main loop never
                  * touches the DB. First refresh happens immediately
                  * (counter 0) so the caches are primed at startup. */
@@ -535,6 +548,12 @@ auto main(int argc, char *argv[]) -> int
         const bool do_per_config_period = now_ms >= next_config_ms;
         tick_guard.run([&]() -> void {
             clients->sendCommand();
+            /* Every tick, not once a second (todo/80): the poller found these
+             * sessions up to a second ago, and the whole point of the split is
+             * that the blocking half runs promptly on the thread that can
+             * afford to block. Drains to nothing on the overwhelming majority
+             * of ticks, where it costs one uncontended mutex acquisition. */
+            clients->disconnectRetiredClients();
             if (do_per_second)
             {
                 clients->cleanupRemovableClients();

--- a/tests/concurrency_client_test.cpp
+++ b/tests/concurrency_client_test.cpp
@@ -122,6 +122,11 @@ public:
         /* An engaged empty map: nobody has a pending command, not a failed read. */
         return std::unordered_map<uint64_t, std::shared_ptr<flight_safety_system::server::asset_command>>{};
     }
+    auto getRetiredAssets(const std::vector<uint64_t> &) -> std::optional<std::unordered_set<uint64_t>> override
+    {
+        /* An engaged empty set: every asset is active, not a failed read. */
+        return std::unordered_set<uint64_t>{};
+    }
     auto getActiveServers() -> std::optional<std::vector<flight_safety_system::server::fss_server_details>> override
     {
         /* An engaged empty vector: no servers configured, not a failed read. */

--- a/tests/db-fixtures.sql
+++ b/tests/db-fixtures.sql
@@ -32,3 +32,10 @@ INSERT INTO config_serverconfig (address, client_port, active, name, config_port
 -- A pending command for test-asset, so the getCommand DB test finds a row.
 INSERT INTO assets_assetcommand (asset_id, command)
     SELECT a.id, 'RTL' FROM assets_asset a WHERE a.name = 'test-asset';
+
+-- todo/80 fixture: an asset retired in fss-web (migration 0013). Seeded
+-- permanently retired and never reactivated, so it is invisible to every other
+-- test -- getAssetId must treat it as an unknown name, which is exactly what
+-- makes it safe to leave lying in the fixture set. The reactivation case flips
+-- a copy of its own making rather than this row.
+INSERT INTO assets_asset (name, retired_at) VALUES ('retired-asset', NOW());

--- a/tests/db_connection_test.cpp
+++ b/tests/db_connection_test.cpp
@@ -179,6 +179,50 @@ TEST_CASE("db_connection: getCommands returns nullopt when the read connection i
     REQUIRE_FALSE(dbc->getCommands({asset_id}).has_value());
 }
 
+TEST_CASE("db_connection: getAssetId treats a retired asset as unknown, not as an error (todo/80)")
+{
+    /* The three-way split retirement introduces. An active name resolves; a
+     * retired name is a *policy* miss -- an engaged 0, the same answer an
+     * unregistered CN gets, because the database answered successfully and the
+     * answer is "no flyable asset by that name"; and only a read failure is
+     * nullopt. Collapsing the middle case into either of the others is the bug:
+     * as an error it would trip the identify path's read-outage handling, and
+     * as a hit it would let a retired aircraft fly. */
+    LIVE_DB_OR_SKIP(dbc);
+
+    auto active = dbc->getAssetId("test-asset");
+    REQUIRE(active.has_value());
+    REQUIRE(*active != 0);
+
+    auto retired = dbc->getAssetId("retired-asset");
+    REQUIRE(retired.has_value()); /* engaged: the read worked */
+    REQUIRE(*retired == 0);       /* and its answer is "unknown" */
+}
+
+TEST_CASE("db_connection: getRetiredAssets short-circuits empty input without a round-trip (todo/80)")
+{
+    /* Mirrors the getCommands empty-input case: the poller calls this with no
+     * ids whenever nobody is identified, and an empty "IN ()" would be invalid
+     * SQL. Engaged and empty -- "nothing to sever" -- never a failed read. */
+    flight_safety_system::server::db_connection dbc(
+        "db.invalid", 5432, "user", flight_safety_system::secure_string(std::string_view{"pass"}), "db");
+    auto retired = dbc.getRetiredAssets({});
+    REQUIRE(retired.has_value());
+    REQUIRE(retired->empty());
+}
+
+TEST_CASE("db_connection: getRetiredAssets returns nullopt when the read connection is down (todo/80)")
+{
+    /* The direction that matters most on this read. An empty set means "every
+     * one of these is active" and would sever nobody -- indistinguishable from
+     * a successful all-active read, so a retired aircraft would keep flying
+     * through a read outage. The failure must be reported, not flattened. */
+    LIVE_DB_OR_SKIP(dbc);
+    auto asset_id = get_test_asset_id(*dbc);
+    db_disconnect(flight_safety_system::server::db_connection::read_conn_name);
+    REQUIRE_FALSE(dbc->getRetiredAssets({asset_id}).has_value());
+}
+
 TEST_CASE("db_connection: recordRtt writes a row without error")
 {
     LIVE_DB_OR_SKIP(dbc);
@@ -358,7 +402,87 @@ public:
     auto operator=(scoped_truncated_server_active &&) -> scoped_truncated_server_active & = delete;
     ~scoped_truncated_server_active() { CHECK(set_truncated_server_active(false) == 0); }
 };
+
+/* Creates an asset for one test to retire and reactivate, and removes it again
+ * however the test ends. A dedicated row rather than the shared 'retired-asset'
+ * fixture: a failed assertion partway through must not be able to leave that
+ * one active, which would silently turn it into a second flyable asset for
+ * every later test. Destructor uses CHECK, not REQUIRE, for the same
+ * noexcept-unwinding reason as scoped_truncated_server_active above. */
+class scoped_lifecycle_asset {
+public:
+    scoped_lifecycle_asset()
+    {
+        REQUIRE(run_psql("DELETE FROM assets_asset WHERE name = 'lifecycle-asset'") == 0);
+        REQUIRE(run_psql("INSERT INTO assets_asset (name) VALUES ('lifecycle-asset')") == 0);
+    }
+    scoped_lifecycle_asset(const scoped_lifecycle_asset &) = delete;
+    scoped_lifecycle_asset(scoped_lifecycle_asset &&) = delete;
+    auto operator=(const scoped_lifecycle_asset &) -> scoped_lifecycle_asset & = delete;
+    auto operator=(scoped_lifecycle_asset &&) -> scoped_lifecycle_asset & = delete;
+    ~scoped_lifecycle_asset() { CHECK(run_psql("DELETE FROM assets_asset WHERE name = 'lifecycle-asset'") == 0); }
+
+    static auto retire() -> int
+    {
+        return run_psql("UPDATE assets_asset SET retired_at = NOW() WHERE name = 'lifecycle-asset'");
+    }
+    static auto reactivate() -> int
+    {
+        return run_psql("UPDATE assets_asset SET retired_at = NULL WHERE name = 'lifecycle-asset'");
+    }
+};
 } // namespace
+
+TEST_CASE("db_connection: an asset survives retirement and reactivation under one id (todo/80)")
+{
+    /* The full reversible lifecycle against a real database, which is the part
+     * unit tests with a mock cannot pin: that retirement is a column on a row
+     * that stays put, so reactivation restores the *same* id and the history
+     * hanging off it. If retirement were ever implemented as a delete, this is
+     * the test that would fail.
+     *
+     * It also covers the batched read's subset contract in the same pass:
+     * active assets are absent from the result, not present-and-false. */
+    LIVE_DB_OR_SKIP(dbc);
+    scoped_lifecycle_asset fixture;
+    auto active_id = get_test_asset_id(*dbc);
+
+    /* Captured while active — the id under test for the rest of the case. */
+    auto original = dbc->getAssetId("lifecycle-asset");
+    REQUIRE(original.has_value());
+    REQUIRE(*original != 0);
+    {
+        auto retired = dbc->getRetiredAssets({active_id, *original});
+        REQUIRE(retired.has_value());
+        REQUIRE(retired->empty());
+    }
+
+    REQUIRE(scoped_lifecycle_asset::retire() == 0);
+    /* Identification now misses: engaged (the read worked) and 0 (no flyable
+     * asset by that name), never nullopt. */
+    auto while_retired = dbc->getAssetId("lifecycle-asset");
+    REQUIRE(while_retired.has_value());
+    REQUIRE(*while_retired == 0);
+    /* And the already-identified session's id is reported for severing, while
+     * the active asset alongside it in the same batch is not. */
+    {
+        auto retired = dbc->getRetiredAssets({active_id, *original});
+        REQUIRE(retired.has_value());
+        REQUIRE(retired->count(*original) == 1);
+        REQUIRE(retired->count(active_id) == 0);
+        REQUIRE(retired->size() == 1);
+    }
+
+    REQUIRE(scoped_lifecycle_asset::reactivate() == 0);
+    auto after = dbc->getAssetId("lifecycle-asset");
+    REQUIRE(after.has_value());
+    REQUIRE(*after == *original); /* the same row, not a new one */
+    {
+        auto retired = dbc->getRetiredAssets({active_id, *original});
+        REQUIRE(retired.has_value());
+        REQUIRE(retired->empty());
+    }
+}
 
 TEST_CASE("db_connection: getActiveServers fails the read when a server address is truncated (todo/41)")
 {

--- a/tests/mock_database.hpp
+++ b/tests/mock_database.hpp
@@ -6,8 +6,10 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <set>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "fss-server.hpp"
@@ -227,6 +229,53 @@ public:
         return res;
     }
 
+    auto getRetiredAssets(const std::vector<uint64_t> &ids) -> std::optional<std::unordered_set<uint64_t>> override
+    {
+        retired_reads++;
+        if (retired_read_fail)
+        {
+            return std::nullopt;
+        }
+        /* Under records_lock, unlike the other read-side maps: retirement is
+         * the one piece of state a test flips *while* the poller thread is
+         * running (that is the behaviour under test — an already-identified
+         * session being severed), so it cannot follow the set-up-before-threads
+         * pattern the asset_ids/commands maps use. */
+        const std::scoped_lock lock(records_lock);
+        std::unordered_set<uint64_t> res;
+        for (uint64_t asset_id : ids)
+        {
+            if (retired_assets.count(asset_id) > 0)
+            {
+                res.insert(asset_id);
+            }
+        }
+        return res;
+    }
+
+    /* Retire or reactivate an asset mid-test. Reactivation is the reversible
+     * half fss-web migration 0013 exists for, so the mock models both. */
+    void setAssetRetired(uint64_t asset_id, bool retired)
+    {
+        const std::scoped_lock lock(records_lock);
+        if (retired)
+        {
+            retired_assets.insert(asset_id);
+        }
+        else
+        {
+            retired_assets.erase(asset_id);
+        }
+    }
+
+    /* When set, getRetiredAssets returns nullopt: a failed read, which must
+     * sever nobody rather than reading as "all active" (todo/80). Atomic
+     * because it is flipped from the test thread while the poller reads it. */
+    std::atomic<bool> retired_read_fail{false};
+    /* Lets tests assert the poller actually issued the retirement read (and at
+     * what cadence) rather than inferring it from the severing alone. */
+    std::atomic<int> retired_reads{0};
+
     auto getActiveServers() -> std::optional<std::vector<flight_safety_system::server::fss_server_details>> override
     {
         if (active_servers_fail)
@@ -272,6 +321,9 @@ private:
     std::vector<recorded_search> searches{};
     std::vector<recorded_dispatch> dispatches{};
     std::vector<recorded_ack> acks{};
+    /* Guarded by records_lock — see getRetiredAssets above for why this one
+     * cannot be a bare public map like asset_ids. */
+    std::set<uint64_t> retired_assets{};
 };
 
 } // namespace fss_test

--- a/tests/server_clients_test.cpp
+++ b/tests/server_clients_test.cpp
@@ -1202,3 +1202,195 @@ TEST_CASE("server_clients: a failed batched read leaves pending commands intact 
     client1->sendCommand();
     REQUIRE(count_sent<fss::transport::fss_message_asset_command>(conn1->sentSnapshot()) == sent_before);
 }
+
+TEST_CASE("server_clients: retiring a live asset severs its session (todo/80)")
+{
+    /* The gap todo/80 closes. Filtering the identify query alone is not enough:
+     * a session caches its asset_id at identification and never repeats that
+     * lookup, so an aircraft that was active when it connected keeps flying,
+     * writing telemetry and receiving commands for as long as it stays
+     * connected. Enforcement has to reach the live session too. */
+    server_clients sc;
+    fss_test::MockDatabase mock;
+    auto client = make_aircraft_client("craft1", mock, sc);
+    sc.clientConnected(client);
+    const uint64_t asset_id = client->getCachedAssetId();
+    REQUIRE(asset_id != 0);
+    REQUIRE(sc.getTotalClients() == 1);
+
+    /* Held from here: fss_client releases its connection during teardown, so
+     * getConnection() is null by the time the severance has happened and the
+     * disconnect_calls counter has to be reached through a pointer taken while
+     * the session is still live. */
+    auto conn = std::dynamic_pointer_cast<FakeConnection>(client->getConnection());
+    REQUIRE(conn != nullptr);
+
+    /* While active, the poll finds nothing and severs nobody. */
+    sc.pollRetiredAssets(&mock);
+    REQUIRE(sc.disconnectRetiredClients() == 0);
+    REQUIRE(sc.getTotalClients() == 1);
+    REQUIRE(conn->disconnect_calls == 0);
+
+    mock.setAssetRetired(asset_id, true);
+    sc.pollRetiredAssets(&mock);
+    REQUIRE(sc.disconnectRetiredClients() == 1);
+    REQUIRE(conn->disconnect_calls > 0);
+    sc.cleanupRemovableClients();
+    REQUIRE(sc.getTotalClients() == 0);
+}
+
+TEST_CASE("server_clients: detection and severing are split across the two threads (todo/80)")
+{
+    /* pollRetiredAssets() runs on the command poller (it is a DB read);
+     * disconnect() blocks on socket I/O and joins the recv thread, so the
+     * severing is the main loop's. The poll must therefore stage the work and
+     * sever nobody itself -- if it ever disconnects inline, one black-holed
+     * peer stalls command polling for the whole fleet. */
+    server_clients sc;
+    fss_test::MockDatabase mock;
+    auto client = make_aircraft_client("craft1", mock, sc);
+    sc.clientConnected(client);
+    mock.setAssetRetired(client->getCachedAssetId(), true);
+    /* Held across the severance -- see the note in the test above. */
+    auto conn = std::dynamic_pointer_cast<FakeConnection>(client->getConnection());
+    REQUIRE(conn != nullptr);
+
+    sc.pollRetiredAssets(&mock);
+    REQUIRE(conn->disconnect_calls == 0); /* staged, not severed */
+    REQUIRE(sc.getTotalClients() == 1);
+
+    REQUIRE(sc.disconnectRetiredClients() == 1);
+    REQUIRE(conn->disconnect_calls > 0);
+}
+
+TEST_CASE("server_clients: repeated polls before a drain sever the session once (todo/80)")
+{
+    /* The poller observes the same retirement every second until the main loop
+     * drains. Severing is idempotent, so a duplicated hand-off would still be
+     * correct -- but it would log a second severance warning for a session that
+     * only ever existed once, which is exactly the sort of thing an operator
+     * reads as a second aircraft. */
+    server_clients sc;
+    fss_test::MockDatabase mock;
+    auto client = make_aircraft_client("craft1", mock, sc);
+    sc.clientConnected(client);
+    mock.setAssetRetired(client->getCachedAssetId(), true);
+
+    sc.pollRetiredAssets(&mock);
+    sc.pollRetiredAssets(&mock);
+    sc.pollRetiredAssets(&mock);
+    REQUIRE(sc.disconnectRetiredClients() == 1);
+    /* And the drain leaves nothing behind for the next tick. */
+    REQUIRE(sc.disconnectRetiredClients() == 0);
+}
+
+TEST_CASE("server_clients: a failed retirement read severs nobody (todo/80)")
+{
+    /* nullopt is not an empty set. An empty set means "every one of these is
+     * active"; a failed read means nothing is known. Both leave the fleet
+     * connected here, but only one of them is allowed to -- the distinction
+     * exists so that a *successful* read finding retirements still severs
+     * while a read outage never does. Asserting the read was attempted keeps
+     * this from passing for the wrong reason (a poll that never ran). */
+    server_clients sc;
+    fss_test::MockDatabase mock;
+    auto client = make_aircraft_client("craft1", mock, sc);
+    sc.clientConnected(client);
+    mock.setAssetRetired(client->getCachedAssetId(), true);
+
+    mock.retired_read_fail = true;
+    const int reads_before = mock.retired_reads.load();
+    sc.pollRetiredAssets(&mock);
+    REQUIRE(mock.retired_reads.load() > reads_before);
+    REQUIRE(sc.disconnectRetiredClients() == 0);
+    REQUIRE(sc.getTotalClients() == 1);
+
+    /* And once the read recovers, the retirement it could not see is enforced
+     * on the next pass rather than being lost. */
+    mock.retired_read_fail = false;
+    sc.pollRetiredAssets(&mock);
+    REQUIRE(sc.disconnectRetiredClients() == 1);
+}
+
+TEST_CASE("server_clients: retirement severs only the retired asset's session (todo/80)")
+{
+    /* The batched read answers for the whole identified fleet at once, so the
+     * failure that matters is a retirement severing its neighbours. */
+    server_clients sc;
+    fss_test::MockDatabase mock;
+    auto doomed = make_aircraft_client("craft1", mock, sc);
+    auto bystander = make_aircraft_client("craft2", mock, sc);
+    sc.clientConnected(doomed);
+    sc.clientConnected(bystander);
+    REQUIRE(doomed->getCachedAssetId() != bystander->getCachedAssetId());
+
+    mock.setAssetRetired(doomed->getCachedAssetId(), true);
+    sc.pollRetiredAssets(&mock);
+    REQUIRE(sc.disconnectRetiredClients() == 1);
+
+    auto *bystander_conn = dynamic_cast<FakeConnection *>(bystander->getConnection().get());
+    REQUIRE(bystander_conn != nullptr);
+    REQUIRE(bystander_conn->disconnect_calls == 0);
+    sc.cleanupRemovableClients();
+    REQUIRE(sc.getTotalClients() == 1);
+}
+
+TEST_CASE("server_clients: an unidentified client is never severed as retired (todo/80)")
+{
+    /* A client that has not identified has no asset_id, so it cannot be
+     * retired -- and must not be swept up by a poll that keys on 0 by
+     * accident. The identify timeout is what removes these, not this path. */
+    server_clients sc;
+    fss_test::MockDatabase mock;
+    auto conn = std::make_shared<FakeConnection>();
+    auto client = std::make_shared<fss::server::fss_client>(conn, &mock, make_null_writer(), &sc);
+    sc.clientConnected(client);
+    REQUIRE(client->getCachedAssetId() == 0);
+
+    /* Retire the id an unidentified client would report if 0 were ever
+     * treated as a real asset id. */
+    mock.setAssetRetired(0, true);
+    sc.pollRetiredAssets(&mock);
+    REQUIRE(sc.disconnectRetiredClients() == 0);
+    REQUIRE(conn->disconnect_calls == 0);
+    REQUIRE(sc.getTotalClients() == 1);
+}
+
+TEST_CASE("server_clients: reactivation lets the same asset identify again (todo/80)")
+{
+    /* Retirement is reversible, and the reversal has to work without a server
+     * restart. The trap is asset_owners: the severed session's claim on the
+     * asset_id is released by clientDisconnected(), and if any severing path
+     * skipped that, the id would stay unclaimable and the reactivated aircraft
+     * would be rejected as a duplicate of a session that no longer exists. */
+    server_clients sc;
+    fss_test::MockDatabase mock;
+    auto client = make_aircraft_client("craft1", mock, sc);
+    sc.clientConnected(client);
+    const uint64_t asset_id = client->getCachedAssetId();
+
+    mock.setAssetRetired(asset_id, true);
+    sc.pollRetiredAssets(&mock);
+    REQUIRE(sc.disconnectRetiredClients() == 1);
+    sc.cleanupRemovableClients();
+    REQUIRE(sc.getTotalClients() == 0);
+
+    /* Reactivated in fss-web: a fresh connection identifies under the original
+     * id, with the history that was never deleted still hanging off it. */
+    mock.setAssetRetired(asset_id, false);
+    auto conn2 = std::make_shared<FakeConnection>();
+    conn2->cert_names.push_back("craft1");
+    auto returned = std::make_shared<fss::server::fss_client>(conn2, &mock, make_null_writer(), &sc);
+    sc.clientConnected(returned);
+    returned->processMessage(std::make_shared<fss::transport::fss_message_identity>("craft1"));
+
+    REQUIRE(returned->getCachedAssetId() == asset_id);
+    REQUIRE(returned->isAircraft());
+    REQUIRE(sc.getTotalClients() == 1);
+
+    /* And it stays connected through a poll, rather than being severed by a
+     * stale observation of the retirement it has just come back from. */
+    sc.pollRetiredAssets(&mock);
+    REQUIRE(sc.disconnectRetiredClients() == 0);
+    REQUIRE(sc.getTotalClients() == 1);
+}


### PR DESCRIPTION
## Description

fss-web migration 0013 retires assets instead of deleting them, keeping the row and its audit history while removing the asset from the active APIs. FSS never read the column, so a retired aircraft could still identify, write telemetry and receive the newest command.

Filtering the identify query alone does not close this: a session caches its asset_id at identification and never repeats the lookup, so an aircraft that was active when it connected keeps flying. Both halves are covered here.

- db_get_asset_id takes AND retired_at IS NULL. A retired row falls out as the existing unknown-asset path, so todo/69's error_out convention already separates it from a read failure with no signature change.
- assets_asset.retired_at joins required_columns[], making it the second startup gate after migration 0008's ack columns: a release that enforces retirement refuses to start against a schema that cannot express it, and names the column (decision 73).
- db_asset_retired_get / getRetiredAssets is a second batched read on the poller's existing asset_ids vector. It could not ride getCommands: that query selects FROM assets_assetcommand, so a retired asset with no pending command emits no row at all, and folding retirement in would mean a LEFT JOIN restructure that also breaks todo/69's "absent means no pending command" contract. A partial read is discarded rather than returned -- a retired asset missing from a truncated list reads as active, which is the one direction that keeps an aircraft flying.
- Detection runs on the command poller (once a second); the severing runs on the main loop, because disconnect() blocks on socket I/O and joins the recv thread, and doing that on the poller would let one black-holed peer stall command dispatch for the whole fleet -- the hazard todo/46 moved db_ping off that thread to avoid. Worst-case observed-to-severed is one second plus the main loop's 100 ms tick.
- Severing reuses the disconnect()+clientDisconnected() pattern shared with disconnectRevokedClients/disconnectAll, so the asset_owners claim is released and a reactivated asset identifies again without a restart.

The e2e schema mirror gains retired_at in the same commit: without it required_columns[] would refuse to start every e2e test.

## Summary by Sourcery

Enforce database-level asset retirement semantics in the server and ensure live sessions for retired assets are detected and disconnected while supporting reversible reactivation, and extend tests and schemas to cover retirement lifecycle behavior.

New Features:
- Add database and server support to detect retired assets and stage their sessions for disconnection from the main loop without impacting command polling.
- Introduce a batched DB API and server integration to query retired assets for identified sessions and treat retired identities as unknown during identification.
- Support reversible asset retirement so reactivated assets reuse the same ID and can reconnect without a server restart.

Enhancements:
- Extend mock database, concurrency stubs, and server client handling with retirement awareness and thread-safe tracking of pending retirements.
- Add comprehensive unit and integration tests covering retirement detection, failure modes, selective severing, and reactivation behavior.

Documentation:
- Update e2e schema and fixtures to model retired_at and retirement-related assets for testing.

Tests:
- Add server and DB tests to verify retired assets are treated as unknown on identify, are polled and severed correctly, and can be reactivated under the same ID.