### PR TITLE
docs: promote the one orphan rationale and state the convention

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,34 @@ several `todo/` items is filed under all of them (`34-45-47-…`).
 | [76 — a position report records whether it is GPS-backed](decisions/76-gps-fix-recording.md) | Safety visibility |
 | [80 — a retired asset cannot fly](decisions/80-retired-asset-enforcement.md) | Server policy |
 
+## Comments and decisions: which carries what
+
+Both are load-bearing and neither replaces the other, but they answer different
+questions and should stop holding two copies of the same argument (todo/75).
+
+- **A code comment** is read by someone holding the function signature, usually
+  mid-edit. It carries the **invariant or constraint they could get wrong**:
+  lock ordering, lifetime proofs, "this must not be called with X held", the
+  claim plus a citation. The test for keeping text inline is *would someone
+  editing this line get it wrong without it?*
+- **A decision file** is read by someone asking why the code is shaped this way,
+  possibly years later, holding only the repository. It carries the
+  **argument**: the context, the alternatives, the evidence behind each
+  rejection, and what would justify revisiting.
+
+Two consequences, both applied **opportunistically** — whenever a file is
+touched for other reasons, never as a sweep or a dedicated churn commit:
+
+1. Where a decision file exists, a header comment that restates its argument
+   shrinks to the invariant plus `see docs/decisions/NN-…`. Motivation,
+   alternatives and history go; invariants and proofs stay.
+2. Rationale found existing **only** as a comment gets promoted to a decision
+   file. This is the direction with independent value: an argument that lives in
+   one comment is one refactor away from being lost, and unlike a duplicate it
+   cannot be recovered from anywhere else.
+   [12 (C7)](decisions/12-listen-socket-is-a-connection.md) was promoted exactly
+   this way.
+
 ## Citing a decision
 
 New code comments, `CHANGELOG.md` entries and commit messages should cite the

--- a/docs/decisions/12-listen-socket-is-a-connection.md
+++ b/docs/decisions/12-listen-socket-is-a-connection.md
@@ -1,0 +1,58 @@
+# 12 (C7) — `fss_listen` inherits from `fss_connection`, deliberately, for now
+
+**Decided** when todo/12 group C was assessed; promoted here 2026-08-05 by the
+todo/75 orphan audit, which found this rationale existing **only** as a comment
+in `src/fss-transport.hpp` — one refactor away from being lost, in a file whose
+shape it explains.
+
+## The wart
+
+`fss_listen` is-a `fss_connection`. A listening socket is not a connection: it
+never sends a message, never receives one, and never negotiates a version. What
+it actually wants from the base class is the file-descriptor and receive-thread
+lifecycle — `shutdownSocket()`/`disconnect()`, the fd ownership rules, the
+thread join discipline. What it *inherits* is all of that plus `sendMsg()`,
+`sendPacked()`, `getMsg()`, the message queue, the sequence counter and the
+negotiated-version state, every one of which is meaningless on a listener.
+
+The clean shape is a small `fd_owner` base holding the fd plus the thread
+lifecycle, with `fss_listen` and `fss_connection` as siblings on top of it.
+
+## Why it has not been done
+
+It is an ABI break, and a large one: `fss-transport.hpp` is an installed header
+exported by all four libraries, and the change moves members between classes and
+rewrites a vtable. Under this project's soname rule
+([the release checklist](../release-checklist.md), step 1) that costs a
+`-version-info` bump and a rebuild of every consumer.
+
+The bump itself is not the objection — this project breaks its ABI when it has a
+reason to, and has done so twice in the 1.x series. The objection is doing it
+*for this alone*: consumers pay a rebuild and the risk of a hierarchy rewrite in
+the transport layer, and get in exchange a cleaner class diagram and no
+behavioural improvement whatsoever. The right time is a release that is
+restructuring the transport for a reason that pays for the risk, and that has not
+happened yet.
+
+**Note for whoever picks this up:** "the next release that breaks the ABI" is
+*not* the trigger, and reading it that way is the likely mistake. A release
+whose soname bump comes from an unrelated change has not made this refactor any
+safer to do — it has only made it cheaper to ship. The trigger is a transport
+rework substantial enough that the hierarchy is being touched anyway.
+
+## What holds it together in the meantime
+
+Nothing in the base class is *wrong* for a listener, only unused: the inherited
+send/receive members are never called on an `fss_listen`, because nothing hands
+one to code that sends. The cost is comprehension, not correctness — a reader of
+`fss_listen` has to work out which half of its inherited surface is real.
+
+## Related
+
+- `src/fss-transport.hpp` carries the short form at `class fss_listen`.
+- [The release checklist](../release-checklist.md) — step 1 is where the ABI
+  consequence above is enforced.
+- The C8 invariant from the same todo/12 group (a single `fss_message` must not
+  be sent concurrently on multiple connections) is documented at `sendMsg()` and
+  `sendPacked()` in the same header; it is an invariant a caller must respect,
+  so it stays inline.

--- a/src/fss-transport.hpp
+++ b/src/fss-transport.hpp
@@ -456,10 +456,11 @@ public:
 
 /* NOTE (todo/12 C7): a listen socket is-a fss_connection only to reuse the fd +
  * recv-thread lifecycle; it inherits sendMsg/getMsg/message-queue members that
- * are meaningless for it. The clean shape is a small fd_owner base shared by
- * sibling fss_listen / fss_connection. Deferred deliberately: it is an ABI break
- * (a -version-info bump — all four libs export this header) not worth doing on
- * its own; fold it into the next transport rework. */
+ * are meaningless for it. Nothing calls them on a listener. The clean shape (a
+ * small fd_owner base shared by sibling fss_listen / fss_connection) is
+ * deliberately deferred to the next transport rework, NOT merely to the next
+ * release that breaks the ABI — see
+ * docs/decisions/12-listen-socket-is-a-connection.md. */
 class fss_listen : public fss_connection {
 private:
     uint16_t port;


### PR DESCRIPTION
## Description

The audit half of the item, which is the half with independent value: rationale that exists only as a comment is one refactor away from being lost, and unlike a duplicate it cannot be recovered from anywhere else.

Scanning the public headers and the server/transport sources for deferred-decision and rejected-alternative arguments turns up exactly one that is nowhere else in the tree: todo/12 C7, the fss_listen-is-a- fss_connection wart and the reason it has not been fixed. It is now docs/decisions/12, and the header keeps the claim plus the citation.

Promoting it surfaced a misreading worth heading off. The comment said "fold it into the next transport rework", and this release breaks the ABI anyway -- so the tempting conclusion is that now is the moment. It is not: a soname bump from an unrelated change makes the refactor cheaper to ship, not safer to do. The decision file says so where the next reader will look.

Everything else the item lists (the C8 invariant, the deferred-close rationale, the lock-ordering notes) is either an invariant a caller must respect, which belongs inline, or already duplicated with a decision file that owns the argument -- no orphans.

docs/README.md now states the division of labour: comments carry the invariant someone mid-edit could get wrong, decision files carry the argument, and both directions -- trimming a duplicate, promoting an orphan -- are applied opportunistically when a file is touched for other reasons. Without that written down, the observation gets re-filed every review cycle, which is what the item says it is trying to stop.

## Summary by Sourcery

Document the division of responsibility between code comments and decision files and promote an orphaned transport-layer rationale into a formal decision record.

Enhancements:
- Update the fss_listen comment in fss-transport.hpp to reference the new decision file and clarify that ABI-breaking releases alone do not justify the refactor.

Documentation:
- Add guidance in docs/README.md on when to use code comments versus decision files, emphasizing invariants in code and arguments in decisions.
- Document the rationale for keeping fss_listen inheriting from fss_connection as decision 12, including why the refactor is deferred despite ABI-breaking releases.