### PR TITLE
docs: stamp 1.3.0 on the decisions it ships

### DIFF
--- a/docs/decisions/25-transport-callback-reentrancy.md
+++ b/docs/decisions/25-transport-callback-reentrancy.md
@@ -1,7 +1,7 @@
 # 25 — Transport callbacks run with the connection's message lock released
 
-**Standing constraint on the transport API.** Decided and shipped 2026-07-25.
-Carries an ABI break: sonames `.so.3` → `.so.4`.
+**Standing constraint on the transport API.** Decided and shipped 2026-07-25,
+released in 1.3.0. Carries an ABI break: sonames `.so.3` → `.so.4`.
 
 ## The constraint
 

--- a/docs/decisions/66-67-client-outbound-fanout.md
+++ b/docs/decisions/66-67-client-outbound-fanout.md
@@ -1,6 +1,6 @@
 # 66/67 — the client fans out through per-server workers, and prunes what it learns
 
-**Decided** 2026-07-26. Config fields `learned_server_expiry_ms` and
+**Decided** 2026-07-26. Shipped in 1.3.0. Config fields `learned_server_expiry_ms` and
 `max_learned_servers` in the client JSON; defaults
 `default_learned_server_expiry_ms` (60 s) and `default_max_learned_servers`
 (16) in `src/fss-client-ssl.hpp`. Broke the ABI of `libfss-client-ssl`; all

--- a/docs/decisions/68-command-redelivery-and-ack-keying.md
+++ b/docs/decisions/68-command-redelivery-and-ack-keying.md
@@ -1,6 +1,6 @@
 # 68 — Command acks name the row; redelivery ends at a terminal ack
 
-**Decided** 2026-07-31. Implemented in `src/client_session.cpp`
+**Decided** 2026-07-31. Shipped in 1.3.0. Implemented in `src/client_session.cpp`
 (`sendCommand`, the `command_ack` handler) and `src/server-db.pgc`
 (`db_command_record_ack`). Revises the fencing argument in
 [48](48-command-ack-terminal-finality.md) and a factual claim in

--- a/docs/decisions/73-startup-schema-verification.md
+++ b/docs/decisions/73-startup-schema-verification.md
@@ -1,6 +1,6 @@
 # 73 — The server verifies the database schema at startup and refuses to run without it
 
-**Decided** 2026-07-28. Unreleased.
+**Decided** 2026-07-28. Shipped in 1.3.0.
 
 ## Context
 

--- a/docs/decisions/76-gps-fix-recording.md
+++ b/docs/decisions/76-gps-fix-recording.md
@@ -1,6 +1,6 @@
 # 76 — Recording whether a reported position is GPS-backed
 
-Status: implemented. Supersedes the transition-table shape sketched in
+Status: implemented, shipped in 1.3.0. Supersedes the transition-table shape sketched in
 `todo/76`; fss-web chose to carry the state on the position row instead.
 
 ## The problem

--- a/docs/decisions/80-retired-asset-enforcement.md
+++ b/docs/decisions/80-retired-asset-enforcement.md
@@ -1,6 +1,6 @@
 # 80 — Enforcing fss-web asset retirement
 
-Status: implemented. Requires fss-web `assets` migration 0013 or later, which is
+Status: implemented, shipped in 1.3.0. Requires fss-web `assets` migration 0013 or later, which is
 already below the deployed floor (0016, decision 76) — so this raises no minimum
 and needs no deployment coordination beyond the note at the end.
 


### PR DESCRIPTION
## Description

Decision 73 said "Unreleased", which stops being true at the tag; the other five settled during this cycle carried a decided-on date and no release, unlike the 1.2.0 records which all name theirs.

## Summary by Sourcery

Documentation:
- Mark decisions 25, 66/67, 68, 73, 76, and 80 as shipped in release 1.3.0 in the decisions documentation.