### PR TITLE
fix(secure-string): include <cstring> for explicit_bzero

### DIFF
--- a/src/secure-string.hpp
+++ b/src/secure-string.hpp
@@ -1,6 +1,10 @@
 #pragma once
 
-#include <strings.h>
+/* <cstring>, not <strings.h>: glibc declares explicit_bzero in <string.h>
+ * (which includes <strings.h>, not the reverse). This header compiled only
+ * because every TU that reached it happened to pull <cstring> in first; a
+ * standalone include failed. */
+#include <cstring>
 #include <string>
 #include <string_view>
 #include <vector>


### PR DESCRIPTION
## Description

glibc declares explicit_bzero in <string.h>, which includes <strings.h> rather than the reverse, so the <strings.h> this header carried never provided the declaration. It compiled anyway because every translation unit that reached secure-string.hpp happened to pull <cstring> in first -- including the Catch2 3.x header the local and CI builds use.

The Debian package build (debian/control Build-Depends on `catch`, not `catch2`) gets Catch 1.x, whose header does not, so secure_string_test.cpp included this header first and failed with 'explicit_bzero was not declared in this scope'.

Every other src/*.hpp was checked and already compiles standalone.

## Summary by Sourcery

Bug Fixes:
- Fix build failure by including <cstring> instead of <strings.h> so explicit_bzero is available in all translation units.