### PR TITLE
fix(transport-ssl): resume a TLS send interrupted by a signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,6 +298,15 @@ not a fleet-wide disconnection some minutes later.
   `RestartSec` chosen to stay inside systemd's default start-rate limit, and
   orders itself after `network-online.target` and a co-hosted
   `postgresql.service` so the common boot race never needs the retry at all.
+- **A signal landing on a sending thread no longer severs the session.** The
+  TLS send path treated every GnuTLS error as fatal, including
+  `GNUTLS_E_INTERRUPTED` — which a process-directed signal produces on
+  whichever thread the kernel delivers it to, because the handlers install
+  without `SA_RESTART` (the main loop's CRL reload depends on that). A SIGHUP
+  CRL reload could therefore sever a healthy aircraft session mid-send,
+  surfacing as an unexplained comms-loss event. Interrupted sends are resumable
+  by re-issuing the same call, which the receive path already did; the send
+  path now retries the same way.
 - **The DB fail-safe no longer recovers on silence** (todo/78,
   `docs/decisions/34-45-47-db-failsafe-latch.md`). Recovery required the write
   queue drained and no failure for the recovery grace — two statements about the

--- a/debian/changelog
+++ b/debian/changelog
@@ -40,6 +40,9 @@ flight-safety-system (1.3.0) stable; urgency=medium
     db_write_failure_disconnect_ticks is renamed to _secs (the old key is
     still accepted, with a warning).
   * secure_string equality is now constant-time.
+  * A signal delivered to a thread mid-TLS-send (e.g. the SIGHUP CRL
+    reload) no longer severs that session: interrupted sends are resumed,
+    as interrupted receives already were.
   * fss-server.service now sets Restart=on-failure and orders itself after
     network-online.target and a co-hosted postgresql.service: the startup
     refusals above lean on the supervisor retrying, and the previous unit

--- a/src/transport-ssl.cpp
+++ b/src/transport-ssl.cpp
@@ -442,9 +442,29 @@ auto flight_safety_system::transport_ssl::fss_connection::sendMsg(
         }
         catch (gnutls::exception &ex)
         {
+            /* AGAIN/INTERRUPTED are resumable, not fatal: the server's signal
+             * handlers install with sa_flags = 0 (no SA_RESTART — the main
+             * loop's CRL reload depends on interrupting its sleep), and a
+             * process-directed SIGHUP is delivered to whichever thread the
+             * kernel picks, including one blocked in gnutls_record_send. GnuTLS
+             * requires the interrupted send to be re-issued with the same
+             * arguments (it caches the pending record internally), and `sent`
+             * has not advanced, so retrying here is exactly that. Treating it
+             * as fatal made every CRL reload a dice roll that could sever a
+             * healthy session mid-send. Mirrors recvBytes() below. */
+            if (ex.get_code() == GNUTLS_E_AGAIN || ex.get_code() == GNUTLS_E_INTERRUPTED)
+            {
+                continue;
+            }
             FSS_LOG_ERROR("ssl", "send: caught gnutls exception: " << ex.get_code() << ", " << ex.what());
             this->usable.store(false);
             return false;
+        }
+        /* Some C++ wrapper variants return AGAIN/INTERRUPTED rather than
+         * throwing (same variance recvBytes() handles). */
+        if (transferred == GNUTLS_E_AGAIN || transferred == GNUTLS_E_INTERRUPTED)
+        {
+            continue;
         }
         if (transferred <= 0)
         {


### PR DESCRIPTION
## Description

The TLS send path treated every gnutls error as fatal — usable latched false, the send failed, and the session was dead to all future sends and recvs. But GNUTLS_E_INTERRUPTED is not a connection failure: the signal handlers install with sa_flags = 0 (no SA_RESTART, which the main loop's CRL reload depends on), and a process-directed SIGHUP is delivered to whichever thread the kernel picks — including an outbound worker blocked in gnutls_record_send. Every CRL reload was therefore a dice roll that could sever a healthy aircraft session mid-send, surfacing to the operator as an unexplained comms-loss event.

GnuTLS defines interrupted sends as resumable by re-issuing the call with the same arguments (the pending record is cached internally), and `sent` has not advanced at that point, so the retry is exactly that. recvBytes() has always retried AGAIN/INTERRUPTED — including the wrapper variant that returns the code instead of throwing — so sendMsg() now mirrors both of its branches. The plain-TCP sendMsg() already retried EINTR, which is what marked this as an oversight rather than a policy.

Folded into the un-tagged 1.3.0 changelog entries alongside the other pre-release fixes.

## Summary by Sourcery

Handle transient TLS send interruptions without tearing down otherwise healthy SSL sessions and document the change in the changelog.

Bug Fixes:
- Prevent TLS sessions from being marked unusable and closed when gnutls_record_send is interrupted by a recoverable AGAIN/INTERRUPTED condition.

Documentation:
- Add changelog entry describing that TLS send interruptions caused by signals are now retried instead of severing the session.