### PR TITLE
fix(db): size the id vector before copying so 32-bit builds compile

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -7,6 +7,7 @@ extern "C" {
 #include <string.h>
 }
 
+#include <algorithm>
 #include <limits>
 #include <mutex>
 #include <string>
@@ -298,8 +299,14 @@ auto flight_safety_system::server::db_connection::getCommands(const std::vector<
     res.reserve(asset_ids.size());
     /* db_asset_commands_get takes the C asset-id type (unsigned long long) used
      * throughout server-db.h; copy into it because uint64_t may be a distinct
-     * type (unsigned long here) whose pointer will not implicitly convert. */
-    std::vector<unsigned long long> ids(asset_ids.begin(), asset_ids.end());
+     * type (unsigned long here) whose pointer will not implicitly convert.
+     * Sized first and then copied into, rather than built from the iterator
+     * range: where uint64_t is already unsigned long long (32-bit targets such
+     * as armhf) the range constructor's inlined copy is one GCC 13 and 14 cannot
+     * prove runs against a non-null allocation, so -Wnull-dereference — -Werror
+     * in the distro package builds — fires inside <bits/stl_algobase.h>. */
+    std::vector<unsigned long long> ids(asset_ids.size());
+    std::copy(asset_ids.begin(), asset_ids.end(), ids.begin());
     struct asset_command_row_s **rows = nullptr;
     int fetch_error = 0;
     {
@@ -341,9 +348,11 @@ auto flight_safety_system::server::db_connection::getRetiredAssets(const std::ve
     {
         return res;
     }
-    /* Same host-type copy as getCommands: uint64_t may be a distinct type from
-     * the unsigned long long server-db.h uses, and the pointers do not convert. */
-    std::vector<unsigned long long> ids(asset_ids.begin(), asset_ids.end());
+    /* Same host-type copy as getCommands, filled the same way and for the same
+     * -Wnull-dereference reason: uint64_t may be a distinct type from the
+     * unsigned long long server-db.h uses, and the pointers do not convert. */
+    std::vector<unsigned long long> ids(asset_ids.size());
+    std::copy(asset_ids.begin(), asset_ids.end(), ids.begin());
     unsigned long long *retired = nullptr;
     size_t retired_count = 0;
     int fetch_error = 0;


### PR DESCRIPTION
## Description

The armhf package builds on trixie and noble failed in getRetiredAssets with -Wnull-dereference (fatal under the build's -Werror) pointing into <bits/stl_algobase.h>.

Both getCommands and getRetiredAssets copy the caller's asset ids into the unsigned long long the C layer takes. On 32-bit targets uint64_t is already unsigned long long, so vector's iterator-range constructor turns that copy into a trivial block copy — and GCC cannot tie it back to the asset_ids.empty() early return above, so it cannot prove the allocation is non-null and warns. On x86-64 the two types differ, the copy takes a different path, and nothing fires; the diagnostic only ever appeared on the 32-bit builders.

Size the vector first and std::copy into it, which both compilers accept. Note that the reserve()+push_back() spelling is not a fix: it is clean on trixie's GCC 14 but still warns on noble's GCC 13, and cppcheck rejects the raw loop as useStlAlgorithm.

Verified by building src/ on real armhf (qemu) against both debian:trixie (GCC 14) and ubuntu:noble (GCC 13) with the package flags.

## Summary by Sourcery

Prevent null-dereference warnings on 32-bit builds when copying asset IDs for database queries.

Bug Fixes:
- Adjust asset ID vector construction in getCommands to avoid GCC null-dereference warnings on 32-bit targets.
- Adjust asset ID vector construction in getRetiredAssets to avoid GCC null-dereference warnings on 32-bit targets.

Enhancements:
- Include the <algorithm> header to support the updated asset ID copying implementation.