### PR TITLE
docs: the command-drop immediate trip covers enqueue drops only, deliberately

### DIFF
--- a/docs/decisions/34-45-47-db-failsafe-latch.md
+++ b/docs/decisions/34-45-47-db-failsafe-latch.md
@@ -28,6 +28,19 @@ dropped dispatch or ack write is known-destroyed audit state, with no threshold
 to age through. A write-*failure* incident trips only when a **new** failure
 arrives while the incident is already `db_write_failure_disconnect_secs` old.
 
+The immediate trip covers *enqueue-time* drops only: a command write that
+reaches the sink and **fails there** counts as a generic write failure and
+takes the sustained-incident path, even though the audit state it carried is
+just as destroyed. That asymmetry is deliberate, not an oversight. An
+enqueue-time command drop means the queue is full — sustained pressure the
+server can already see, so severing on it acts on established evidence. A sink
+failure can be a single blip on an otherwise healthy database, and severing the
+whole fleet for one lost ack write trades a recoverable audit gap (the command
+row keeps its dispatch state; fss-web shows the command unacknowledged) for a
+guaranteed fleet-wide comms-loss event — the wrong side of the trade. The blip
+is still logged at ERROR on first occurrence, and a real outage fails more
+than one write inside the disconnect window and trips normally.
+
 That second condition also fixed a defect in the shipped 34 tracker: a *single*
 transient failure kept the incident active through the recovery grace and
 tripped at the age threshold with no further failure — one blipped INSERT

--- a/src/server-failsafe.hpp
+++ b/src/server-failsafe.hpp
@@ -26,7 +26,11 @@ namespace server {
  * - Any command dispatch/ack drop: trips immediately on the first
  *   counter increase. A dropped command write is known-destroyed audit state
  *   (the command/ack link, or the aircraft's reported outcome), so there is
- *   no threshold to age through.
+ *   no threshold to age through. "Drop" means an enqueue-time drop under
+ *   queue pressure; a command write that reaches the sink and fails there
+ *   counts as a generic write failure and takes the sustained-incident path
+ *   instead — deliberately, see the trigger discussion in
+ *   docs/decisions/34-45-47-db-failsafe-latch.md.
  *
  * A trip latches the degraded state: the caller severs every client
  * *and* gates new admissions (server_clients::setDegraded) so aircraft get one


### PR DESCRIPTION
## Description

The fail-safe's stated invariant — a lost command dispatch/ack write is known-destroyed audit state and trips immediately — is only implemented for enqueue-time queue drops. A command write that reaches the sink and fails there increments the generic write-failure counter and takes the sustained-incident path, so a one-off blip landing on exactly a command write loses the audit link without severing anybody.

The 1.3.0 defect review flagged that asymmetry as an undocumented gap in a documented invariant. It is the intended trade, now stated in the decision record and beside the invariant in server-failsafe.hpp: an enqueue drop is evidence of sustained pressure the server can already see, while severing the fleet for one failed ack write trades a recoverable audit gap for a guaranteed fleet-wide comms-loss event. A real outage fails more than one write inside the disconnect window and trips normally.

## Summary by Sourcery

Clarify the documented behavior of the database failsafe latch for command write drops, explicitly defining that immediate trips apply only to enqueue-time drops while sink-side failures follow the sustained-incident path.

Documentation:
- Update the decision record to explain why enqueue-time command drops trigger immediate severing while sink-side command write failures are treated as generic write failures.
- Align the server failsafe header documentation with the decision record by defining "drop" as an enqueue-time queue-pressure event and cross-referencing the rationale.