### PR TITLE
test(e2e): drive an intermittent write fault through both episodes

### DIFF
--- a/docs/decisions/34-45-47-db-failsafe-latch.md
+++ b/docs/decisions/34-45-47-db-failsafe-latch.md
@@ -219,10 +219,80 @@ fault) all fail the probe as it stands, and the upgrade path is named below.
   probe; it cannot manufacture one. The stall bound stays `PGTCPUSERTIMEOUT`
   (25 s) at the socket.
 
-**Still open (todo/81):** an *intermittent* write fault can still flap. The
-probe can catch a good moment, recovery readmits the fleet, real traffic fails,
-and the fail-safe re-trips. Closing that needs K-consecutive-successes or a
-grace multiplier that backs off per re-trip within a window.
+### The recovery grace backs off per re-trip (revised 2026-08-05, todo/81)
+
+The probe answers "does a write work **right now**?", and that is the whole
+question against a database which is dead or persistently faulted: it never
+answers yes, so the latch holds. An *intermittently* faulted one answers yes
+honestly, over and over. A fault whose good periods outlast the grace window
+gives: queue drained, window quiet, probe succeeds, fleet readmitted, real
+telemetry resumes, fault returns, incident ages past
+`db_write_failure_disconnect_secs`, trip — round again. Every readmission is
+backed by evidence that was true when it was taken. The cycle is much slower
+than the pre-78 one, a full incident timescale rather than a fixed ~20 s timer,
+but an aircraft is still being moved in and out of its comms-loss state by a
+fault the server has already seen.
+
+The missing question is not "does a write work now?" but "**has this database
+been reliable long enough to trust it with the fleet?**", which is about a
+history rather than a moment.
+
+**Decision.** The recovery grace is multiplied by the length of the current run
+of trips, capped:
+
+```
+effective grace  =  db_write_failure_recovery_grace_secs
+                 ×  min(trips in the current run, db_write_failure_recovery_backoff_max)
+```
+
+A trip within an hour of the previous one continues that run; a trip after a
+quiet hour starts a new one at 1. At the defaults (15 s grace, cap 8) a first
+trip holds the admission gate for 15 s and an eighth within the hour holds it
+for two minutes.
+
+- **The first trip of a run is untouched**, so a one-off incident — the common
+  case, and the one the field reports are about — behaves exactly as it did.
+  What grows is the cost of a fault that keeps coming back, which is what makes
+  a flap a flap.
+- **The cap is required, not optional.** An unbounded multiplier would
+  eventually refuse a fleet against a database that had genuinely recovered:
+  the fail-safe's own failure mode, arrived at from the cautious side. `1`
+  disables the back-off and restores the todo/78 behaviour exactly; `0` is read
+  as `1` rather than as a grace of zero, which would readmit the fleet on the
+  first quiet tick.
+- **Only the recovery role of the grace is backed off.** The same config value
+  also decides how long failures may pause and still chain into one incident.
+  Stretching that would make each successive trip *later* as well as longer,
+  i.e. leave the fleet writing into a database already known to be failing.
+  A unit case pins the separation.
+- **The run count doubles as the has-tripped-before flag**, for the same reason
+  `incident_active` exists (todo/70): `last_trip_ms == 0` is a legitimate
+  reading on a clock that has just started, so a zero timestamp cannot mean
+  "never".
+- **The still-degraded and recovered log lines report the effective window**,
+  not the configured one. After a repeat trip the configured value would tell an
+  operator watching a flapping database to expect readmission several multiples
+  of the hold too early.
+- **The one-hour window is fixed rather than configurable.** It only has to be
+  long enough that a fault returning after one hold is judged the same fault,
+  and the longest hold the cap allows is two orders of magnitude below it. One
+  configuration field for the cap is the whole surface this adds.
+
+**Rejected: K consecutive probe successes** (option 1 in the item). The grace
+window already delivers an approximation of it for free — any probe failure
+restarts the window, so recovery in the default configuration already implies
+roughly fifteen consecutive successes. The real gap was never the count within
+an episode; it was that the count restarts from zero after each recovery no
+matter how many times the same fault has come back. K-consecutive answers the
+within-episode question that was already answered, and leaves the across-episode
+one open.
+
+`e2e/test_db_failsafe_backoff.py` drives the flap end to end: install the fault,
+let it trip, heal the database, watch the gate come down, let the fault return,
+and assert the second episode holds for twice as long — measured from the moment
+the database became healthy again, so the number is the window and not the
+duration of the fault. The negative case was run: with the cap forced to 1 the
+second episode recovers on the configured 15 s window and the test fails.
 
 ## Alternatives deliberately not taken
 

--- a/e2e/test_db_failsafe_backoff.py
+++ b/e2e/test_db_failsafe_backoff.py
@@ -1,0 +1,174 @@
+"""e2e: a database that keeps failing holds the gate longer each time (todo/81).
+
+todo/78 closed the *permanent* failure case: recovery needs a probe write to
+have succeeded, and against a dead database it never does, so the fail-safe
+holds and the aircraft gets one latched comms-loss event
+(test_db_write_only_failure.py asserts exactly that).
+
+This file drives the case todo/78 left open. The fault here is *intermittent*:
+it is installed, removed once the fail-safe has tripped, and installed again
+once the readmitted fleet is writing. Every readmission is therefore backed by
+honest evidence — the queue really drained, the window really went quiet, a
+probe write really succeeded — and the aircraft still cycles in and out of its
+comms-loss state as the fault returns. The recovery grace now backs off per
+re-trip, so the second episode holds the gate for twice the configured window,
+which is what this test observes.
+
+The fault is driven from the test rather than from a self-toggling trigger
+(a counter table, or random() in the trigger function) because the behaviour
+under test is about the *repetition*: the point that has to be pinned is that
+episode two costs more than episode one, and that is only legible if the test
+decides when each episode begins and ends.
+
+The observable is the recovery log line, which names the window the episode
+actually cleared: "quiet for 15s" the first time and "quiet for 30s" the
+second. The wall-clock hold is asserted too — the log line and the behaviour
+could in principle disagree, and the one that matters to an aircraft is the
+hold.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from conftest import _wait_for
+from test_db_write_only_failure import _install_write_failure, _remove_write_failure
+
+# The server's defaults, which this test deliberately runs at rather than
+# tuning down: they are what a deployment gets, and the multiplier is only
+# meaningful against the configured grace.
+RECOVERY_GRACE_SECS = 15
+DISCONNECT_SECS = 5
+
+
+def _count(text: str, needle: str) -> int:
+    return text.count(needle)
+
+
+# Worst-case budget, so the next person does not have to re-derive it:
+# 25 (baseline row) + 30 (first trip) + 40 (first recovery) + 20 (re-identify)
+# + 25 (telemetry resumes) + 40 (second trip) + 70 (the backed-off second
+# recovery: 30 s of quiet, plus the probe cadence and the slack the first
+# recovery gets) = 250 s, plus this test's share of fixture setup (postgis
+# container, migration, cert generation, server + client spawn), which
+# pytest-timeout counts because it is not running in func_only mode. The second
+# recovery is the one wait that cannot be shortened without disabling the very
+# behaviour under test. e2e/pytest.ini's global 60 s default is overridden here.
+@pytest.mark.requires_docker
+@pytest.mark.slow
+@pytest.mark.timeout(420)
+def test_repeated_write_failure_holds_the_gate_longer(db_conn, fake_client, server_proc):
+    """An intermittent write fault: the second degraded episode holds the
+    admission gate for twice as long as the first."""
+    log_path = server_proc["log"]
+
+    def log_text() -> str:
+        return log_path.read_text(errors="replace")
+
+    with db_conn.cursor() as cur:
+        cur.execute("INSERT INTO assets_asset (name) VALUES ('test1') RETURNING id")
+        asset_id = cur.fetchone()[0]
+
+    client = fake_client("test1")
+
+    def position_count() -> int:
+        with db_conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM assets_assetposition WHERE asset_id = %s", (asset_id,)
+            )
+            return cur.fetchone()[0]
+
+    assert _wait_for(lambda: position_count() > 0, timeout=25.0), (
+        "no baseline position row before injecting the write failure\n"
+        f"-- server log --\n{log_text()}\n"
+        f"-- client log --\n{client['log'].read_text(errors='replace')}"
+    )
+
+    def run_episode(number: int, trip_timeout: float, recovery_timeout: float) -> float:
+        """Install the fault, wait for the trip, remove it, wait for recovery.
+
+        Returns how long the gate stayed up after the fault was removed — the
+        number an aircraft experiences, measured the same way for both
+        episodes so they can be compared.
+        """
+        try:
+            _install_write_failure(db_conn)
+            # The incident must span db_write_failure_disconnect_secs of
+            # recurring failures before tripping; RTT writes recur ~1s.
+            assert _wait_for(
+                lambda: _count(log_text(), "DB fail-safe tripped") == number,
+                timeout=trip_timeout,
+                poll=0.2,
+            ), (
+                f"fail-safe did not trip for episode {number} "
+                f"(disconnect threshold {DISCONNECT_SECS}s)\n" + log_text()
+            )
+        finally:
+            _remove_write_failure(db_conn)
+        # From here the database is healthy: the probe starts succeeding within
+        # a cadence or two and only the quiet window stands between the fleet
+        # and readmission. That is what makes this an honest measurement of the
+        # window rather than of how long the fault happened to last.
+        healed_at = time.monotonic()
+        assert _wait_for(
+            lambda: _count(log_text(), "DB fail-safe recovered") == number,
+            timeout=recovery_timeout,
+            poll=0.5,
+        ), (
+            f"fail-safe never recovered for episode {number} after the write fault was "
+            "removed\n" + log_text()
+        )
+        return time.monotonic() - healed_at
+
+    first_hold = run_episode(1, trip_timeout=30.0, recovery_timeout=40.0)
+
+    # The gate is down: the same client re-identifies and telemetry stores
+    # again. The second episode needs the fleet actually writing, or there is
+    # nothing to fail.
+    assert _wait_for(
+        lambda: log_text().count("Aircraft client identified: test1") >= 2, timeout=20.0
+    ), "client never re-identified after the first recovery\n" + log_text()
+    resumed_from = position_count()
+    assert _wait_for(lambda: position_count() > resumed_from, timeout=25.0), (
+        "telemetry did not resume storing after the first recovery\n"
+        f"-- server log --\n{log_text()}\n"
+        f"-- client log --\n{client['log'].read_text(errors='replace')}"
+    )
+
+    # Same fault, same server, within the hour: this is a re-trip, not a fresh
+    # incident, and the recovery grace doubles.
+    second_hold = run_episode(2, trip_timeout=40.0, recovery_timeout=70.0)
+
+    final = log_text()
+    # The log names the window each episode actually cleared. An operator
+    # watching a flapping database reads this line to know when the fleet comes
+    # back, so it has to report the effective window and not the configured one.
+    assert f"quiet for {RECOVERY_GRACE_SECS}s" in final, (
+        "the first recovery did not report the configured grace window\n" + final
+    )
+    assert f"quiet for {2 * RECOVERY_GRACE_SECS}s" in final, (
+        "the second recovery did not report a backed-off grace window — the re-trip was "
+        "treated as a fresh incident (todo/81)\n" + final
+    )
+
+    # And the behaviour itself, not just the line describing it. The second
+    # hold must clear the un-backed-off window by a margin no scheduling slop
+    # accounts for; both holds are measured from the moment the database became
+    # healthy again, so the difference is the back-off and nothing else.
+    assert second_hold > RECOVERY_GRACE_SECS + 5, (
+        f"the second degraded episode held the gate for {second_hold:.1f}s, no longer than "
+        f"the configured {RECOVERY_GRACE_SECS}s grace — the fleet is being readmitted into "
+        "a database that has already failed twice\n" + final
+    )
+    assert second_hold > first_hold + 5, (
+        f"the second degraded episode ({second_hold:.1f}s) did not hold materially longer "
+        f"than the first ({first_hold:.1f}s)\n" + final
+    )
+
+    # Two episodes, two trips, two recoveries: the back-off lengthens the hold,
+    # it does not add or suppress transitions.
+    assert _count(final, "DB fail-safe tripped") == 2
+    assert _count(final, "DB fail-safe recovered") == 2
+    assert client["proc"].poll() is None, "fake client died during the test"
+    assert server_proc["proc"].poll() is None, "server died during the test"


### PR DESCRIPTION
## Description

Installs the write-only trigger, lets the fail-safe trip, heals the database, watches the gate come down, then lets the same fault return and asserts the second degraded episode holds twice as long. Both holds are measured from the moment the database became healthy again, so what is compared is the recovery window and not how long the fault happened to last.

The fault is driven by the test rather than by a self-toggling trigger (a counter table, or random() in the trigger function, as the item suggests): the behaviour under test is the repetition, and "episode two costs more than episode one" is only legible if the test decides when each episode begins and ends.

Both the log line and the behaviour are asserted. The recovered line names the window the episode actually cleared -- "quiet for 15s", then "quiet for 30s" -- and an operator reads it to know when the fleet comes back, so it has to stay honest; but the number that matters to an aircraft is the hold, and the two could in principle disagree.

The negative case was run: with db_write_failure_recovery_backoff_max forced to 1 the second episode recovers on the configured 15s window and the test fails on the "quiet for 30s" assertion. Runtime is ~75s against the 420s budget documented in the file.

Decision 34/45/47 gains the back-off section and loses its "still open (todo/81)" note; the K-consecutive-successes alternative is recorded as rejected, with the reason it does not address the gap.

## Summary by Sourcery

Document and validate the new back-off behaviour for database write fail-safe recovery under intermittent faults.

Documentation:
- Describe the recovery grace back-off strategy for repeated database write fail-safe trips and record rejection of the K-consecutive-successes alternative.

Tests:
- Add an end-to-end test that drives an intermittent database write failure and asserts the second degraded episode holds the admission gate longer and reports an increased recovery window.