### PR TITLE
release: 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-08-05
+
+**Consumers must rebuild.** All four library sonames bump `.so.3` → `.so.4`
+(`-version-info 4:0:0`); see the ABI break note under *Changed*. A same-soname
+mix of an old library and the new headers corrupts object layout at runtime
+rather than failing to link.
+
+**Deployments require `fss-web`'s `assets` migration 0016 or later.** The
+server verifies this at startup and refuses to run without it, naming what is
+missing — an FSS upgraded ahead of `fss-web` is a startup failure you can read,
+not a fleet-wide disconnection some minutes later.
+
 ### Added
 - **A retired asset can no longer fly** (todo/80,
   `docs/decisions/80-retired-asset-enforcement.md`). `fss-web` retires an asset
@@ -80,8 +92,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an ABI break reached a tag unbumped. Open work items stay in `todo/`.
   Citations in the public headers and the fail-safe monitor now point at the
   tracked documents; the rest are retargeted as those files are next touched.
+- Two further design records, both documentation-only (todo/71, todo/75).
+  **The client does not validate the server's v2 message sequence, and that is
+  deliberate** (`docs/decisions/71-client-sequence-not-enforced.md`): the server
+  enforces the in-order/duplicate check on what it receives and disconnects on a
+  mismatch, the client checks nothing, and until now nothing said whether that
+  asymmetry was a decision or an oversight. It is a decision — TLS provides the
+  real reorder and replay guarantee, and an aircraft that dropped its server
+  connection over one bad sequence number would trade a diagnostic for a
+  control-link outage — so mirroring the server, disconnect included, is
+  recorded as explicitly rejected. Third-party client implementations are free
+  to add a check of their own. **And the `fss_listen`-is-a-`fss_connection`
+  wart** (`docs/decisions/12-listen-socket-is-a-connection.md`) is now recorded
+  where it can be found: a listening socket inherits a send/receive surface that
+  is meaningless for it, the clean shape is a shared `fd_owner` base, and the
+  refactor is deferred to a transport rework rather than to the next release
+  that happens to break the ABI. `docs/README.md` gains the convention that
+  produced both: a comment carries the invariant someone mid-edit could get
+  wrong, a decision file carries the argument, and rationale found living only
+  in a comment gets promoted.
 
 ### Changed
+- **A database that keeps failing now holds the admission gate longer each
+  time** (todo/81, `docs/decisions/34-45-47-db-failsafe-latch.md`). The health
+  probe below answers "does a write work right now?", which is the whole
+  question against a database that is dead or persistently faulted — it never
+  answers yes, so the fail-safe holds. An *intermittently* faulted one answers
+  yes honestly, over and over: the queue drains, the window goes quiet, a probe
+  succeeds, the fleet is readmitted, real telemetry resumes, the fault returns,
+  and the fail-safe trips again. Every readmission is backed by evidence that
+  was true when it was taken, and an aircraft is still being moved in and out of
+  its comms-loss state by a fault the server has already seen. The recovery
+  grace is now multiplied by the length of the current run of trips, capped: a
+  trip within an hour of the previous one continues that run, a trip after a
+  quiet hour starts afresh. The first trip of a run is unaffected, so a one-off
+  incident behaves exactly as before; what grows is the cost of a fault that
+  keeps coming back. The new config field
+  **`db_write_failure_recovery_backoff_max`** (default 8) caps the multiplier,
+  so at the default 15 s grace a first trip holds the gate for 15 s and an
+  eighth within the hour holds it for two minutes; `1` disables the back-off
+  entirely. Only the recovery role of `db_write_failure_recovery_grace_secs` is
+  backed off — its other role, how long failures may pause and still chain into
+  one incident, is untouched, since stretching that would make each successive
+  trip later as well as longer. The still-degraded and recovered log lines now
+  report the effective window rather than the configured one.
 - **The DB fail-safe's thresholds are measured in real time, not in loop
   iterations** (todo/70). `db_failsafe` opened each tick with `elapsed_secs++`
   and compared every threshold against that counter, but the caller advances it
@@ -234,6 +288,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   where a mismatch falls.
 
 ### Fixed
+- **The DB fail-safe no longer recovers on silence** (todo/78,
+  `docs/decisions/34-45-47-db-failsafe-latch.md`). Recovery required the write
+  queue drained and no failure for the recovery grace — two statements about the
+  *absence* of failure, both of which the trip's own action guarantees:
+  severing every session and refusing new ones removes everything that could
+  produce a failure, so no telemetry arrives, nothing is queued and nothing
+  fails. Drained-and-quiet was therefore satisfied by construction about 15 s
+  after every trip, whatever the database was doing. Against a permanently dead
+  database — observed in the field: PostgreSQL hit a `PANIC` on a full disk and
+  its own crash recovery could not write either — that made a ~20 second cycle
+  forever, each turn taking a connected aircraft out of and back into its
+  comms-loss failsafe, which is the opposite of the one clean latched event the
+  fail-safe exists to produce. Recovery now additionally requires a **health
+  probe** to have succeeded: a real INSERT on the write connection that failed,
+  rolled back so nothing fictional is stored. The probe gates the quiet window
+  rather than replacing it, and the success must be observed on the recovering
+  tick itself — a probe that *hangs*, against a partitioned or frozen database,
+  returns neither answer, so the absence of fresh evidence is the only thing
+  that can see it. A read-based check (`SELECT 1`) would not do: a write-only
+  fault leaves reads perfectly healthy, which is precisely the fault class this
+  exists for. The probe runs on the write queue's worker thread, so no
+  synchronous database work reaches the main loop. While degraded, the server
+  now also logs once a minute naming the elapsed time, the probe counters and
+  the last probe error, since silence is now the *correct* outcome against a
+  dead database and silence is what an operator cannot act on.
+- **A server that refuses the client no longer counts as a working server**
+  (todo/79). `fss_client` counted a server as service once the TCP connection
+  and TLS handshake completed, but admission is a later, server-side decision:
+  a server that is degraded (or that rejects the identity) accepts the
+  connection and then refuses the session. A client locked out by every server
+  it knew therefore reported itself connected, and the connection-status
+  callback — the aircraft's own signal that it has a control link — said so too.
+  A server now counts only once it has admitted us, cleared whenever the
+  connection ends so a reconnect into a refusing server cannot inherit the
+  previous session's admission. This is the client half of the same reconnect
+  flap todo/78 fixes on the server.
 - **A database read failure is no longer reported as an empty result on the
   command and SMM paths** (todo/69, extending
   `docs/decisions/24-database-read-error-control-flow.md`). Two of the four
@@ -890,6 +980,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.12.3] - 2025-11-07
 
+[1.3.0]: https://github.com/canterbury-air-patrol/flight-safety-system/compare/1.2.1...1.3.0
+[1.2.1]: https://github.com/canterbury-air-patrol/flight-safety-system/compare/1.2.0...1.2.1
 [1.2.0]: https://github.com/canterbury-air-patrol/flight-safety-system/compare/1.1.1...1.2.0
 [1.1.1]: https://github.com/canterbury-air-patrol/flight-safety-system/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/canterbury-air-patrol/flight-safety-system/compare/1.0.3...1.1.0

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([flight-safety-system], [1.2.1], [sjp@canterburyairpatrol.org])
+AC_INIT([flight-safety-system], [1.3.0], [sjp@canterburyairpatrol.org])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign -Wno-portability])
 
 m4_include([m4/ax_cxx_compile_stdcxx.m4])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,48 @@
+flight-safety-system (1.3.0) stable; urgency=medium
+
+  * SONAME bump: all four libraries move .so.3 -> .so.4. Consumers must be
+    rebuilt; a same-soname mix of an old library and the new headers
+    corrupts object layout at runtime rather than failing to link.
+  * Deployments now require fss-web's assets migration 0016 or later. The
+    server verifies the database schema before the listener binds and
+    refuses to start against a database missing anything it uses, naming
+    what is absent -- previously an un-migrated deployment started cleanly,
+    accepted every aircraft, and then severed the whole fleet on the first
+    command dispatch, permanently.
+  * A retired asset can no longer fly: identification refuses one, and a
+    session whose asset is retired mid-flight is severed within about 1.1
+    seconds. Clearing retired_at readmits the aircraft under its original
+    id without a restart.
+  * A position report now records whether its coordinates are backed by a
+    GPS fix, instead of being discarded: a dead-reckoned estimate keeps its
+    coordinates and is marked, a report carrying none stores NULL geometry.
+  * The DB fail-safe no longer recovers on silence. Recovery needs a health
+    probe -- a real write on the failing connection, rolled back -- to have
+    succeeded on the recovering tick, so a dead database no longer cycles
+    aircraft in and out of comms-loss every ~20 seconds. A database that
+    keeps failing intermittently now holds the admission gate longer on
+    each repeat trip, capped by the new
+    db_write_failure_recovery_backoff_max setting.
+  * A command issued once no longer destroys and rewrites its own stored
+    acknowledgement every 10 seconds; acks are matched on the command row's
+    primary key and redelivery stops at a terminal ack, scoped to the
+    connection.
+  * Database read failures on the command and SMM paths are no longer
+    indistinguishable from an empty result, so a transient outage cannot
+    clear an aircraft's pending command or wipe its cached settings.
+  * The client library's sendMsgAll() and attemptReconnect() are now
+    non-blocking -- each server has its own outbound worker -- so one
+    black-holed server can no longer hold telemetry to every healthy one.
+    Clients also expire and cap the servers they learn from broadcasts, and
+    count a server as service only once it has admitted them.
+  * The fail-safe's thresholds are measured against a clock rather than
+    counted loop iterations; the config key
+    db_write_failure_disconnect_ticks is renamed to _secs (the old key is
+    still accepted, with a warning).
+  * secure_string equality is now constant-time.
+
+ -- Scott Parlane <sjp@canterburyairpatrol.org>  Wed, 05 Aug 2026 10:00:00 +1200
+
 flight-safety-system (1.2.1) stable; urgency=medium
 
   * Stop a two-server client from tearing down and redialling both healthy


### PR DESCRIPTION
## Description

Version numbers per docs/release-checklist.md step 3: AC_INIT, the debian/changelog stanza, and the accumulated CHANGELOG entries moved under a 1.3.0 heading. -version-info needs no change here -- 6a47192 already bumped all four libraries 3:0:0 -> 4:0:0 for the todo/25 layout change, and the rule is one bump per release however many breaks it covers.

1.3.0 rather than 1.2.2: the release breaks the ABI, and both previous soname bumps in the 1.x series rode a minor bump (1.1.0 at 2:0:0, 1.2.0 at 3:0:0).

The heading leads with the two things a deployment has to act on before it upgrades -- consumers must rebuild, and fss-web's assets migration 0016 is required or the server will refuse to start -- because the release checklist's step 2 exists to get exactly those in front of whoever runs the deploy.

Three entries were missing from the accumulated section and are added here rather than left for the tag to hide: todo/78 (the fail-safe recovered on silence, which is the field-observed ~20s flap against a dead database), todo/79 (a server that refuses the client counted as service, the client half of the same flap), and todo/81 (the recovery grace now backs off per re-trip). The two design records from this sitting, todo/71 and todo/75, are recorded under Added with the rest of the docs work.

Debian packaging needs no change for the soname: the binary package names are unversioned (libfss, not libfss3) and the .install globs are wildcards, as they were for the 1.1.0 and 1.2.0 bumps. The changelog's missing [1.2.1] compare link is restored alongside the new [1.3.0] one.

## Summary by Sourcery

Cut a 1.3.0 release with an ABI-breaking soname bump and updated release documentation, including operational guidance for deployments and database fail-safe behaviour.

New Features:
- Document two new design decisions around client/server message sequencing and the `fss_listen`/`fss_connection` relationship.

Bug Fixes:
- Prevent the DB fail-safe from auto-recovering on silence by requiring a successful write health probe before recovery.
- Ensure `fss_client` only reports a working server once the session is actually admitted, fixing misleading connection status reporting.
- Treat database read failures correctly instead of surfacing them as empty results on command and SMM paths.

Enhancements:
- Introduce exponential-style backoff for DB fail-safe recovery windows so repeated failures hold the admission gate longer.
- Measure DB fail-safe thresholds against real time rather than loop iterations for more accurate behaviour.
- Clarify and extend documentation around database fail-safe latching and recovery configuration, including new logging while degraded.

Build:
- Update the project version in Autotools configuration to 1.3.0.

Documentation:
- Add a 1.3.0 changelog section summarizing ABI changes, deployment requirements, and behavioural changes.
- Restore and add GitHub comparison links for releases, including the new 1.3.0 and missing 1.2.1 entries.