### PR TITLE
feat(server): back off the fail-safe recovery grace per re-trip

### DIFF
--- a/src/server-failsafe.hpp
+++ b/src/server-failsafe.hpp
@@ -32,7 +32,8 @@ namespace server {
  * *and* gates new admissions (server_clients::setDegraded) so aircraft get one
  * clean comms-loss event instead of a disconnect/reconnect flap into the same
  * unhealthy server. Recovery requires the write queue fully drained, more than
- * recovery_grace_secs with no new failure, drop or probe failure, AND a
+ * the *effective* recovery grace (recovery_grace_secs, backed off per re-trip —
+ * see recoveryGraceMs()) with no new failure, drop or probe failure, AND a
  * *successful health probe* observed on that very tick (todo/78).
  *
  * That last condition is the one field evidence forced. Drain-plus-quiet are
@@ -53,6 +54,19 @@ namespace server {
  * which HANGS rather than fails — against a partitioned or frozen database it
  * returns neither answer, so no counter moves and there is nothing else to
  * notice.
+ *
+ * The probe answers "does a write work right now?", which is the whole question
+ * against a database that is dead or persistently faulted. It is not the
+ * question an *intermittently* faulted one poses (todo/81): a fault whose good
+ * periods outlast the grace window lets every readmission be backed by evidence
+ * that was true when it was taken, and the fleet still moves in and out of its
+ * comms-loss state as the fault returns. So the recovery grace also backs off
+ * per re-trip — the second trip inside backoff_window_ms holds the gate twice as
+ * long, the third three times, capped at recovery_backoff_max. The first trip is
+ * unaffected, so nothing about a one-off incident changes; what grows is the
+ * cost of a fault that keeps coming back, which is what makes a flap a flap. A
+ * cap is required rather than optional: an unbounded multiplier would eventually
+ * refuse a fleet against a database that had genuinely recovered.
  *
  * Thresholds are measured against an injectable IClock, not against a count of
  * tick() calls (todo/70). The caller drives this from a loop whose period is
@@ -96,8 +110,15 @@ public:
     };
 private:
     static constexpr uint64_t ms_per_sec = 1000;
+    /* How close together two trips must be to count as the same run of trips
+     * for the back-off (todo/81). Fixed rather than configurable: it only has to
+     * be long enough that a fault which returns after one hold is still judged
+     * the same fault, and the longest hold the cap allows (at the defaults,
+     * 8 x 15 s) is two orders of magnitude below it. */
+    static constexpr uint64_t backoff_window_ms = 60ULL * 60ULL * ms_per_sec;
     uint64_t disconnect_age_ms;
     uint64_t recovery_grace_ms;
+    uint64_t recovery_backoff_max;
     std::shared_ptr<IClock> clock;
     uint64_t now_ms{0}; // the clock reading taken by the current tick
     uint64_t incident_start_ms{0};
@@ -117,6 +138,18 @@ private:
      * clock keeps the age consistent with the decision it describes — the same
      * reason incidentAgeSecs() exists. */
     uint64_t degraded_since_ms{0};
+    /* Trips in the current run (todo/81): 0 before the first, then 1 for a trip
+     * whose predecessor is older than backoff_window_ms and one more than the
+     * predecessor otherwise. Read only through recoveryGraceMs(), and updated
+     * only at a trip — so the multiplier an episode recovers against is the one
+     * its own trip established, and a run decays by a later trip finding the
+     * previous one stale rather than by anything ticking it down.
+     *
+     * The count doubles as the has-tripped-before flag, for the reason
+     * incident_active exists: last_trip_ms == 0 is a legitimate reading on a
+     * clock that has just started, so a zero timestamp cannot mean "never". */
+    uint64_t recent_trips{0};
+    uint64_t last_trip_ms{0};
     /* An explicit flag rather than incident_start_ms == 0. A monotonic clock
      * that has just started, and every test clock, legitimately reads 0, so a
      * zero sentinel would silently discard an incident that began at the
@@ -124,13 +157,50 @@ private:
     bool incident_active{false};
     bool degraded_{false};
     trip_reason reason_{trip_reason::none};
+    /* Latch the degraded state. Both trip sites route through here so the
+     * probe-counter bookkeeping recovery depends on cannot be updated on one
+     * path and forgotten on the other; what differs between them (whether a
+     * write-failure incident is left standing) stays at the call site. */
+    auto trip(trip_reason t_reason, const db_health_counters &counters) -> event
+    {
+        this->degraded_ = true;
+        this->probe_successes_at_trip = counters.probe_successes;
+        this->last_probe_successes = counters.probe_successes;
+        this->degraded_since_ms = this->now_ms;
+        this->reason_ = t_reason;
+        /* A trip within backoff_window_ms of the previous one continues that
+         * run and lengthens the hold; one after a quiet hour starts afresh at
+         * the configured grace (todo/81). */
+        bool continues_run = this->recent_trips > 0 && (this->now_ms - this->last_trip_ms) <= backoff_window_ms;
+        this->recent_trips = continues_run ? this->recent_trips + 1 : 1;
+        this->last_trip_ms = this->now_ms;
+        return event::tripped;
+    }
+    /* The quiet window this degraded episode must clear: the configured grace
+     * multiplied by the length of the current run of trips, capped (todo/81).
+     * Only the *recovery* role of recovery_grace_ms is backed off. Its other
+     * role — how long failures may pause and still chain into one incident — is
+     * about recognising a single incident, not about how much the fleet should
+     * pay for a repeat, and stretching it would make the trip itself later. */
+    [[nodiscard]] auto recoveryGraceMs() const -> uint64_t
+    {
+        uint64_t multiplier = this->recent_trips < 1 ? 1 : this->recent_trips;
+        return this->recovery_grace_ms *
+               (multiplier > this->recovery_backoff_max ? this->recovery_backoff_max : multiplier);
+    }
 public:
     /* Thresholds are given in seconds, as the config file states them, and held
      * in milliseconds because that is what IClock reports. A null clock falls
-     * back to MonotonicClock, matching fss_client::setClock. */
-    db_failsafe(uint64_t t_disconnect_age_secs, uint64_t t_recovery_grace_secs,
+     * back to MonotonicClock, matching fss_client::setClock.
+     *
+     * t_recovery_backoff_max is a multiplier cap, not a duration: 1 disables the
+     * per-re-trip back-off entirely (todo/81) and restores the behaviour that
+     * shipped with todo/78. 0 is meaningless and is read as 1 rather than as a
+     * grace of zero, which would readmit the fleet on the first quiet tick. */
+    db_failsafe(uint64_t t_disconnect_age_secs, uint64_t t_recovery_grace_secs, uint64_t t_recovery_backoff_max = 1,
                 std::shared_ptr<IClock> t_clock = nullptr)
         : disconnect_age_ms(t_disconnect_age_secs * ms_per_sec), recovery_grace_ms(t_recovery_grace_secs * ms_per_sec),
+          recovery_backoff_max(t_recovery_backoff_max < 1 ? 1 : t_recovery_backoff_max),
           clock(t_clock == nullptr ? std::make_shared<MonotonicClock>() : std::move(t_clock))
     {
     }
@@ -165,7 +235,7 @@ public:
              * they keep producing failures, and a nonempty-but-quiet queue
              * (e.g. a wedged sink) is not health either. */
             bool quiet = !new_write_failure && !new_command_drop && !new_probe_failure &&
-                         (this->now_ms - this->last_event_ms) > this->recovery_grace_ms;
+                         (this->now_ms - this->last_event_ms) > this->recoveryGraceMs();
             /* The positive evidence (todo/78). Without it, drain and quiet are
              * both guaranteed by the severance this state performed, so the
              * degraded state ended on a timer no matter how dead the database
@@ -225,15 +295,10 @@ public:
         }
         if (new_command_drop)
         {
-            this->degraded_ = true;
-            this->probe_successes_at_trip = counters.probe_successes;
-            this->degraded_since_ms = this->now_ms;
-            this->last_probe_successes = counters.probe_successes;
-            this->reason_ = trip_reason::command_drop;
             /* No write-failure incident is implicated, so do not leave one
              * standing for incidentAgeSecs() to report against this trip. */
             this->incident_active = false;
-            return event::tripped;
+            return this->trip(trip_reason::command_drop, counters);
         }
         if (new_write_failure)
         {
@@ -247,16 +312,11 @@ public:
              * check on its own tick. */
             if ((this->now_ms - this->incident_start_ms) >= this->disconnect_age_ms)
             {
-                this->degraded_ = true;
-                this->probe_successes_at_trip = counters.probe_successes;
-                this->degraded_since_ms = this->now_ms;
-                this->last_probe_successes = counters.probe_successes;
-                this->reason_ = trip_reason::write_failure;
-                /* Deliberately left active, unlike the command-drop path: the
-                 * caller logs incidentAgeSecs() with the trip, and nothing
-                 * consults the incident while degraded — the branch above
-                 * returns before reaching it. Recovery clears it. */
-                return event::tripped;
+                /* The incident is deliberately left active, unlike the
+                 * command-drop path: the caller logs incidentAgeSecs() with the
+                 * trip, and nothing consults the incident while degraded — the
+                 * branch above returns before reaching it. Recovery clears it. */
+                return this->trip(trip_reason::write_failure, counters);
             }
         }
         else if (this->incident_active && (this->now_ms - this->last_event_ms) > this->recovery_grace_ms)
@@ -291,6 +351,12 @@ public:
     {
         return this->degraded_ ? (this->now_ms - this->degraded_since_ms) / ms_per_sec : 0;
     }
+    /* The quiet window this episode actually has to clear, in seconds, for the
+     * caller's still-degraded log. The configured value is the right number to
+     * report only on the first trip of a run; after that, logging it would tell
+     * an operator watching a flapping database to expect a readmission several
+     * multiples of the hold too early (todo/81). */
+    [[nodiscard]] auto recoveryGraceSecs() const -> uint64_t { return this->recoveryGraceMs() / ms_per_sec; }
 };
 
 } // namespace server

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -102,6 +102,11 @@ auto main(int argc, char *argv[]) -> int
      * While degraded: the quiet window that, once the write queue has also
      * drained, ends the degraded state and readmits sessions (todo/47). */
     constexpr uint64_t default_db_write_failure_recovery_grace_secs = 15;
+    /* todo/81: how many times the recovery grace above may be multiplied for a
+     * database that keeps failing (see server-failsafe.hpp). At the two defaults
+     * a first trip holds the gate for 15s and an eighth trip within the hour
+     * holds it for two minutes. 1 disables the back-off. */
+    constexpr uint64_t default_db_write_failure_recovery_backoff_max = 8;
     constexpr unsigned int default_tls_handshake_timeout_ms =
         flight_safety_system::transport_ssl::default_handshake_timeout_ms;
     constexpr std::size_t default_max_concurrent_handshakes = 64;
@@ -122,6 +127,7 @@ auto main(int argc, char *argv[]) -> int
     auto duplicate_identity_policy = default_duplicate_identity_policy;
     uint64_t db_write_failure_disconnect_secs = default_db_write_failure_disconnect_secs;
     uint64_t db_write_failure_recovery_grace_secs = default_db_write_failure_recovery_grace_secs;
+    uint64_t db_write_failure_recovery_backoff_max = default_db_write_failure_recovery_backoff_max;
     unsigned int tls_handshake_timeout_ms = default_tls_handshake_timeout_ms;
     std::size_t max_concurrent_handshakes = default_max_concurrent_handshakes;
     std::string ca_public_key;
@@ -298,6 +304,20 @@ auto main(int argc, char *argv[]) -> int
         if (config.isMember("db_write_failure_recovery_grace_secs"))
         {
             db_write_failure_recovery_grace_secs = config["db_write_failure_recovery_grace_secs"].asUInt64();
+        }
+        if (config.isMember("db_write_failure_recovery_backoff_max"))
+        {
+            db_write_failure_recovery_backoff_max = config["db_write_failure_recovery_backoff_max"].asUInt64();
+        }
+        if (db_write_failure_recovery_backoff_max == 0)
+        {
+            /* A multiplier of 0 would mean a recovery grace of 0 -- readmitting
+             * the fleet on the first quiet tick, which is the opposite of what
+             * this setting is for. 1, not 0, is how the back-off is disabled. */
+            FSS_LOG_WARN("server", "db_write_failure_recovery_backoff_max must be > 0 (1 disables the back-off); "
+                                   "using default "
+                                       << default_db_write_failure_recovery_backoff_max);
+            db_write_failure_recovery_backoff_max = default_db_write_failure_recovery_backoff_max;
         }
         if (config.isMember("tls_handshake_timeout_ms"))
         {
@@ -562,7 +582,8 @@ auto main(int argc, char *argv[]) -> int
                 using flight_safety_system::server::db_failsafe;
                 static uint64_t last_failure_count = 0;
                 static uint64_t last_command_dropped = 0;
-                static db_failsafe failsafe(db_write_failure_disconnect_secs, db_write_failure_recovery_grace_secs);
+                static db_failsafe failsafe(db_write_failure_disconnect_secs, db_write_failure_recovery_grace_secs,
+                                            db_write_failure_recovery_backoff_max);
                 uint64_t current_failures = writer->write_failure_count();
                 if (current_failures != last_failure_count)
                 {
@@ -625,8 +646,11 @@ auto main(int argc, char *argv[]) -> int
                          * write actually succeeded on the connection that
                          * failed. The e2e suite matches this line on its
                          * "DB fail-safe recovered" prefix only. */
+                        /* The window the episode actually cleared, which after a
+                         * repeat trip is a multiple of the configured grace
+                         * (todo/81), not the configured value itself. */
                         FSS_LOG_ERROR("server", "DB fail-safe recovered: write queue drained, quiet for "
-                                                    << db_write_failure_recovery_grace_secs
+                                                    << failsafe.recoveryGraceSecs()
                                                     << "s, and a probe write succeeded; accepting sessions again");
                         break;
                     case db_failsafe::event::none: break;
@@ -650,9 +674,8 @@ auto main(int argc, char *argv[]) -> int
                             "DB fail-safe still degraded after "
                                 << failsafe.degradedAgeSecs()
                                 << "s; sessions stay refused until the write queue is drained, quiet for "
-                                << db_write_failure_recovery_grace_secs
-                                << "s and a probe write has succeeded (queue depth=" << writer->pending_count()
-                                << ", probe successes=" << writer->probe_success_count()
+                                << failsafe.recoveryGraceSecs() << "s and a probe write has succeeded (queue depth="
+                                << writer->pending_count() << ", probe successes=" << writer->probe_success_count()
                                 << ", failures=" << writer->probe_failure_count()
                                 << ", inconclusive=" << writer->probe_inconclusive_count() << ", last probe error: "
                                 << (probe_error.empty() ? std::string{"none"} : probe_error) << ")");

--- a/tests/server_failsafe_test.cpp
+++ b/tests/server_failsafe_test.cpp
@@ -49,8 +49,11 @@ namespace {
  * explicitly. */
 class FailsafeHarness {
 public:
-    FailsafeHarness(uint64_t t_disconnect_age_secs, uint64_t t_recovery_grace_secs)
-        : f(t_disconnect_age_secs, t_recovery_grace_secs, clock)
+    /* The back-off multiplier cap defaults to 1 — no back-off — so every case
+     * written before todo/81 measures the configured grace and reads unchanged.
+     * The cases that are about the back-off pass it explicitly. */
+    FailsafeHarness(uint64_t t_disconnect_age_secs, uint64_t t_recovery_grace_secs, uint64_t t_recovery_backoff_max = 1)
+        : f(t_disconnect_age_secs, t_recovery_grace_secs, t_recovery_backoff_max, clock)
     {
     }
     /* One nominal second of the caller's loop, against a database whose probe
@@ -74,7 +77,25 @@ public:
         this->clock->advance(ms);
         return this->f.tick(counters);
     }
+    /* Tick a degraded monitor against a database that is answering — healthy
+     * probe, no new failures, empty queue — until it recovers, and report how
+     * many nominal seconds that took. The bound is there so a regression that
+     * stops recovery altogether fails the case instead of hanging the suite; it
+     * is far above any window the cases below configure. */
+    auto secondsToRecover(uint64_t write_failures, uint64_t command_drops) -> uint64_t
+    {
+        constexpr uint64_t bound = 600;
+        for (uint64_t secs = 1; secs <= bound; secs++)
+        {
+            if (this->tick(write_failures, command_drops, 0) == db_failsafe::event::recovered)
+            {
+                return secs;
+            }
+        }
+        return 0;
+    }
     [[nodiscard]] auto degraded() const -> bool { return this->f.degraded(); }
+    [[nodiscard]] auto recoveryGraceSecs() const -> uint64_t { return this->f.recoveryGraceSecs(); }
     [[nodiscard]] auto wantsProbe() const -> bool { return this->f.wantsProbe(); }
     [[nodiscard]] auto reason() const -> db_failsafe::trip_reason { return this->f.reason(); }
     [[nodiscard]] auto incidentAgeSecs() const -> uint64_t { return this->f.incidentAgeSecs(); }
@@ -747,4 +768,126 @@ TEST_CASE("db_failsafe: degradedAgeSecs measures the severance, not the incident
         REQUIRE(f.tickCounters(1000, {0, 1, 0, 0, 0}) == db_failsafe::event::none);
         REQUIRE(f.degradedAgeSecs() == 1);
     }
+}
+
+TEST_CASE("db_failsafe: a repeated trip holds the gate proportionally longer (todo/81)")
+{
+    /* The intermittent-fault case todo/78 left open. Every readmission below is
+     * backed by evidence that was true when it was taken — a fresh probe
+     * success after a full quiet window — and the fault still comes back, so
+     * without the back-off the aircraft would keep cycling in and out of its
+     * comms-loss state at the incident timescale. What grows is the cost of the
+     * repetition; the first trip is untouched. */
+    FailsafeHarness f(0, 3, 4);
+    uint64_t failures = 0;
+    /* First trip of the run: the configured grace, so recovery lands on the
+     * first tick strictly past it. */
+    REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::tripped);
+    REQUIRE(f.recoveryGraceSecs() == 3);
+    REQUIRE(f.secondsToRecover(failures, 0) == 4);
+    /* The fault returns as soon as the readmitted fleet writes again. */
+    REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::tripped);
+    REQUIRE(f.recoveryGraceSecs() == 6);
+    REQUIRE(f.secondsToRecover(failures, 0) == 7);
+    REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::tripped);
+    REQUIRE(f.recoveryGraceSecs() == 9);
+    REQUIRE(f.secondsToRecover(failures, 0) == 10);
+}
+
+TEST_CASE("db_failsafe: the recovery back-off is capped (todo/81)")
+{
+    /* Unbounded growth would eventually refuse a fleet against a database that
+     * had genuinely recovered — the fail-safe's own failure mode, arrived at
+     * from the cautious side. */
+    FailsafeHarness f(0, 3, 2);
+    uint64_t failures = 0;
+    REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::tripped);
+    REQUIRE(f.secondsToRecover(failures, 0) == 4);
+    REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::tripped);
+    REQUIRE(f.secondsToRecover(failures, 0) == 7); // 2x, the cap
+    for (int i = 0; i < 3; i++)
+    {
+        REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::tripped);
+        REQUIRE(f.recoveryGraceSecs() == 6);
+        REQUIRE(f.secondsToRecover(failures, 0) == 7);
+    }
+}
+
+TEST_CASE("db_failsafe: a cap of 1 disables the back-off (todo/81)")
+{
+    /* The escape hatch, and the pre-todo/81 behaviour: a deployment that would
+     * rather readmit early every time can say so. A cap of 0 is read as 1 by
+     * the constructor rather than as a grace of zero, which would readmit on
+     * the first quiet tick. */
+    for (uint64_t cap : {uint64_t{1}, uint64_t{0}})
+    {
+        FailsafeHarness f(0, 3, cap);
+        uint64_t failures = 0;
+        for (int i = 0; i < 4; i++)
+        {
+            REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::tripped);
+            REQUIRE(f.recoveryGraceSecs() == 3);
+            REQUIRE(f.secondsToRecover(failures, 0) == 4);
+        }
+    }
+}
+
+TEST_CASE("db_failsafe: a trip after a quiet hour starts a fresh run (todo/81)")
+{
+    /* The back-off is about a fault that keeps coming back, not a tally kept
+     * for the life of the process: an unrelated incident tomorrow must cost the
+     * fleet no more than today's first one did. */
+    FailsafeHarness f(0, 3, 4);
+    uint64_t failures = 0;
+    REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::tripped);
+    REQUIRE(f.secondsToRecover(failures, 0) == 4);
+    REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::tripped);
+    REQUIRE(f.recoveryGraceSecs() == 6);
+    REQUIRE(f.secondsToRecover(failures, 0) == 7);
+    /* Two hours of a healthy database, then a new fault. */
+    constexpr uint64_t two_hours_ms = 2 * 60 * 60 * 1000;
+    REQUIRE(f.tickAfter(two_hours_ms, failures, 0, 0) == db_failsafe::event::none);
+    REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::tripped);
+    REQUIRE(f.recoveryGraceSecs() == 3);
+    REQUIRE(f.secondsToRecover(failures, 0) == 4);
+}
+
+TEST_CASE("db_failsafe: the back-off applies to a command-drop trip too (todo/81)")
+{
+    /* Both trip triggers latch the same degraded state and both are readmitted
+     * by the same window, so a database dropping command writes intermittently
+     * flaps exactly as a write-failing one does. */
+    FailsafeHarness f(5, 3, 4);
+    uint64_t drops = 0;
+    REQUIRE(f.tick(0, ++drops, 0) == db_failsafe::event::tripped);
+    REQUIRE(f.reason() == db_failsafe::trip_reason::command_drop);
+    REQUIRE(f.secondsToRecover(0, drops) == 4);
+    REQUIRE(f.tick(0, ++drops, 0) == db_failsafe::event::tripped);
+    REQUIRE(f.recoveryGraceSecs() == 6);
+    REQUIRE(f.secondsToRecover(0, drops) == 7);
+}
+
+TEST_CASE("db_failsafe: the back-off does not stretch the trip threshold (todo/81)")
+{
+    /* recovery_grace_secs has a second role outside a degraded episode: how
+     * long failures may pause and still chain into one incident. Backing that
+     * off too would make each successive trip *later* as well as longer — the
+     * fleet would keep writing into a database already known to be failing. */
+    FailsafeHarness f(5, 3, 4);
+    uint64_t failures = 0;
+    for (int age = 0; age < 5; age++)
+    {
+        REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::none);
+    }
+    REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::tripped);
+    REQUIRE(f.secondsToRecover(failures, 0) == 4);
+    /* Second incident, same shape: the trip still needs failures spanning
+     * exactly disconnect_age_secs, and the incident-chaining window is still
+     * the configured 3s — only the hold that follows is doubled. */
+    for (int age = 0; age < 5; age++)
+    {
+        REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::none);
+    }
+    REQUIRE(f.tick(++failures, 0, 0) == db_failsafe::event::tripped);
+    REQUIRE(f.secondsToRecover(failures, 0) == 7);
 }


### PR DESCRIPTION
## Description

todo/78 made recovery require positive evidence -- a probe write that succeeded since the trip -- which closes the permanent-failure case: a dead or persistently write-faulted database never produces one, so the fail-safe holds and the fleet gets a single latched comms-loss event.

An *intermittently* faulted database is not covered by that. The probe answers "does a write work right now?", and a fault whose good periods outlast the recovery grace answers it honestly every time: the queue drains, the window goes quiet, a probe succeeds, the fleet is readmitted, real telemetry resumes, the fault returns, the incident ages past the disconnect threshold and the fail-safe trips again. Every readmission is backed by evidence that was true when it was taken, and the aircraft still moves in and out of its comms-loss state on a fault the server has already seen -- now on the incident timescale rather than a ~20 s timer.

Option 2 from the item: the recovery grace is multiplied by the length of the current run of trips, capped. A trip within an hour of the previous one continues that run; one after a quiet hour starts afresh. The first trip of a run is unaffected, so a one-off incident behaves exactly as it did; what grows is the cost of a fault that keeps coming back, which is what makes a flap a flap. At the defaults (15 s grace, cap 8) a first trip holds the gate for 15 s and an eighth within the hour holds it for two minutes. db_write_failure_recovery_backoff_max configures the cap; 1 disables the back-off, and 0 is read as 1 rather than as a grace of zero, which would readmit on the first quiet tick.

Only the recovery role of recovery_grace_secs is backed off. Its other role -- how long failures may pause and still chain into one incident -- is about recognising a single incident, and stretching it would make each successive trip later as well as longer, i.e. leave the fleet writing into a database already known to be failing. A test pins that.

The run count doubles as the has-tripped-before flag for the reason incident_active exists (todo/70): last_trip_ms == 0 is a legitimate reading on a clock that has just started, so a zero timestamp cannot mean "never".

The two trip sites now route through one private trip(), so the probe-counter bookkeeping recovery depends on cannot be updated on one path and forgotten on the other; the still-degraded and recovered log lines report the effective window rather than the configured one, which after a repeat trip is several multiples out.

## Summary by Sourcery

Introduce configurable per-trip back-off for database fail-safe recovery to mitigate intermittent fault flapping and expose this behaviour in server logs and configuration.

New Features:
- Add configurable db_write_failure_recovery_backoff_max setting to scale recovery grace per repeated fail-safe trip, with a default back-off cap.
- Expose the effective recovery grace window via db_failsafe::recoveryGraceSecs for use in logs and tests.

Enhancements:
- Refine db_failsafe to track recent trips and compute an effective recovery grace without affecting incident detection thresholds.
- Refactor fail-safe trip handling into a shared helper to ensure consistent bookkeeping between write-failure and command-drop paths.
- Update server fail-safe logging to report the effective recovery grace instead of the configured base value.

Tests:
- Extend server fail-safe tests with scenarios covering recovery back-off behaviour, cap enforcement, disabling back-off, run reset after a quiet period, application to command-drop trips, and preservation of the trip threshold.