### PR TITLE
test(e2e): drive a real retirement through the whole stack (todo/80)

### DIFF
--- a/e2e/test_asset_retirement.py
+++ b/e2e/test_asset_retirement.py
@@ -1,0 +1,166 @@
+"""Retired assets are refused, and live sessions are severed (todo/80).
+
+fss-web migration 0013 retires an asset instead of deleting it, so the row and
+its audit history survive and the retirement is reversible. The unit suite pins
+both halves at their own seams -- db_connection_test.cpp for the queries,
+server_clients_test.cpp for the poll/sever split. What only the real stack can
+show is that the two halves are actually wired to each other: that setting one
+column in the database, with nothing else touched and no restart, takes a flying
+aircraft off the server and keeps it off until the column is cleared again.
+
+The bound under test is the documented one from
+docs/decisions/80-retired-asset-enforcement.md: the poller observes retirement
+within one second and the main loop severs on its next 100 ms tick.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+# Worst-case observed-to-severed is ~1.1 s by design. The margin is for process
+# scheduling and the log write, not for a slower enforcement path -- a failure
+# here means the bound moved, which is a documentation change as much as a code
+# one.
+SEVER_TIMEOUT_S = 10.0
+
+
+def _server_log_text(server_proc) -> str:
+    return server_proc["log"].read_text(errors="replace")
+
+
+def _wait_for_text(server_proc, needle: str, timeout: float = 15.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if needle in _server_log_text(server_proc):
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def _identify_count(server_proc, name: str) -> int:
+    return _server_log_text(server_proc).count(f"Aircraft client identified: {name}")
+
+
+def _wait_for_identify_count(server_proc, name: str, count: int, timeout: float = 15.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if _identify_count(server_proc, name) >= count:
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def _position_count(db_conn, asset_id: int) -> int:
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM assets_assetposition WHERE asset_id = %s", (asset_id,)
+        )
+        return cur.fetchone()[0]
+
+
+@pytest.mark.satisfies("TC-SRV-008")
+@pytest.mark.requires_docker
+def test_retirement_severs_a_live_session_and_reactivation_restores_it(
+    db_conn, reset_db, fake_client, server_proc
+):
+    """The whole reversible lifecycle against a real server and database.
+
+    Deliberately one test rather than three: reactivation is only meaningful as
+    the state *after* a severance, and the id-preservation assertion at the end
+    is the one that would catch retirement being implemented as a delete. Split
+    up, each part would need to rebuild the previous part's state anyway.
+    """
+    with db_conn.cursor() as cur:
+        cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
+        asset_id = cur.fetchone()[0]
+
+    # --- active: identifies and flies normally -----------------------------
+    fake_client("test1")
+    assert _wait_for_identify_count(server_proc, "test1", 1), (
+        "client never identified while its asset was active\n"
+        + _server_log_text(server_proc)
+    )
+
+    # Telemetry is landing, so the severance below is removing something real.
+    deadline = time.monotonic() + 15.0
+    while time.monotonic() < deadline and _position_count(db_conn, asset_id) < 1:
+        time.sleep(0.1)
+    assert _position_count(db_conn, asset_id) >= 1, (
+        "no position rows stored while the asset was active; the rest of this "
+        "test cannot distinguish enforcement from a client that was never flying"
+    )
+
+    # --- retire: the live session is severed within the documented bound ----
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "UPDATE assets_asset SET retired_at = NOW() WHERE id = %s", (asset_id,)
+        )
+
+    assert _wait_for_text(
+        server_proc,
+        f"Disconnecting session for retired asset_id {asset_id}",
+        timeout=SEVER_TIMEOUT_S,
+    ), (
+        f"server did not sever the retired asset's session within "
+        f"{SEVER_TIMEOUT_S}s\n" + _server_log_text(server_proc)
+    )
+
+    # Nothing more is accepted for that session. Sampled after a pause rather
+    # than immediately: writes already queued when the severance happened may
+    # still drain under the existing writer contract, and that is allowed --
+    # what must not happen is the count continuing to climb afterwards.
+    time.sleep(3)
+    settled = _position_count(db_conn, asset_id)
+    time.sleep(3)
+    assert _position_count(db_conn, asset_id) == settled, (
+        "position rows kept arriving after the session was severed for "
+        "retirement; the aircraft is still being accepted"
+    )
+
+    # --- retired: its own reconnects are refused at identify ----------------
+    # No second fake_client is launched: the severed client redials on its own
+    # (examples/fake_client.cpp retries once a second), which is exactly the
+    # real behaviour under test -- an aircraft does not accept being cut off,
+    # so "severed" is only meaningful if the reconnect is refused too.
+    assert _wait_for_text(
+        server_proc,
+        "Rejecting identity 'test1': no matching asset in the database",
+    ), (
+        "a retired asset's reconnect was not refused at identify\n"
+        + _server_log_text(server_proc)
+    )
+    assert _identify_count(server_proc, "test1") == 1, (
+        "a retired asset identified again on reconnect\n" + _server_log_text(server_proc)
+    )
+
+    # --- reactivate: back in service under the original id ------------------
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "UPDATE assets_asset SET retired_at = NULL WHERE id = %s", (asset_id,)
+        )
+
+    # Same client, still redialing -- nothing is restarted and no new process
+    # is introduced, so a success here is the reactivation and nothing else.
+    assert _wait_for_identify_count(server_proc, "test1", 2, timeout=SEVER_TIMEOUT_S), (
+        "reactivated asset never identified again -- if the asset_owners claim "
+        "from the severed session was not released, the id stays unclaimable "
+        "until the server restarts\n" + _server_log_text(server_proc)
+    )
+
+    # The row was never deleted, so the id and the history hanging off it are
+    # the ones the asset always had. This is what retirement buys over a delete.
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT id FROM assets_asset WHERE name = 'test1'")
+        assert cur.fetchone()[0] == asset_id
+    assert _position_count(db_conn, asset_id) >= settled, (
+        "position history from before retirement was lost across the cycle"
+    )
+
+    # And it is flying again: new rows land under the original id.
+    deadline = time.monotonic() + 15.0
+    while time.monotonic() < deadline and _position_count(db_conn, asset_id) <= settled:
+        time.sleep(0.1)
+    assert _position_count(db_conn, asset_id) > settled, (
+        "reactivated asset identified but its telemetry is not being stored"
+    )

--- a/e2e/test_schema_check.py
+++ b/e2e/test_schema_check.py
@@ -12,6 +12,13 @@ operator depends on when it fires: the process exits non-zero, the log names the
 column that is missing, and no listener is left behind for an aircraft to
 connect to.
 
+Parametrised over every column that gates startup for a *safety* reason, so
+adding one to required_columns[] means adding a case here. The second is
+assets_asset.retired_at (fss-web migration 0013, todo/80): an FSS release that
+enforces retirement must not run against a schema that cannot express it, or a
+retired aircraft keeps flying. The refusal is the intended behaviour on an
+upgrade done in the wrong order, which is why the release note says so.
+
 The unit suite covers the same contract at the db_connection seam
 (db_connection_test.cpp); what only a real process can show is the exit status
 and the log.
@@ -40,13 +47,40 @@ from conftest import (
 REFUSAL_TIMEOUT_S = 15
 
 
+# Each case is (table, column, drop_sql, restore_sql). Every entry must restore
+# the table *exactly*, indexes included -- see the finally block below for why.
+GATED_COLUMNS = [
+    pytest.param(
+        "assets_assetcommand",
+        "ack_state",
+        "ALTER TABLE assets_assetcommand DROP COLUMN ack_state",
+        "ALTER TABLE assets_assetcommand ADD COLUMN ack_state SMALLINT",
+        id="ack_state-migration-0008",
+    ),
+    pytest.param(
+        # todo/80. Dropping the column drops its index with it, so the restore
+        # re-creates both; the name matches schema/001_init.sql so a later
+        # re-apply of that file behaves identically.
+        "assets_asset",
+        "retired_at",
+        "ALTER TABLE assets_asset DROP COLUMN retired_at",
+        "ALTER TABLE assets_asset ADD COLUMN retired_at TIMESTAMP WITH TIME ZONE; "
+        "CREATE INDEX assets_asset_retired_at_idx ON assets_asset (retired_at)",
+        id="retired_at-migration-0013",
+    ),
+]
+
+
 @pytest.mark.satisfies("TC-SRV-007")
 @pytest.mark.requires_docker
-def test_server_refuses_to_start_without_the_ack_columns(certs_dir, tmp_path, migrated_db):
-    """Drop assets_assetcommand.ack_state and assert fss-server fail-stops.
+@pytest.mark.parametrize(("table", "column", "drop_sql", "restore_sql"), GATED_COLUMNS)
+def test_server_refuses_to_start_without_a_required_column(
+    certs_dir, tmp_path, migrated_db, table, column, drop_sql, restore_sql
+):
+    """Drop a required column and assert fss-server fail-stops naming it.
 
-    ack_state is nullable with no default, index or constraint, so dropping and
-    re-adding it restores the table exactly.
+    Both columns here are nullable with no default or constraint, so dropping
+    and re-adding restores the table exactly.
 
     The restore in the finally block is mandatory, not tidiness: in CI the
     database is a shared long-lived service (FSS_E2E_EXTERNAL_DB), tests run
@@ -69,7 +103,7 @@ def test_server_refuses_to_start_without_the_ack_columns(certs_dir, tmp_path, mi
     conn.autocommit = True
     try:
         with conn.cursor() as cur:
-            cur.execute("ALTER TABLE assets_assetcommand DROP COLUMN ack_state")
+            cur.execute(drop_sql)
 
         port = _pick_port()
         config_path = tmp_path / "server-bad-schema.json"
@@ -109,18 +143,18 @@ def test_server_refuses_to_start_without_the_ack_columns(certs_dir, tmp_path, mi
                     proc.wait(timeout=5)
                 pytest.fail(
                     f"fss-server did not exit within {REFUSAL_TIMEOUT_S}s with "
-                    f"assets_assetcommand.ack_state missing; log:\n{log_path.read_text()}"
+                    f"{table}.{column} missing; log:\n{log_path.read_text()}"
                 )
 
         log = log_path.read_text()
         assert rc != 0, (
-            f"fss-server exited 0 against a database missing ack_state "
+            f"fss-server exited 0 against a database missing {table}.{column} "
             f"(expected non-zero); log:\n{log}"
         )
         # The message must name the column: "schema check failed" alone leaves
         # the operator to go and find which migration is missing.
-        assert "ack_state" in log, (
-            f"startup refusal did not name the missing column; log:\n{log}"
+        assert column in log, (
+            f"startup refusal did not name the missing column {column}; log:\n{log}"
         )
 
         # Nothing may be left listening — an aircraft must not be able to reach
@@ -131,5 +165,5 @@ def test_server_refuses_to_start_without_the_ack_columns(certs_dir, tmp_path, mi
                 s.connect(("127.0.0.1", port))
     finally:
         with conn.cursor() as cur:
-            cur.execute("ALTER TABLE assets_assetcommand ADD COLUMN ack_state SMALLINT")
+            cur.execute(restore_sql)
         conn.close()


### PR DESCRIPTION
## Description

The unit suite pins each half of retirement enforcement at its own seam; what only the real stack shows is that they are wired to each other -- setting one column, with nothing else touched and no restart, takes a flying aircraft off the server and keeps it off until it is cleared.

test_asset_retirement.py runs the full reversible lifecycle on one client: it identifies and stores telemetry, retirement severs it within the documented bound, its own reconnects are refused at identify, and clearing retired_at brings the same client back under the original asset id with its history intact. No second client process is launched -- the fake client already redials once a second, and that is the real behaviour worth testing, since an aircraft does not accept being cut off. The post-severance check samples the row count twice: writes queued before the observation may still drain, but the count must stop climbing.

test_schema_check.py is parametrised over the columns that gate startup for a safety reason, so retired_at joins ack_state rather than being tested by a near-copy of it. Adding a column to required_columns[] now means adding a case there.

## Summary by Sourcery

Add end-to-end coverage for asset retirement enforcement and extend schema gating tests to include the retirement column.

Tests:
- Add an end-to-end test that verifies retiring an asset severs live sessions, rejects reconnects, and allows reversible reactivation with history preserved.
- Parametrize server startup schema-check tests over safety-gated columns and add coverage for the assets_asset.retired_at column, ensuring the server fail-stops when retirement cannot be expressed.