### PR TITLE
fix(systemd): make the shipped unit retry the startup refusals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,6 +288,16 @@ not a fleet-wide disconnection some minutes later.
   where a mismatch falls.
 
 ### Fixed
+- **The shipped systemd unit now retries the startup refusals this release
+  introduces.** The server deliberately exits rather than run against a
+  database that is unreachable, cannot be introspected, or is missing the
+  required fss-web migration — a design that leans on the supervisor retrying —
+  but the installed `fss-server.service` had no `Restart=` line, so a host that
+  booted before PostgreSQL (or an FSS upgraded ahead of fss-web) stayed down
+  until someone noticed. The unit now sets `Restart=on-failure` with a
+  `RestartSec` chosen to stay inside systemd's default start-rate limit, and
+  orders itself after `network-online.target` and a co-hosted
+  `postgresql.service` so the common boot race never needs the retry at all.
 - **The DB fail-safe no longer recovers on silence** (todo/78,
   `docs/decisions/34-45-47-db-failsafe-latch.md`). Recovery required the write
   queue drained and no failure for the recovery grace — two statements about the

--- a/debian/changelog
+++ b/debian/changelog
@@ -40,6 +40,11 @@ flight-safety-system (1.3.0) stable; urgency=medium
     db_write_failure_disconnect_ticks is renamed to _secs (the old key is
     still accepted, with a warning).
   * secure_string equality is now constant-time.
+  * fss-server.service now sets Restart=on-failure and orders itself after
+    network-online.target and a co-hosted postgresql.service: the startup
+    refusals above lean on the supervisor retrying, and the previous unit
+    never did, leaving the service down after a boot-order race or an
+    upgrade applied ahead of fss-web's migrations.
 
  -- Scott Parlane <sjp@canterburyairpatrol.org>  Wed, 05 Aug 2026 10:00:00 +1200
 

--- a/examples/fss-server.service.in
+++ b/examples/fss-server.service.in
@@ -1,8 +1,23 @@
 [Unit]
 Description=Flight-Safety-System Server
+# The server refuses to start rather than run degraded: an unreachable
+# database, a failed schema introspection, or a missing fss-web migration all
+# exit(1) on the expectation that the supervisor retries
+# (docs/decisions/73-startup-schema-verification.md). These orderings make the
+# common transient case — booting before the network or a co-hosted PostgreSQL
+# is up — not require a retry at all; postgresql.service is ignored where the
+# database is remote.
+Wants=network-online.target
+After=network-online.target postgresql.service
 
 [Service]
 ExecStart=@PREFIX@/fss-server
+# The retry the refuse-to-start design leans on. 5 s keeps two starts inside
+# systemd's default 10 s rate-limit window (StartLimitBurst=5), so a database
+# that stays down — or an fss-web migration not yet applied — is retried
+# indefinitely instead of tripping the start limit and staying down after it.
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Description

The server deliberately exits rather than run against a database that is unreachable, cannot be introspected, or is missing the required fss-web migration — a design whose stated contract is "refuse and let the supervisor retry" (docs/decisions/73-startup-schema-verification.md). But the installed fss-server.service had no Restart= line and no ordering, so the retry never happened: a host that booted fss-server before PostgreSQL or the network, or an FSS upgraded ahead of fss-web's migrations, exited once and stayed down until an operator noticed.

Restart=on-failure supplies the retry; RestartSec=5 keeps two starts inside systemd's default 10 s StartLimitBurst=5 window so an indefinitely-down database is retried forever rather than tripping the start limit. Wants/After network-online.target and After a co-hosted postgresql.service make the common boot race not need the retry at all; the postgresql ordering is inert where the database is remote.

Both changelogs fold this into the un-tagged 1.3.0 entry, since the refuse-to-start behaviour is what that release introduces.

## Summary by Sourcery

Ensure the fss-server systemd unit automatically retries startup when the database or network are initially unavailable, and align changelogs with this behaviour.

Bug Fixes:
- Configure the shipped fss-server.service systemd unit to restart on failure with appropriate timing so startup refusals are retried instead of leaving the service down after a single failed boot.

Enhancements:
- Order the fss-server systemd unit after network-online.target and an optional local postgresql.service to avoid common boot races without relying on retries.

Documentation:
- Document the revised systemd unit behaviour and retry semantics in both the main changelog and the Debian changelog.