### PR TITLE
docs: record that the v2 sequence check is server-side only (todo/71)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,10 @@ several `todo/` items is filed under all of them (`34-45-47-…`).
 | [51 — optional trailing wire fields are prefix-closed](decisions/51-optional-trailing-field-rule.md) | Protocol |
 | [66/67 — the client fans out through per-server workers, and prunes what it learns](decisions/66-67-client-outbound-fanout.md) | Client library |
 | [68 — command acks name the row; redelivery ends at a terminal ack](decisions/68-command-redelivery-and-ack-keying.md) | Protocol / audit |
+| [71 — the v2 sequence check is server-side only](decisions/71-client-sequence-not-enforced.md) | Protocol |
 | [73 — the server verifies the database schema at startup](decisions/73-startup-schema-verification.md) | Database seam |
+| [76 — a position report records whether it is GPS-backed](decisions/76-gps-fix-recording.md) | Safety visibility |
+| [80 — a retired asset cannot fly](decisions/80-retired-asset-enforcement.md) | Server policy |
 
 ## Citing a decision
 

--- a/docs/decisions/71-client-sequence-not-enforced.md
+++ b/docs/decisions/71-client-sequence-not-enforced.md
@@ -1,0 +1,83 @@
+# 71 — The v2 sequence check is server-side only
+
+**Decided** 2026-08-05, documentation only: no code changed, and none is
+intended to. The asymmetry described here has existed since protocol v2
+shipped; what was missing was any statement that it is deliberate.
+
+## Context
+
+Protocol v2 numbers every message a peer sends with a monotonic per-connection
+counter (`fss_connection::getMessageId()`). The **server** enforces it:
+`client_session.cpp` anchors `expected_seq` at the version handshake, requires
+each subsequent `fss_message::getSeq()` to match, and disconnects the session on
+a mismatch — todo/39 chose disconnect over a silent drop, because `expected_seq`
+only advances on a match, so dropping would freeze the session until the 30 s
+liveness timeout.
+
+`client_ssl::fss_server::processMessage()` does no such check. It negotiates the
+version, stores it on the connection, and then dispatches on message type. A
+server that reordered, duplicated or skipped a message id would be accepted
+silently by every client.
+
+The server's own comment already states the guarantee this rests on:
+
+> This is an application-level integrity check that rejects reordered or
+> duplicated messages within a session — it is **NOT** a security replay
+> defence. Under its security assumptions TLS already provides replay and
+> reorder protection at the record layer.
+
+## Decision
+
+The asymmetry stands, and is recorded rather than removed.
+
+- **TLS does the real work.** If the record layer already rules out genuine
+  reorder and replay, a second implementation on the client adds nothing against
+  an attacker. The server-side check earns its place for a different reason —
+  see below — not as a defence.
+- **The two sides face different risks.** The server accepts connections from
+  many peers of unknown quality and must be able to reject one cheaply. The
+  client is the resource-constrained side, running on the aircraft, and talks
+  only to servers the operator configured or a configured server vouched for.
+- **The client's residual value is diagnostic, not defensive.** The server-side
+  check also catches *local framing bugs* — todo/39 names a consumed-but-never-
+  sent id (todo/38) as a cause a mismatch would surface. The server→client
+  direction has the same failure modes (`sendPacked`'s id rollback, `sendMsg`'s
+  rollback) and nothing would notice. That is a real, if small, loss, and it is
+  the reason option 2 below stays open rather than being rejected outright.
+
+## Rejected: mirroring the server, disconnect included
+
+This is the change a reader who spots the inconsistency will reach for, so it is
+recorded as rejected explicitly.
+
+An aircraft that drops its server connection over one bad sequence number has
+traded a diagnostic for a safety regression: that connection carries TERM,
+RTL and DISARM. The server dropping one aircraft costs that aircraft a
+reconnect; the client dropping its server costs the operator their control link,
+and does so on exactly the kind of transient the check is least able to
+attribute. Whatever a client does about a mismatch, it must not be that.
+
+## Left open: a log-only check
+
+Tracking `expected_seq` client-side, logging a **throttled** WARN on mismatch,
+advancing to the observed value and never disconnecting would recover the
+diagnostic without the availability risk. It is small, needs no wire change and
+no schema change, and the state fits on `fss_connection` beside
+`negotiated_version`.
+
+It is not taken here because it is not free: `fss_connection` is in the
+installed ABI, so a new data member costs a soname bump
+(`docs/release-checklist.md`, step 1) and must therefore ride a release that is
+already breaking the ABI for another reason. Worth more now than when the item
+was filed, because `sendPacked()` stamps ids directly into cloned bytes and
+bypasses `fss_message::setId` — a newer path than the sequence check itself. If
+it is ever taken, the acceptance test is a client connection driven with a
+deliberately skipped id asserting exactly one throttled WARN and **no**
+disconnect.
+
+## Related
+
+- `src/fss-client-ssl.hpp` carries the short form of this at
+  `fss_server::processMessage()`, which is where a reader meets the asymmetry.
+- [25 — transport callbacks run without the connection's lock](25-transport-callback-reentrancy.md)
+  covers the other standing property of the same callback path.

--- a/src/fss-client-ssl.hpp
+++ b/src/fss-client-ssl.hpp
@@ -390,6 +390,18 @@ public:
     auto operator=(fss_server &) -> fss_server & = delete;
     auto operator=(fss_server &&) -> fss_server & = delete;
     ~fss_server() override;
+    /* Note for anyone writing a third-party client, or reading this next to
+     * client_session.cpp's expected_seq check and wondering which side is
+     * wrong: this client deliberately does NOT validate the v2 per-connection
+     * sequence on messages it receives (docs/decisions/71-client-sequence-not-
+     * enforced.md). The server enforces it on the client→server direction and
+     * disconnects on a mismatch; the server→client direction is unchecked. TLS
+     * provides the real reorder/replay guarantee at the record layer, the
+     * server is the side that must defend against many peers of unknown
+     * quality, and an aircraft dropping its command link over one bad sequence
+     * would trade a diagnostic for a safety regression. Mirroring the server,
+     * disconnect included, is recorded as rejected there — the asymmetry is
+     * the decision, not an oversight. */
     void processMessage(std::shared_ptr<flight_safety_system::transport::fss_message> message) override;
     /* Queue a pre-packed frame for this server's outbound worker instead of
      * sending it inline (docs/decisions/66-67-client-outbound-fanout.md).


### PR DESCRIPTION
## Description

The server anchors expected_seq at the version handshake and disconnects on a mismatch; client_ssl::fss_server::processMessage() does no check at all, so a server that reordered, duplicated or skipped a message id would be accepted silently by every client. That is defensible -- TLS provides the real reorder/replay guarantee, the server is the side facing many peers of unknown quality, and the client is the constrained side -- but nothing said so, and the undocumented asymmetry was the actual defect.

Option 1 from the item: a decision file plus the short form in fss-client-ssl.hpp, at processMessage(), which is where a reader meets the asymmetry.

Mirroring the server including the disconnect is recorded as explicitly rejected, since it is what a reader who spots the inconsistency will reach for: an aircraft that drops its server connection over one bad sequence number has traded a diagnostic for a safety regression, on a link carrying TERM, RTL and DISARM.

The log-only variant (option 2) is recorded as left open rather than rejected -- it recovers the local-framing-bug diagnostic the server side also provides, and sendPacked() bypassing fss_message::setId makes it worth more than when the item was filed. It is not free: the state belongs on fss_connection, which is in the installed ABI, so it has to ride a release that is already breaking the soname.

The decisions index also gains 76 and 80, which shipped without being listed.

## Summary by Sourcery

Document the deliberate asymmetry in v2 message sequence checking, clarifying that only the server enforces per-connection sequencing while the client does not, and record this as a formal decision alongside related protocol and policy decisions.

Documentation:
- Add a decision document explaining that v2 per-connection sequence checks are enforced server-side only, with rationale and rejected alternatives.
- Update the decisions index to include the new sequence-check decision and previously undocumented decisions 76 and 80.
- Annotate the client SSL server message handler with a concise note pointing readers to the documented decision about not enforcing client-side sequence checks.