### PR TITLE
fix(clock): widen tv_sec before the ms multiply on 32-bit time_t

### DIFF
--- a/src/fss-main.cpp
+++ b/src/fss-main.cpp
@@ -7,9 +7,11 @@ auto flight_safety_system::fss_current_timestamp() -> uint64_t
 {
     struct timeval tv = {};
     gettimeofday(&tv, nullptr);
-    constexpr int sec_to_msec = 1000;
-    constexpr int usec_to_msec = 1000;
-    return tv.tv_sec * sec_to_msec + (tv.tv_usec / usec_to_msec);
+    /* Widen before multiplying: on 32-bit time_t platforms (bookworm armhf)
+     * tv_sec * 1000 overflows a 32-bit long and sign-extends into the return. */
+    constexpr uint64_t sec_to_msec = 1000;
+    constexpr uint64_t usec_to_msec = 1000;
+    return static_cast<uint64_t>(tv.tv_sec) * sec_to_msec + static_cast<uint64_t>(tv.tv_usec) / usec_to_msec;
 }
 
 auto flight_safety_system::WallClock::now_ms() const -> uint64_t


### PR DESCRIPTION
## Description

fss_current_timestamp() computed `tv.tv_sec * 1000` in time_t, which is a 32-bit long on bookworm/armhf. The product overflows, wraps negative, and sign-extends into the uint64_t return, so every wall-clock timestamp on those platforms — including stored telemetry times — came out as 0xffffffff________. MonotonicClock::now_ms() already widened first; this brings the wall clock into line.

Caught by "clock: WallClock reports the real time of day" on the bookworm armhf build.

## Summary by Sourcery

Bug Fixes:
- Fix overflow in fss_current_timestamp() where tv_sec * 1000 could wrap on 32-bit time_t platforms, producing incorrect wall-clock timestamps.