### PR TITLE
test(log): ignore other threads' output in the concurrent-writers case

### DIFF
--- a/tests/log_test.cpp
+++ b/tests/log_test.cpp
@@ -112,6 +112,18 @@ TEST_CASE("log: concurrent writers produce no interleaved lines")
     auto out = cap.str();
     std::regex line(R"(^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z \[INFO \] \[thr\] tid=\d+ i=\d+$)");
 
+    /* capture_cerr swaps std::cerr's rdbuf process-wide, so this buffer also
+     * collects anything *other* threads write while the test runs -- a
+     * transport thread that outlived an earlier TEST_CASE, or ECPG's
+     * sqlprint() writing "SQL error: ..." straight to stderr. Those are not
+     * what this case is about, and requiring the buffer to hold nothing else
+     * made it fail intermittently (seen in CI under valgrind, which is slow
+     * enough to widen the window a great deal).
+     *
+     * Skip lines this test's writers did not emit, and assert on the rest.
+     * Tearing is still caught both ways: a corrupted line that kept its tag
+     * fails the regex outright, and one that lost the tag is skipped here but
+     * leaves the final count short of thread_count * lines_per_thread. */
     size_t start_off = 0;
     size_t count = 0;
     while (start_off < out.size())
@@ -122,6 +134,11 @@ TEST_CASE("log: concurrent writers produce no interleaved lines")
             break;
         }
         std::string ln = out.substr(start_off, nl - start_off);
+        if (ln.find("[thr]") == std::string::npos)
+        {
+            start_off = nl + 1;
+            continue;
+        }
         REQUIRE(std::regex_match(ln, line));
         ++count;
         start_off = nl + 1;


### PR DESCRIPTION
## Description

capture_cerr swaps std::cerr's rdbuf process-wide, so the buffer this test inspects also collects whatever other threads write while it runs: a transport thread that outlived an earlier TEST_CASE logging via FSS_LOG, or ECPG's sqlprint() writing "SQL error: ..." straight to stderr. Requiring the buffer to contain nothing but this test's own lines therefore made it fail intermittently -- most recently in the valgrind CI job on PR #438, where the change under test was a single #include in a header. Valgrind is slow enough to widen the window a great deal, and the same commit passed build-and-check, thread-sanitizer and sanitizers.

The logger was never at fault: fss-log.hpp:102 holds a scoped_lock across the whole write, so its lines cannot tear. What the case is really asserting is that this test's 8000 lines each arrive intact.

Skip lines that are not ours and assert on the rest. Tearing is still caught from both sides: a corrupted line that kept its [thr] tag fails the regex outright, and one that lost the tag is skipped but leaves the final count short. Both directions were verified by temporarily injecting a foreign FSS_LOG line, a raw stderr write, and a corrupted [thr] line -- the first two now pass, the third still fails.

## Summary by Sourcery

Bug Fixes:
- Prevent intermittent failures in the concurrent logging test by skipping stderr lines not emitted by the test’s own writer threads.